### PR TITLE
Fixed Recursive Pack handling for deep compendium folders

### DIFF
--- a/src/packs/ancestries/ancestry_Clank_AzKMOIpXnCSLLDEB.json
+++ b/src/packs/ancestries/ancestry_Clank_AzKMOIpXnCSLLDEB.json
@@ -1,30 +1,30 @@
 {
-    "name": "Clank",
-    "type": "ancestry",
-    "_id": "AzKMOIpXnCSLLDEB",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "description": "<p><strong>Purposeful Design</strong>: Decide who made you and for what purpose. At character creation, choose one of your Experiences that best aligns with this purpose and gain a permanent +1 bonus to it.</p><p><strong>Efficient</strong>: When you take a short rest, you can choose a long rest move instead of a short rest move.</p>",
-        "abilities": []
-    },
-    "effects": [],
-    "folder": null,
-    "sort": 100000,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1747990113503,
-        "modifiedTime": 1747999445342,
-        "lastModifiedBy": "NqO2eQGMjrvUO6v9"
-    },
-    "_key": "!items!AzKMOIpXnCSLLDEB"
+  "name": "Clank",
+  "type": "ancestry",
+  "_id": "AzKMOIpXnCSLLDEB",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": "<p><strong>Purposeful Design</strong>: Decide who made you and for what purpose. At character creation, choose one of your Experiences that best aligns with this purpose and gain a permanent +1 bonus to it.</p><p><strong>Efficient</strong>: When you take a short rest, you can choose a long rest move instead of a short rest move.</p>",
+    "abilities": []
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 100000,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747990113503,
+    "modifiedTime": 1747999445342,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!AzKMOIpXnCSLLDEB"
 }

--- a/src/packs/class-features/feature_Arcane_Sense_D5HUGwdizhBVZ0RW.json
+++ b/src/packs/class-features/feature_Arcane_Sense_D5HUGwdizhBVZ0RW.json
@@ -1,44 +1,44 @@
 {
-    "name": "Arcane Sense",
-    "type": "feature",
-    "_id": "D5HUGwdizhBVZ0RW",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "action",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>You can sense the presence of magical people and objects within Close range.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "class"
+  "name": "Arcane Sense",
+  "type": "feature",
+  "_id": "D5HUGwdizhBVZ0RW",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "action",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "ei8OkswTzyDp4IGC": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748033779155,
-        "modifiedTime": 1748033799399,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!D5HUGwdizhBVZ0RW"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>You can sense the presence of magical people and objects within Close range.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "class"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748033779155,
+    "modifiedTime": 1748033799399,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!D5HUGwdizhBVZ0RW"
 }

--- a/src/packs/class-features/feature_Attack_of_Opportunity_VfUbJwGU4Cka0xLP.json
+++ b/src/packs/class-features/feature_Attack_of_Opportunity_VfUbJwGU4Cka0xLP.json
@@ -1,44 +1,44 @@
 {
-    "name": "Attack of Opportunity",
-    "type": "feature",
-    "_id": "VfUbJwGU4Cka0xLP",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "action",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>When an adversary within Melee range attempts to leave that range, make a reaction roll using a trait of your choice against their Difficulty. Choose one effect on a success, or two if you critically succeed:</p><p>• They can’t move from where they are.</p><p>• You deal damage to them equal to your primary weapon’s damage.</p><p>• You move with them.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "class"
+  "name": "Attack of Opportunity",
+  "type": "feature",
+  "_id": "VfUbJwGU4Cka0xLP",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "action",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "ei8OkswTzyDp4IGC": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748034185325,
-        "modifiedTime": 1748034212853,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!VfUbJwGU4Cka0xLP"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>When an adversary within Melee range attempts to leave that range, make a reaction roll using a trait of your choice against their Difficulty. Choose one effect on a success, or two if you critically succeed:</p><p>• They can’t move from where they are.</p><p>• You deal damage to them equal to your primary weapon’s damage.</p><p>• You move with them.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "class"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748034185325,
+    "modifiedTime": 1748034212853,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!VfUbJwGU4Cka0xLP"
 }

--- a/src/packs/class-features/feature_Beastform_NkSKDXGNNiOUlFqm.json
+++ b/src/packs/class-features/feature_Beastform_NkSKDXGNNiOUlFqm.json
@@ -1,44 +1,44 @@
 {
-    "name": "Beastform",
-    "type": "feature",
-    "_id": "NkSKDXGNNiOUlFqm",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "action",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>Mark a Stress to magically transform into a creature of your tier or lower from the Beastform list. You can drop out of this form at any time. While transformed, you can’t use weapons or cast spells from domain cards, but you can still use other features or abilities you have access to. Spells you cast before you transform stay active and last for their normal duration, and you can talk and communicate as normal. Additionally, you gain the Beastform’s features, add their Evasion bonus to your Evasion, and use the trait specified in their statistics for your attack. While you’re in a Beastform, your armor becomes part of your body and you mark Armor Slots as usual; when you drop out of a Beastform, those marked Armor Slots remain marked. If you mark your last Hit Point, you automatically drop out of this form.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "class"
+  "name": "Beastform",
+  "type": "feature",
+  "_id": "NkSKDXGNNiOUlFqm",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "action",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "ei8OkswTzyDp4IGC": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748028817729,
-        "modifiedTime": 1748028856597,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!NkSKDXGNNiOUlFqm"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>Mark a Stress to magically transform into a creature of your tier or lower from the Beastform list. You can drop out of this form at any time. While transformed, you can’t use weapons or cast spells from domain cards, but you can still use other features or abilities you have access to. Spells you cast before you transform stay active and last for their normal duration, and you can talk and communicate as normal. Additionally, you gain the Beastform’s features, add their Evasion bonus to your Evasion, and use the trait specified in their statistics for your attack. While you’re in a Beastform, your armor becomes part of your body and you mark Armor Slots as usual; when you drop out of a Beastform, those marked Armor Slots remain marked. If you mark your last Hit Point, you automatically drop out of this form.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "class"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748028817729,
+    "modifiedTime": 1748028856597,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!NkSKDXGNNiOUlFqm"
 }

--- a/src/packs/class-features/feature_Channel_Raw_Power_ovxuqhl01XZSwx2n.json
+++ b/src/packs/class-features/feature_Channel_Raw_Power_ovxuqhl01XZSwx2n.json
@@ -1,46 +1,46 @@
 {
-    "name": "Channel Raw Power",
-    "type": "feature",
-    "_id": "ovxuqhl01XZSwx2n",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "action",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": {
-            "type": "longRest"
-        },
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>Once per long rest, you can place a domain card from your loadout into your vault and choose to either:</p><p>• Gain Hope equal to the level of the card.</p><p>• Enhance a spell that deals damage, gaining a bonus to your damage roll equal to twice the level of the card.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "class"
+  "name": "Channel Raw Power",
+  "type": "feature",
+  "_id": "ovxuqhl01XZSwx2n",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "action",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "ei8OkswTzyDp4IGC": 3
+    "refreshData": {
+      "type": "longRest"
     },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748033854379,
-        "modifiedTime": 1748033877334,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!ovxuqhl01XZSwx2n"
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>Once per long rest, you can place a domain card from your loadout into your vault and choose to either:</p><p>• Gain Hope equal to the level of the card.</p><p>• Enhance a spell that deals damage, gaining a bonus to your damage roll equal to twice the level of the card.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "class"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748033854379,
+    "modifiedTime": 1748033877334,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!ovxuqhl01XZSwx2n"
 }

--- a/src/packs/class-features/feature_Cloaked_TpaoHSJ3npjWiBOf.json
+++ b/src/packs/class-features/feature_Cloaked_TpaoHSJ3npjWiBOf.json
@@ -1,44 +1,44 @@
 {
-    "name": "Cloaked",
-    "type": "feature",
-    "_id": "TpaoHSJ3npjWiBOf",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "action",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>Any time you would be Hidden, you are instead Cloaked. In addition to the benefits of the Hidden condition, while Cloaked you remain unseen if you are stationary when an adversary moves to where they would normally see you. After you make an attack or end a move within line of sight of an adversary, you are no longer Cloaked.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "class"
+  "name": "Cloaked",
+  "type": "feature",
+  "_id": "TpaoHSJ3npjWiBOf",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "action",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "ei8OkswTzyDp4IGC": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748032226905,
-        "modifiedTime": 1748032258303,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!TpaoHSJ3npjWiBOf"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>Any time you would be Hidden, you are instead Cloaked. In addition to the benefits of the Hidden condition, while Cloaked you remain unseen if you are stationary when an adversary moves to where they would normally see you. After you make an attack or end a move within line of sight of an adversary, you are no longer Cloaked.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "class"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748032226905,
+    "modifiedTime": 1748032258303,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!TpaoHSJ3npjWiBOf"
 }

--- a/src/packs/class-features/feature_Combat_Training_elb6ZVertgu6OdKA.json
+++ b/src/packs/class-features/feature_Combat_Training_elb6ZVertgu6OdKA.json
@@ -1,44 +1,44 @@
 {
-    "name": "Combat Training",
-    "type": "feature",
-    "_id": "elb6ZVertgu6OdKA",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "passive",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>You ignore burden when equipping weapons. When you deal physical damage, you gain a bonus to your damage roll equal to your level.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "class"
+  "name": "Combat Training",
+  "type": "feature",
+  "_id": "elb6ZVertgu6OdKA",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "passive",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "ei8OkswTzyDp4IGC": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748034225886,
-        "modifiedTime": 1748034251807,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!elb6ZVertgu6OdKA"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>You ignore burden when equipping weapons. When you deal physical damage, you gain a bonus to your damage roll equal to your level.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "class"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748034225886,
+    "modifiedTime": 1748034251807,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!elb6ZVertgu6OdKA"
 }

--- a/src/packs/class-features/feature_Combo_Strikes_RNC8NT8F6x73gRZi.json
+++ b/src/packs/class-features/feature_Combo_Strikes_RNC8NT8F6x73gRZi.json
@@ -1,44 +1,44 @@
 {
-    "name": "Combo Strikes",
-    "type": "feature",
-    "_id": "RNC8NT8F6x73gRZi",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "action",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>After making a damage roll with a Melee weapon but before dealing that damage to the target, mark a Stress to start a combo strike.</p><p>When you do, roll a Combo Die and note its value. Then, roll another Combo Die. If the value of the second die is equal to or greater than your first Combo Die, continue rolling additional dice until the latest Combo Die’s value is less than the roll that preceeded it. Total all rolled Combo Dice and add the value to your weapon’s damage.</p><p>Your Combo Die starts as a d4. When you level up, once per tier you may use one of your advancement options to increase your Combo Die instead.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "class"
+  "name": "Combo Strikes",
+  "type": "feature",
+  "_id": "RNC8NT8F6x73gRZi",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "action",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "ei8OkswTzyDp4IGC": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748031102847,
-        "modifiedTime": 1748031132259,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!RNC8NT8F6x73gRZi"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>After making a damage roll with a Melee weapon but before dealing that damage to the target, mark a Stress to start a combo strike.</p><p>When you do, roll a Combo Die and note its value. Then, roll another Combo Die. If the value of the second die is equal to or greater than your first Combo Die, continue rolling additional dice until the latest Combo Die’s value is less than the roll that preceeded it. Total all rolled Combo Dice and add the value to your weapon’s damage.</p><p>Your Combo Die starts as a d4. When you level up, once per tier you may use one of your advancement options to increase your Combo Die instead.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "class"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748031102847,
+    "modifiedTime": 1748031132259,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!RNC8NT8F6x73gRZi"
 }

--- a/src/packs/class-features/feature_Evolution_bZxfyPTZ6rsakyA2.json
+++ b/src/packs/class-features/feature_Evolution_bZxfyPTZ6rsakyA2.json
@@ -1,44 +1,44 @@
 {
-    "name": "Evolution",
-    "type": "feature",
-    "_id": "bZxfyPTZ6rsakyA2",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "action",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>Spend 3 Hope to transform into a Beastform without marking a Stress. When you do, choose one trait to raise by +1 until you drop out of that Beastform.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "class"
+  "name": "Evolution",
+  "type": "feature",
+  "_id": "bZxfyPTZ6rsakyA2",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "action",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "ei8OkswTzyDp4IGC": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748028774087,
-        "modifiedTime": 1748028862047,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!bZxfyPTZ6rsakyA2"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>Spend 3 Hope to transform into a Beastform without marking a Stress. When you do, choose one trait to raise by +1 until you drop out of that Beastform.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "class"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748028774087,
+    "modifiedTime": 1748028862047,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!bZxfyPTZ6rsakyA2"
 }

--- a/src/packs/class-features/feature_Frontline_Tank_ftUZznLFJ5xbcxcu.json
+++ b/src/packs/class-features/feature_Frontline_Tank_ftUZznLFJ5xbcxcu.json
@@ -1,44 +1,44 @@
 {
-    "name": "Frontline Tank",
-    "type": "feature",
-    "_id": "ftUZznLFJ5xbcxcu",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "action",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>Spend 3 Hope to clear 2 Armor Slots</p>",
-        "effects": {},
-        "actions": [],
-        "type": "class"
+  "name": "Frontline Tank",
+  "type": "feature",
+  "_id": "ftUZznLFJ5xbcxcu",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "action",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "ei8OkswTzyDp4IGC": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748030942761,
-        "modifiedTime": 1748030954992,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!ftUZznLFJ5xbcxcu"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>Spend 3 Hope to clear 2 Armor Slots</p>",
+    "effects": {},
+    "actions": [],
+    "type": "class"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748030942761,
+    "modifiedTime": 1748030954992,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!ftUZznLFJ5xbcxcu"
 }

--- a/src/packs/class-features/feature_Hold_Them_Off_FSx2ojskU0pRE72g.json
+++ b/src/packs/class-features/feature_Hold_Them_Off_FSx2ojskU0pRE72g.json
@@ -1,44 +1,44 @@
 {
-    "name": "Hold Them Off",
-    "type": "feature",
-    "_id": "FSx2ojskU0pRE72g",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "action",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>Spend 3 Hope when you succeed on an attack with a weapon to use that same roll against two additional adversaries within range of the attack</p>",
-        "effects": {},
-        "actions": [],
-        "type": "class"
+  "name": "Hold Them Off",
+  "type": "feature",
+  "_id": "FSx2ojskU0pRE72g",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "action",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "ei8OkswTzyDp4IGC": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748030888304,
-        "modifiedTime": 1748030905059,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!FSx2ojskU0pRE72g"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>Spend 3 Hope when you succeed on an attack with a weapon to use that same roll against two additional adversaries within range of the attack</p>",
+    "effects": {},
+    "actions": [],
+    "type": "class"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748030888304,
+    "modifiedTime": 1748030905059,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!FSx2ojskU0pRE72g"
 }

--- a/src/packs/class-features/feature_I_Am_The_Weapon_ihtvQaH18eG56RWY.json
+++ b/src/packs/class-features/feature_I_Am_The_Weapon_ihtvQaH18eG56RWY.json
@@ -1,44 +1,44 @@
 {
-    "name": "I Am The Weapon",
-    "type": "feature",
-    "_id": "ihtvQaH18eG56RWY",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "passive",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>While you don’t have any equipped weapons, your evasion has a +1 bonus. Your unarmed strikes are considered a Melee weapon, use the trait of your choice, and deal d10+your tier phy damage.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "class"
+  "name": "I Am The Weapon",
+  "type": "feature",
+  "_id": "ihtvQaH18eG56RWY",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "passive",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "ei8OkswTzyDp4IGC": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748031035883,
-        "modifiedTime": 1748031085182,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!ihtvQaH18eG56RWY"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>While you don’t have any equipped weapons, your evasion has a +1 bonus. Your unarmed strikes are considered a Melee weapon, use the trait of your choice, and deal d10+your tier phy damage.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "class"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748031035883,
+    "modifiedTime": 1748031085182,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!ihtvQaH18eG56RWY"
 }

--- a/src/packs/class-features/feature_Life_Support_UZ9UjZArSJh6UHXG.json
+++ b/src/packs/class-features/feature_Life_Support_UZ9UjZArSJh6UHXG.json
@@ -1,44 +1,44 @@
 {
-    "name": "Life Support",
-    "type": "feature",
-    "_id": "UZ9UjZArSJh6UHXG",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "action",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>Spend 3 Hope to clear a Hit Point on an ally within Close range.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "class"
+  "name": "Life Support",
+  "type": "feature",
+  "_id": "UZ9UjZArSJh6UHXG",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "action",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "ei8OkswTzyDp4IGC": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748033044907,
-        "modifiedTime": 1748033065659,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!UZ9UjZArSJh6UHXG"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>Spend 3 Hope to clear a Hit Point on an ally within Close range.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "class"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748033044907,
+    "modifiedTime": 1748033065659,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!UZ9UjZArSJh6UHXG"
 }

--- a/src/packs/class-features/feature_Make_a_Scene_Ddk0PAgwM4VLRbyY.json
+++ b/src/packs/class-features/feature_Make_a_Scene_Ddk0PAgwM4VLRbyY.json
@@ -1,44 +1,44 @@
 {
-    "name": "Make a Scene",
-    "type": "feature",
-    "_id": "Ddk0PAgwM4VLRbyY",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "action",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>Spend 3 Hope to temporarily Distract a target within Close range, giving them a -2 penalty to their Difficulty.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "class"
+  "name": "Make a Scene",
+  "type": "feature",
+  "_id": "Ddk0PAgwM4VLRbyY",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "action",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1747991384366,
-        "modifiedTime": 1747991421484,
-        "lastModifiedBy": "NqO2eQGMjrvUO6v9"
-    },
-    "_key": "!items!Ddk0PAgwM4VLRbyY"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>Spend 3 Hope to temporarily Distract a target within Close range, giving them a -2 penalty to their Difficulty.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "class"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747991384366,
+    "modifiedTime": 1747991421484,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!Ddk0PAgwM4VLRbyY"
 }

--- a/src/packs/class-features/feature_Minor_Illusion_qFq7kynAZhbWTbT5.json
+++ b/src/packs/class-features/feature_Minor_Illusion_qFq7kynAZhbWTbT5.json
@@ -1,44 +1,44 @@
 {
-    "name": "Minor Illusion",
-    "type": "feature",
-    "_id": "qFq7kynAZhbWTbT5",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "action",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>Make a Spellcast Roll (10). On a success, you create a minor visual illusion no larger than yourself within Close range. This illusion is convincing to anyone at Close range or farther.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "class"
+  "name": "Minor Illusion",
+  "type": "feature",
+  "_id": "qFq7kynAZhbWTbT5",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "action",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "ei8OkswTzyDp4IGC": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748033817443,
-        "modifiedTime": 1748033834348,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!qFq7kynAZhbWTbT5"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>Make a Spellcast Roll (10). On a success, you create a minor visual illusion no larger than yourself within Close range. This illusion is convincing to anyone at Close range or farther.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "class"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748033817443,
+    "modifiedTime": 1748033834348,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!qFq7kynAZhbWTbT5"
 }

--- a/src/packs/class-features/feature_No_Mercy_t3tLoq4h9wgQD7E9.json
+++ b/src/packs/class-features/feature_No_Mercy_t3tLoq4h9wgQD7E9.json
@@ -1,44 +1,44 @@
 {
-    "name": "No Mercy",
-    "type": "feature",
-    "_id": "t3tLoq4h9wgQD7E9",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "action",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>Spend 3 Hope to gain a +1 bonus to your attack rolls until your next rest.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "class"
+  "name": "No Mercy",
+  "type": "feature",
+  "_id": "t3tLoq4h9wgQD7E9",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "action",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "ei8OkswTzyDp4IGC": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748034146678,
-        "modifiedTime": 1748034158455,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!t3tLoq4h9wgQD7E9"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>Spend 3 Hope to gain a +1 bonus to your attack rolls until your next rest.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "class"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748034146678,
+    "modifiedTime": 1748034158455,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!t3tLoq4h9wgQD7E9"
 }

--- a/src/packs/class-features/feature_Not_This_Time_5msGbQyFwdwdFdYs.json
+++ b/src/packs/class-features/feature_Not_This_Time_5msGbQyFwdwdFdYs.json
@@ -1,44 +1,44 @@
 {
-    "name": "Not This Time",
-    "type": "feature",
-    "_id": "5msGbQyFwdwdFdYs",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "reaction",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>Spend 3 Hope to force an adversary within Far range to reroll an attack or damage roll</p>",
-        "effects": {},
-        "actions": [],
-        "type": "class"
+  "name": "Not This Time",
+  "type": "feature",
+  "_id": "5msGbQyFwdwdFdYs",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "reaction",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "ei8OkswTzyDp4IGC": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748034883014,
-        "modifiedTime": 1748034907509,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!5msGbQyFwdwdFdYs"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>Spend 3 Hope to force an adversary within Far range to reroll an attack or damage roll</p>",
+    "effects": {},
+    "actions": [],
+    "type": "class"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748034883014,
+    "modifiedTime": 1748034907509,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!5msGbQyFwdwdFdYs"
 }

--- a/src/packs/class-features/feature_Prayer_Dice_jXfGnLnU8PswJYJd.json
+++ b/src/packs/class-features/feature_Prayer_Dice_jXfGnLnU8PswJYJd.json
@@ -1,47 +1,47 @@
 {
-    "name": "Prayer Dice",
-    "type": "feature",
-    "_id": "jXfGnLnU8PswJYJd",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "action",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 6,
-                "numbers": {},
-                "value": "d4"
-            }
-        },
-        "refreshData": {
-            "type": "session"
-        },
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>At the beginning of each session, roll a number of d4s equal to your subclass’s Spellcast trait and place them on this sheet in the space provided. These are your Prayer Dice. You can spend any number of Prayer Dice to aid yourself or an ally within Far range. You can use a spent die’s value to reduce incoming damage, add to a roll’s result after the roll is made, or gain Hope equal to the result. At the end of each session, clear all unspent Prayer Dice.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "class"
+  "name": "Prayer Dice",
+  "type": "feature",
+  "_id": "jXfGnLnU8PswJYJd",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "action",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 6,
+        "numbers": {},
+        "value": "d4"
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "ei8OkswTzyDp4IGC": 3
+    "refreshData": {
+      "type": "session"
     },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748033372327,
-        "modifiedTime": 1748033499150,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!jXfGnLnU8PswJYJd"
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>At the beginning of each session, roll a number of d4s equal to your subclass’s Spellcast trait and place them on this sheet in the space provided. These are your Prayer Dice. You can spend any number of Prayer Dice to aid yourself or an ally within Far range. You can use a spent die’s value to reduce incoming damage, add to a roll’s result after the roll is made, or gain Hope equal to the result. At the end of each session, clear all unspent Prayer Dice.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "class"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748033372327,
+    "modifiedTime": 1748033499150,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!jXfGnLnU8PswJYJd"
 }

--- a/src/packs/class-features/feature_Prestidigitation_ofBmJIn6NWxA0wPz.json
+++ b/src/packs/class-features/feature_Prestidigitation_ofBmJIn6NWxA0wPz.json
@@ -1,44 +1,44 @@
 {
-    "name": "Prestidigitation",
-    "type": "feature",
-    "_id": "ofBmJIn6NWxA0wPz",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "action",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>You can perform harmless, subtle magical effects at will. For example, you can change an object’s color, create a smell, light a candle, cause a tiny object to float, illuminate a room, or repair a small object.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "class"
+  "name": "Prestidigitation",
+  "type": "feature",
+  "_id": "ofBmJIn6NWxA0wPz",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "action",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "ei8OkswTzyDp4IGC": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748034934147,
-        "modifiedTime": 1748034955883,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!ofBmJIn6NWxA0wPz"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>You can perform harmless, subtle magical effects at will. For example, you can change an object’s color, create a smell, light a candle, cause a tiny object to float, illuminate a room, or repair a small object.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "class"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748034934147,
+    "modifiedTime": 1748034955883,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!ofBmJIn6NWxA0wPz"
 }

--- a/src/packs/class-features/feature_Rally_8uORDWrXtNFzA00U.json
+++ b/src/packs/class-features/feature_Rally_8uORDWrXtNFzA00U.json
@@ -1,47 +1,47 @@
 {
-    "name": "Rally",
-    "type": "feature",
-    "_id": "8uORDWrXtNFzA00U",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "action",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {},
-                "value": "d6"
-            }
-        },
-        "refreshData": {
-            "type": "session"
-        },
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>Once per session, describe how you rally the party and give yourself and each of your allies a Rally Die. At level 1, your Rally Die is a d6. A PC can spend their Rally Die to roll it, adding the result to their action roll, reaction roll, damage roll, or to clear a number of Stress equal to the result. At the end of each session, clear all unspent Rally Dice.</p><p>At level 5, your Rally Die increases to a d8.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "class"
+  "name": "Rally",
+  "type": "feature",
+  "_id": "8uORDWrXtNFzA00U",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "action",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {},
+        "value": "d6"
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3
+    "refreshData": {
+      "type": "session"
     },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1747991484460,
-        "modifiedTime": 1747991546148,
-        "lastModifiedBy": "NqO2eQGMjrvUO6v9"
-    },
-    "_key": "!items!8uORDWrXtNFzA00U"
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>Once per session, describe how you rally the party and give yourself and each of your allies a Rally Die. At level 1, your Rally Die is a d6. A PC can spend their Rally Die to roll it, adding the result to their action roll, reaction roll, damage roll, or to clear a number of Stress equal to the result. At the end of each session, clear all unspent Rally Dice.</p><p>At level 5, your Rally Die increases to a d8.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "class"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747991484460,
+    "modifiedTime": 1747991546148,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!8uORDWrXtNFzA00U"
 }

--- a/src/packs/class-features/feature_Ranger_s_Focus_b4O4r2HPbWU8s59q.json
+++ b/src/packs/class-features/feature_Ranger_s_Focus_b4O4r2HPbWU8s59q.json
@@ -1,44 +1,44 @@
 {
-    "name": "Ranger's Focus",
-    "type": "feature",
-    "_id": "b4O4r2HPbWU8s59q",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "action",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>Spend a Hope and make an attack against a target. On a success, deal your attack’s normal damage and temporarily make the attack’s target your Focus. Until this feature ends or you make a different creature yourFocus, you gain the following benefits against your Focus:</p><p>• You know precisely what direction they are in.</p><p>• When you deal damage to them, they must mark a Stress.</p><p>• When you fail an attack against them, you can end your Ranger’s Focus feature to reroll your Duality Dice.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "class"
+  "name": "Ranger's Focus",
+  "type": "feature",
+  "_id": "b4O4r2HPbWU8s59q",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "action",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "ei8OkswTzyDp4IGC": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748030780267,
-        "modifiedTime": 1748030834985,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!b4O4r2HPbWU8s59q"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>Spend a Hope and make an attack against a target. On a success, deal your attack’s normal damage and temporarily make the attack’s target your Focus. Until this feature ends or you make a different creature yourFocus, you gain the following benefits against your Focus:</p><p>• You know precisely what direction they are in.</p><p>• When you deal damage to them, they must mark a Stress.</p><p>• When you fail an attack against them, you can end your Ranger’s Focus feature to reroll your Duality Dice.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "class"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748030780267,
+    "modifiedTime": 1748030834985,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!b4O4r2HPbWU8s59q"
 }

--- a/src/packs/class-features/feature_Rogue_s_Dodge_fPGn9JNV24nt1G9d.json
+++ b/src/packs/class-features/feature_Rogue_s_Dodge_fPGn9JNV24nt1G9d.json
@@ -1,44 +1,44 @@
 {
-    "name": "Rogue’s Dodge",
-    "type": "feature",
-    "_id": "fPGn9JNV24nt1G9d",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "action",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>Spend 3 Hope to gain a +2 bonus to your Evasion until the next time an attack succeeds against you. Otherwise, this bonus lasts until your next rest.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "class"
+  "name": "Rogue’s Dodge",
+  "type": "feature",
+  "_id": "fPGn9JNV24nt1G9d",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "action",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "ei8OkswTzyDp4IGC": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748032185608,
-        "modifiedTime": 1748032213243,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!fPGn9JNV24nt1G9d"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>Spend 3 Hope to gain a +2 bonus to your Evasion until the next time an attack succeeds against you. Otherwise, this bonus lasts until your next rest.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "class"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748032185608,
+    "modifiedTime": 1748032213243,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!fPGn9JNV24nt1G9d"
 }

--- a/src/packs/class-features/feature_Sneak_Attack_PhHOmsoYUDC42by6.json
+++ b/src/packs/class-features/feature_Sneak_Attack_PhHOmsoYUDC42by6.json
@@ -1,44 +1,44 @@
 {
-    "name": "Sneak Attack",
-    "type": "feature",
-    "_id": "PhHOmsoYUDC42by6",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "action",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>When you succeed on an attack while Cloaked or while an ally is within Melee range of your target, add a number of d6s equal to your tier to your damage roll.</p><p>Level 1 is Tier 1</p><p>Levels 2–4 are Tier 2</p><p>Levels 5–7 are Tier 3</p><p>Levels 8–10 are Tier 4</p>",
-        "effects": {},
-        "actions": [],
-        "type": "class"
+  "name": "Sneak Attack",
+  "type": "feature",
+  "_id": "PhHOmsoYUDC42by6",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "action",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "ei8OkswTzyDp4IGC": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748032274441,
-        "modifiedTime": 1748032300923,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!PhHOmsoYUDC42by6"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>When you succeed on an attack while Cloaked or while an ally is within Melee range of your target, add a number of d6s equal to your tier to your damage roll.</p><p>Level 1 is Tier 1</p><p>Levels 2–4 are Tier 2</p><p>Levels 5–7 are Tier 3</p><p>Levels 8–10 are Tier 4</p>",
+    "effects": {},
+    "actions": [],
+    "type": "class"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748032274441,
+    "modifiedTime": 1748032300923,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!PhHOmsoYUDC42by6"
 }

--- a/src/packs/class-features/feature_Staggering_Strike_xC0ZG862KrjHGHlx.json
+++ b/src/packs/class-features/feature_Staggering_Strike_xC0ZG862KrjHGHlx.json
@@ -1,44 +1,44 @@
 {
-    "name": "Staggering Strike",
-    "type": "feature",
-    "_id": "xC0ZG862KrjHGHlx",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "action",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>Spend 3 Hope when you hit an adversary to also deal them a Stress and make them temporarily Staggered.</p><p>While Staggered, all attack rolls they make are at disadvantage.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "class"
+  "name": "Staggering Strike",
+  "type": "feature",
+  "_id": "xC0ZG862KrjHGHlx",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "action",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "ei8OkswTzyDp4IGC": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748030990710,
-        "modifiedTime": 1748031014128,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!xC0ZG862KrjHGHlx"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>Spend 3 Hope when you hit an adversary to also deal them a Stress and make them temporarily Staggered.</p><p>While Staggered, all attack rolls they make are at disadvantage.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "class"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748030990710,
+    "modifiedTime": 1748031014128,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!xC0ZG862KrjHGHlx"
 }

--- a/src/packs/class-features/feature_Strange_Patterns_ONtJ7r2g6tN5q6Ga.json
+++ b/src/packs/class-features/feature_Strange_Patterns_ONtJ7r2g6tN5q6Ga.json
@@ -1,44 +1,44 @@
 {
-    "name": "Strange Patterns",
-    "type": "feature",
-    "_id": "ONtJ7r2g6tN5q6Ga",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "action",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>Choose a number between 1 and 12. When you roll that number on a Duality Die, gain a Hope or clear a Stress. You can change this number when you take a long rest.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "class"
+  "name": "Strange Patterns",
+  "type": "feature",
+  "_id": "ONtJ7r2g6tN5q6Ga",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "action",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "ei8OkswTzyDp4IGC": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748034976746,
-        "modifiedTime": 1748034998077,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!ONtJ7r2g6tN5q6Ga"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>Choose a number between 1 and 12. When you roll that number on a Duality Die, gain a Hope or clear a Stress. You can change this number when you take a long rest.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "class"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748034976746,
+    "modifiedTime": 1748034998077,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!ONtJ7r2g6tN5q6Ga"
 }

--- a/src/packs/class-features/feature_Unstoppable_rlpNYKW18FX4Hw7t.json
+++ b/src/packs/class-features/feature_Unstoppable_rlpNYKW18FX4Hw7t.json
@@ -1,46 +1,46 @@
 {
-    "name": "Unstoppable",
-    "type": "feature",
-    "_id": "rlpNYKW18FX4Hw7t",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "action",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": {
-            "type": "longRest"
-        },
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>Once per long rest, you can become Unstoppable.</p><p>You gain an Unstoppable Die. At level 1, your Unstoppable Die is a [[d4]]. Place it on this sheet in the space provided, starting with the 1 value facing up. After you make a damage roll that deals 1 or more Hit Points to a target, increase the Unstoppable Die value by one. When the die’s value would exceed its maximum value or when the scene ends, remove the die and drop out of Unstoppable. At level 5, your Unstoppable Die increases to a d6.</p><p>While Unstoppable, you gain the following benefits:</p><p>• You reduce the severity of physical damage by one threshold (Severe to Major, Major to Minor, Minor to None).</p><p>• You add the current value of the Unstoppable Die to your damage roll.</p><p>• You can’t be Restrained or Vulnerable.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "class"
+  "name": "Unstoppable",
+  "type": "feature",
+  "_id": "rlpNYKW18FX4Hw7t",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "action",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "ei8OkswTzyDp4IGC": 3
+    "refreshData": {
+      "type": "longRest"
     },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748030398960,
-        "modifiedTime": 1748030576414,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!rlpNYKW18FX4Hw7t"
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>Once per long rest, you can become Unstoppable.</p><p>You gain an Unstoppable Die. At level 1, your Unstoppable Die is a [[d4]]. Place it on this sheet in the space provided, starting with the 1 value facing up. After you make a damage roll that deals 1 or more Hit Points to a target, increase the Unstoppable Die value by one. When the die’s value would exceed its maximum value or when the scene ends, remove the die and drop out of Unstoppable. At level 5, your Unstoppable Die increases to a d6.</p><p>While Unstoppable, you gain the following benefits:</p><p>• You reduce the severity of physical damage by one threshold (Severe to Major, Major to Minor, Minor to None).</p><p>• You add the current value of the Unstoppable Die to your damage roll.</p><p>• You can’t be Restrained or Vulnerable.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "class"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748030398960,
+    "modifiedTime": 1748030576414,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!rlpNYKW18FX4Hw7t"
 }

--- a/src/packs/class-features/feature_Volatile_Magic_J3TdB5ZsmyJ68rxZ.json
+++ b/src/packs/class-features/feature_Volatile_Magic_J3TdB5ZsmyJ68rxZ.json
@@ -1,44 +1,44 @@
 {
-    "name": "Volatile Magic",
-    "type": "feature",
-    "_id": "J3TdB5ZsmyJ68rxZ",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "action",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>Spend 3 Hope to reroll any number of your damage dice on an attack that deals magic damage.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "class"
+  "name": "Volatile Magic",
+  "type": "feature",
+  "_id": "J3TdB5ZsmyJ68rxZ",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "action",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "ei8OkswTzyDp4IGC": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748033750328,
-        "modifiedTime": 1748033766963,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!J3TdB5ZsmyJ68rxZ"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>Spend 3 Hope to reroll any number of your damage dice on an attack that deals magic damage.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "class"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748033750328,
+    "modifiedTime": 1748033766963,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!J3TdB5ZsmyJ68rxZ"
 }

--- a/src/packs/class-features/feature_Wildtouch_Dy0lco20C0Nk6yQo.json
+++ b/src/packs/class-features/feature_Wildtouch_Dy0lco20C0Nk6yQo.json
@@ -1,44 +1,44 @@
 {
-    "name": "Wildtouch",
-    "type": "feature",
-    "_id": "Dy0lco20C0Nk6yQo",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "action",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>You can perform harmless, subtle effects that involve nature—such as causing a flower to rapidly grow, summoning a slight gust of wind, or starting a campfire—at will.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "class"
+  "name": "Wildtouch",
+  "type": "feature",
+  "_id": "Dy0lco20C0Nk6yQo",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "action",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "ei8OkswTzyDp4IGC": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748028880107,
-        "modifiedTime": 1748028893170,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!Dy0lco20C0Nk6yQo"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>You can perform harmless, subtle effects that involve nature—such as causing a flower to rapidly grow, summoning a slight gust of wind, or starting a campfire—at will.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "class"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748028880107,
+    "modifiedTime": 1748028893170,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!Dy0lco20C0Nk6yQo"
 }

--- a/src/packs/classes/class_Bard_yKicceU4LesCgKwF.json
+++ b/src/packs/classes/class_Bard_yKicceU4LesCgKwF.json
@@ -1,101 +1,104 @@
 {
-    "name": "Bard",
-    "type": "class",
-    "_id": "yKicceU4LesCgKwF",
-    "img": "systems/daggerheart/assets/icons/classes/bard.png",
-    "system": {
-        "domains": ["grace", "codex"],
-        "classItems": [],
-        "damageThresholds": {
-            "minor": 0,
-            "major": 0,
-            "severe": 0
-        },
-        "evasion": 10,
-        "features": [
-            {
-                "name": "Make a Scene",
-                "img": "icons/svg/item-bag.svg",
-                "uuid": "Compendium.daggerheart.class-features.Item.Ddk0PAgwM4VLRbyY"
-            },
-            {
-                "img": "icons/svg/item-bag.svg",
-                "name": "Rally",
-                "uuid": "Compendium.daggerheart.class-features.Item.8uORDWrXtNFzA00U"
-            }
-        ],
-        "subclasses": [
-            {
-                "name": "Troubadour",
-                "img": "icons/svg/item-bag.svg",
-                "uuid": "Compendium.daggerheart.subclasses.Item.T1iBO8i0xRF5c8Q2"
-            },
-            {
-                "img": "icons/svg/item-bag.svg",
-                "name": "Wordsmith",
-                "uuid": "Compendium.daggerheart.subclasses.Item.FXT65YDVWFy85EI0"
-            }
-        ],
-        "inventory": {
-            "take": [],
-            "choiceA": [],
-            "choiceB": [],
-            "extra": {
-                "title": "",
-                "description": ""
-            }
-        },
-        "characterGuide": {
-            "suggestedTraits": {
-                "agility": 0,
-                "strength": -1,
-                "finesse": 1,
-                "instinct": 0,
-                "presence": 2,
-                "knowledge": 1
-            },
-            "suggestedPrimaryWeapon": null,
-            "suggestedSecondaryWeapon": null,
-            "suggestedArmor": null,
-            "characterDescription": {
-                "clothes": "",
-                "eyes": "",
-                "body": "",
-                "color": "",
-                "attitude": ""
-            },
-            "backgroundQuestions": [
-                "Who from your community taught you to have such confidence in yourself?",
-                "You were in love once. Who did you adore, and how did they hurt you?",
-                "You’ve always looked up to another bard. Who are they, and why do you idolize them?"
-            ],
-            "connections": [
-                "What made you realize we were going to be such good friends?",
-                "What do I do that annoys you?",
-                "Why do you grab my hand at night?"
-            ]
-        },
-        "multiclass": null,
+  "name": "Bard",
+  "type": "class",
+  "_id": "yKicceU4LesCgKwF",
+  "img": "systems/daggerheart/assets/icons/classes/bard.png",
+  "system": {
+    "domains": [
+      "grace",
+      "codex"
+    ],
+    "classItems": [],
+    "damageThresholds": {
+      "minor": 0,
+      "major": 0,
+      "severe": 0
+    },
+    "evasion": 10,
+    "features": [
+      {
+        "name": "Make a Scene",
+        "img": "icons/svg/item-bag.svg",
+        "uuid": "Compendium.daggerheart.class-features.Item.Ddk0PAgwM4VLRbyY"
+      },
+      {
+        "img": "icons/svg/item-bag.svg",
+        "name": "Rally",
+        "uuid": "Compendium.daggerheart.class-features.Item.8uORDWrXtNFzA00U"
+      }
+    ],
+    "subclasses": [
+      {
+        "name": "Troubadour",
+        "img": "icons/svg/item-bag.svg",
+        "uuid": "Compendium.daggerheart.subclasses.Item.T1iBO8i0xRF5c8Q2"
+      },
+      {
+        "img": "icons/svg/item-bag.svg",
+        "name": "Wordsmith",
+        "uuid": "Compendium.daggerheart.subclasses.Item.FXT65YDVWFy85EI0"
+      }
+    ],
+    "inventory": {
+      "take": [],
+      "choiceA": [],
+      "choiceB": [],
+      "extra": {
+        "title": "",
         "description": ""
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3
+    "characterGuide": {
+      "suggestedTraits": {
+        "agility": 0,
+        "strength": -1,
+        "finesse": 1,
+        "instinct": 0,
+        "presence": 2,
+        "knowledge": 1
+      },
+      "suggestedPrimaryWeapon": null,
+      "suggestedSecondaryWeapon": null,
+      "suggestedArmor": null,
+      "characterDescription": {
+        "clothes": "",
+        "eyes": "",
+        "body": "",
+        "color": "",
+        "attitude": ""
+      },
+      "backgroundQuestions": [
+        "Who from your community taught you to have such confidence in yourself?",
+        "You were in love once. Who did you adore, and how did they hurt you?",
+        "You’ve always looked up to another bard. Who are they, and why do you idolize them?"
+      ],
+      "connections": [
+        "What made you realize we were going to be such good friends?",
+        "What do I do that annoys you?",
+        "Why do you grab my hand at night?"
+      ]
     },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1747946810798,
-        "modifiedTime": 1748029620943,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!yKicceU4LesCgKwF"
+    "multiclass": null,
+    "description": ""
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747946810798,
+    "modifiedTime": 1748029620943,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!yKicceU4LesCgKwF"
 }

--- a/src/packs/classes/class_Druid_HEh27jDQCJmnPsXH.json
+++ b/src/packs/classes/class_Druid_HEh27jDQCJmnPsXH.json
@@ -1,95 +1,98 @@
 {
-    "name": "Druid",
-    "type": "class",
-    "_id": "HEh27jDQCJmnPsXH",
-    "img": "systems/daggerheart/assets/icons/classes/druid.png",
-    "system": {
-        "domains": ["sage", "arcana"],
-        "classItems": [],
-        "damageThresholds": {
-            "minor": 0,
-            "major": 0,
-            "severe": 0
-        },
-        "evasion": 10,
-        "features": [
-            {
-                "name": "Evolution",
-                "img": "icons/svg/item-bag.svg",
-                "uuid": "Compendium.daggerheart.class-features.Item.bZxfyPTZ6rsakyA2"
-            },
-            {
-                "name": "Beastform",
-                "img": "icons/svg/item-bag.svg",
-                "uuid": "Compendium.daggerheart.class-features.Item.NkSKDXGNNiOUlFqm"
-            },
-            {
-                "img": "icons/svg/item-bag.svg",
-                "name": "Wildtouch",
-                "uuid": "Compendium.daggerheart.class-features.Item.Dy0lco20C0Nk6yQo"
-            }
-        ],
-        "subclasses": [],
-        "inventory": {
-            "take": [],
-            "choiceA": [],
-            "choiceB": [],
-            "extra": {
-                "title": "",
-                "description": ""
-            }
-        },
-        "characterGuide": {
-            "suggestedTraits": {
-                "agility": 1,
-                "strength": 0,
-                "finesse": 1,
-                "instinct": 2,
-                "presence": -1,
-                "knowledge": 0
-            },
-            "suggestedPrimaryWeapon": null,
-            "suggestedSecondaryWeapon": null,
-            "suggestedArmor": null,
-            "characterDescription": {
-                "clothes": "",
-                "eyes": "",
-                "body": "",
-                "color": "",
-                "attitude": ""
-            },
-            "backgroundQuestions": [
-                "Why was the community you grew up in so reliant on nature and its creatures?",
-                "Who was the first wild animal you bonded with? Why did your bond end?",
-                "Who has been trying to hunt you down? What do they want from you?"
-            ],
-            "connections": [
-                "What did you confide in me that makes me leap into danger for you every time?",
-                "What animal do I say you remind me of?",
-                "What affectionate nickname have you given me?"
-            ]
-        },
-        "multiclass": null,
+  "name": "Druid",
+  "type": "class",
+  "_id": "HEh27jDQCJmnPsXH",
+  "img": "systems/daggerheart/assets/icons/classes/druid.png",
+  "system": {
+    "domains": [
+      "sage",
+      "arcana"
+    ],
+    "classItems": [],
+    "damageThresholds": {
+      "minor": 0,
+      "major": 0,
+      "severe": 0
+    },
+    "evasion": 10,
+    "features": [
+      {
+        "name": "Evolution",
+        "img": "icons/svg/item-bag.svg",
+        "uuid": "Compendium.daggerheart.class-features.Item.bZxfyPTZ6rsakyA2"
+      },
+      {
+        "name": "Beastform",
+        "img": "icons/svg/item-bag.svg",
+        "uuid": "Compendium.daggerheart.class-features.Item.NkSKDXGNNiOUlFqm"
+      },
+      {
+        "img": "icons/svg/item-bag.svg",
+        "name": "Wildtouch",
+        "uuid": "Compendium.daggerheart.class-features.Item.Dy0lco20C0Nk6yQo"
+      }
+    ],
+    "subclasses": [],
+    "inventory": {
+      "take": [],
+      "choiceA": [],
+      "choiceB": [],
+      "extra": {
+        "title": "",
         "description": ""
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3
+    "characterGuide": {
+      "suggestedTraits": {
+        "agility": 1,
+        "strength": 0,
+        "finesse": 1,
+        "instinct": 2,
+        "presence": -1,
+        "knowledge": 0
+      },
+      "suggestedPrimaryWeapon": null,
+      "suggestedSecondaryWeapon": null,
+      "suggestedArmor": null,
+      "characterDescription": {
+        "clothes": "",
+        "eyes": "",
+        "body": "",
+        "color": "",
+        "attitude": ""
+      },
+      "backgroundQuestions": [
+        "Why was the community you grew up in so reliant on nature and its creatures?",
+        "Who was the first wild animal you bonded with? Why did your bond end?",
+        "Who has been trying to hunt you down? What do they want from you?"
+      ],
+      "connections": [
+        "What did you confide in me that makes me leap into danger for you every time?",
+        "What animal do I say you remind me of?",
+        "What affectionate nickname have you given me?"
+      ]
     },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1747946822837,
-        "modifiedTime": 1748029712119,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!HEh27jDQCJmnPsXH"
+    "multiclass": null,
+    "description": ""
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747946822837,
+    "modifiedTime": 1748029712119,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!HEh27jDQCJmnPsXH"
 }

--- a/src/packs/classes/class_Fighter_HPzaWaZBc6RvElKd.json
+++ b/src/packs/classes/class_Fighter_HPzaWaZBc6RvElKd.json
@@ -1,95 +1,98 @@
 {
-    "name": "Fighter",
-    "type": "class",
-    "_id": "HPzaWaZBc6RvElKd",
-    "img": "systems/daggerheart/assets/icons/classes/fighter.png",
-    "system": {
-        "domains": ["bone", "valor"],
-        "classItems": [],
-        "damageThresholds": {
-            "minor": 0,
-            "major": 0,
-            "severe": 0
-        },
-        "evasion": 11,
-        "features": [
-            {
-                "name": "Staggering Strike",
-                "img": "icons/svg/item-bag.svg",
-                "uuid": "Compendium.daggerheart.class-features.Item.xC0ZG862KrjHGHlx"
-            },
-            {
-                "name": "I Am The Weapon",
-                "img": "icons/svg/item-bag.svg",
-                "uuid": "Compendium.daggerheart.class-features.Item.ihtvQaH18eG56RWY"
-            },
-            {
-                "img": "icons/svg/item-bag.svg",
-                "name": "Combo Strikes",
-                "uuid": "Compendium.daggerheart.class-features.Item.RNC8NT8F6x73gRZi"
-            }
-        ],
-        "subclasses": [],
-        "inventory": {
-            "take": [],
-            "choiceA": [],
-            "choiceB": [],
-            "extra": {
-                "title": "",
-                "description": ""
-            }
-        },
-        "characterGuide": {
-            "suggestedTraits": {
-                "agility": 1,
-                "strength": 1,
-                "finesse": 0,
-                "instinct": 2,
-                "presence": 10,
-                "knowledge": -1
-            },
-            "suggestedPrimaryWeapon": null,
-            "suggestedSecondaryWeapon": null,
-            "suggestedArmor": null,
-            "characterDescription": {
-                "clothes": "",
-                "eyes": "",
-                "body": "",
-                "color": "",
-                "attitude": ""
-            },
-            "backgroundQuestions": [
-                "Where did you spend time during your formative years that taught you, directly or indirectly, how to fight in the style you use?",
-                "What group or organization that has always had your back, and how did you get in their good graces?",
-                "Who did you lose to long ago that you are desperate for a rematch against?"
-            ],
-            "connections": [
-                "What is one thing we’re both afraid of?",
-                "I rely on your for something important during our travels together. What is it and how do you feel about it?",
-                "I still haven't forgiven you for something you said to me. What was it and why did you say it?"
-            ]
-        },
-        "multiclass": null,
+  "name": "Fighter",
+  "type": "class",
+  "_id": "HPzaWaZBc6RvElKd",
+  "img": "systems/daggerheart/assets/icons/classes/fighter.png",
+  "system": {
+    "domains": [
+      "bone",
+      "valor"
+    ],
+    "classItems": [],
+    "damageThresholds": {
+      "minor": 0,
+      "major": 0,
+      "severe": 0
+    },
+    "evasion": 11,
+    "features": [
+      {
+        "name": "Staggering Strike",
+        "img": "icons/svg/item-bag.svg",
+        "uuid": "Compendium.daggerheart.class-features.Item.xC0ZG862KrjHGHlx"
+      },
+      {
+        "name": "I Am The Weapon",
+        "img": "icons/svg/item-bag.svg",
+        "uuid": "Compendium.daggerheart.class-features.Item.ihtvQaH18eG56RWY"
+      },
+      {
+        "img": "icons/svg/item-bag.svg",
+        "name": "Combo Strikes",
+        "uuid": "Compendium.daggerheart.class-features.Item.RNC8NT8F6x73gRZi"
+      }
+    ],
+    "subclasses": [],
+    "inventory": {
+      "take": [],
+      "choiceA": [],
+      "choiceB": [],
+      "extra": {
+        "title": "",
         "description": ""
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3
+    "characterGuide": {
+      "suggestedTraits": {
+        "agility": 1,
+        "strength": 1,
+        "finesse": 0,
+        "instinct": 2,
+        "presence": 10,
+        "knowledge": -1
+      },
+      "suggestedPrimaryWeapon": null,
+      "suggestedSecondaryWeapon": null,
+      "suggestedArmor": null,
+      "characterDescription": {
+        "clothes": "",
+        "eyes": "",
+        "body": "",
+        "color": "",
+        "attitude": ""
+      },
+      "backgroundQuestions": [
+        "Where did you spend time during your formative years that taught you, directly or indirectly, how to fight in the style you use?",
+        "What group or organization that has always had your back, and how did you get in their good graces?",
+        "Who did you lose to long ago that you are desperate for a rematch against?"
+      ],
+      "connections": [
+        "What is one thing we’re both afraid of?",
+        "I rely on your for something important during our travels together. What is it and how do you feel about it?",
+        "I still haven't forgiven you for something you said to me. What was it and why did you say it?"
+      ]
     },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1747946839346,
-        "modifiedTime": 1748031139229,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!HPzaWaZBc6RvElKd"
+    "multiclass": null,
+    "description": ""
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747946839346,
+    "modifiedTime": 1748031139229,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!HPzaWaZBc6RvElKd"
 }

--- a/src/packs/classes/class_Guardian_hyfigmrAoLxFPOW2.json
+++ b/src/packs/classes/class_Guardian_hyfigmrAoLxFPOW2.json
@@ -1,90 +1,93 @@
 {
-    "name": "Guardian",
-    "type": "class",
-    "_id": "hyfigmrAoLxFPOW2",
-    "img": "systems/daggerheart/assets/icons/classes/guardian.png",
-    "system": {
-        "domains": ["valor", "blade"],
-        "classItems": [],
-        "damageThresholds": {
-            "minor": 0,
-            "major": 0,
-            "severe": 0
-        },
-        "evasion": 9,
-        "features": [
-            {
-                "name": "Frontline Tank",
-                "img": "icons/svg/item-bag.svg",
-                "uuid": "Compendium.daggerheart.class-features.Item.ftUZznLFJ5xbcxcu"
-            },
-            {
-                "img": "icons/svg/item-bag.svg",
-                "name": "Unstoppable",
-                "uuid": "Compendium.daggerheart.class-features.Item.rlpNYKW18FX4Hw7t"
-            }
-        ],
-        "subclasses": [],
-        "inventory": {
-            "take": [],
-            "choiceA": [],
-            "choiceB": [],
-            "extra": {
-                "title": "",
-                "description": ""
-            }
-        },
-        "characterGuide": {
-            "suggestedTraits": {
-                "agility": 1,
-                "strength": 2,
-                "finesse": -1,
-                "instinct": 0,
-                "presence": 1,
-                "knowledge": 0
-            },
-            "suggestedPrimaryWeapon": null,
-            "suggestedSecondaryWeapon": null,
-            "suggestedArmor": null,
-            "characterDescription": {
-                "clothes": "",
-                "eyes": "",
-                "body": "",
-                "color": "",
-                "attitude": ""
-            },
-            "backgroundQuestions": [
-                "Who from your community did you fail to protect, and why do you still think of them?",
-                "You’ve been tasked with protecting something important and delivering it somewhere dangerous. What is it, and where does it need to go?",
-                "You consider an aspect of yourself to be a weakness. What is it, and how has it affected you?"
-            ],
-            "connections": [
-                "How did I save your life the first time we met",
-                "What small gift did you give me that you notice I always carry with me?",
-                "What lie have you told me about yourself that I absolutely believe?"
-            ]
-        },
-        "multiclass": null,
+  "name": "Guardian",
+  "type": "class",
+  "_id": "hyfigmrAoLxFPOW2",
+  "img": "systems/daggerheart/assets/icons/classes/guardian.png",
+  "system": {
+    "domains": [
+      "valor",
+      "blade"
+    ],
+    "classItems": [],
+    "damageThresholds": {
+      "minor": 0,
+      "major": 0,
+      "severe": 0
+    },
+    "evasion": 9,
+    "features": [
+      {
+        "name": "Frontline Tank",
+        "img": "icons/svg/item-bag.svg",
+        "uuid": "Compendium.daggerheart.class-features.Item.ftUZznLFJ5xbcxcu"
+      },
+      {
+        "img": "icons/svg/item-bag.svg",
+        "name": "Unstoppable",
+        "uuid": "Compendium.daggerheart.class-features.Item.rlpNYKW18FX4Hw7t"
+      }
+    ],
+    "subclasses": [],
+    "inventory": {
+      "take": [],
+      "choiceA": [],
+      "choiceB": [],
+      "extra": {
+        "title": "",
         "description": ""
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3
+    "characterGuide": {
+      "suggestedTraits": {
+        "agility": 1,
+        "strength": 2,
+        "finesse": -1,
+        "instinct": 0,
+        "presence": 1,
+        "knowledge": 0
+      },
+      "suggestedPrimaryWeapon": null,
+      "suggestedSecondaryWeapon": null,
+      "suggestedArmor": null,
+      "characterDescription": {
+        "clothes": "",
+        "eyes": "",
+        "body": "",
+        "color": "",
+        "attitude": ""
+      },
+      "backgroundQuestions": [
+        "Who from your community did you fail to protect, and why do you still think of them?",
+        "You’ve been tasked with protecting something important and delivering it somewhere dangerous. What is it, and where does it need to go?",
+        "You consider an aspect of yourself to be a weakness. What is it, and how has it affected you?"
+      ],
+      "connections": [
+        "How did I save your life the first time we met",
+        "What small gift did you give me that you notice I always carry with me?",
+        "What lie have you told me about yourself that I absolutely believe?"
+      ]
     },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1747946853583,
-        "modifiedTime": 1748030966166,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!hyfigmrAoLxFPOW2"
+    "multiclass": null,
+    "description": ""
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747946853583,
+    "modifiedTime": 1748030966166,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!hyfigmrAoLxFPOW2"
 }

--- a/src/packs/classes/class_Ranger_XoUsU9sCxEq8t3We.json
+++ b/src/packs/classes/class_Ranger_XoUsU9sCxEq8t3We.json
@@ -1,90 +1,93 @@
 {
-    "name": "Ranger",
-    "type": "class",
-    "_id": "XoUsU9sCxEq8t3We",
-    "img": "systems/daggerheart/assets/icons/classes/ranger.png",
-    "system": {
-        "domains": ["bone", "sage"],
-        "classItems": [],
-        "damageThresholds": {
-            "minor": 0,
-            "major": 0,
-            "severe": 0
-        },
-        "evasion": 12,
-        "features": [
-            {
-                "name": "Hold Them Off",
-                "img": "icons/svg/item-bag.svg",
-                "uuid": "Compendium.daggerheart.class-features.Item.FSx2ojskU0pRE72g"
-            },
-            {
-                "img": "icons/svg/item-bag.svg",
-                "name": "Ranger's Focus",
-                "uuid": "Compendium.daggerheart.class-features.Item.b4O4r2HPbWU8s59q"
-            }
-        ],
-        "subclasses": [],
-        "inventory": {
-            "take": [],
-            "choiceA": [],
-            "choiceB": [],
-            "extra": {
-                "title": "",
-                "description": ""
-            }
-        },
-        "characterGuide": {
-            "suggestedTraits": {
-                "agility": 2,
-                "strength": 0,
-                "finesse": 1,
-                "instinct": 1,
-                "presence": -1,
-                "knowledge": 0
-            },
-            "suggestedPrimaryWeapon": null,
-            "suggestedSecondaryWeapon": null,
-            "suggestedArmor": null,
-            "characterDescription": {
-                "clothes": "",
-                "eyes": "",
-                "body": "",
-                "color": "",
-                "attitude": ""
-            },
-            "backgroundQuestions": [
-                "A terrible creature hurt your community, and you’ve vowed to hunt them down. What are they, and what unique trail or sign do they leave behind?",
-                "Your first kill almost killed you, too. What was it, and what part of you was never the same after that event?",
-                "You’ve traveled many dangerous lands, but what is the one place you refuse to go?"
-            ],
-            "connections": [
-                "What friendly competition do we have?",
-                "Why do you act differently when we’re alone than when others are around?",
-                "What threat have you asked me to watch for, and why are you worried about it?"
-            ]
-        },
-        "multiclass": null,
+  "name": "Ranger",
+  "type": "class",
+  "_id": "XoUsU9sCxEq8t3We",
+  "img": "systems/daggerheart/assets/icons/classes/ranger.png",
+  "system": {
+    "domains": [
+      "bone",
+      "sage"
+    ],
+    "classItems": [],
+    "damageThresholds": {
+      "minor": 0,
+      "major": 0,
+      "severe": 0
+    },
+    "evasion": 12,
+    "features": [
+      {
+        "name": "Hold Them Off",
+        "img": "icons/svg/item-bag.svg",
+        "uuid": "Compendium.daggerheart.class-features.Item.FSx2ojskU0pRE72g"
+      },
+      {
+        "img": "icons/svg/item-bag.svg",
+        "name": "Ranger's Focus",
+        "uuid": "Compendium.daggerheart.class-features.Item.b4O4r2HPbWU8s59q"
+      }
+    ],
+    "subclasses": [],
+    "inventory": {
+      "take": [],
+      "choiceA": [],
+      "choiceB": [],
+      "extra": {
+        "title": "",
         "description": ""
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3
+    "characterGuide": {
+      "suggestedTraits": {
+        "agility": 2,
+        "strength": 0,
+        "finesse": 1,
+        "instinct": 1,
+        "presence": -1,
+        "knowledge": 0
+      },
+      "suggestedPrimaryWeapon": null,
+      "suggestedSecondaryWeapon": null,
+      "suggestedArmor": null,
+      "characterDescription": {
+        "clothes": "",
+        "eyes": "",
+        "body": "",
+        "color": "",
+        "attitude": ""
+      },
+      "backgroundQuestions": [
+        "A terrible creature hurt your community, and you’ve vowed to hunt them down. What are they, and what unique trail or sign do they leave behind?",
+        "Your first kill almost killed you, too. What was it, and what part of you was never the same after that event?",
+        "You’ve traveled many dangerous lands, but what is the one place you refuse to go?"
+      ],
+      "connections": [
+        "What friendly competition do we have?",
+        "Why do you act differently when we’re alone than when others are around?",
+        "What threat have you asked me to watch for, and why are you worried about it?"
+      ]
     },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1747946878680,
-        "modifiedTime": 1748030921142,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!XoUsU9sCxEq8t3We"
+    "multiclass": null,
+    "description": ""
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747946878680,
+    "modifiedTime": 1748030921142,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!XoUsU9sCxEq8t3We"
 }

--- a/src/packs/classes/class_Rogue_V1a5AKCLe8qtoPlA.json
+++ b/src/packs/classes/class_Rogue_V1a5AKCLe8qtoPlA.json
@@ -1,95 +1,98 @@
 {
-    "name": "Rogue",
-    "type": "class",
-    "_id": "V1a5AKCLe8qtoPlA",
-    "img": "systems/daggerheart/assets/icons/classes/rogue.png",
-    "system": {
-        "domains": ["midnight", "grace"],
-        "classItems": [],
-        "damageThresholds": {
-            "minor": 0,
-            "major": 0,
-            "severe": 0
-        },
-        "evasion": 12,
-        "features": [
-            {
-                "name": "Rogue’s Dodge",
-                "img": "icons/svg/item-bag.svg",
-                "uuid": "Compendium.daggerheart.class-features.Item.fPGn9JNV24nt1G9d"
-            },
-            {
-                "name": "Cloaked",
-                "img": "icons/svg/item-bag.svg",
-                "uuid": "Compendium.daggerheart.class-features.Item.TpaoHSJ3npjWiBOf"
-            },
-            {
-                "img": "icons/svg/item-bag.svg",
-                "name": "Sneak Attack",
-                "uuid": "Compendium.daggerheart.class-features.Item.PhHOmsoYUDC42by6"
-            }
-        ],
-        "subclasses": [],
-        "inventory": {
-            "take": [],
-            "choiceA": [],
-            "choiceB": [],
-            "extra": {
-                "title": "",
-                "description": ""
-            }
-        },
-        "characterGuide": {
-            "suggestedTraits": {
-                "agility": 1,
-                "strength": -1,
-                "finesse": 2,
-                "instinct": 0,
-                "presence": 1,
-                "knowledge": 0
-            },
-            "suggestedPrimaryWeapon": null,
-            "suggestedSecondaryWeapon": null,
-            "suggestedArmor": null,
-            "characterDescription": {
-                "clothes": "",
-                "eyes": "",
-                "body": "",
-                "color": "",
-                "attitude": ""
-            },
-            "backgroundQuestions": [
-                "What did you get caught doing that got you exiled from your home community?",
-                "You used to have a different life, but you’ve tried to leave it behind. Who from your past is still chasing you?",
-                "Who from your past were you most sad to say goodbye to?"
-            ],
-            "connections": [
-                "What did I recently convince you to do that got us both in trouble?",
-                "What have I discovered about your past that I hold secret from the others?",
-                "Who do you know from my past, and how have they influenced your feelings about me?"
-            ]
-        },
-        "multiclass": null,
+  "name": "Rogue",
+  "type": "class",
+  "_id": "V1a5AKCLe8qtoPlA",
+  "img": "systems/daggerheart/assets/icons/classes/rogue.png",
+  "system": {
+    "domains": [
+      "midnight",
+      "grace"
+    ],
+    "classItems": [],
+    "damageThresholds": {
+      "minor": 0,
+      "major": 0,
+      "severe": 0
+    },
+    "evasion": 12,
+    "features": [
+      {
+        "name": "Rogue’s Dodge",
+        "img": "icons/svg/item-bag.svg",
+        "uuid": "Compendium.daggerheart.class-features.Item.fPGn9JNV24nt1G9d"
+      },
+      {
+        "name": "Cloaked",
+        "img": "icons/svg/item-bag.svg",
+        "uuid": "Compendium.daggerheart.class-features.Item.TpaoHSJ3npjWiBOf"
+      },
+      {
+        "img": "icons/svg/item-bag.svg",
+        "name": "Sneak Attack",
+        "uuid": "Compendium.daggerheart.class-features.Item.PhHOmsoYUDC42by6"
+      }
+    ],
+    "subclasses": [],
+    "inventory": {
+      "take": [],
+      "choiceA": [],
+      "choiceB": [],
+      "extra": {
+        "title": "",
         "description": ""
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3
+    "characterGuide": {
+      "suggestedTraits": {
+        "agility": 1,
+        "strength": -1,
+        "finesse": 2,
+        "instinct": 0,
+        "presence": 1,
+        "knowledge": 0
+      },
+      "suggestedPrimaryWeapon": null,
+      "suggestedSecondaryWeapon": null,
+      "suggestedArmor": null,
+      "characterDescription": {
+        "clothes": "",
+        "eyes": "",
+        "body": "",
+        "color": "",
+        "attitude": ""
+      },
+      "backgroundQuestions": [
+        "What did you get caught doing that got you exiled from your home community?",
+        "You used to have a different life, but you’ve tried to leave it behind. Who from your past is still chasing you?",
+        "Who from your past were you most sad to say goodbye to?"
+      ],
+      "connections": [
+        "What did I recently convince you to do that got us both in trouble?",
+        "What have I discovered about your past that I hold secret from the others?",
+        "Who do you know from my past, and how have they influenced your feelings about me?"
+      ]
     },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1747946902620,
-        "modifiedTime": 1748032307699,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!V1a5AKCLe8qtoPlA"
+    "multiclass": null,
+    "description": ""
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747946902620,
+    "modifiedTime": 1748032307699,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!V1a5AKCLe8qtoPlA"
 }

--- a/src/packs/classes/class_Seraph_qW7yLIe87vd5bbto.json
+++ b/src/packs/classes/class_Seraph_qW7yLIe87vd5bbto.json
@@ -1,90 +1,93 @@
 {
-    "name": "Seraph",
-    "type": "class",
-    "_id": "qW7yLIe87vd5bbto",
-    "img": "systems/daggerheart/assets/icons/classes/seraph.png",
-    "system": {
-        "domains": ["splendor", "valor"],
-        "classItems": [],
-        "damageThresholds": {
-            "minor": 0,
-            "major": 0,
-            "severe": 0
-        },
-        "evasion": 9,
-        "features": [
-            {
-                "name": "Life Support",
-                "img": "icons/svg/item-bag.svg",
-                "uuid": "Compendium.daggerheart.class-features.Item.UZ9UjZArSJh6UHXG"
-            },
-            {
-                "img": "icons/svg/item-bag.svg",
-                "name": "Prayer Dice",
-                "uuid": "Compendium.daggerheart.class-features.Item.jXfGnLnU8PswJYJd"
-            }
-        ],
-        "subclasses": [],
-        "inventory": {
-            "take": [],
-            "choiceA": [],
-            "choiceB": [],
-            "extra": {
-                "title": "",
-                "description": ""
-            }
-        },
-        "characterGuide": {
-            "suggestedTraits": {
-                "agility": 0,
-                "strength": 2,
-                "finesse": 0,
-                "instinct": 1,
-                "presence": 1,
-                "knowledge": -1
-            },
-            "suggestedPrimaryWeapon": null,
-            "suggestedSecondaryWeapon": null,
-            "suggestedArmor": null,
-            "characterDescription": {
-                "clothes": "",
-                "eyes": "",
-                "body": "",
-                "color": "",
-                "attitude": ""
-            },
-            "backgroundQuestions": [
-                "Which god did you devote yourself to? What incredible feat did they perform for you in a moment of desperation?",
-                "How did your appearance change after taking your oath?",
-                "In what strange or unique way do you communicate with your god?"
-            ],
-            "connections": [
-                "What promise did you make me agree to, should you die on the battlefield?",
-                "Why do you ask me so many questions about my god?",
-                "You’ve told me to protect one member of our party above all others, even yourself. Who are they and why?"
-            ]
-        },
-        "multiclass": null,
+  "name": "Seraph",
+  "type": "class",
+  "_id": "qW7yLIe87vd5bbto",
+  "img": "systems/daggerheart/assets/icons/classes/seraph.png",
+  "system": {
+    "domains": [
+      "splendor",
+      "valor"
+    ],
+    "classItems": [],
+    "damageThresholds": {
+      "minor": 0,
+      "major": 0,
+      "severe": 0
+    },
+    "evasion": 9,
+    "features": [
+      {
+        "name": "Life Support",
+        "img": "icons/svg/item-bag.svg",
+        "uuid": "Compendium.daggerheart.class-features.Item.UZ9UjZArSJh6UHXG"
+      },
+      {
+        "img": "icons/svg/item-bag.svg",
+        "name": "Prayer Dice",
+        "uuid": "Compendium.daggerheart.class-features.Item.jXfGnLnU8PswJYJd"
+      }
+    ],
+    "subclasses": [],
+    "inventory": {
+      "take": [],
+      "choiceA": [],
+      "choiceB": [],
+      "extra": {
+        "title": "",
         "description": ""
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3
+    "characterGuide": {
+      "suggestedTraits": {
+        "agility": 0,
+        "strength": 2,
+        "finesse": 0,
+        "instinct": 1,
+        "presence": 1,
+        "knowledge": -1
+      },
+      "suggestedPrimaryWeapon": null,
+      "suggestedSecondaryWeapon": null,
+      "suggestedArmor": null,
+      "characterDescription": {
+        "clothes": "",
+        "eyes": "",
+        "body": "",
+        "color": "",
+        "attitude": ""
+      },
+      "backgroundQuestions": [
+        "Which god did you devote yourself to? What incredible feat did they perform for you in a moment of desperation?",
+        "How did your appearance change after taking your oath?",
+        "In what strange or unique way do you communicate with your god?"
+      ],
+      "connections": [
+        "What promise did you make me agree to, should you die on the battlefield?",
+        "Why do you ask me so many questions about my god?",
+        "You’ve told me to protect one member of our party above all others, even yourself. Who are they and why?"
+      ]
     },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1747946916585,
-        "modifiedTime": 1748033639820,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!qW7yLIe87vd5bbto"
+    "multiclass": null,
+    "description": ""
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747946916585,
+    "modifiedTime": 1748033639820,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!qW7yLIe87vd5bbto"
 }

--- a/src/packs/classes/class_Sorcerer_aacMxI9mOTmLO4cj.json
+++ b/src/packs/classes/class_Sorcerer_aacMxI9mOTmLO4cj.json
@@ -1,100 +1,103 @@
 {
-    "name": "Sorcerer",
-    "type": "class",
-    "_id": "aacMxI9mOTmLO4cj",
-    "img": "systems/daggerheart/assets/icons/classes/sorcerer.png",
-    "system": {
-        "domains": ["arcana", "midnight"],
-        "classItems": [],
-        "damageThresholds": {
-            "minor": 0,
-            "major": 0,
-            "severe": 0
-        },
-        "evasion": 10,
-        "features": [
-            {
-                "name": "Volatile Magic",
-                "img": "icons/svg/item-bag.svg",
-                "uuid": "Compendium.daggerheart.class-features.Item.J3TdB5ZsmyJ68rxZ"
-            },
-            {
-                "name": "Arcane Sense",
-                "img": "icons/svg/item-bag.svg",
-                "uuid": "Compendium.daggerheart.class-features.Item.D5HUGwdizhBVZ0RW"
-            },
-            {
-                "name": "Minor Illusion",
-                "img": "icons/svg/item-bag.svg",
-                "uuid": "Compendium.daggerheart.class-features.Item.qFq7kynAZhbWTbT5"
-            },
-            {
-                "img": "icons/svg/item-bag.svg",
-                "name": "Channel Raw Power",
-                "uuid": "Compendium.daggerheart.class-features.Item.ovxuqhl01XZSwx2n"
-            }
-        ],
-        "subclasses": [],
-        "inventory": {
-            "take": [],
-            "choiceA": [],
-            "choiceB": [],
-            "extra": {
-                "title": "",
-                "description": ""
-            }
-        },
-        "characterGuide": {
-            "suggestedTraits": {
-                "agility": 0,
-                "strength": -1,
-                "finesse": 1,
-                "instinct": 2,
-                "presence": 1,
-                "knowledge": 0
-            },
-            "suggestedPrimaryWeapon": null,
-            "suggestedSecondaryWeapon": null,
-            "suggestedArmor": null,
-            "characterDescription": {
-                "clothes": "",
-                "eyes": "",
-                "body": "",
-                "color": "",
-                "attitude": ""
-            },
-            "backgroundQuestions": [
-                "What did you do that made the people in your community wary of you?",
-                "What mentor taught you to control your untamed magic, and why are they no longer able to guide you?",
-                "You have a deep fear you hide from everyone. What is it, and why does it scare you?"
-            ],
-            "connections": [
-                "Why do you trust me so deeply?",
-                "What did I do that makes you cautious around me?",
-                "Why do we keep our shared past a secret?"
-            ]
-        },
-        "multiclass": null,
+  "name": "Sorcerer",
+  "type": "class",
+  "_id": "aacMxI9mOTmLO4cj",
+  "img": "systems/daggerheart/assets/icons/classes/sorcerer.png",
+  "system": {
+    "domains": [
+      "arcana",
+      "midnight"
+    ],
+    "classItems": [],
+    "damageThresholds": {
+      "minor": 0,
+      "major": 0,
+      "severe": 0
+    },
+    "evasion": 10,
+    "features": [
+      {
+        "name": "Volatile Magic",
+        "img": "icons/svg/item-bag.svg",
+        "uuid": "Compendium.daggerheart.class-features.Item.J3TdB5ZsmyJ68rxZ"
+      },
+      {
+        "name": "Arcane Sense",
+        "img": "icons/svg/item-bag.svg",
+        "uuid": "Compendium.daggerheart.class-features.Item.D5HUGwdizhBVZ0RW"
+      },
+      {
+        "name": "Minor Illusion",
+        "img": "icons/svg/item-bag.svg",
+        "uuid": "Compendium.daggerheart.class-features.Item.qFq7kynAZhbWTbT5"
+      },
+      {
+        "img": "icons/svg/item-bag.svg",
+        "name": "Channel Raw Power",
+        "uuid": "Compendium.daggerheart.class-features.Item.ovxuqhl01XZSwx2n"
+      }
+    ],
+    "subclasses": [],
+    "inventory": {
+      "take": [],
+      "choiceA": [],
+      "choiceB": [],
+      "extra": {
+        "title": "",
         "description": ""
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3
+    "characterGuide": {
+      "suggestedTraits": {
+        "agility": 0,
+        "strength": -1,
+        "finesse": 1,
+        "instinct": 2,
+        "presence": 1,
+        "knowledge": 0
+      },
+      "suggestedPrimaryWeapon": null,
+      "suggestedSecondaryWeapon": null,
+      "suggestedArmor": null,
+      "characterDescription": {
+        "clothes": "",
+        "eyes": "",
+        "body": "",
+        "color": "",
+        "attitude": ""
+      },
+      "backgroundQuestions": [
+        "What did you do that made the people in your community wary of you?",
+        "What mentor taught you to control your untamed magic, and why are they no longer able to guide you?",
+        "You have a deep fear you hide from everyone. What is it, and why does it scare you?"
+      ],
+      "connections": [
+        "Why do you trust me so deeply?",
+        "What did I do that makes you cautious around me?",
+        "Why do we keep our shared past a secret?"
+      ]
     },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1747946940010,
-        "modifiedTime": 1748033881134,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!aacMxI9mOTmLO4cj"
+    "multiclass": null,
+    "description": ""
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747946940010,
+    "modifiedTime": 1748033881134,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!aacMxI9mOTmLO4cj"
 }

--- a/src/packs/classes/class_Warlock_kSSIqmgxFTm1Xr9s.json
+++ b/src/packs/classes/class_Warlock_kSSIqmgxFTm1Xr9s.json
@@ -1,62 +1,70 @@
 {
-    "name": "Warlock",
-    "type": "class",
-    "_id": "kSSIqmgxFTm1Xr9s",
-    "img": "systems/daggerheart/assets/icons/classes/warlock.png",
-    "system": {
-        "domains": [],
-        "classItems": [],
-        "damageThresholds": {
-            "minor": 0,
-            "major": 0,
-            "severe": 0
-        },
-        "evasion": 0,
-        "features": [],
-        "subclasses": [],
-        "inventory": {
-            "take": [],
-            "choiceA": [],
-            "choiceB": [],
-            "extra": null
-        },
-        "characterGuide": {
-            "suggestedTraits": {
-                "agility": 0,
-                "strength": 0,
-                "finesse": 0,
-                "instinct": 0,
-                "presence": 0,
-                "knowledge": 0
-            },
-            "suggestedPrimaryWeapon": null,
-            "suggestedSecondaryWeapon": null,
-            "suggestedArmor": null,
-            "characterDescription": {},
-            "backgroundQuestions": ["", "", ""],
-            "connections": ["", "", ""]
-        },
-        "multiclass": null,
-        "description": ""
+  "name": "Warlock",
+  "type": "class",
+  "_id": "kSSIqmgxFTm1Xr9s",
+  "img": "systems/daggerheart/assets/icons/classes/warlock.png",
+  "system": {
+    "domains": [],
+    "classItems": [],
+    "damageThresholds": {
+      "minor": 0,
+      "major": 0,
+      "severe": 0
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3
+    "evasion": 0,
+    "features": [],
+    "subclasses": [],
+    "inventory": {
+      "take": [],
+      "choiceA": [],
+      "choiceB": [],
+      "extra": null
     },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1747946952119,
-        "modifiedTime": 1747946955843,
-        "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+    "characterGuide": {
+      "suggestedTraits": {
+        "agility": 0,
+        "strength": 0,
+        "finesse": 0,
+        "instinct": 0,
+        "presence": 0,
+        "knowledge": 0
+      },
+      "suggestedPrimaryWeapon": null,
+      "suggestedSecondaryWeapon": null,
+      "suggestedArmor": null,
+      "characterDescription": {},
+      "backgroundQuestions": [
+        "",
+        "",
+        ""
+      ],
+      "connections": [
+        "",
+        "",
+        ""
+      ]
     },
-    "_key": "!items!kSSIqmgxFTm1Xr9s"
+    "multiclass": null,
+    "description": ""
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747946952119,
+    "modifiedTime": 1747946955843,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!kSSIqmgxFTm1Xr9s"
 }

--- a/src/packs/classes/class_Warrior_ishqAXCT8xLgEbBp.json
+++ b/src/packs/classes/class_Warrior_ishqAXCT8xLgEbBp.json
@@ -1,95 +1,98 @@
 {
-    "name": "Warrior",
-    "type": "class",
-    "_id": "ishqAXCT8xLgEbBp",
-    "img": "systems/daggerheart/assets/icons/classes/warrior.png",
-    "system": {
-        "domains": ["blade", "bone"],
-        "classItems": [],
-        "damageThresholds": {
-            "minor": 0,
-            "major": 0,
-            "severe": 0
-        },
-        "evasion": 11,
-        "features": [
-            {
-                "name": "No Mercy",
-                "img": "icons/svg/item-bag.svg",
-                "uuid": "Compendium.daggerheart.class-features.Item.t3tLoq4h9wgQD7E9"
-            },
-            {
-                "name": "Attack of Opportunity",
-                "img": "icons/svg/item-bag.svg",
-                "uuid": "Compendium.daggerheart.class-features.Item.VfUbJwGU4Cka0xLP"
-            },
-            {
-                "img": "icons/svg/item-bag.svg",
-                "name": "Combat Training",
-                "uuid": "Compendium.daggerheart.class-features.Item.elb6ZVertgu6OdKA"
-            }
-        ],
-        "subclasses": [],
-        "inventory": {
-            "take": [],
-            "choiceA": [],
-            "choiceB": [],
-            "extra": {
-                "title": "",
-                "description": ""
-            }
-        },
-        "characterGuide": {
-            "suggestedTraits": {
-                "agility": 2,
-                "strength": 1,
-                "finesse": 0,
-                "instinct": 1,
-                "presence": -1,
-                "knowledge": 0
-            },
-            "suggestedPrimaryWeapon": null,
-            "suggestedSecondaryWeapon": null,
-            "suggestedArmor": null,
-            "characterDescription": {
-                "clothes": "",
-                "eyes": "",
-                "body": "",
-                "color": "",
-                "attitude": ""
-            },
-            "backgroundQuestions": [
-                "Who taught you to fight, and why did they stay behind when you left home?",
-                "Somebody defeated you in battle years ago and left you to die. Who was it, and how did they betray you?",
-                "What legendary place have you always wanted to visit, and why is it so special?"
-            ],
-            "connections": [
-                "We knew each other long before this party came together. How?",
-                "What mundane task do you usually help me with off the battlefield",
-                "What fear am I helping you overcome?"
-            ]
-        },
-        "multiclass": null,
+  "name": "Warrior",
+  "type": "class",
+  "_id": "ishqAXCT8xLgEbBp",
+  "img": "systems/daggerheart/assets/icons/classes/warrior.png",
+  "system": {
+    "domains": [
+      "blade",
+      "bone"
+    ],
+    "classItems": [],
+    "damageThresholds": {
+      "minor": 0,
+      "major": 0,
+      "severe": 0
+    },
+    "evasion": 11,
+    "features": [
+      {
+        "name": "No Mercy",
+        "img": "icons/svg/item-bag.svg",
+        "uuid": "Compendium.daggerheart.class-features.Item.t3tLoq4h9wgQD7E9"
+      },
+      {
+        "name": "Attack of Opportunity",
+        "img": "icons/svg/item-bag.svg",
+        "uuid": "Compendium.daggerheart.class-features.Item.VfUbJwGU4Cka0xLP"
+      },
+      {
+        "img": "icons/svg/item-bag.svg",
+        "name": "Combat Training",
+        "uuid": "Compendium.daggerheart.class-features.Item.elb6ZVertgu6OdKA"
+      }
+    ],
+    "subclasses": [],
+    "inventory": {
+      "take": [],
+      "choiceA": [],
+      "choiceB": [],
+      "extra": {
+        "title": "",
         "description": ""
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3
+    "characterGuide": {
+      "suggestedTraits": {
+        "agility": 2,
+        "strength": 1,
+        "finesse": 0,
+        "instinct": 1,
+        "presence": -1,
+        "knowledge": 0
+      },
+      "suggestedPrimaryWeapon": null,
+      "suggestedSecondaryWeapon": null,
+      "suggestedArmor": null,
+      "characterDescription": {
+        "clothes": "",
+        "eyes": "",
+        "body": "",
+        "color": "",
+        "attitude": ""
+      },
+      "backgroundQuestions": [
+        "Who taught you to fight, and why did they stay behind when you left home?",
+        "Somebody defeated you in battle years ago and left you to die. Who was it, and how did they betray you?",
+        "What legendary place have you always wanted to visit, and why is it so special?"
+      ],
+      "connections": [
+        "We knew each other long before this party came together. How?",
+        "What mundane task do you usually help me with off the battlefield",
+        "What fear am I helping you overcome?"
+      ]
     },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1747946965065,
-        "modifiedTime": 1748034254542,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!ishqAXCT8xLgEbBp"
+    "multiclass": null,
+    "description": ""
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747946965065,
+    "modifiedTime": 1748034254542,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!ishqAXCT8xLgEbBp"
 }

--- a/src/packs/classes/class_Wizard_uhj2mZPOC8nbIMTy.json
+++ b/src/packs/classes/class_Wizard_uhj2mZPOC8nbIMTy.json
@@ -1,95 +1,98 @@
 {
-    "name": "Wizard",
-    "type": "class",
-    "_id": "uhj2mZPOC8nbIMTy",
-    "img": "systems/daggerheart/assets/icons/classes/wizard.png",
-    "system": {
-        "domains": ["codex", "splendor"],
-        "classItems": [],
-        "damageThresholds": {
-            "minor": 0,
-            "major": 0,
-            "severe": 0
-        },
-        "evasion": 11,
-        "features": [
-            {
-                "name": "Not This Time",
-                "img": "icons/svg/item-bag.svg",
-                "uuid": "Compendium.daggerheart.class-features.Item.5msGbQyFwdwdFdYs"
-            },
-            {
-                "name": "Prestidigitation",
-                "img": "icons/svg/item-bag.svg",
-                "uuid": "Compendium.daggerheart.class-features.Item.ofBmJIn6NWxA0wPz"
-            },
-            {
-                "img": "icons/svg/item-bag.svg",
-                "name": "Strange Patterns",
-                "uuid": "Compendium.daggerheart.class-features.Item.ONtJ7r2g6tN5q6Ga"
-            }
-        ],
-        "subclasses": [],
-        "inventory": {
-            "take": [],
-            "choiceA": [],
-            "choiceB": [],
-            "extra": {
-                "title": "",
-                "description": ""
-            }
-        },
-        "characterGuide": {
-            "suggestedTraits": {
-                "agility": -1,
-                "strength": 0,
-                "finesse": 0,
-                "instinct": 1,
-                "presence": 1,
-                "knowledge": 2
-            },
-            "suggestedPrimaryWeapon": null,
-            "suggestedSecondaryWeapon": null,
-            "suggestedArmor": null,
-            "characterDescription": {
-                "clothes": "",
-                "eyes": "",
-                "body": "",
-                "color": "",
-                "attitude": ""
-            },
-            "backgroundQuestions": [
-                "What responsibilities did your community once count on you for? How did you let them down?",
-                "You’ve spent your life searching for a book or object of great significance. What is it, and why is it so important to you",
-                "You have a powerful rival. Who are they, and why are you so determined to defeat them?"
-            ],
-            "connections": [
-                "What favor have I asked of you that you’re not sure you can fulfill?",
-                "What weird hobby or strange fascination do we both share?",
-                "What secret about yourself have you entrusted only to me?"
-            ]
-        },
-        "multiclass": null,
+  "name": "Wizard",
+  "type": "class",
+  "_id": "uhj2mZPOC8nbIMTy",
+  "img": "systems/daggerheart/assets/icons/classes/wizard.png",
+  "system": {
+    "domains": [
+      "codex",
+      "splendor"
+    ],
+    "classItems": [],
+    "damageThresholds": {
+      "minor": 0,
+      "major": 0,
+      "severe": 0
+    },
+    "evasion": 11,
+    "features": [
+      {
+        "name": "Not This Time",
+        "img": "icons/svg/item-bag.svg",
+        "uuid": "Compendium.daggerheart.class-features.Item.5msGbQyFwdwdFdYs"
+      },
+      {
+        "name": "Prestidigitation",
+        "img": "icons/svg/item-bag.svg",
+        "uuid": "Compendium.daggerheart.class-features.Item.ofBmJIn6NWxA0wPz"
+      },
+      {
+        "img": "icons/svg/item-bag.svg",
+        "name": "Strange Patterns",
+        "uuid": "Compendium.daggerheart.class-features.Item.ONtJ7r2g6tN5q6Ga"
+      }
+    ],
+    "subclasses": [],
+    "inventory": {
+      "take": [],
+      "choiceA": [],
+      "choiceB": [],
+      "extra": {
+        "title": "",
         "description": ""
+      }
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3
+    "characterGuide": {
+      "suggestedTraits": {
+        "agility": -1,
+        "strength": 0,
+        "finesse": 0,
+        "instinct": 1,
+        "presence": 1,
+        "knowledge": 2
+      },
+      "suggestedPrimaryWeapon": null,
+      "suggestedSecondaryWeapon": null,
+      "suggestedArmor": null,
+      "characterDescription": {
+        "clothes": "",
+        "eyes": "",
+        "body": "",
+        "color": "",
+        "attitude": ""
+      },
+      "backgroundQuestions": [
+        "What responsibilities did your community once count on you for? How did you let them down?",
+        "You’ve spent your life searching for a book or object of great significance. What is it, and why is it so important to you",
+        "You have a powerful rival. Who are they, and why are you so determined to defeat them?"
+      ],
+      "connections": [
+        "What favor have I asked of you that you’re not sure you can fulfill?",
+        "What weird hobby or strange fascination do we both share?",
+        "What secret about yourself have you entrusted only to me?"
+      ]
     },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1747946791380,
-        "modifiedTime": 1748035008107,
-        "lastModifiedBy": "ei8OkswTzyDp4IGC"
-    },
-    "_key": "!items!uhj2mZPOC8nbIMTy"
+    "multiclass": null,
+    "description": ""
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747946791380,
+    "modifiedTime": 1748035008107,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!uhj2mZPOC8nbIMTy"
 }

--- a/src/packs/communities/community_Highborne_8AcV556QwoIzkkea.json
+++ b/src/packs/communities/community_Highborne_8AcV556QwoIzkkea.json
@@ -1,36 +1,36 @@
 {
-    "name": "Highborne",
-    "type": "community",
-    "_id": "8AcV556QwoIzkkea",
-    "img": "systems/daggerheart/assets/icons/communities/highborne.png",
-    "system": {
-        "description": "<p>Being part of a highborne community means you're accustomed to life of elegance, opulence, and prestige within the upper echelons of society. Traditionally, members of a highborne community possess incredible material wealth. While this can take a variety of forms depending on the community—including gold and other minerals, land, or controlling the means of production—this status always comes with power and influence. Highborne place great value on titles and possessions, and there is little social mobility within their ranks. Members of a highborne community often control the political and economic status of the areas in which they live due to their ability to influence people and the economy with their substantial wealth. The health and safety of the less affluent people who live in these locations often hinges on the ability of this highborne ruling class to prioritize the well-being of their subjects over profit.</p><p><em>Highborne are often amiable, candid, conniving, enterprising, ostentatious, and unflappable.</em></p>",
-        "abilities": [
-            {
-                "img": "icons/svg/item-bag.svg",
-                "name": "Privilege",
-                "uuid": "Compendium.world.community-features.Item.WoMZCTnDcK8GPSh1"
-            }
-        ]
-    },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1747940320728,
-        "modifiedTime": 1747990568291,
-        "lastModifiedBy": "NqO2eQGMjrvUO6v9"
-    },
-    "_key": "!items!8AcV556QwoIzkkea"
+  "name": "Highborne",
+  "type": "community",
+  "_id": "8AcV556QwoIzkkea",
+  "img": "systems/daggerheart/assets/icons/communities/highborne.png",
+  "system": {
+    "description": "<p>Being part of a highborne community means you're accustomed to life of elegance, opulence, and prestige within the upper echelons of society. Traditionally, members of a highborne community possess incredible material wealth. While this can take a variety of forms depending on the community—including gold and other minerals, land, or controlling the means of production—this status always comes with power and influence. Highborne place great value on titles and possessions, and there is little social mobility within their ranks. Members of a highborne community often control the political and economic status of the areas in which they live due to their ability to influence people and the economy with their substantial wealth. The health and safety of the less affluent people who live in these locations often hinges on the ability of this highborne ruling class to prioritize the well-being of their subjects over profit.</p><p><em>Highborne are often amiable, candid, conniving, enterprising, ostentatious, and unflappable.</em></p>",
+    "abilities": [
+      {
+        "img": "icons/svg/item-bag.svg",
+        "name": "Privilege",
+        "uuid": "Compendium.world.community-features.Item.WoMZCTnDcK8GPSh1"
+      }
+    ]
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747940320728,
+    "modifiedTime": 1747990568291,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!8AcV556QwoIzkkea"
 }

--- a/src/packs/communities/community_Loreborne_fgJHuCdoyXX4Q84O.json
+++ b/src/packs/communities/community_Loreborne_fgJHuCdoyXX4Q84O.json
@@ -1,36 +1,36 @@
 {
-    "name": "Loreborne",
-    "type": "community",
-    "_id": "fgJHuCdoyXX4Q84O",
-    "img": "systems/daggerheart/assets/icons/communities/loreborne.png",
-    "system": {
-        "description": "<p>Being part of a loreborne community means you’re from a society that favors strong academic or political prowess. Loreborne communities highly value knowledge, frequently in the form of historical preservation, political advancement, scientific study, skill development, or lore and mythology compilation. Most members of these communities research in institutions built in bastions of civilization, while some eclectic few thrive in gathering information from the natural world. Some may be isolationists, operating in smaller enclaves, schools, or guilds and following their own unique ethos. Others still wield their knowledge on a larger scale, making deft political maneuvers across governmental landscapes.</p><p><em>Loreborne are often direct, eloquent, inquisitive, patient,</em></p><p>rhapsodic, and witty.</p>",
-        "abilities": [
-            {
-                "img": "icons/svg/item-bag.svg",
-                "name": "Well-Read",
-                "uuid": "Compendium.world.community-features.Item.MUfVlf8hoJ3HZidv"
-            }
-        ]
-    },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1747940300210,
-        "modifiedTime": 1747990671092,
-        "lastModifiedBy": "NqO2eQGMjrvUO6v9"
-    },
-    "_key": "!items!fgJHuCdoyXX4Q84O"
+  "name": "Loreborne",
+  "type": "community",
+  "_id": "fgJHuCdoyXX4Q84O",
+  "img": "systems/daggerheart/assets/icons/communities/loreborne.png",
+  "system": {
+    "description": "<p>Being part of a loreborne community means you’re from a society that favors strong academic or political prowess. Loreborne communities highly value knowledge, frequently in the form of historical preservation, political advancement, scientific study, skill development, or lore and mythology compilation. Most members of these communities research in institutions built in bastions of civilization, while some eclectic few thrive in gathering information from the natural world. Some may be isolationists, operating in smaller enclaves, schools, or guilds and following their own unique ethos. Others still wield their knowledge on a larger scale, making deft political maneuvers across governmental landscapes.</p><p><em>Loreborne are often direct, eloquent, inquisitive, patient,</em></p><p>rhapsodic, and witty.</p>",
+    "abilities": [
+      {
+        "img": "icons/svg/item-bag.svg",
+        "name": "Well-Read",
+        "uuid": "Compendium.world.community-features.Item.MUfVlf8hoJ3HZidv"
+      }
+    ]
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747940300210,
+    "modifiedTime": 1747990671092,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!fgJHuCdoyXX4Q84O"
 }

--- a/src/packs/communities/community_Orderborne_Cg39GoSa6lxhXndW.json
+++ b/src/packs/communities/community_Orderborne_Cg39GoSa6lxhXndW.json
@@ -1,36 +1,36 @@
 {
-    "name": "Orderborne",
-    "type": "community",
-    "_id": "Cg39GoSa6lxhXndW",
-    "img": "systems/daggerheart/assets/icons/communities/orderborne.png",
-    "system": {
-        "description": "<p>Being part of an orderborne community means you’re from a collective that focuses on discipline or faith, and you uphold a set of principles that reflect your experience there. Orderborne are frequently some of the most powerful among the surrounding communities.</p><p>By aligning the members of their society around a common value or goal, such as a god, doctrine, ethos, or even a shared business or trade, the ruling bodies of these enclaves are able to mobilize larger populations with less effort.</p><p>While orderborne communities take a variety of forms—some even profoundly pacifistic—perhaps the most feared are those that structure themselves around military prowess. In such a case, it’s not uncommon for orderborne to provide soldiers for hire to other cities or  countries.</p><p><em>Orderborne are often ambitious, benevolent, pensive, prudent, sardonic, and stoic.</em></p>",
-        "abilities": [
-            {
-                "img": "icons/svg/item-bag.svg",
-                "name": "Dedicated",
-                "uuid": "Compendium.world.community-features.Item.b7LmL7ti1gL5kfGq"
-            }
-        ]
-    },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1747940332147,
-        "modifiedTime": 1747990820386,
-        "lastModifiedBy": "NqO2eQGMjrvUO6v9"
-    },
-    "_key": "!items!Cg39GoSa6lxhXndW"
+  "name": "Orderborne",
+  "type": "community",
+  "_id": "Cg39GoSa6lxhXndW",
+  "img": "systems/daggerheart/assets/icons/communities/orderborne.png",
+  "system": {
+    "description": "<p>Being part of an orderborne community means you’re from a collective that focuses on discipline or faith, and you uphold a set of principles that reflect your experience there. Orderborne are frequently some of the most powerful among the surrounding communities.</p><p>By aligning the members of their society around a common value or goal, such as a god, doctrine, ethos, or even a shared business or trade, the ruling bodies of these enclaves are able to mobilize larger populations with less effort.</p><p>While orderborne communities take a variety of forms—some even profoundly pacifistic—perhaps the most feared are those that structure themselves around military prowess. In such a case, it’s not uncommon for orderborne to provide soldiers for hire to other cities or  countries.</p><p><em>Orderborne are often ambitious, benevolent, pensive, prudent, sardonic, and stoic.</em></p>",
+    "abilities": [
+      {
+        "img": "icons/svg/item-bag.svg",
+        "name": "Dedicated",
+        "uuid": "Compendium.world.community-features.Item.b7LmL7ti1gL5kfGq"
+      }
+    ]
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747940332147,
+    "modifiedTime": 1747990820386,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!Cg39GoSa6lxhXndW"
 }

--- a/src/packs/communities/community_Ridgeborne_DAQoNvVlc9w7NmZd.json
+++ b/src/packs/communities/community_Ridgeborne_DAQoNvVlc9w7NmZd.json
@@ -1,36 +1,36 @@
 {
-    "name": "Ridgeborne",
-    "type": "community",
-    "_id": "DAQoNvVlc9w7NmZd",
-    "img": "systems/daggerheart/assets/icons/communities/ridgeborne.png",
-    "system": {
-        "description": "<p>Being part of a ridgeborne community means you’ve called the rocky peaks and sharp cliffs of the mountainside home. Those who’ve lived in the mountains often consider themselves hardier than most because they’ve thrived among the most dangerous terrain many continents have to offer. These groups are adept at adaptation, developing unique technologies and equipment to move both people and products across difficult terrain. As such, ridgeborne grow up scrambling and climbing, making them sturdy and strong-willed. Ridgeborne localities appear in a variety of forms—some cities carve out entire cliff faces, others construct castles of stone, and still more live in small homes on windblown peaks. Outside forces often struggle to attack ridgeborne groups, as the small militias and large military forces of the mountains are adept at utilizing their high-ground  advantage.</p><p><em>Ridgeborne are often bold, hardy, indomitable, loyal, reserved, and stubborn.</em></p>",
-        "abilities": [
-            {
-                "img": "icons/svg/item-bag.svg",
-                "name": "Steady",
-                "uuid": "Compendium.world.community-features.Item.hKGv54dst9crq3Sw"
-            }
-        ]
-    },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1747940346633,
-        "modifiedTime": 1747990891669,
-        "lastModifiedBy": "NqO2eQGMjrvUO6v9"
-    },
-    "_key": "!items!DAQoNvVlc9w7NmZd"
+  "name": "Ridgeborne",
+  "type": "community",
+  "_id": "DAQoNvVlc9w7NmZd",
+  "img": "systems/daggerheart/assets/icons/communities/ridgeborne.png",
+  "system": {
+    "description": "<p>Being part of a ridgeborne community means you’ve called the rocky peaks and sharp cliffs of the mountainside home. Those who’ve lived in the mountains often consider themselves hardier than most because they’ve thrived among the most dangerous terrain many continents have to offer. These groups are adept at adaptation, developing unique technologies and equipment to move both people and products across difficult terrain. As such, ridgeborne grow up scrambling and climbing, making them sturdy and strong-willed. Ridgeborne localities appear in a variety of forms—some cities carve out entire cliff faces, others construct castles of stone, and still more live in small homes on windblown peaks. Outside forces often struggle to attack ridgeborne groups, as the small militias and large military forces of the mountains are adept at utilizing their high-ground  advantage.</p><p><em>Ridgeborne are often bold, hardy, indomitable, loyal, reserved, and stubborn.</em></p>",
+    "abilities": [
+      {
+        "img": "icons/svg/item-bag.svg",
+        "name": "Steady",
+        "uuid": "Compendium.world.community-features.Item.hKGv54dst9crq3Sw"
+      }
+    ]
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747940346633,
+    "modifiedTime": 1747990891669,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!DAQoNvVlc9w7NmZd"
 }

--- a/src/packs/communities/community_Seaborne_ivrXToGxyuVdqZtG.json
+++ b/src/packs/communities/community_Seaborne_ivrXToGxyuVdqZtG.json
@@ -1,36 +1,36 @@
 {
-    "name": "Seaborne",
-    "type": "community",
-    "_id": "ivrXToGxyuVdqZtG",
-    "img": "systems/daggerheart/assets/icons/communities/seaborne.png",
-    "system": {
-        "description": "<p>Being part of a seaborne community means you lived on or near a large body of water. Seaborne communities are built, both physically and culturally, around the specific waters they call home.</p><p>Some of these groups live along the shore, constructing ports for locals and travelers alike. These harbors function as centers of commerce, tourist attractions, or even just a safe place to lay down one’s head after weeks of travel. Other seaborne live on the water in small boats or large ships, with the idea of “home” comprising a ship and its crew, rather than any one landmass.</p><p>No matter their exact location, seaborne communities are closely tied to the ocean tides and the creatures who inhabit them. Seaborne learn to fish at a young age, and train from birth to hold their breath and swim in even the most tumultuous waters. Individuals from these groups are highly sought after for their sailing skills, and many become captains of vessels, whether within their own community, working for another, or even at the helm of a powerful naval operation.<br><em><br>Seaborne are often candid, cooperative, exuberant, fierce, resolute, and weathered.</em></p>",
-        "abilities": [
-            {
-                "img": "icons/svg/item-bag.svg",
-                "name": "Know the Tide",
-                "uuid": "Compendium.world.community-features.Item.coBcBEFpXgtxD1Jt"
-            }
-        ]
-    },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1747940375520,
-        "modifiedTime": 1747990980804,
-        "lastModifiedBy": "NqO2eQGMjrvUO6v9"
-    },
-    "_key": "!items!ivrXToGxyuVdqZtG"
+  "name": "Seaborne",
+  "type": "community",
+  "_id": "ivrXToGxyuVdqZtG",
+  "img": "systems/daggerheart/assets/icons/communities/seaborne.png",
+  "system": {
+    "description": "<p>Being part of a seaborne community means you lived on or near a large body of water. Seaborne communities are built, both physically and culturally, around the specific waters they call home.</p><p>Some of these groups live along the shore, constructing ports for locals and travelers alike. These harbors function as centers of commerce, tourist attractions, or even just a safe place to lay down one’s head after weeks of travel. Other seaborne live on the water in small boats or large ships, with the idea of “home” comprising a ship and its crew, rather than any one landmass.</p><p>No matter their exact location, seaborne communities are closely tied to the ocean tides and the creatures who inhabit them. Seaborne learn to fish at a young age, and train from birth to hold their breath and swim in even the most tumultuous waters. Individuals from these groups are highly sought after for their sailing skills, and many become captains of vessels, whether within their own community, working for another, or even at the helm of a powerful naval operation.<br><em><br>Seaborne are often candid, cooperative, exuberant, fierce, resolute, and weathered.</em></p>",
+    "abilities": [
+      {
+        "img": "icons/svg/item-bag.svg",
+        "name": "Know the Tide",
+        "uuid": "Compendium.world.community-features.Item.coBcBEFpXgtxD1Jt"
+      }
+    ]
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747940375520,
+    "modifiedTime": 1747990980804,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!ivrXToGxyuVdqZtG"
 }

--- a/src/packs/communities/community_Slyborne_rwsUCLenOkE9CS7v.json
+++ b/src/packs/communities/community_Slyborne_rwsUCLenOkE9CS7v.json
@@ -1,36 +1,36 @@
 {
-    "name": "Slyborne",
-    "type": "community",
-    "_id": "rwsUCLenOkE9CS7v",
-    "img": "systems/daggerheart/assets/icons/communities/slyborne.png",
-    "system": {
-        "description": "<p>Being part of a slyborne community means you come from a group that operates outside the law, including all manner of criminals, grifters, and con artists. Members of slyborne communities are brought together by their disreputable goals and their clever means of achieving them. Many people in these communities have an array of unscrupulous skills: forging, thievery, smuggling, and violence. People of any social class can be slyborne, from those who have garnered vast wealth and influence to those without a coin to their name. To the outside eye, slyborne might appear to be ruffians with no loyalty, but these communities possess some of the strictest codes of honor which, when broken, can result in a terrifying end for the transgressor.</p><p></p><p><em>Slyborne are often calculating, clever, formidable, perceptive, shrewd, and tenacious.</em></p>",
-        "abilities": [
-            {
-                "img": "icons/svg/item-bag.svg",
-                "name": "Scoundrel",
-                "uuid": "Compendium.world.community-features.Item.p2PipVUiMt0Cy0ws"
-            }
-        ]
-    },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1747940388725,
-        "modifiedTime": 1747991089836,
-        "lastModifiedBy": "NqO2eQGMjrvUO6v9"
-    },
-    "_key": "!items!rwsUCLenOkE9CS7v"
+  "name": "Slyborne",
+  "type": "community",
+  "_id": "rwsUCLenOkE9CS7v",
+  "img": "systems/daggerheart/assets/icons/communities/slyborne.png",
+  "system": {
+    "description": "<p>Being part of a slyborne community means you come from a group that operates outside the law, including all manner of criminals, grifters, and con artists. Members of slyborne communities are brought together by their disreputable goals and their clever means of achieving them. Many people in these communities have an array of unscrupulous skills: forging, thievery, smuggling, and violence. People of any social class can be slyborne, from those who have garnered vast wealth and influence to those without a coin to their name. To the outside eye, slyborne might appear to be ruffians with no loyalty, but these communities possess some of the strictest codes of honor which, when broken, can result in a terrifying end for the transgressor.</p><p></p><p><em>Slyborne are often calculating, clever, formidable, perceptive, shrewd, and tenacious.</em></p>",
+    "abilities": [
+      {
+        "img": "icons/svg/item-bag.svg",
+        "name": "Scoundrel",
+        "uuid": "Compendium.world.community-features.Item.p2PipVUiMt0Cy0ws"
+      }
+    ]
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747940388725,
+    "modifiedTime": 1747991089836,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!rwsUCLenOkE9CS7v"
 }

--- a/src/packs/communities/community_Underborne_CXQN2zcQUIjUOx1i.json
+++ b/src/packs/communities/community_Underborne_CXQN2zcQUIjUOx1i.json
@@ -1,36 +1,36 @@
 {
-    "name": "Underborne",
-    "type": "community",
-    "_id": "CXQN2zcQUIjUOx1i",
-    "img": "systems/daggerheart/assets/icons/communities/underborne.png",
-    "system": {
-        "description": "<p>Being part of an underborne community means you’re from a subterranean society. Many underborne live right beneath the cities and villages of other collectives, while some live much deeper. These communities range from small family groups in burrows to massive metropolises in caverns of stone. In many locales, underborne are recognized for their incredible boldness and skill that enable great feats of architecture and engineering. Underborne are regularly hired for their bravery, as even the least daring among them has likely encountered formidable belowground beasts, and learning to dispatch such creatures is common practice amongst these societies.</p><p>Because of the dangers of their environment, many underborne communities develop unique nonverbal languages that prove equally useful on the surface.</p><p><em>Underborne are often composed, elusive, indomitable, innovative, resourceful, and unpretentious.</em></p>",
-        "abilities": [
-            {
-                "img": "icons/svg/item-bag.svg",
-                "name": "Low-Light Living",
-                "uuid": "Compendium.world.community-features.Item.p12Le1M3DPWXa0vh"
-            }
-        ]
-    },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1747940403160,
-        "modifiedTime": 1747991158174,
-        "lastModifiedBy": "NqO2eQGMjrvUO6v9"
-    },
-    "_key": "!items!CXQN2zcQUIjUOx1i"
+  "name": "Underborne",
+  "type": "community",
+  "_id": "CXQN2zcQUIjUOx1i",
+  "img": "systems/daggerheart/assets/icons/communities/underborne.png",
+  "system": {
+    "description": "<p>Being part of an underborne community means you’re from a subterranean society. Many underborne live right beneath the cities and villages of other collectives, while some live much deeper. These communities range from small family groups in burrows to massive metropolises in caverns of stone. In many locales, underborne are recognized for their incredible boldness and skill that enable great feats of architecture and engineering. Underborne are regularly hired for their bravery, as even the least daring among them has likely encountered formidable belowground beasts, and learning to dispatch such creatures is common practice amongst these societies.</p><p>Because of the dangers of their environment, many underborne communities develop unique nonverbal languages that prove equally useful on the surface.</p><p><em>Underborne are often composed, elusive, indomitable, innovative, resourceful, and unpretentious.</em></p>",
+    "abilities": [
+      {
+        "img": "icons/svg/item-bag.svg",
+        "name": "Low-Light Living",
+        "uuid": "Compendium.world.community-features.Item.p12Le1M3DPWXa0vh"
+      }
+    ]
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747940403160,
+    "modifiedTime": 1747991158174,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!CXQN2zcQUIjUOx1i"
 }

--- a/src/packs/communities/community_Wanderborne_DHB5uSzbBeJCJuvC.json
+++ b/src/packs/communities/community_Wanderborne_DHB5uSzbBeJCJuvC.json
@@ -1,36 +1,36 @@
 {
-    "name": "Wanderborne",
-    "type": "community",
-    "_id": "DHB5uSzbBeJCJuvC",
-    "img": "systems/daggerheart/assets/icons/communities/wanderborne.png",
-    "system": {
-        "description": "<p>Being part of a wanderborne community means you’ve lived as a nomad, forgoing a permanent home and experiencing a wide variety of cultures. Unlike many communities that are defined by their locale, wanderborne are defined by their traveling lifestyle. Because of their frequent migration, wanderborne put less value on the accumulation of material possessions in favor of acquiring information, skills, and connections. While some wanderborne are allied by a common ethos, such as a religion or a set of political or economic values, others come together after shared tragedy, such as the loss of their home or land. No matter the reason, the dangers posed by life on the road and the choice to continue down that road together mean that wanderborne are known for their unwavering loyalty.</p><p><em>Wanderborne are often inscrutable, magnanimous, mirthful, reliable, savvy, and unorthodox.</em></p>",
-        "abilities": [
-            {
-                "img": "icons/svg/item-bag.svg",
-                "name": "Nomadic Pack",
-                "uuid": "Compendium.world.community-features.Item.NeuBdFDpV0HTzOIM"
-            }
-        ]
-    },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1747940414913,
-        "modifiedTime": 1747991238462,
-        "lastModifiedBy": "NqO2eQGMjrvUO6v9"
-    },
-    "_key": "!items!DHB5uSzbBeJCJuvC"
+  "name": "Wanderborne",
+  "type": "community",
+  "_id": "DHB5uSzbBeJCJuvC",
+  "img": "systems/daggerheart/assets/icons/communities/wanderborne.png",
+  "system": {
+    "description": "<p>Being part of a wanderborne community means you’ve lived as a nomad, forgoing a permanent home and experiencing a wide variety of cultures. Unlike many communities that are defined by their locale, wanderborne are defined by their traveling lifestyle. Because of their frequent migration, wanderborne put less value on the accumulation of material possessions in favor of acquiring information, skills, and connections. While some wanderborne are allied by a common ethos, such as a religion or a set of political or economic values, others come together after shared tragedy, such as the loss of their home or land. No matter the reason, the dangers posed by life on the road and the choice to continue down that road together mean that wanderborne are known for their unwavering loyalty.</p><p><em>Wanderborne are often inscrutable, magnanimous, mirthful, reliable, savvy, and unorthodox.</em></p>",
+    "abilities": [
+      {
+        "img": "icons/svg/item-bag.svg",
+        "name": "Nomadic Pack",
+        "uuid": "Compendium.world.community-features.Item.NeuBdFDpV0HTzOIM"
+      }
+    ]
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747940414913,
+    "modifiedTime": 1747991238462,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!DHB5uSzbBeJCJuvC"
 }

--- a/src/packs/communities/community_Wildborne_jUzXIVyBx0mlIFWa.json
+++ b/src/packs/communities/community_Wildborne_jUzXIVyBx0mlIFWa.json
@@ -1,36 +1,36 @@
 {
-    "name": "Wildborne",
-    "type": "community",
-    "_id": "jUzXIVyBx0mlIFWa",
-    "img": "systems/daggerheart/assets/icons/communities/wildborne.png",
-    "system": {
-        "description": "<p>Being part of a wildborne community means you lived deep within the forest. Wildborne communities are defined by their dedication to the conservation of their homelands, and many have strong religious or cultural ties to the fauna they live among.</p><p>This results in unique architectural and technological advancements that favor sustainability over short-term, high-yield results.</p><p>It is a hallmark of wildborne societies to integrate their villages and cities with the natural environment and avoid disturbing the lives of the plants and animals. While some construct their lodgings high in the branches of trees, others establish their homes on the ground beneath the forest canopy. It’s not uncommon for wildborne to remain reclusive and hidden within their woodland homes.</p><p><em>Wildborne are often hardy, loyal, nurturing, reclusive, sagacious, and vibrant.</em></p>",
-        "abilities": [
-            {
-                "img": "icons/svg/item-bag.svg",
-                "name": "Lightfoot",
-                "uuid": "Compendium.world.community-features.Item.4VaugxNAouI7SKKz"
-            }
-        ]
-    },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1747940432585,
-        "modifiedTime": 1747991300734,
-        "lastModifiedBy": "NqO2eQGMjrvUO6v9"
-    },
-    "_key": "!items!jUzXIVyBx0mlIFWa"
+  "name": "Wildborne",
+  "type": "community",
+  "_id": "jUzXIVyBx0mlIFWa",
+  "img": "systems/daggerheart/assets/icons/communities/wildborne.png",
+  "system": {
+    "description": "<p>Being part of a wildborne community means you lived deep within the forest. Wildborne communities are defined by their dedication to the conservation of their homelands, and many have strong religious or cultural ties to the fauna they live among.</p><p>This results in unique architectural and technological advancements that favor sustainability over short-term, high-yield results.</p><p>It is a hallmark of wildborne societies to integrate their villages and cities with the natural environment and avoid disturbing the lives of the plants and animals. While some construct their lodgings high in the branches of trees, others establish their homes on the ground beneath the forest canopy. It’s not uncommon for wildborne to remain reclusive and hidden within their woodland homes.</p><p><em>Wildborne are often hardy, loyal, nurturing, reclusive, sagacious, and vibrant.</em></p>",
+    "abilities": [
+      {
+        "img": "icons/svg/item-bag.svg",
+        "name": "Lightfoot",
+        "uuid": "Compendium.world.community-features.Item.4VaugxNAouI7SKKz"
+      }
+    ]
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747940432585,
+    "modifiedTime": 1747991300734,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!jUzXIVyBx0mlIFWa"
 }

--- a/src/packs/community-features/feature_Dedicated_ZiBpJxtDSsh6wY3h.json
+++ b/src/packs/community-features/feature_Dedicated_ZiBpJxtDSsh6wY3h.json
@@ -1,46 +1,46 @@
 {
-    "name": "Dedicated",
-    "type": "feature",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "action",
-        "featureType": {
-            "type": "input",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {},
-                "value": "d20"
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>Record three sayings or values your upbringing instilled in you. Once per rest, when you describe how you’re embodying one of these principles through your current action, you can roll a d20 as your Hope Die.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "community"
+  "name": "Dedicated",
+  "type": "feature",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "action",
+    "featureType": {
+      "type": "input",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {},
+        "value": "d20"
+      }
     },
-    "effects": [],
-    "folder": null,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3,
-        "JKaKJsbixtjbUa07": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748008847578,
-        "modifiedTime": 1748008847578,
-        "lastModifiedBy": "JKaKJsbixtjbUa07"
-    },
-    "_id": "ZiBpJxtDSsh6wY3h",
-    "sort": 0,
-    "_key": "!items!ZiBpJxtDSsh6wY3h"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>Record three sayings or values your upbringing instilled in you. Once per rest, when you describe how you’re embodying one of these principles through your current action, you can roll a d20 as your Hope Die.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "community"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008847578,
+    "modifiedTime": 1748008847578,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "ZiBpJxtDSsh6wY3h",
+  "sort": 0,
+  "_key": "!items!ZiBpJxtDSsh6wY3h"
 }

--- a/src/packs/community-features/feature_Know_the_Tide_0mdoYz7uZNWCcK5Z.json
+++ b/src/packs/community-features/feature_Know_the_Tide_0mdoYz7uZNWCcK5Z.json
@@ -1,45 +1,45 @@
 {
-    "name": "Know the Tide",
-    "type": "feature",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "passive",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>You can sense the ebb and flow of life. When you roll with Fear, place a token on your community card. You can hold a number of tokens equal to your level. Before you make an action roll, you can spend any number of these tokens to gain a +1 bonus to the roll for each token spent. At the end of each session, clear all unspent tokens.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "community"
+  "name": "Know the Tide",
+  "type": "feature",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "passive",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3,
-        "JKaKJsbixtjbUa07": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748008848585,
-        "modifiedTime": 1748008848585,
-        "lastModifiedBy": "JKaKJsbixtjbUa07"
-    },
-    "_id": "0mdoYz7uZNWCcK5Z",
-    "sort": 0,
-    "_key": "!items!0mdoYz7uZNWCcK5Z"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>You can sense the ebb and flow of life. When you roll with Fear, place a token on your community card. You can hold a number of tokens equal to your level. Before you make an action roll, you can spend any number of these tokens to gain a +1 bonus to the roll for each token spent. At the end of each session, clear all unspent tokens.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "community"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008848585,
+    "modifiedTime": 1748008848585,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "0mdoYz7uZNWCcK5Z",
+  "sort": 0,
+  "_key": "!items!0mdoYz7uZNWCcK5Z"
 }

--- a/src/packs/community-features/feature_Lightfoot_LY9c4DCgMcB1uEiv.json
+++ b/src/packs/community-features/feature_Lightfoot_LY9c4DCgMcB1uEiv.json
@@ -1,45 +1,45 @@
 {
-    "name": "Lightfoot",
-    "type": "feature",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "passive",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>Your movement is naturally silent. You have advantage on rolls to move without being heard.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "community"
+  "name": "Lightfoot",
+  "type": "feature",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "passive",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3,
-        "JKaKJsbixtjbUa07": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748008849798,
-        "modifiedTime": 1748008849798,
-        "lastModifiedBy": "JKaKJsbixtjbUa07"
-    },
-    "_id": "LY9c4DCgMcB1uEiv",
-    "sort": 0,
-    "_key": "!items!LY9c4DCgMcB1uEiv"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>Your movement is naturally silent. You have advantage on rolls to move without being heard.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "community"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008849798,
+    "modifiedTime": 1748008849798,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "LY9c4DCgMcB1uEiv",
+  "sort": 0,
+  "_key": "!items!LY9c4DCgMcB1uEiv"
 }

--- a/src/packs/community-features/feature_Low_Light_Living_hX85YvTQcMzc25hW.json
+++ b/src/packs/community-features/feature_Low_Light_Living_hX85YvTQcMzc25hW.json
@@ -1,45 +1,45 @@
 {
-    "name": "Low-Light Living",
-    "type": "feature",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "passive",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>When you’re in an area with low light or heavy shadow, you have advantage on rolls to hide, investigate, or perceive details within that area.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "community"
+  "name": "Low-Light Living",
+  "type": "feature",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "passive",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3,
-        "JKaKJsbixtjbUa07": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748008850934,
-        "modifiedTime": 1748008850934,
-        "lastModifiedBy": "JKaKJsbixtjbUa07"
-    },
-    "_id": "hX85YvTQcMzc25hW",
-    "sort": 0,
-    "_key": "!items!hX85YvTQcMzc25hW"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>When you’re in an area with low light or heavy shadow, you have advantage on rolls to hide, investigate, or perceive details within that area.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "community"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008850934,
+    "modifiedTime": 1748008850934,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "hX85YvTQcMzc25hW",
+  "sort": 0,
+  "_key": "!items!hX85YvTQcMzc25hW"
 }

--- a/src/packs/community-features/feature_Nomadic_Pack_o3Q88Rws9Eb5ae5D.json
+++ b/src/packs/community-features/feature_Nomadic_Pack_o3Q88Rws9Eb5ae5D.json
@@ -1,45 +1,45 @@
 {
-    "name": "Nomadic Pack",
-    "type": "feature",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "passive",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>Add a Nomadic Pack to your inventory. Once per session, you can spend a Hope to reach into this pack and pull out a mundane item that’s useful to your situation. Work with the GM to figure out what item you take out.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "community"
+  "name": "Nomadic Pack",
+  "type": "feature",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "passive",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3,
-        "JKaKJsbixtjbUa07": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748008852219,
-        "modifiedTime": 1748008852219,
-        "lastModifiedBy": "JKaKJsbixtjbUa07"
-    },
-    "_id": "o3Q88Rws9Eb5ae5D",
-    "sort": 0,
-    "_key": "!items!o3Q88Rws9Eb5ae5D"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>Add a Nomadic Pack to your inventory. Once per session, you can spend a Hope to reach into this pack and pull out a mundane item that’s useful to your situation. Work with the GM to figure out what item you take out.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "community"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008852219,
+    "modifiedTime": 1748008852219,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "o3Q88Rws9Eb5ae5D",
+  "sort": 0,
+  "_key": "!items!o3Q88Rws9Eb5ae5D"
 }

--- a/src/packs/community-features/feature_Privilege_AgJiUvad5tgeam57.json
+++ b/src/packs/community-features/feature_Privilege_AgJiUvad5tgeam57.json
@@ -1,45 +1,45 @@
 {
-    "name": "Privilege",
-    "type": "feature",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "passive",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>You have advantage on rolls to consort with nobles, negotiate prices, or leverage your reputation to get what you want.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "community"
+  "name": "Privilege",
+  "type": "feature",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "passive",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748008853598,
-        "modifiedTime": 1748008853598,
-        "lastModifiedBy": "JKaKJsbixtjbUa07"
-    },
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3,
-        "JKaKJsbixtjbUa07": 3
-    },
-    "_id": "AgJiUvad5tgeam57",
-    "sort": 0,
-    "_key": "!items!AgJiUvad5tgeam57"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>You have advantage on rolls to consort with nobles, negotiate prices, or leverage your reputation to get what you want.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "community"
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008853598,
+    "modifiedTime": 1748008853598,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "AgJiUvad5tgeam57",
+  "sort": 0,
+  "_key": "!items!AgJiUvad5tgeam57"
 }

--- a/src/packs/community-features/feature_Scoundrel_5BUCiSPswsiB0RDW.json
+++ b/src/packs/community-features/feature_Scoundrel_5BUCiSPswsiB0RDW.json
@@ -1,45 +1,45 @@
 {
-    "name": "Scoundrel",
-    "type": "feature",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "passive",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>You have advantage on rolls to negotiate with criminals, detect lies, or find a safe place to hide.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "community"
+  "name": "Scoundrel",
+  "type": "feature",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "passive",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3,
-        "JKaKJsbixtjbUa07": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748008855001,
-        "modifiedTime": 1748008855001,
-        "lastModifiedBy": "JKaKJsbixtjbUa07"
-    },
-    "_id": "5BUCiSPswsiB0RDW",
-    "sort": 0,
-    "_key": "!items!5BUCiSPswsiB0RDW"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>You have advantage on rolls to negotiate with criminals, detect lies, or find a safe place to hide.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "community"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008855001,
+    "modifiedTime": 1748008855001,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "5BUCiSPswsiB0RDW",
+  "sort": 0,
+  "_key": "!items!5BUCiSPswsiB0RDW"
 }

--- a/src/packs/community-features/feature_Steady_Oky51ziMZp6bbuUQ.json
+++ b/src/packs/community-features/feature_Steady_Oky51ziMZp6bbuUQ.json
@@ -1,45 +1,45 @@
 {
-    "name": "Steady",
-    "type": "feature",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "passive",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {}
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>You have advantage on rolls to traverse dangerous cliffs and ledges, navigate harsh environments, and use your survival knowledge.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "community"
+  "name": "Steady",
+  "type": "feature",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "passive",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {}
+      }
     },
-    "effects": [],
-    "folder": null,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3,
-        "JKaKJsbixtjbUa07": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748008856287,
-        "modifiedTime": 1748008856287,
-        "lastModifiedBy": "JKaKJsbixtjbUa07"
-    },
-    "_id": "Oky51ziMZp6bbuUQ",
-    "sort": 0,
-    "_key": "!items!Oky51ziMZp6bbuUQ"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>You have advantage on rolls to traverse dangerous cliffs and ledges, navigate harsh environments, and use your survival knowledge.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "community"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008856287,
+    "modifiedTime": 1748008856287,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "Oky51ziMZp6bbuUQ",
+  "sort": 0,
+  "_key": "!items!Oky51ziMZp6bbuUQ"
 }

--- a/src/packs/community-features/feature_Well_Read_n2RA9iZNiVbGlxco.json
+++ b/src/packs/community-features/feature_Well_Read_n2RA9iZNiVbGlxco.json
@@ -1,46 +1,46 @@
 {
-    "name": "Well-Read",
-    "type": "feature",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "actionType": "passive",
-        "featureType": {
-            "type": "normal",
-            "data": {
-                "property": "spellcastingTrait",
-                "max": 1,
-                "numbers": {},
-                "value": "d4"
-            }
-        },
-        "refreshData": null,
-        "multiclass": null,
-        "disabled": false,
-        "description": "<p>You have advantage on rolls that involve the history, culture, or politics of a prominent person or place.</p>",
-        "effects": {},
-        "actions": [],
-        "type": "community"
+  "name": "Well-Read",
+  "type": "feature",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "actionType": "passive",
+    "featureType": {
+      "type": "normal",
+      "data": {
+        "property": "spellcastingTrait",
+        "max": 1,
+        "numbers": {},
+        "value": "d4"
+      }
     },
-    "effects": [],
-    "folder": null,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3,
-        "JKaKJsbixtjbUa07": 3
-    },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1748008857389,
-        "modifiedTime": 1748008857389,
-        "lastModifiedBy": "JKaKJsbixtjbUa07"
-    },
-    "_id": "n2RA9iZNiVbGlxco",
-    "sort": 0,
-    "_key": "!items!n2RA9iZNiVbGlxco"
+    "refreshData": null,
+    "multiclass": null,
+    "disabled": false,
+    "description": "<p>You have advantage on rolls that involve the history, culture, or politics of a prominent person or place.</p>",
+    "effects": {},
+    "actions": [],
+    "type": "community"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008857389,
+    "modifiedTime": 1748008857389,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "n2RA9iZNiVbGlxco",
+  "sort": 0,
+  "_key": "!items!n2RA9iZNiVbGlxco"
 }

--- a/src/packs/items/armor/tier1/armor_Chainmail_Armor_s7PUmApOFX0YryDG.json
+++ b/src/packs/items/armor/tier1/armor_Chainmail_Armor_s7PUmApOFX0YryDG.json
@@ -1,0 +1,40 @@
+{
+  "name": "Chainmail Armor",
+  "type": "armor",
+  "img": "systems/daggerheart/assets/icons/armor/tier_1/chainmail_armor.png",
+  "system": {
+    "baseScore": 4,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "description": "",
+    "feature": "heavy",
+    "baseThresholds": {
+      "major": 7,
+      "severe": 15
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008741139,
+    "modifiedTime": 1748028173861,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_id": "s7PUmApOFX0YryDG",
+  "sort": 100000,
+  "_key": "!items!s7PUmApOFX0YryDG"
+}

--- a/src/packs/items/armor/tier1/armor_Full_Plate_Armor_LLL9gflIUF8ZFkzZ.json
+++ b/src/packs/items/armor/tier1/armor_Full_Plate_Armor_LLL9gflIUF8ZFkzZ.json
@@ -1,0 +1,40 @@
+{
+  "name": "Full Plate Armor",
+  "type": "armor",
+  "img": "systems/daggerheart/assets/icons/armor/tier_1/full_plate_armor.png",
+  "system": {
+    "baseScore": 4,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "description": "",
+    "feature": "veryHeavy",
+    "baseThresholds": {
+      "major": 8,
+      "severe": 17
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008742116,
+    "modifiedTime": 1748028187244,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_id": "LLL9gflIUF8ZFkzZ",
+  "sort": 300000,
+  "_key": "!items!LLL9gflIUF8ZFkzZ"
+}

--- a/src/packs/items/armor/tier1/armor_Gambeson_Armor_alp2w20UmD7jKXOL.json
+++ b/src/packs/items/armor/tier1/armor_Gambeson_Armor_alp2w20UmD7jKXOL.json
@@ -1,0 +1,40 @@
+{
+  "name": "Gambeson Armor",
+  "type": "armor",
+  "img": "systems/daggerheart/assets/icons/armor/tier_1/gambeson_armor.png",
+  "system": {
+    "baseScore": 3,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "description": "",
+    "feature": "light",
+    "baseThresholds": {
+      "major": 5,
+      "severe": 11
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008742848,
+    "modifiedTime": 1748028147106,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_id": "alp2w20UmD7jKXOL",
+  "sort": 400000,
+  "_key": "!items!alp2w20UmD7jKXOL"
+}

--- a/src/packs/items/armor/tier1/armor_Leather_Armor_QMCh4ooGamb9oIGz.json
+++ b/src/packs/items/armor/tier1/armor_Leather_Armor_QMCh4ooGamb9oIGz.json
@@ -1,0 +1,40 @@
+{
+  "name": "Leather Armor",
+  "type": "armor",
+  "img": "systems/daggerheart/assets/icons/armor/tier_1/leather_armor.png",
+  "system": {
+    "baseScore": 3,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "description": "",
+    "feature": "",
+    "baseThresholds": {
+      "major": 6,
+      "severe": 13
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008743698,
+    "modifiedTime": 1748028160837,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_id": "QMCh4ooGamb9oIGz",
+  "sort": 200000,
+  "_key": "!items!QMCh4ooGamb9oIGz"
+}

--- a/src/packs/items/armor/tier2/armor_Elundrian_Chain_Armor_ED8RhELKD9Pgnxgb.json
+++ b/src/packs/items/armor/tier2/armor_Elundrian_Chain_Armor_ED8RhELKD9Pgnxgb.json
@@ -1,0 +1,40 @@
+{
+  "name": "Elundrian Chain Armor",
+  "type": "armor",
+  "img": "systems/daggerheart/assets/icons/armor/tier_2/elundrian_chain_armor.png",
+  "system": {
+    "baseScore": 4,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "description": "",
+    "feature": "warded",
+    "baseThresholds": {
+      "major": 9,
+      "severe": 21
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008765138,
+    "modifiedTime": 1748028270334,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_id": "ED8RhELKD9Pgnxgb",
+  "sort": 100000,
+  "_key": "!items!ED8RhELKD9Pgnxgb"
+}

--- a/src/packs/items/armor/tier2/armor_Harrowbone_Armor_Rl8dZeOnM3foAnth.json
+++ b/src/packs/items/armor/tier2/armor_Harrowbone_Armor_Rl8dZeOnM3foAnth.json
@@ -1,0 +1,40 @@
+{
+  "name": "Harrowbone Armor",
+  "type": "armor",
+  "img": "systems/daggerheart/assets/icons/armor/tier_2/harrowbone_armor.png",
+  "system": {
+    "baseScore": 4,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "description": "",
+    "feature": "resistant",
+    "baseThresholds": {
+      "major": 9,
+      "severe": 21
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008765925,
+    "modifiedTime": 1748028291278,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_id": "Rl8dZeOnM3foAnth",
+  "sort": 300000,
+  "_key": "!items!Rl8dZeOnM3foAnth"
+}

--- a/src/packs/items/armor/tier2/armor_Improved_Chainmail_Armor_kVpH1vvbdK5prOT5.json
+++ b/src/packs/items/armor/tier2/armor_Improved_Chainmail_Armor_kVpH1vvbdK5prOT5.json
@@ -1,0 +1,40 @@
+{
+  "name": "Improved Chainmail Armor",
+  "type": "armor",
+  "img": "systems/daggerheart/assets/icons/armor/tier_2/improved_chainmail_armor.png",
+  "system": {
+    "baseScore": 5,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "description": "",
+    "feature": "heavy",
+    "baseThresholds": {
+      "major": 11,
+      "severe": 24
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008766641,
+    "modifiedTime": 1748028242876,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_id": "kVpH1vvbdK5prOT5",
+  "sort": 400000,
+  "_key": "!items!kVpH1vvbdK5prOT5"
+}

--- a/src/packs/items/armor/tier2/armor_Improved_Full_Plate_Armor_E6asa0VMozd4zZbV.json
+++ b/src/packs/items/armor/tier2/armor_Improved_Full_Plate_Armor_E6asa0VMozd4zZbV.json
@@ -1,0 +1,40 @@
+{
+  "name": "Improved Full Plate Armor",
+  "type": "armor",
+  "img": "systems/daggerheart/assets/icons/armor/tier_2/improved_full_plate_armor.png",
+  "system": {
+    "baseScore": 5,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "description": "",
+    "feature": "veryHeavy",
+    "baseThresholds": {
+      "major": 13,
+      "severe": 28
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008767365,
+    "modifiedTime": 1748028257241,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_id": "E6asa0VMozd4zZbV",
+  "sort": 500000,
+  "_key": "!items!E6asa0VMozd4zZbV"
+}

--- a/src/packs/items/armor/tier2/armor_Improved_Gambeson_Armor_ou0he5rHyi06dqO3.json
+++ b/src/packs/items/armor/tier2/armor_Improved_Gambeson_Armor_ou0he5rHyi06dqO3.json
@@ -1,0 +1,40 @@
+{
+  "name": "Improved Gambeson Armor",
+  "type": "armor",
+  "img": "systems/daggerheart/assets/icons/armor/tier_2/improved_gambeson_armor.png",
+  "system": {
+    "baseScore": 4,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "description": "<p><strong>Flexible</strong>: +1 to Evasion</p>",
+    "feature": "light",
+    "baseThresholds": {
+      "major": 7,
+      "severe": 16
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008768058,
+    "modifiedTime": 1748028207851,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_id": "ou0he5rHyi06dqO3",
+  "sort": 600000,
+  "_key": "!items!ou0he5rHyi06dqO3"
+}

--- a/src/packs/items/armor/tier2/armor_Improved_Leather_Armor_Lx94Q7Cl7wMwcl58.json
+++ b/src/packs/items/armor/tier2/armor_Improved_Leather_Armor_Lx94Q7Cl7wMwcl58.json
@@ -1,0 +1,40 @@
+{
+  "name": "Improved Leather Armor",
+  "type": "armor",
+  "img": "systems/daggerheart/assets/icons/armor/tier_2/improved_leather_armor.png",
+  "system": {
+    "baseScore": 4,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "description": "",
+    "feature": "",
+    "baseThresholds": {
+      "major": 9,
+      "severe": 20
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008768829,
+    "modifiedTime": 1748028224201,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_id": "Lx94Q7Cl7wMwcl58",
+  "sort": 700000,
+  "_key": "!items!Lx94Q7Cl7wMwcl58"
+}

--- a/src/packs/items/armor/tier2/armor_Irontree_Breastplate_Armor_4ImHfMsKbDzIFRNF.json
+++ b/src/packs/items/armor/tier2/armor_Irontree_Breastplate_Armor_4ImHfMsKbDzIFRNF.json
@@ -1,0 +1,40 @@
+{
+  "name": "Irontree Breastplate Armor",
+  "type": "armor",
+  "img": "systems/daggerheart/assets/icons/armor/tier_2/irontree_breastplate_armor.png",
+  "system": {
+    "baseScore": 4,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "description": "",
+    "feature": "reinforced",
+    "baseThresholds": {
+      "major": 9,
+      "severe": 20
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008769590,
+    "modifiedTime": 1748028314955,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_id": "4ImHfMsKbDzIFRNF",
+  "sort": 800000,
+  "_key": "!items!4ImHfMsKbDzIFRNF"
+}

--- a/src/packs/items/armor/tier2/armor_Rosewild_Armor_Cd0jzt1EBUiihcEQ.json
+++ b/src/packs/items/armor/tier2/armor_Rosewild_Armor_Cd0jzt1EBUiihcEQ.json
@@ -1,0 +1,40 @@
+{
+  "name": "Rosewild Armor",
+  "type": "armor",
+  "img": "systems/daggerheart/assets/icons/armor/tier_2/rosewild_armor.png",
+  "system": {
+    "baseScore": 5,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "description": "",
+    "feature": "hopeful",
+    "baseThresholds": {
+      "major": 11,
+      "severe": 23
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008770268,
+    "modifiedTime": 1748028371396,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_id": "Cd0jzt1EBUiihcEQ",
+  "sort": 900000,
+  "_key": "!items!Cd0jzt1EBUiihcEQ"
+}

--- a/src/packs/items/armor/tier2/armor_Runetan_Floating_Armor_VUYFNEt6xNVHw9Yd.json
+++ b/src/packs/items/armor/tier2/armor_Runetan_Floating_Armor_VUYFNEt6xNVHw9Yd.json
@@ -1,0 +1,40 @@
+{
+  "name": "Runetan Floating Armor",
+  "type": "armor",
+  "img": "systems/daggerheart/assets/icons/armor/tier_2/runetan_floating_armor.png",
+  "system": {
+    "baseScore": 4,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "description": "",
+    "feature": "sharp",
+    "baseThresholds": {
+      "major": 9,
+      "severe": 20
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008770925,
+    "modifiedTime": 1748028339907,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_id": "VUYFNEt6xNVHw9Yd",
+  "sort": 1000000,
+  "_key": "!items!VUYFNEt6xNVHw9Yd"
+}

--- a/src/packs/items/armor/tier2/armor_Tyris_Soft_Armor_0mqF7VUJvEUq2Umv.json
+++ b/src/packs/items/armor/tier2/armor_Tyris_Soft_Armor_0mqF7VUJvEUq2Umv.json
@@ -1,0 +1,40 @@
+{
+  "name": "Tyris Soft Armor",
+  "type": "armor",
+  "img": "systems/daggerheart/assets/icons/armor/tier_2/tyris_soft_armor.png",
+  "system": {
+    "baseScore": 5,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "description": "",
+    "feature": "quiet",
+    "baseThresholds": {
+      "major": 8,
+      "severe": 18
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008771577,
+    "modifiedTime": 1748028353841,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_id": "0mqF7VUJvEUq2Umv",
+  "sort": 200000,
+  "_key": "!items!0mqF7VUJvEUq2Umv"
+}

--- a/src/packs/items/armor/tier3/armor_Advanced_Chainmail_Armor_X5k7Stier3vxz4V0.json
+++ b/src/packs/items/armor/tier3/armor_Advanced_Chainmail_Armor_X5k7Stier3vxz4V0.json
@@ -1,0 +1,40 @@
+{
+  "name": "Advanced Chainmail Armor",
+  "type": "armor",
+  "img": "systems/daggerheart/assets/icons/armor/tier_3/advanced_chainmail_armor.png",
+  "system": {
+    "baseScore": 6,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "description": "",
+    "feature": "heavy",
+    "baseThresholds": {
+      "major": 13,
+      "severe": 31
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008781137,
+    "modifiedTime": 1748028510367,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_id": "X5k7Stier3vxz4V0",
+  "sort": 100000,
+  "_key": "!items!X5k7Stier3vxz4V0"
+}

--- a/src/packs/items/armor/tier3/armor_Advanced_Full_Plate_Armor_IaHC7MKRdxUh1VqK.json
+++ b/src/packs/items/armor/tier3/armor_Advanced_Full_Plate_Armor_IaHC7MKRdxUh1VqK.json
@@ -1,0 +1,40 @@
+{
+  "name": "Advanced Full Plate Armor",
+  "type": "armor",
+  "img": "systems/daggerheart/assets/icons/armor/tier_3/advanced_full_plate_armor.png",
+  "system": {
+    "baseScore": 6,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "description": "",
+    "feature": "veryHeavy",
+    "baseThresholds": {
+      "major": 15,
+      "severe": 35
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008781890,
+    "modifiedTime": 1748028521542,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_id": "IaHC7MKRdxUh1VqK",
+  "sort": 300000,
+  "_key": "!items!IaHC7MKRdxUh1VqK"
+}

--- a/src/packs/items/armor/tier3/armor_Advanced_Gambeson_Armor_45Ecu1PgMahpKbsN.json
+++ b/src/packs/items/armor/tier3/armor_Advanced_Gambeson_Armor_45Ecu1PgMahpKbsN.json
@@ -1,0 +1,40 @@
+{
+  "name": "Advanced Gambeson Armor",
+  "type": "armor",
+  "img": "systems/daggerheart/assets/icons/armor/tier_3/advanced_gambeson_armor.png",
+  "system": {
+    "baseScore": 5,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "description": "",
+    "feature": "light",
+    "baseThresholds": {
+      "major": 9,
+      "severe": 23
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008782599,
+    "modifiedTime": 1748028482409,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_id": "45Ecu1PgMahpKbsN",
+  "sort": 400000,
+  "_key": "!items!45Ecu1PgMahpKbsN"
+}

--- a/src/packs/items/armor/tier3/armor_Advanced_Leather_Armor_v6V96UsXSuyx1UV7.json
+++ b/src/packs/items/armor/tier3/armor_Advanced_Leather_Armor_v6V96UsXSuyx1UV7.json
@@ -1,0 +1,40 @@
+{
+  "name": "Advanced Leather Armor",
+  "type": "armor",
+  "img": "systems/daggerheart/assets/icons/armor/tier_3/advanced_leather_armor.png",
+  "system": {
+    "baseScore": 5,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "description": "",
+    "feature": "",
+    "baseThresholds": {
+      "major": 11,
+      "severe": 27
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008783273,
+    "modifiedTime": 1748028496110,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_id": "v6V96UsXSuyx1UV7",
+  "sort": 500000,
+  "_key": "!items!v6V96UsXSuyx1UV7"
+}

--- a/src/packs/items/armor/tier3/armor_Bellamoi_Fine_Armor_iBbmRG7cNXmqs4ga.json
+++ b/src/packs/items/armor/tier3/armor_Bellamoi_Fine_Armor_iBbmRG7cNXmqs4ga.json
@@ -1,0 +1,40 @@
+{
+  "name": "Bellamoi Fine Armor",
+  "type": "armor",
+  "img": "systems/daggerheart/assets/icons/armor/tier_3/bellamoi_fine_armor.png",
+  "system": {
+    "baseScore": 5,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "description": "",
+    "feature": "gilded",
+    "baseThresholds": {
+      "major": 11,
+      "severe": 27
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008783947,
+    "modifiedTime": 1748028554404,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_id": "iBbmRG7cNXmqs4ga",
+  "sort": 600000,
+  "_key": "!items!iBbmRG7cNXmqs4ga"
+}

--- a/src/packs/items/armor/tier3/armor_Bladefare_Armor_YVfTNS1YD5sbKx3S.json
+++ b/src/packs/items/armor/tier3/armor_Bladefare_Armor_YVfTNS1YD5sbKx3S.json
@@ -1,0 +1,40 @@
+{
+  "name": "Bladefare Armor",
+  "type": "armor",
+  "img": "systems/daggerheart/assets/icons/armor/tier_3/bladefare_armor.png",
+  "system": {
+    "baseScore": 6,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "description": "",
+    "feature": "physical",
+    "baseThresholds": {
+      "major": 16,
+      "severe": 39
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008784769,
+    "modifiedTime": 1748028597257,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_id": "YVfTNS1YD5sbKx3S",
+  "sort": 700000,
+  "_key": "!items!YVfTNS1YD5sbKx3S"
+}

--- a/src/packs/items/armor/tier3/armor_Dragonscale_Armor_XeoC52EJA4dV9l6W.json
+++ b/src/packs/items/armor/tier3/armor_Dragonscale_Armor_XeoC52EJA4dV9l6W.json
@@ -1,0 +1,40 @@
+{
+  "name": "Dragonscale Armor",
+  "type": "armor",
+  "img": "systems/daggerheart/assets/icons/armor/tier_3/dragonscale_armor.png",
+  "system": {
+    "baseScore": 5,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "description": "",
+    "feature": "impenetrable",
+    "baseThresholds": {
+      "major": 11,
+      "severe": 27
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008785541,
+    "modifiedTime": 1748028567955,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_id": "XeoC52EJA4dV9l6W",
+  "sort": 800000,
+  "_key": "!items!XeoC52EJA4dV9l6W"
+}

--- a/src/packs/items/armor/tier3/armor_Monett_s_Cloak_eqdjA5Z2eiu3w9z3.json
+++ b/src/packs/items/armor/tier3/armor_Monett_s_Cloak_eqdjA5Z2eiu3w9z3.json
@@ -1,0 +1,40 @@
+{
+  "name": "Monett's Cloak",
+  "type": "armor",
+  "img": "systems/daggerheart/assets/icons/armor/tier_3/monetts_cloak.png",
+  "system": {
+    "baseScore": 6,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "description": "",
+    "feature": "magic",
+    "baseThresholds": {
+      "major": 16,
+      "severe": 39
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008786218,
+    "modifiedTime": 1748028612656,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_id": "eqdjA5Z2eiu3w9z3",
+  "sort": 900000,
+  "_key": "!items!eqdjA5Z2eiu3w9z3"
+}

--- a/src/packs/items/armor/tier3/armor_Runes_of_Fortification_FBUDL6gCPh9HiOSu.json
+++ b/src/packs/items/armor/tier3/armor_Runes_of_Fortification_FBUDL6gCPh9HiOSu.json
@@ -1,0 +1,40 @@
+{
+  "name": "Runes of Fortification",
+  "type": "armor",
+  "img": "systems/daggerheart/assets/icons/armor/tier_3/runes_of_fortification.png",
+  "system": {
+    "baseScore": 6,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "description": "",
+    "feature": "painful",
+    "baseThresholds": {
+      "major": 17,
+      "severe": 43
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008787018,
+    "modifiedTime": 1748028627292,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_id": "FBUDL6gCPh9HiOSu",
+  "sort": 1000000,
+  "_key": "!items!FBUDL6gCPh9HiOSu"
+}

--- a/src/packs/items/armor/tier3/armor_Spiked_Plate_Armor_Enscb2W5lei9FGuc.json
+++ b/src/packs/items/armor/tier3/armor_Spiked_Plate_Armor_Enscb2W5lei9FGuc.json
@@ -1,0 +1,40 @@
+{
+  "name": "Spiked Plate Armor",
+  "type": "armor",
+  "img": "systems/daggerheart/assets/icons/armor/tier_3/spiked_plate_armor.png",
+  "system": {
+    "baseScore": 5,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "description": "",
+    "feature": "sharp",
+    "baseThresholds": {
+      "major": 10,
+      "severe": 25
+    }
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748008787719,
+    "modifiedTime": 1748028581947,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_id": "Enscb2W5lei9FGuc",
+  "sort": 200000,
+  "_key": "!items!Enscb2W5lei9FGuc"
+}

--- a/src/packs/items/armor/tier4/armor_Channeling_Armor_oceDrXoEGSTQXeJd.json
+++ b/src/packs/items/armor/tier4/armor_Channeling_Armor_oceDrXoEGSTQXeJd.json
@@ -1,0 +1,39 @@
+{
+  "name": "Channeling Armor",
+  "type": "armor",
+  "_id": "oceDrXoEGSTQXeJd",
+  "img": "systems/daggerheart/assets/icons/armor/tier_4/channeling_armor.png",
+  "system": {
+    "baseScore": 5,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "baseThresholds": {
+      "major": 13,
+      "severe": 36
+    },
+    "description": "",
+    "feature": "channeling"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748027971730,
+    "modifiedTime": 1748027988576,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!oceDrXoEGSTQXeJd"
+}

--- a/src/packs/items/armor/tier4/armor_Dunamis_Silkchain_ffIEaWPRHLlWy1Ft.json
+++ b/src/packs/items/armor/tier4/armor_Dunamis_Silkchain_ffIEaWPRHLlWy1Ft.json
@@ -1,0 +1,39 @@
+{
+  "name": "Dunamis Silkchain",
+  "type": "armor",
+  "_id": "ffIEaWPRHLlWy1Ft",
+  "img": "systems/daggerheart/assets/icons/armor/tier_4/dunamis_silkchain.png",
+  "system": {
+    "baseScore": 7,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "baseThresholds": {
+      "major": 13,
+      "severe": 36
+    },
+    "description": "",
+    "feature": "timeslowing"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748027943461,
+    "modifiedTime": 1748027965045,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!ffIEaWPRHLlWy1Ft"
+}

--- a/src/packs/items/armor/tier4/armor_Emberwoven_Armor_8YhysA01kwSSX8Vg.json
+++ b/src/packs/items/armor/tier4/armor_Emberwoven_Armor_8YhysA01kwSSX8Vg.json
@@ -1,0 +1,39 @@
+{
+  "name": "Emberwoven Armor",
+  "type": "armor",
+  "_id": "8YhysA01kwSSX8Vg",
+  "img": "systems/daggerheart/assets/icons/armor/tier_4/emberwoven_armor.png",
+  "system": {
+    "baseScore": 6,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "baseThresholds": {
+      "major": 13,
+      "severe": 36
+    },
+    "description": "",
+    "feature": "burning"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748027998531,
+    "modifiedTime": 1748028013331,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!8YhysA01kwSSX8Vg"
+}

--- a/src/packs/items/armor/tier4/armor_Full_Fortified_Armor_Zk0WWk1WTc5X4DSv.json
+++ b/src/packs/items/armor/tier4/armor_Full_Fortified_Armor_Zk0WWk1WTc5X4DSv.json
@@ -1,0 +1,39 @@
+{
+  "name": "Full Fortified Armor",
+  "type": "armor",
+  "_id": "Zk0WWk1WTc5X4DSv",
+  "img": "systems/daggerheart/assets/icons/armor/tier_4/full_fortified_armor.png",
+  "system": {
+    "baseScore": 4,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "baseThresholds": {
+      "major": 15,
+      "severe": 40
+    },
+    "description": "",
+    "feature": ""
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748028024206,
+    "modifiedTime": 1748028050721,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!Zk0WWk1WTc5X4DSv"
+}

--- a/src/packs/items/armor/tier4/armor_Legendary_Chainmail_Armor_CiH20oR05hKNUdp3.json
+++ b/src/packs/items/armor/tier4/armor_Legendary_Chainmail_Armor_CiH20oR05hKNUdp3.json
@@ -1,0 +1,39 @@
+{
+  "name": "Legendary Chainmail Armor",
+  "type": "armor",
+  "_id": "CiH20oR05hKNUdp3",
+  "img": "systems/daggerheart/assets/icons/armor/tier_4/legendary_chainmail_armor.png",
+  "system": {
+    "baseScore": 7,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "baseThresholds": {
+      "major": 15,
+      "severe": 40
+    },
+    "description": "",
+    "feature": "heavy"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748027874542,
+    "modifiedTime": 1748027898156,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!CiH20oR05hKNUdp3"
+}

--- a/src/packs/items/armor/tier4/armor_Legendary_Full_Plate_Armor_h172qCAmBNvPhE25.json
+++ b/src/packs/items/armor/tier4/armor_Legendary_Full_Plate_Armor_h172qCAmBNvPhE25.json
@@ -1,0 +1,39 @@
+{
+  "name": "Legendary Full Plate Armor",
+  "type": "armor",
+  "_id": "h172qCAmBNvPhE25",
+  "img": "systems/daggerheart/assets/icons/armor/tier_4/legendary_full_plate_armor.png",
+  "system": {
+    "baseScore": 7,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "baseThresholds": {
+      "major": 17,
+      "severe": 44
+    },
+    "description": "",
+    "feature": "veryHeavy"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748027908657,
+    "modifiedTime": 1748027926684,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!h172qCAmBNvPhE25"
+}

--- a/src/packs/items/armor/tier4/armor_Legendary_Gambeson_Armor_CJLU4txFc0QYJF7G.json
+++ b/src/packs/items/armor/tier4/armor_Legendary_Gambeson_Armor_CJLU4txFc0QYJF7G.json
@@ -1,0 +1,39 @@
+{
+  "name": "Legendary Gambeson Armor",
+  "type": "armor",
+  "_id": "CJLU4txFc0QYJF7G",
+  "img": "systems/daggerheart/assets/icons/armor/tier_4/legendary_gambeson_armor.png",
+  "system": {
+    "baseScore": 6,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "baseThresholds": {
+      "major": 11,
+      "severe": 32
+    },
+    "description": "",
+    "feature": ""
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748027753507,
+    "modifiedTime": 1748027822574,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!CJLU4txFc0QYJF7G"
+}

--- a/src/packs/items/armor/tier4/armor_Legendary_Leather_Armor_XguKW7nNTCOqyWRw.json
+++ b/src/packs/items/armor/tier4/armor_Legendary_Leather_Armor_XguKW7nNTCOqyWRw.json
@@ -1,0 +1,39 @@
+{
+  "name": "Legendary Leather Armor",
+  "type": "armor",
+  "_id": "XguKW7nNTCOqyWRw",
+  "img": "systems/daggerheart/assets/icons/armor/tier_4/legendary_leather_armor.png",
+  "system": {
+    "baseScore": 6,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "baseThresholds": {
+      "major": 13,
+      "severe": 36
+    },
+    "description": "",
+    "feature": ""
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748027838790,
+    "modifiedTime": 1748027856107,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!XguKW7nNTCOqyWRw"
+}

--- a/src/packs/items/armor/tier4/armor_Savior_Chainmail_ixcNkPjIPpLgPuaA.json
+++ b/src/packs/items/armor/tier4/armor_Savior_Chainmail_ixcNkPjIPpLgPuaA.json
@@ -1,0 +1,39 @@
+{
+  "name": "Savior Chainmail",
+  "type": "armor",
+  "_id": "ixcNkPjIPpLgPuaA",
+  "img": "systems/daggerheart/assets/icons/armor/tier_4/savior_chainmail.png",
+  "system": {
+    "baseScore": 8,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "baseThresholds": {
+      "major": 18,
+      "severe": 48
+    },
+    "description": "",
+    "feature": "difficult"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748028096316,
+    "modifiedTime": 1748028114965,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!ixcNkPjIPpLgPuaA"
+}

--- a/src/packs/items/armor/tier4/armor_Veritas_Oal_Armor_QM9sfBKRcrKXZXHV.json
+++ b/src/packs/items/armor/tier4/armor_Veritas_Oal_Armor_QM9sfBKRcrKXZXHV.json
@@ -1,0 +1,39 @@
+{
+  "name": "Veritas Oal Armor",
+  "type": "armor",
+  "_id": "QM9sfBKRcrKXZXHV",
+  "img": "systems/daggerheart/assets/icons/armor/tier_4/veritas_opal_armor.png",
+  "system": {
+    "baseScore": 6,
+    "marks": {
+      "max": 6,
+      "value": 0
+    },
+    "baseThresholds": {
+      "major": 13,
+      "severe": 36
+    },
+    "description": "",
+    "feature": "truthseeking"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748028069751,
+    "modifiedTime": 1748028084978,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!QM9sfBKRcrKXZXHV"
+}

--- a/src/packs/items/armors/tier3/weapon_Advanced_Arcane_Gauntlets_YZ6rEX9nDsMy4aSK.json
+++ b/src/packs/items/armors/tier3/weapon_Advanced_Arcane_Gauntlets_YZ6rEX9nDsMy4aSK.json
@@ -1,0 +1,40 @@
+{
+  "name": "Advanced Arcane Gauntlets",
+  "type": "weapon",
+  "_id": "YZ6rEX9nDsMy4aSK",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/advanced_arcane_gauntlets.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+9",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747988845243,
+    "modifiedTime": 1747988860214,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!YZ6rEX9nDsMy4aSK"
+}

--- a/src/packs/items/armors/tier3/weapon_Advanced_Battleaxe_dKl2EXaTKUS4eH2m.json
+++ b/src/packs/items/armors/tier3/weapon_Advanced_Battleaxe_dKl2EXaTKUS4eH2m.json
@@ -1,0 +1,40 @@
+{
+  "name": "Advanced Battleaxe",
+  "type": "weapon",
+  "_id": "dKl2EXaTKUS4eH2m",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_battleaxe.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+9",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747987617406,
+    "modifiedTime": 1747987634618,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!dKl2EXaTKUS4eH2m"
+}

--- a/src/packs/items/armors/tier3/weapon_Advanced_Broadsword_AG91AzjFmKwBELst.json
+++ b/src/packs/items/armors/tier3/weapon_Advanced_Broadsword_AG91AzjFmKwBELst.json
@@ -1,0 +1,41 @@
+{
+  "name": "Advanced Broadsword",
+  "type": "weapon",
+  "_id": "AG91AzjFmKwBELst",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_broadsword.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+6",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "melee",
+    "burden": "oneHanded",
+    "feature": "reliable"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747987557617,
+    "modifiedTime": 1747987580626,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!AG91AzjFmKwBELst"
+}

--- a/src/packs/items/armors/tier3/weapon_Advanced_Crossbow_SxWOgH5BUgR8bmcZ.json
+++ b/src/packs/items/armors/tier3/weapon_Advanced_Crossbow_SxWOgH5BUgR8bmcZ.json
@@ -1,0 +1,40 @@
+{
+  "name": "Advanced Crossbow",
+  "type": "weapon",
+  "_id": "SxWOgH5BUgR8bmcZ",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_crossbow.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+7",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "far",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747988153303,
+    "modifiedTime": 1747988178060,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!SxWOgH5BUgR8bmcZ"
+}

--- a/src/packs/items/armors/tier3/weapon_Advanced_Cutlass_ANmFKsNEmAoSC9cI.json
+++ b/src/packs/items/armors/tier3/weapon_Advanced_Cutlass_ANmFKsNEmAoSC9cI.json
@@ -1,0 +1,40 @@
+{
+  "name": "Advanced Cutlass",
+  "type": "weapon",
+  "_id": "ANmFKsNEmAoSC9cI",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_cutlass.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+7",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "presence",
+    "range": "melee",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747987908578,
+    "modifiedTime": 1747987922978,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!ANmFKsNEmAoSC9cI"
+}

--- a/src/packs/items/armors/tier3/weapon_Advanced_Dagger_t9LLpnTQ1uw1agjV.json
+++ b/src/packs/items/armors/tier3/weapon_Advanced_Dagger_t9LLpnTQ1uw1agjV.json
@@ -1,0 +1,40 @@
+{
+  "name": "Advanced Dagger",
+  "type": "weapon",
+  "_id": "t9LLpnTQ1uw1agjV",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_dagger.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+7",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "melee",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747987854428,
+    "modifiedTime": 1747987874248,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!t9LLpnTQ1uw1agjV"
+}

--- a/src/packs/items/armors/tier3/weapon_Advanced_Dualstaff_YB2IqevpBAsFAGGH.json
+++ b/src/packs/items/armors/tier3/weapon_Advanced_Dualstaff_YB2IqevpBAsFAGGH.json
@@ -1,0 +1,40 @@
+{
+  "name": "Advanced Dualstaff",
+  "type": "weapon",
+  "_id": "YB2IqevpBAsFAGGH",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/advanced_dualstaff.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+9",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "range": "far",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747989263143,
+    "modifiedTime": 1747989288909,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!YB2IqevpBAsFAGGH"
+}

--- a/src/packs/items/armors/tier3/weapon_Advanced_Glowing_Rings_9jpVSmzYpqXBK8NA.json
+++ b/src/packs/items/armors/tier3/weapon_Advanced_Glowing_Rings_9jpVSmzYpqXBK8NA.json
@@ -1,0 +1,40 @@
+{
+  "name": "Advanced Glowing Rings",
+  "type": "weapon",
+  "_id": "9jpVSmzYpqXBK8NA",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/advanced_glowing_rings.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+8",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "veryClose",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747988897863,
+    "modifiedTime": 1747988913363,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!9jpVSmzYpqXBK8NA"
+}

--- a/src/packs/items/armors/tier3/weapon_Advanced_Greatstaff_adq1OwOknvfhkmEc.json
+++ b/src/packs/items/armors/tier3/weapon_Advanced_Greatstaff_adq1OwOknvfhkmEc.json
@@ -1,0 +1,41 @@
+{
+  "name": "Advanced Greatstaff",
+  "type": "weapon",
+  "_id": "adq1OwOknvfhkmEc",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/advanced_greatstaff.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+6",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "knowledge",
+    "range": "veryFar",
+    "burden": "twoHanded",
+    "feature": "powerful"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747989350920,
+    "modifiedTime": 1747989369138,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!adq1OwOknvfhkmEc"
+}

--- a/src/packs/items/armors/tier3/weapon_Advanced_Greatsword_TVsDORHfXs4ogW6w.json
+++ b/src/packs/items/armors/tier3/weapon_Advanced_Greatsword_TVsDORHfXs4ogW6w.json
@@ -1,0 +1,41 @@
+{
+  "name": "Advanced Greatsword",
+  "type": "weapon",
+  "_id": "TVsDORHfXs4ogW6w",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_greatsword.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+9",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "twoHanded",
+    "feature": "massive"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747987646690,
+    "modifiedTime": 1747987668738,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!TVsDORHfXs4ogW6w"
+}

--- a/src/packs/items/armors/tier3/weapon_Advanced_Halberd_ySK1c9H0384D2Osx.json
+++ b/src/packs/items/armors/tier3/weapon_Advanced_Halberd_ySK1c9H0384D2Osx.json
@@ -1,0 +1,41 @@
+{
+  "name": "Advanced Halberd",
+  "type": "weapon",
+  "_id": "ySK1c9H0384D2Osx",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_halberd.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+8",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "veryClose",
+    "burden": "twoHanded",
+    "feature": "cumbersome"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747988002843,
+    "modifiedTime": 1747988024433,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!ySK1c9H0384D2Osx"
+}

--- a/src/packs/items/armors/tier3/weapon_Advanced_Hallowed_Axe_Dj2Mepa7VnRchju1.json
+++ b/src/packs/items/armors/tier3/weapon_Advanced_Hallowed_Axe_Dj2Mepa7VnRchju1.json
@@ -1,0 +1,40 @@
+{
+  "name": "Advanced Hallowed Axe",
+  "type": "weapon",
+  "_id": "Dj2Mepa7VnRchju1",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/advanced_hallowed_axe.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+7",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747988871282,
+    "modifiedTime": 1747988887363,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!Dj2Mepa7VnRchju1"
+}

--- a/src/packs/items/armors/tier3/weapon_Advanced_Hand_Runes_aAljOewyWfbMU1mQ.json
+++ b/src/packs/items/armors/tier3/weapon_Advanced_Hand_Runes_aAljOewyWfbMU1mQ.json
@@ -1,0 +1,40 @@
+{
+  "name": "Advanced Hand Runes",
+  "type": "weapon",
+  "_id": "aAljOewyWfbMU1mQ",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/advanced_hand_runes.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+6",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "range": "veryClose",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747988922902,
+    "modifiedTime": 1747988940731,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!aAljOewyWfbMU1mQ"
+}

--- a/src/packs/items/armors/tier3/weapon_Advanced_Longbow_BfKjIK0A9mDVWntg.json
+++ b/src/packs/items/armors/tier3/weapon_Advanced_Longbow_BfKjIK0A9mDVWntg.json
@@ -1,0 +1,41 @@
+{
+  "name": "Advanced Longbow",
+  "type": "weapon",
+  "_id": "BfKjIK0A9mDVWntg",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_longbow.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+9",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "veryFar",
+    "burden": "twoHanded",
+    "feature": "cumbersome"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747988185736,
+    "modifiedTime": 1747988212515,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!BfKjIK0A9mDVWntg"
+}

--- a/src/packs/items/armors/tier3/weapon_Advanced_Longsword_HnEZjiBt4lNAbbZj.json
+++ b/src/packs/items/armors/tier3/weapon_Advanced_Longsword_HnEZjiBt4lNAbbZj.json
@@ -1,0 +1,40 @@
+{
+  "name": "Advanced Longsword",
+  "type": "weapon",
+  "_id": "HnEZjiBt4lNAbbZj",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_longsword.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+9",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "melee",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747987589599,
+    "modifiedTime": 1747987606154,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!HnEZjiBt4lNAbbZj"
+}

--- a/src/packs/items/armors/tier3/weapon_Advanced_Mace_esocQdA22XWUkQ8n.json
+++ b/src/packs/items/armors/tier3/weapon_Advanced_Mace_esocQdA22XWUkQ8n.json
@@ -1,0 +1,40 @@
+{
+  "name": "Advanced Mace",
+  "type": "weapon",
+  "_id": "esocQdA22XWUkQ8n",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_mace.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+7",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747987678478,
+    "modifiedTime": 1747987694119,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!esocQdA22XWUkQ8n"
+}

--- a/src/packs/items/armors/tier3/weapon_Advanced_Quarterstaff_cFmDMl0bFFK8XKvt.json
+++ b/src/packs/items/armors/tier3/weapon_Advanced_Quarterstaff_cFmDMl0bFFK8XKvt.json
@@ -1,0 +1,40 @@
+{
+  "name": "Advanced Quarterstaff",
+  "type": "weapon",
+  "_id": "cFmDMl0bFFK8XKvt",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_quarterstaff.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+9",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "range": "melee",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747987881903,
+    "modifiedTime": 1747987898698,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!cFmDMl0bFFK8XKvt"
+}

--- a/src/packs/items/armors/tier3/weapon_Advanced_Rapier_xsE7LlyCxySE1cgG.json
+++ b/src/packs/items/armors/tier3/weapon_Advanced_Rapier_xsE7LlyCxySE1cgG.json
@@ -1,0 +1,41 @@
+{
+  "name": "Advanced Rapier",
+  "type": "weapon",
+  "_id": "xsE7LlyCxySE1cgG",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_rapier.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+7",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "presence",
+    "range": "melee",
+    "burden": "oneHanded",
+    "feature": "quick"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747987967108,
+    "modifiedTime": 1747987992444,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!xsE7LlyCxySE1cgG"
+}

--- a/src/packs/items/armors/tier3/weapon_Advanced_Returning_Blade_7Npd8JLIrQ6JmmsW.json
+++ b/src/packs/items/armors/tier3/weapon_Advanced_Returning_Blade_7Npd8JLIrQ6JmmsW.json
@@ -1,0 +1,41 @@
+{
+  "name": "Advanced Returning Blade",
+  "type": "weapon",
+  "_id": "7Npd8JLIrQ6JmmsW",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/advanced_returning_blade.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+6",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "close",
+    "burden": "oneHanded",
+    "feature": "retrieve"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747988985388,
+    "modifiedTime": 1747989013062,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!7Npd8JLIrQ6JmmsW"
+}

--- a/src/packs/items/armors/tier3/weapon_Advanced_Scepter_gWN2ujNDkD53yhhc.json
+++ b/src/packs/items/armors/tier3/weapon_Advanced_Scepter_gWN2ujNDkD53yhhc.json
@@ -1,0 +1,41 @@
+{
+  "name": "Advanced Scepter",
+  "type": "weapon",
+  "_id": "gWN2ujNDkD53yhhc",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/advanced_scepter.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+6",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "presence",
+    "range": "far",
+    "burden": "twoHanded",
+    "feature": "versatile"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747989299631,
+    "modifiedTime": 1747989316089,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!gWN2ujNDkD53yhhc"
+}

--- a/src/packs/items/armors/tier3/weapon_Advanced_Shortbow_xjiJpCeCDNLMqNbp.json
+++ b/src/packs/items/armors/tier3/weapon_Advanced_Shortbow_xjiJpCeCDNLMqNbp.json
@@ -1,0 +1,40 @@
+{
+  "name": "Advanced Shortbow",
+  "type": "weapon",
+  "_id": "xjiJpCeCDNLMqNbp",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_shortbow.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+9",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "far",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747988105894,
+    "modifiedTime": 1747988124440,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!xjiJpCeCDNLMqNbp"
+}

--- a/src/packs/items/armors/tier3/weapon_Advanced_Shortstaff_KfPfygzU4zj7YUby.json
+++ b/src/packs/items/armors/tier3/weapon_Advanced_Shortstaff_KfPfygzU4zj7YUby.json
@@ -1,0 +1,40 @@
+{
+  "name": "Advanced Shortstaff",
+  "type": "weapon",
+  "_id": "KfPfygzU4zj7YUby",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/advanced_shortstaff.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+7",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "range": "close",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747989233909,
+    "modifiedTime": 1747989252391,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!KfPfygzU4zj7YUby"
+}

--- a/src/packs/items/armors/tier3/weapon_Advanced_Spear_6vBnRFRofNcR3ch6.json
+++ b/src/packs/items/armors/tier3/weapon_Advanced_Spear_6vBnRFRofNcR3ch6.json
@@ -1,0 +1,41 @@
+{
+  "name": "Advanced Spear",
+  "type": "weapon",
+  "_id": "6vBnRFRofNcR3ch6",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_spear.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+8",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "veryClose",
+    "burden": "twoHanded",
+    "feature": "cumbersome"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747988071381,
+    "modifiedTime": 1747988089008,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!6vBnRFRofNcR3ch6"
+}

--- a/src/packs/items/armors/tier3/weapon_Advanced_Wand_1nqyLMdvFE8WOMt6.json
+++ b/src/packs/items/armors/tier3/weapon_Advanced_Wand_1nqyLMdvFE8WOMt6.json
@@ -1,0 +1,40 @@
+{
+  "name": "Advanced Wand",
+  "type": "weapon",
+  "_id": "1nqyLMdvFE8WOMt6",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/advanced_wand.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+7",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "knowledge",
+    "range": "far",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747989327277,
+    "modifiedTime": 1747989342340,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!1nqyLMdvFE8WOMt6"
+}

--- a/src/packs/items/armors/tier3/weapon_Advanced_Warhammer_Q7hmQuxzlU0wTZo5.json
+++ b/src/packs/items/armors/tier3/weapon_Advanced_Warhammer_Q7hmQuxzlU0wTZo5.json
@@ -1,0 +1,41 @@
+{
+  "name": "Advanced Warhammer",
+  "type": "weapon",
+  "_id": "Q7hmQuxzlU0wTZo5",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_warhammer.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d12+9",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "twoHanded",
+    "feature": "heavy"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747987705689,
+    "modifiedTime": 1747987733833,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!Q7hmQuxzlU0wTZo5"
+}

--- a/src/packs/items/armors/tier3/weapon_Axe_of_Fortunis_rdtbKI6PpOlJv24z.json
+++ b/src/packs/items/armors/tier3/weapon_Axe_of_Fortunis_rdtbKI6PpOlJv24z.json
@@ -1,0 +1,41 @@
+{
+  "name": "Axe of Fortunis",
+  "type": "weapon",
+  "_id": "rdtbKI6PpOlJv24z",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/axe_of_fortunis.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+8",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "twoHanded",
+    "feature": "lucky"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747989384191,
+    "modifiedTime": 1747989403391,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!rdtbKI6PpOlJv24z"
+}

--- a/src/packs/items/armors/tier3/weapon_Black_Powder_Revolver_i77P3DNvdgrJmrgy.json
+++ b/src/packs/items/armors/tier3/weapon_Black_Powder_Revolver_i77P3DNvdgrJmrgy.json
@@ -1,0 +1,41 @@
+{
+  "name": "Black Powder Revolver",
+  "type": "weapon",
+  "_id": "i77P3DNvdgrJmrgy",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/black_powder_revolver.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+8",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "far",
+    "burden": "oneHanded",
+    "feature": "reloading"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747988751494,
+    "modifiedTime": 1747988767956,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!i77P3DNvdgrJmrgy"
+}

--- a/src/packs/items/armors/tier3/weapon_Blessed_Anlace_593VRjaHGyqLtxqu.json
+++ b/src/packs/items/armors/tier3/weapon_Blessed_Anlace_593VRjaHGyqLtxqu.json
@@ -1,0 +1,41 @@
+{
+  "name": "Blessed Anlace",
+  "type": "weapon",
+  "_id": "593VRjaHGyqLtxqu",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/blessed_anlace.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+6",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "range": "melee",
+    "burden": "oneHanded",
+    "feature": "healing"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747989418576,
+    "modifiedTime": 1747989444239,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!593VRjaHGyqLtxqu"
+}

--- a/src/packs/items/armors/tier3/weapon_Bravesword_L38wCuX6EXSyhrQ2.json
+++ b/src/packs/items/armors/tier3/weapon_Bravesword_L38wCuX6EXSyhrQ2.json
@@ -1,0 +1,41 @@
+{
+  "name": "Bravesword",
+  "type": "weapon",
+  "_id": "L38wCuX6EXSyhrQ2",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/bravesword.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d12+7",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "twoHanded",
+    "feature": "barrier"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747988294215,
+    "modifiedTime": 1747988377212,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!L38wCuX6EXSyhrQ2"
+}

--- a/src/packs/items/armors/tier3/weapon_Double_Flail_9Ov0VMRJ0NFfyuul.json
+++ b/src/packs/items/armors/tier3/weapon_Double_Flail_9Ov0VMRJ0NFfyuul.json
@@ -1,0 +1,41 @@
+{
+  "name": "Double Flail",
+  "type": "weapon",
+  "_id": "9Ov0VMRJ0NFfyuul",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/double_flail.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+8",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "veryClose",
+    "burden": "twoHanded",
+    "feature": "powerful"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747988655918,
+    "modifiedTime": 1747988705389,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!9Ov0VMRJ0NFfyuul"
+}

--- a/src/packs/items/armors/tier3/weapon_Firestaff_AlnfhwnIlFsETzMs.json
+++ b/src/packs/items/armors/tier3/weapon_Firestaff_AlnfhwnIlFsETzMs.json
@@ -1,0 +1,41 @@
+{
+  "name": "Firestaff",
+  "type": "weapon",
+  "_id": "AlnfhwnIlFsETzMs",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/firestaff.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+7",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "range": "far",
+    "burden": "twoHanded",
+    "feature": "burn"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747989647918,
+    "modifiedTime": 1747989673619,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!AlnfhwnIlFsETzMs"
+}

--- a/src/packs/items/armors/tier3/weapon_Flickerfly_Blade_tQBXeberaULAyDvH.json
+++ b/src/packs/items/armors/tier3/weapon_Flickerfly_Blade_tQBXeberaULAyDvH.json
@@ -1,0 +1,41 @@
+{
+  "name": "Flickerfly Blade",
+  "type": "weapon",
+  "_id": "tQBXeberaULAyDvH",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/flickerfly_blade.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+5",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "melee",
+    "burden": "oneHanded",
+    "feature": "sheltering"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747988227660,
+    "modifiedTime": 1747988260944,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!tQBXeberaULAyDvH"
+}

--- a/src/packs/items/armors/tier3/weapon_Ghostblade_x62U2X6CsgsXTCQm.json
+++ b/src/packs/items/armors/tier3/weapon_Ghostblade_x62U2X6CsgsXTCQm.json
@@ -1,0 +1,41 @@
+{
+  "name": "Ghostblade",
+  "type": "weapon",
+  "_id": "x62U2X6CsgsXTCQm",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/ghostblade.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+7",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "presence",
+    "range": "melee",
+    "burden": "oneHanded",
+    "feature": "otherwordly"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747989458690,
+    "modifiedTime": 1747989482860,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!x62U2X6CsgsXTCQm"
+}

--- a/src/packs/items/armors/tier3/weapon_Gilded_Bow_3AnkArj95kwR5xDm.json
+++ b/src/packs/items/armors/tier3/weapon_Gilded_Bow_3AnkArj95kwR5xDm.json
@@ -1,0 +1,41 @@
+{
+  "name": "Gilded Bow",
+  "type": "weapon",
+  "_id": "3AnkArj95kwR5xDm",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/guilded_bow.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+7",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "far",
+    "burden": "twoHanded",
+    "feature": "selfCorrecting"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747989619963,
+    "modifiedTime": 1747989637673,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!3AnkArj95kwR5xDm"
+}

--- a/src/packs/items/armors/tier3/weapon_Hammer_of_Wrath_MMYYguOmhoo4ytDI.json
+++ b/src/packs/items/armors/tier3/weapon_Hammer_of_Wrath_MMYYguOmhoo4ytDI.json
@@ -1,0 +1,41 @@
+{
+  "name": "Hammer of Wrath",
+  "type": "weapon",
+  "_id": "MMYYguOmhoo4ytDI",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/hammer_of_wrath.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+7",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "twoHanded",
+    "feature": "devastating"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747988406922,
+    "modifiedTime": 1747988429894,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!MMYYguOmhoo4ytDI"
+}

--- a/src/packs/items/armors/tier3/weapon_Ilmari_s_Rifle_P6MDr1tDHB2rzA39.json
+++ b/src/packs/items/armors/tier3/weapon_Ilmari_s_Rifle_P6MDr1tDHB2rzA39.json
@@ -1,0 +1,41 @@
+{
+  "name": "Ilmari's Rifle",
+  "type": "weapon",
+  "_id": "P6MDr1tDHB2rzA39",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/ilmaris_rifle.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+6",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "veryFar",
+    "burden": "oneHanded",
+    "feature": "reloading"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747989731386,
+    "modifiedTime": 1747989749201,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!P6MDr1tDHB2rzA39"
+}

--- a/src/packs/items/armors/tier3/weapon_Labrys_Axe_zReTMjOxmSwDbrn9.json
+++ b/src/packs/items/armors/tier3/weapon_Labrys_Axe_zReTMjOxmSwDbrn9.json
@@ -1,0 +1,41 @@
+{
+  "name": "Labrys Axe",
+  "type": "weapon",
+  "_id": "zReTMjOxmSwDbrn9",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/labrys_axe.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+7",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "twoHanded",
+    "feature": "protective"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747988447879,
+    "modifiedTime": 1747988481507,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!zReTMjOxmSwDbrn9"
+}

--- a/src/packs/items/armors/tier3/weapon_Mage_Orb_TUEydRo4XV3B7Lls.json
+++ b/src/packs/items/armors/tier3/weapon_Mage_Orb_TUEydRo4XV3B7Lls.json
@@ -1,0 +1,41 @@
+{
+  "name": "Mage Orb",
+  "type": "weapon",
+  "_id": "TUEydRo4XV3B7Lls",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/mage_orb.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+7",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "knowledge",
+    "range": "far",
+    "burden": "oneHanded",
+    "feature": "powerful"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747989683025,
+    "modifiedTime": 1747989719601,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!TUEydRo4XV3B7Lls"
+}

--- a/src/packs/items/armors/tier3/weapon_Meridian_Cutlass_jjjGt7Hf4IwMR2vc.json
+++ b/src/packs/items/armors/tier3/weapon_Meridian_Cutlass_jjjGt7Hf4IwMR2vc.json
@@ -1,0 +1,41 @@
+{
+  "name": "Meridian Cutlass",
+  "type": "weapon",
+  "_id": "jjjGt7Hf4IwMR2vc",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/meridian_cutlass.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+5",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "presence",
+    "range": "melee",
+    "burden": "oneHanded",
+    "feature": "doubleDuty"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747988541196,
+    "modifiedTime": 1747988582864,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!jjjGt7Hf4IwMR2vc"
+}

--- a/src/packs/items/armors/tier3/weapon_Retractable_Saber_ckxwHZX8Mq0qjPn5.json
+++ b/src/packs/items/armors/tier3/weapon_Retractable_Saber_ckxwHZX8Mq0qjPn5.json
@@ -1,0 +1,41 @@
+{
+  "name": "Retractable Saber",
+  "type": "weapon",
+  "_id": "ckxwHZX8Mq0qjPn5",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/retractable_saber.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+7",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "presence",
+    "range": "melee",
+    "burden": "oneHanded",
+    "feature": "retractable"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747988614020,
+    "modifiedTime": 1747988637545,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!ckxwHZX8Mq0qjPn5"
+}

--- a/src/packs/items/armors/tier3/weapon_Runes_of_Ruination_QyvqYtJtII34l00S.json
+++ b/src/packs/items/armors/tier3/weapon_Runes_of_Ruination_QyvqYtJtII34l00S.json
@@ -1,0 +1,41 @@
+{
+  "name": "Runes of Ruination",
+  "type": "weapon",
+  "_id": "QyvqYtJtII34l00S",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/runes_of_ruination.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d20+4",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "knowledge",
+    "range": "veryClose",
+    "burden": "oneHanded",
+    "feature": "painful"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747989498106,
+    "modifiedTime": 1747989524339,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!QyvqYtJtII34l00S"
+}

--- a/src/packs/items/armors/tier3/weapon_Spiked_Bow_0FYRW7WAYmfb0QHt.json
+++ b/src/packs/items/armors/tier3/weapon_Spiked_Bow_0FYRW7WAYmfb0QHt.json
@@ -1,0 +1,41 @@
+{
+  "name": "Spiked Bow",
+  "type": "weapon",
+  "_id": "0FYRW7WAYmfb0QHt",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/spiked_bow.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+7",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "veryFar",
+    "burden": "twoHanded",
+    "feature": "versatile"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747988774732,
+    "modifiedTime": 1747988791189,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!0FYRW7WAYmfb0QHt"
+}

--- a/src/packs/items/armors/tier3/weapon_Talon_Blades_rKROT91BD6p7QJTJ.json
+++ b/src/packs/items/armors/tier3/weapon_Talon_Blades_rKROT91BD6p7QJTJ.json
@@ -1,0 +1,41 @@
+{
+  "name": "Talon Blades",
+  "type": "weapon",
+  "_id": "rKROT91BD6p7QJTJ",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/talon_blades.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+7",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "close",
+    "burden": "twoHanded",
+    "feature": "brutal"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747988716459,
+    "modifiedTime": 1747988739839,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!rKROT91BD6p7QJTJ"
+}

--- a/src/packs/items/armors/tier3/weapon_Widogast_Pendant_l0LaIyqLbbNnIlbQ.json
+++ b/src/packs/items/armors/tier3/weapon_Widogast_Pendant_l0LaIyqLbbNnIlbQ.json
@@ -1,0 +1,41 @@
+{
+  "name": "Widogast Pendant",
+  "type": "weapon",
+  "_id": "l0LaIyqLbbNnIlbQ",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/widogast_pendant.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+5",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "knowledge",
+    "range": "close",
+    "burden": "oneHanded",
+    "feature": "timebender"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747989579323,
+    "modifiedTime": 1747989601802,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!l0LaIyqLbbNnIlbQ"
+}

--- a/src/packs/items/general/miscellaneous_Airblade_Charm_CyUH6pvP1rGhsMtQ.json
+++ b/src/packs/items/general/miscellaneous_Airblade_Charm_CyUH6pvP1rGhsMtQ.json
@@ -1,0 +1,31 @@
+{
+  "name": "Airblade Charm",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/airblade_charm.png",
+  "system": {
+    "description": "<p>You can attach this charm to a weapon with a Melee range. Three times per rest, you can activate the charm and attack a target within Close range.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009147603,
+    "modifiedTime": 1748009147603,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "CyUH6pvP1rGhsMtQ",
+  "sort": 0,
+  "_key": "!items!CyUH6pvP1rGhsMtQ"
+}

--- a/src/packs/items/general/miscellaneous_Alistair_s_Torch_8ah8OiuUZnlg64g5.json
+++ b/src/packs/items/general/miscellaneous_Alistair_s_Torch_8ah8OiuUZnlg64g5.json
@@ -1,0 +1,31 @@
+{
+  "name": "Alistair’s Torch",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/alistairs_torch.png",
+  "system": {
+    "description": "<p>You can light this magic torch at will. The flame’s light fills a much larger space than it should, enough to illuminate a cave bright as day.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009146702,
+    "modifiedTime": 1748009146702,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "8ah8OiuUZnlg64g5",
+  "sort": 0,
+  "_key": "!items!8ah8OiuUZnlg64g5"
+}

--- a/src/packs/items/general/miscellaneous_Arcane_Cloak_R8ArJcZrYQzc5Y98.json
+++ b/src/packs/items/general/miscellaneous_Arcane_Cloak_R8ArJcZrYQzc5Y98.json
@@ -1,0 +1,31 @@
+{
+  "name": "Arcane Cloak",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/arcane_cloak.png",
+  "system": {
+    "description": "<p>A creature with a Spellcast trait wearing this cloak can adjust its color, texture, and size at will.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009145941,
+    "modifiedTime": 1748009145941,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "R8ArJcZrYQzc5Y98",
+  "sort": 0,
+  "_key": "!items!R8ArJcZrYQzc5Y98"
+}

--- a/src/packs/items/general/miscellaneous_Arcane_Prism_vFLyAPu1v0dGf3G7.json
+++ b/src/packs/items/general/miscellaneous_Arcane_Prism_vFLyAPu1v0dGf3G7.json
@@ -1,0 +1,31 @@
+{
+  "name": "Arcane Prism",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/arcane_prism.png",
+  "system": {
+    "description": "<p>Position this prism in a location of your choosing and activate it. All allies within Close range of it gain a +1 bonus to their Spellcast Rolls. While activated, the prism can’t be moved. Once the prism is deactivated, it can’t be activated again until your next long rest.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009144434,
+    "modifiedTime": 1748009144434,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "vFLyAPu1v0dGf3G7",
+  "sort": 0,
+  "_key": "!items!vFLyAPu1v0dGf3G7"
+}

--- a/src/packs/items/general/miscellaneous_Attune_Relic_O2Z6tdqzYYy3Yjeq.json
+++ b/src/packs/items/general/miscellaneous_Attune_Relic_O2Z6tdqzYYy3Yjeq.json
@@ -1,0 +1,31 @@
+{
+  "name": "Attune Relic",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/attune_relic.png",
+  "system": {
+    "description": "<p>You gain a +1 bonus to your Instinct. You can only carry one relic.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009143587,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "O2Z6tdqzYYy3Yjeq",
+  "sort": 400000,
+  "_key": "!items!O2Z6tdqzYYy3Yjeq"
+}

--- a/src/packs/items/general/miscellaneous_Bag_of_Ficklesand_NTYzGMkMzkh1tCT8.json
+++ b/src/packs/items/general/miscellaneous_Bag_of_Ficklesand_NTYzGMkMzkh1tCT8.json
@@ -1,0 +1,31 @@
+{
+  "name": "Bag of Ficklesand",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/bag_of_ficklesand.png",
+  "system": {
+    "description": "<p>You can convince this small bag of sand to be much heavier or lighter with a successful Presence Roll (10). Additionally, on a successful Finesse Roll (10), you can blow a bit of sand into a target’s face to make them temporarily Vulnerable.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009142817,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "NTYzGMkMzkh1tCT8",
+  "sort": 700000,
+  "_key": "!items!NTYzGMkMzkh1tCT8"
+}

--- a/src/packs/items/general/miscellaneous_Belt_of_Unity_ZNltlkAdBfyStHfg.json
+++ b/src/packs/items/general/miscellaneous_Belt_of_Unity_ZNltlkAdBfyStHfg.json
@@ -1,0 +1,31 @@
+{
+  "name": "Belt of Unity",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/belt_of_unity.png",
+  "system": {
+    "description": "<p>Once per session, you can spend 5 Hope to lead a Tag Team Roll with three PCs instead of two.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009141974,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "ZNltlkAdBfyStHfg",
+  "sort": 600000,
+  "_key": "!items!ZNltlkAdBfyStHfg"
+}

--- a/src/packs/items/general/miscellaneous_Bloodstone_8k7Eoalz5bjjq5N8.json
+++ b/src/packs/items/general/miscellaneous_Bloodstone_8k7Eoalz5bjjq5N8.json
@@ -1,0 +1,31 @@
+{
+  "name": "Bloodstone",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/bloodstone.png",
+  "system": {
+    "description": "<p>You can attach this stone to a weapon that doesn’t already have a feature. The weapon gains the following feature.</p><p><strong>Brutal</strong>: When you roll the maximum value on a damage die, roll an additional damage die.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009141115,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "8k7Eoalz5bjjq5N8",
+  "sort": 500000,
+  "_key": "!items!8k7Eoalz5bjjq5N8"
+}

--- a/src/packs/items/general/miscellaneous_Bolster_Relic_tlrEsXwEJuq1mdnT.json
+++ b/src/packs/items/general/miscellaneous_Bolster_Relic_tlrEsXwEJuq1mdnT.json
@@ -1,0 +1,31 @@
+{
+  "name": "Bolster Relic",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/bolster_relic.png",
+  "system": {
+    "description": "<p>You gain a +1 bonus to your Strength. You can only carry one relic.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009140095,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "tlrEsXwEJuq1mdnT",
+  "sort": 300000,
+  "_key": "!items!tlrEsXwEJuq1mdnT"
+}

--- a/src/packs/items/general/miscellaneous_Box_of_Many_Goods_I5R0JkibkfDsz4ct.json
+++ b/src/packs/items/general/miscellaneous_Box_of_Many_Goods_I5R0JkibkfDsz4ct.json
@@ -1,0 +1,31 @@
+{
+  "name": "Box of Many Goods",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/box_of_many_goods.png",
+  "system": {
+    "description": "<p>Once per long rest, you can open this small box and roll a [[d12]]. On a result of 1–6, it’s empty. On a result of 7–10, it contains one random common consumable. On a result of 11–12, it contains two random common consumables.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009137689,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "I5R0JkibkfDsz4ct",
+  "sort": 200000,
+  "_key": "!items!I5R0JkibkfDsz4ct"
+}

--- a/src/packs/items/general/miscellaneous_Calming_Pendant_8apc52Pt4Zyq093R.json
+++ b/src/packs/items/general/miscellaneous_Calming_Pendant_8apc52Pt4Zyq093R.json
@@ -1,0 +1,31 @@
+{
+  "name": "Calming Pendant",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/calming_pendant.png",
+  "system": {
+    "description": "<p>When you would mark your last Stress, roll a [[d6]]. On a result of 5 or higher, don’t mark it.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009136803,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "8apc52Pt4Zyq093R",
+  "sort": 100000,
+  "_key": "!items!8apc52Pt4Zyq093R"
+}

--- a/src/packs/items/general/miscellaneous_Charging_Quiver_bOVsrjYXOWmup9uv.json
+++ b/src/packs/items/general/miscellaneous_Charging_Quiver_bOVsrjYXOWmup9uv.json
@@ -1,0 +1,31 @@
+{
+  "name": "Charging Quiver",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/charging_quiver.png",
+  "system": {
+    "description": "<p>When you succeed on an attack with an arrow stored in this quiver, gain a bonus to the damage roll equal to your current tier.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009135914,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "bOVsrjYXOWmup9uv",
+  "sort": 1100000,
+  "_key": "!items!bOVsrjYXOWmup9uv"
+}

--- a/src/packs/items/general/miscellaneous_Charm_Relic_u3mroLAMlfRmiTBI.json
+++ b/src/packs/items/general/miscellaneous_Charm_Relic_u3mroLAMlfRmiTBI.json
@@ -1,0 +1,31 @@
+{
+  "name": "Charm Relic",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/charm_relic.png",
+  "system": {
+    "description": "<p>You gain a +1 bonus to your Presence. You can only carry one relic.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009134768,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "u3mroLAMlfRmiTBI",
+  "sort": 1500000,
+  "_key": "!items!u3mroLAMlfRmiTBI"
+}

--- a/src/packs/items/general/miscellaneous_Clay_Companion_tCBka1QANgZyXXMT.json
+++ b/src/packs/items/general/miscellaneous_Clay_Companion_tCBka1QANgZyXXMT.json
@@ -1,0 +1,31 @@
+{
+  "name": "Clay Companion",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/clay_companion.png",
+  "system": {
+    "description": "<p>When you sculpt this ball of clay into a clay animal companion, it behaves as that animal. For example, a clay spider can spin clay webs, while a clay bird can fly. The clay companion retains memory and identity across different shapes, but they can adopt new mannerisms with each form.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009133288,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "tCBka1QANgZyXXMT",
+  "sort": 1400000,
+  "_key": "!items!tCBka1QANgZyXXMT"
+}

--- a/src/packs/items/general/miscellaneous_Companion_Case_fSYJAp9tFBUVSYcK.json
+++ b/src/packs/items/general/miscellaneous_Companion_Case_fSYJAp9tFBUVSYcK.json
@@ -1,0 +1,31 @@
+{
+  "name": "Companion Case",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/companion_case.png",
+  "system": {
+    "description": "<p>This case can fit a small animal companion. While the companion is inside, the animal and case are immune to all damage and harmful effects.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009132318,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "fSYJAp9tFBUVSYcK",
+  "sort": 1300000,
+  "_key": "!items!fSYJAp9tFBUVSYcK"
+}

--- a/src/packs/items/general/miscellaneous_Control_Relic_iZnHMmtt5k0F2uma.json
+++ b/src/packs/items/general/miscellaneous_Control_Relic_iZnHMmtt5k0F2uma.json
@@ -1,0 +1,31 @@
+{
+  "name": "Control Relic",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/control_relic.png",
+  "system": {
+    "description": "<p>You gain a +1 bonus to your Finesse. You can only carry one relic.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009131234,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "iZnHMmtt5k0F2uma",
+  "sort": 1200000,
+  "_key": "!items!iZnHMmtt5k0F2uma"
+}

--- a/src/packs/items/general/miscellaneous_Corrector_Sprite_rPNgedgA8HdzVPlH.json
+++ b/src/packs/items/general/miscellaneous_Corrector_Sprite_rPNgedgA8HdzVPlH.json
@@ -1,0 +1,31 @@
+{
+  "name": "Corrector Sprite",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/corrector_sprite.png",
+  "system": {
+    "description": "<p>This tiny sprite sits in the curve of your ear canal and whispers helpful advice during combat. Once per short rest, you can gain advantage on an attack roll.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009130261,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "rPNgedgA8HdzVPlH",
+  "sort": 1000000,
+  "_key": "!items!rPNgedgA8HdzVPlH"
+}

--- a/src/packs/items/general/miscellaneous_Dual_Flask_cUk6sSRdrpFPaiT7.json
+++ b/src/packs/items/general/miscellaneous_Dual_Flask_cUk6sSRdrpFPaiT7.json
@@ -1,0 +1,31 @@
+{
+  "name": "Dual Flask",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/dual_flask.png",
+  "system": {
+    "description": "<p>This flask can hold two different liquids. You can swap between them by flipping a small switch on the flask’s side.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009127730,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "cUk6sSRdrpFPaiT7",
+  "sort": 900000,
+  "_key": "!items!cUk6sSRdrpFPaiT7"
+}

--- a/src/packs/items/general/miscellaneous_Elusive_Amulet_qdBpDOgFI9iJX8bH.json
+++ b/src/packs/items/general/miscellaneous_Elusive_Amulet_qdBpDOgFI9iJX8bH.json
@@ -1,0 +1,31 @@
+{
+  "name": "Elusive Amulet",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/elusive_amulet.png",
+  "system": {
+    "description": "<p>Once per long rest, you can activate this amulet to become Hidden until you move. While Hidden in this way, you remain unseen even if an adversary moves to where they would normally see you.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009126524,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "qdBpDOgFI9iJX8bH",
+  "sort": 800000,
+  "_key": "!items!qdBpDOgFI9iJX8bH"
+}

--- a/src/packs/items/general/miscellaneous_Empty_Chest_bmPjeLeLb6Bq6vtf.json
+++ b/src/packs/items/general/miscellaneous_Empty_Chest_bmPjeLeLb6Bq6vtf.json
@@ -1,0 +1,31 @@
+{
+  "name": "Empty Chest",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/empty_chest.png",
+  "system": {
+    "description": "<p>This magical chest appears empty. When you speak a specific trigger word or action and open the chest, you can see the items stored within it.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009125466,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "bmPjeLeLb6Bq6vtf",
+  "sort": 1900000,
+  "_key": "!items!bmPjeLeLb6Bq6vtf"
+}

--- a/src/packs/items/general/miscellaneous_Enlighten_Relic_v7tdq3aM5UsHD8tx.json
+++ b/src/packs/items/general/miscellaneous_Enlighten_Relic_v7tdq3aM5UsHD8tx.json
@@ -1,0 +1,31 @@
+{
+  "name": "Enlighten Relic",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/enlighten_relic.png",
+  "system": {
+    "description": "<p>You gain a +1 bonus to your Knowledge. You can only carry one relic.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009124593,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "v7tdq3aM5UsHD8tx",
+  "sort": 2300000,
+  "_key": "!items!v7tdq3aM5UsHD8tx"
+}

--- a/src/packs/items/general/miscellaneous_Fire_Jar_aXYUZQ7hoOKBct12.json
+++ b/src/packs/items/general/miscellaneous_Fire_Jar_aXYUZQ7hoOKBct12.json
@@ -1,0 +1,31 @@
+{
+  "name": "Fire Jar",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/fire_jar.png",
+  "system": {
+    "description": "<p>You can pour out the strange liquid contents of this jar to instantly produce fire. The contents regenerate when you take a long rest.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009123524,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "aXYUZQ7hoOKBct12",
+  "sort": 2200000,
+  "_key": "!items!aXYUZQ7hoOKBct12"
+}

--- a/src/packs/items/general/miscellaneous_Flickerfly_Pendant_QVDGEg42teRurSXp.json
+++ b/src/packs/items/general/miscellaneous_Flickerfly_Pendant_QVDGEg42teRurSXp.json
@@ -1,0 +1,31 @@
+{
+  "name": "Flickerfly Pendant",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/flickerfly_pendant.png",
+  "system": {
+    "description": "<p>While you carry this pendant, your weapons with a Melee range that deal physical damage have a gossamer sheen and can attack targets within Very Close range.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009122655,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "QVDGEg42teRurSXp",
+  "sort": 2100000,
+  "_key": "!items!QVDGEg42teRurSXp"
+}

--- a/src/packs/items/general/miscellaneous_Gecko_Gloves_16z0fAO99LLOO1Px.json
+++ b/src/packs/items/general/miscellaneous_Gecko_Gloves_16z0fAO99LLOO1Px.json
@@ -1,0 +1,31 @@
+{
+  "name": "Gecko Gloves",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/gecko_gloves.png",
+  "system": {
+    "description": "<p>You can climb up vertical surfaces and across ceilings.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009121448,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "16z0fAO99LLOO1Px",
+  "sort": 2000000,
+  "_key": "!items!16z0fAO99LLOO1Px"
+}

--- a/src/packs/items/general/miscellaneous_Gem_of_Alacrity_WpIffLlgTd3v7lFR.json
+++ b/src/packs/items/general/miscellaneous_Gem_of_Alacrity_WpIffLlgTd3v7lFR.json
@@ -1,0 +1,31 @@
+{
+  "name": "Gem of Alacrity",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/gem_of_alacrity.png",
+  "system": {
+    "description": "<p>You can attach this gem to a weapon, allowing you to use your Agility when making an attack with that weapon.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009120525,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "WpIffLlgTd3v7lFR",
+  "sort": 1800000,
+  "_key": "!items!WpIffLlgTd3v7lFR"
+}

--- a/src/packs/items/general/miscellaneous_Gem_of_Audacity_tRodc01kCgW1I0C9.json
+++ b/src/packs/items/general/miscellaneous_Gem_of_Audacity_tRodc01kCgW1I0C9.json
@@ -1,0 +1,31 @@
+{
+  "name": "Gem of Audacity",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/gem_of_audacity.png",
+  "system": {
+    "description": "<p>You can attach this gem to a weapon, allowing you to use your Presence when making an attack with that weapon.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009118172,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "tRodc01kCgW1I0C9",
+  "sort": 1700000,
+  "_key": "!items!tRodc01kCgW1I0C9"
+}

--- a/src/packs/items/general/miscellaneous_Gem_of_Insight_SRS1y2KTaJiI3DRD.json
+++ b/src/packs/items/general/miscellaneous_Gem_of_Insight_SRS1y2KTaJiI3DRD.json
@@ -1,0 +1,31 @@
+{
+  "name": "Gem of Insight",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/gem_of_insight.png",
+  "system": {
+    "description": "<p>You can attach this gem to a weapon, allowing you to use your Instinct when making an attack with that weapon.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009117304,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "SRS1y2KTaJiI3DRD",
+  "sort": 1600000,
+  "_key": "!items!SRS1y2KTaJiI3DRD"
+}

--- a/src/packs/items/general/miscellaneous_Gem_of_Might_otQUU7REbc6XP3Em.json
+++ b/src/packs/items/general/miscellaneous_Gem_of_Might_otQUU7REbc6XP3Em.json
@@ -1,0 +1,31 @@
+{
+  "name": "Gem of Might",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/gem_of_might.png",
+  "system": {
+    "description": "<p>You can attach this gem to a weapon, allowing you to use your Strength when making an attack with that weapon.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009116508,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "otQUU7REbc6XP3Em",
+  "sort": 2700000,
+  "_key": "!items!otQUU7REbc6XP3Em"
+}

--- a/src/packs/items/general/miscellaneous_Gem_of_Precision_UhWgZtY7GchaWH9X.json
+++ b/src/packs/items/general/miscellaneous_Gem_of_Precision_UhWgZtY7GchaWH9X.json
@@ -1,0 +1,31 @@
+{
+  "name": "Gem of Precision",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/gem_of_precision.png",
+  "system": {
+    "description": "<p>You can attach this gem to a weapon, allowing you to use your Finesse when making an attack with that weapon.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009115526,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "UhWgZtY7GchaWH9X",
+  "sort": 3100000,
+  "_key": "!items!UhWgZtY7GchaWH9X"
+}

--- a/src/packs/items/general/miscellaneous_Gem_of_Sagacity_MIguWkeZvN4g5Wy2.json
+++ b/src/packs/items/general/miscellaneous_Gem_of_Sagacity_MIguWkeZvN4g5Wy2.json
@@ -1,0 +1,31 @@
+{
+  "name": "Gem of Sagacity",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/gem_of_sagacity.png",
+  "system": {
+    "description": "<p>You can attach this gem to a weapon, allowing you to use your Knowledge when making an attack with that weapon.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009114561,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "MIguWkeZvN4g5Wy2",
+  "sort": 3000000,
+  "_key": "!items!MIguWkeZvN4g5Wy2"
+}

--- a/src/packs/items/general/miscellaneous_Glamour_Stone_sqhQYeVDAwDtZMPm.json
+++ b/src/packs/items/general/miscellaneous_Glamour_Stone_sqhQYeVDAwDtZMPm.json
@@ -1,0 +1,31 @@
+{
+  "name": "Glamour Stone",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/glamour_stone.png",
+  "system": {
+    "description": "<p>Activate this pebble-sized stone to memorize the appearance of someone you can see. Spend a Hope to magically recreate this guise on yourself as an illusion.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009113828,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "sqhQYeVDAwDtZMPm",
+  "sort": 2900000,
+  "_key": "!items!sqhQYeVDAwDtZMPm"
+}

--- a/src/packs/items/general/miscellaneous_Glider_MPbJbRn2tgFuWx4Z.json
+++ b/src/packs/items/general/miscellaneous_Glider_MPbJbRn2tgFuWx4Z.json
@@ -1,0 +1,31 @@
+{
+  "name": "Glider",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/glider.png",
+  "system": {
+    "description": "<p>While falling, you can mark a Stress to deploy this small parachute and glide safely to the ground.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009112826,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "MPbJbRn2tgFuWx4Z",
+  "sort": 2800000,
+  "_key": "!items!MPbJbRn2tgFuWx4Z"
+}

--- a/src/packs/items/general/miscellaneous_Greatstone_UkOwMJtusXYODPxQ.json
+++ b/src/packs/items/general/miscellaneous_Greatstone_UkOwMJtusXYODPxQ.json
@@ -1,0 +1,31 @@
+{
+  "name": "Greatstone",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/greatstone.png",
+  "system": {
+    "description": "<p>You can attach this stone to a weapon that doesn’t already have a feature. The weapon gains the following feature.</p><p><strong>Powerful</strong>: On a successful attack, roll an additional damage die and discard the lowest result.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009111955,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "UkOwMJtusXYODPxQ",
+  "sort": 2600000,
+  "_key": "!items!UkOwMJtusXYODPxQ"
+}

--- a/src/packs/items/general/miscellaneous_Homing_Compasses_RhtsgQz7ZaU7lPnH.json
+++ b/src/packs/items/general/miscellaneous_Homing_Compasses_RhtsgQz7ZaU7lPnH.json
@@ -1,0 +1,31 @@
+{
+  "name": "Homing Compasses",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/homing_compass.png",
+  "system": {
+    "description": "<p>These two compasses point toward each other no matter how far apart they are.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009110886,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "RhtsgQz7ZaU7lPnH",
+  "sort": 2500000,
+  "_key": "!items!RhtsgQz7ZaU7lPnH"
+}

--- a/src/packs/items/general/miscellaneous_Honing_Relic_iIO2TKSHpdwksAMF.json
+++ b/src/packs/items/general/miscellaneous_Honing_Relic_iIO2TKSHpdwksAMF.json
@@ -1,0 +1,31 @@
+{
+  "name": "Honing Relic",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/honing_relic.png",
+  "system": {
+    "description": "<p>You gain a +1 bonus to an Experience of your choice. You can only carry one relic.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009107465,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "iIO2TKSHpdwksAMF",
+  "sort": 2400000,
+  "_key": "!items!iIO2TKSHpdwksAMF"
+}

--- a/src/packs/items/general/miscellaneous_Hopekeeper_Locket_kn6AIJk6UZsiKOjn.json
+++ b/src/packs/items/general/miscellaneous_Hopekeeper_Locket_kn6AIJk6UZsiKOjn.json
@@ -1,0 +1,31 @@
+{
+  "name": "Hopekeeper Locket",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/hopekeeper_locket.png",
+  "system": {
+    "description": "<p>During a long rest, if you have 6 Hope, you can spend a Hope to imbue this locket with your bountiful resolve. When you have 0 Hope, you can use the locket to immediately gain a Hope. The locket must be re-imbued before it can be used this way again.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009106535,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "kn6AIJk6UZsiKOjn",
+  "sort": 3400000,
+  "_key": "!items!kn6AIJk6UZsiKOjn"
+}

--- a/src/packs/items/general/miscellaneous_Infinite_Bag_iw9qd8SHpTMo6cOW.json
+++ b/src/packs/items/general/miscellaneous_Infinite_Bag_iw9qd8SHpTMo6cOW.json
@@ -1,0 +1,31 @@
+{
+  "name": "Infinite Bag",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/infinite_bag.png",
+  "system": {
+    "description": "<p>When you store items in this bag, they are kept in a pocket dimension that never runs out of space. You can retrieve an item at any time.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009105653,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "iw9qd8SHpTMo6cOW",
+  "sort": 3800000,
+  "_key": "!items!iw9qd8SHpTMo6cOW"
+}

--- a/src/packs/items/general/miscellaneous_Lakestrider_Boots_jEZrG7E8krKYee7j.json
+++ b/src/packs/items/general/miscellaneous_Lakestrider_Boots_jEZrG7E8krKYee7j.json
@@ -1,0 +1,31 @@
+{
+  "name": "Lakestrider Boots",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/lakestrider_boots.png",
+  "system": {
+    "description": "<p>You can walk on the surface of water as if it were soft ground.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009104985,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "jEZrG7E8krKYee7j",
+  "sort": 3700000,
+  "_key": "!items!jEZrG7E8krKYee7j"
+}

--- a/src/packs/items/general/miscellaneous_Lorekeeper_U1IdgxKT6CNa9SUh.json
+++ b/src/packs/items/general/miscellaneous_Lorekeeper_U1IdgxKT6CNa9SUh.json
@@ -1,0 +1,31 @@
+{
+  "name": "Lorekeeper",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/lorekeeper.png",
+  "system": {
+    "description": "<p>You can store the name and details of up to three hostile creatures inside this book. You gain a +1 bonus to action rolls against those creatures.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009104255,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "U1IdgxKT6CNa9SUh",
+  "sort": 3600000,
+  "_key": "!items!U1IdgxKT6CNa9SUh"
+}

--- a/src/packs/items/general/miscellaneous_Manacles_ItHEkRuzBMRF1jvm.json
+++ b/src/packs/items/general/miscellaneous_Manacles_ItHEkRuzBMRF1jvm.json
@@ -1,0 +1,31 @@
+{
+  "name": "Manacles",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/manacles.png",
+  "system": {
+    "description": "<p>This pair of locking cuffs comes with a key.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009103489,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "ItHEkRuzBMRF1jvm",
+  "sort": 3500000,
+  "_key": "!items!ItHEkRuzBMRF1jvm"
+}

--- a/src/packs/items/general/miscellaneous_Minor_Health_Potion_Recipe_XkvYkna8SF1x0sep.json
+++ b/src/packs/items/general/miscellaneous_Minor_Health_Potion_Recipe_XkvYkna8SF1x0sep.json
@@ -1,0 +1,31 @@
+{
+  "name": "Minor Health Potion Recipe",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/minor_health_potion_recipe.png",
+  "system": {
+    "description": "<p>As a downtime move, you can use a vial of blood to craft a Minor Health Potion.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009102731,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "XkvYkna8SF1x0sep",
+  "sort": 3300000,
+  "_key": "!items!XkvYkna8SF1x0sep"
+}

--- a/src/packs/items/general/miscellaneous_Minor_Stamina_Potion_Recipe_YO4E2pVHAmrODPtF.json
+++ b/src/packs/items/general/miscellaneous_Minor_Stamina_Potion_Recipe_YO4E2pVHAmrODPtF.json
@@ -1,0 +1,31 @@
+{
+  "name": "Minor Stamina Potion Recipe",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/minor_stamina_potion_recipe.png",
+  "system": {
+    "description": "<p>As a downtime move, you can use the bone of a creature to craft a Minor Stamina Potion.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009101832,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "YO4E2pVHAmrODPtF",
+  "sort": 3200000,
+  "_key": "!items!YO4E2pVHAmrODPtF"
+}

--- a/src/packs/items/general/miscellaneous_Mythic_Dust_Recipe_mVX1FUiEe3jRiuGQ.json
+++ b/src/packs/items/general/miscellaneous_Mythic_Dust_Recipe_mVX1FUiEe3jRiuGQ.json
@@ -1,0 +1,31 @@
+{
+  "name": "Mythic Dust Recipe",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/mythic_dust_recipe.png",
+  "system": {
+    "description": "<p>As a downtime move, you can use a handful of fine gold dust to craft Mythic Dust.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009099533,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "mVX1FUiEe3jRiuGQ",
+  "sort": 4100000,
+  "_key": "!items!mVX1FUiEe3jRiuGQ"
+}

--- a/src/packs/items/general/miscellaneous_Paragon_s_Chain_uZnJM4VHUg1JHQ6z.json
+++ b/src/packs/items/general/miscellaneous_Paragon_s_Chain_uZnJM4VHUg1JHQ6z.json
@@ -1,0 +1,31 @@
+{
+  "name": "Paragon's Chain",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/paragons_chain.png",
+  "system": {
+    "description": "<p>As a downtime move, you can meditate on an ideal or principle you hold dear and focus your will into this chain. Once per long rest, you can spend a Hope to roll a [[d20]] as your Hope Die for rolls that directly align with that principle.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009098183,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "uZnJM4VHUg1JHQ6z",
+  "sort": 4500000,
+  "_key": "!items!uZnJM4VHUg1JHQ6z"
+}

--- a/src/packs/items/general/miscellaneous_Phoenix_Feather_RkOa2edxkqEQwL37.json
+++ b/src/packs/items/general/miscellaneous_Phoenix_Feather_RkOa2edxkqEQwL37.json
@@ -1,0 +1,31 @@
+{
+  "name": "Phoenix Feather",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/phoenix_feather.png",
+  "system": {
+    "description": "<p>If you have at least one Phoenix Feather on you when you fall unconscious, you gain a +1 bonus to the roll you make to determine whether you gain a scar.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009095994,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "RkOa2edxkqEQwL37",
+  "sort": 4400000,
+  "_key": "!items!RkOa2edxkqEQwL37"
+}

--- a/src/packs/items/general/miscellaneous_Piercing_Arrows_C5KmTPU1tQQyg7Id.json
+++ b/src/packs/items/general/miscellaneous_Piercing_Arrows_C5KmTPU1tQQyg7Id.json
@@ -1,0 +1,31 @@
+{
+  "name": "Piercing Arrows",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/piercing_arrows.png",
+  "system": {
+    "description": "<p>Three times per rest when you succeed on an attack with one of these arrows, you can add your Proficiency to the damage roll.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009095162,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "C5KmTPU1tQQyg7Id",
+  "sort": 4300000,
+  "_key": "!items!C5KmTPU1tQQyg7Id"
+}

--- a/src/packs/items/general/miscellaneous_Piper_Whistle_I3YOGFP6jmF6wYcZ.json
+++ b/src/packs/items/general/miscellaneous_Piper_Whistle_I3YOGFP6jmF6wYcZ.json
@@ -1,0 +1,31 @@
+{
+  "name": "Piper Whistle",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/piper_whistle.png",
+  "system": {
+    "description": "<p>This handcrafted whistle has a distinctive sound. When you blow this whistle, its piercing tone can be heard within a 1-mile radius.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009094394,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "I3YOGFP6jmF6wYcZ",
+  "sort": 4200000,
+  "_key": "!items!I3YOGFP6jmF6wYcZ"
+}

--- a/src/packs/items/general/miscellaneous_Portal_Seed_1FpooC9ILQKobVS3.json
+++ b/src/packs/items/general/miscellaneous_Portal_Seed_1FpooC9ILQKobVS3.json
@@ -1,0 +1,31 @@
+{
+  "name": "Portal Seed",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/portal_seed.png",
+  "system": {
+    "description": "<p>You can plant this seed in the ground to grow a portal in that spot. The portal is ready to use in 24 hours. You can use this portal to travel to any other location where you planted a portal seed. A portal can be destroyed by dealing any amount of magic damage to it.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009093573,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "1FpooC9ILQKobVS3",
+  "sort": 4000000,
+  "_key": "!items!1FpooC9ILQKobVS3"
+}

--- a/src/packs/items/general/miscellaneous_Premium_Bedroll_O4oywDenBWAi2h8t.json
+++ b/src/packs/items/general/miscellaneous_Premium_Bedroll_O4oywDenBWAi2h8t.json
@@ -1,0 +1,31 @@
+{
+  "name": "Premium Bedroll",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/premium_bedroll.png",
+  "system": {
+    "description": "<p>During downtime, you automatically clear a Stress.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009092730,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "O4oywDenBWAi2h8t",
+  "sort": 3900000,
+  "_key": "!items!O4oywDenBWAi2h8t"
+}

--- a/src/packs/items/general/miscellaneous_Ring_of_Resistance_4nqRRPYVLB9Oqb6Q.json
+++ b/src/packs/items/general/miscellaneous_Ring_of_Resistance_4nqRRPYVLB9Oqb6Q.json
@@ -1,0 +1,31 @@
+{
+  "name": "Ring of Resistance",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/ring_of_resistance.png",
+  "system": {
+    "description": "<p>Once per long rest, you can activate this ring after a successful attack against you to halve the damage.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009091733,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "4nqRRPYVLB9Oqb6Q",
+  "sort": 5000000,
+  "_key": "!items!4nqRRPYVLB9Oqb6Q"
+}

--- a/src/packs/items/general/miscellaneous_Ring_of_Silence_zw8UhND7qIdFYiRg.json
+++ b/src/packs/items/general/miscellaneous_Ring_of_Silence_zw8UhND7qIdFYiRg.json
@@ -1,0 +1,31 @@
+{
+  "name": "Ring of Silence",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/ring_of_silence.png",
+  "system": {
+    "description": "<p>Spend a Hope to activate this ring. Your footsteps are silent until your next rest.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009090530,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "zw8UhND7qIdFYiRg",
+  "sort": 5600000,
+  "_key": "!items!zw8UhND7qIdFYiRg"
+}

--- a/src/packs/items/general/miscellaneous_Ring_of_Unbreakable_Resolve_dJzMhS1SKz8gJzKY.json
+++ b/src/packs/items/general/miscellaneous_Ring_of_Unbreakable_Resolve_dJzMhS1SKz8gJzKY.json
@@ -1,0 +1,31 @@
+{
+  "name": "Ring of Unbreakable Resolve",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/ring_of_unbreakable_resolve.png",
+  "system": {
+    "description": "<p>Once per session, when the GM spends a Fear, you can spend 4 Hope to cancel the effects of that spent Fear.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009083656,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "dJzMhS1SKz8gJzKY",
+  "sort": 5500000,
+  "_key": "!items!dJzMhS1SKz8gJzKY"
+}

--- a/src/packs/items/general/miscellaneous_Shard_of_Memory_2nv0fA4wLhuI5CuX.json
+++ b/src/packs/items/general/miscellaneous_Shard_of_Memory_2nv0fA4wLhuI5CuX.json
@@ -1,0 +1,31 @@
+{
+  "name": "Shard of Memory",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/shard_of_memory.png",
+  "system": {
+    "description": "<p>Once per long rest, you can spend 2 Hope to recall a domain card from your vault instead of paying its Recall Cost.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009082575,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "2nv0fA4wLhuI5CuX",
+  "sort": 5400000,
+  "_key": "!items!2nv0fA4wLhuI5CuX"
+}

--- a/src/packs/items/general/miscellaneous_Skeleton_Key_s91E77MCWpD0j6po.json
+++ b/src/packs/items/general/miscellaneous_Skeleton_Key_s91E77MCWpD0j6po.json
@@ -1,0 +1,31 @@
+{
+  "name": "Skeleton Key",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/skeleton_key.png",
+  "system": {
+    "description": "<p>When you use this key to open a locked door, you gain advantage on the Finesse Roll.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009081592,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "s91E77MCWpD0j6po",
+  "sort": 5300000,
+  "_key": "!items!s91E77MCWpD0j6po"
+}

--- a/src/packs/items/general/miscellaneous_Speaking_Orbs_aMujq8kf36Qtw5Bh.json
+++ b/src/packs/items/general/miscellaneous_Speaking_Orbs_aMujq8kf36Qtw5Bh.json
@@ -1,0 +1,31 @@
+{
+  "name": "Speaking Orbs",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/speaking_orbs.png",
+  "system": {
+    "description": "<p>This pair of orbs allows any creatures holding them to communicate with each other across any distance.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009080619,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "aMujq8kf36Qtw5Bh",
+  "sort": 5200000,
+  "_key": "!items!aMujq8kf36Qtw5Bh"
+}

--- a/src/packs/items/general/miscellaneous_Stride_Relic_MA1hzd2g9ffXq3cU.json
+++ b/src/packs/items/general/miscellaneous_Stride_Relic_MA1hzd2g9ffXq3cU.json
@@ -1,0 +1,31 @@
+{
+  "name": "Stride Relic",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/stride_relic.png",
+  "system": {
+    "description": "<p>You gain a +1 bonus to your Agility. You can only carry one relic.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009079450,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "MA1hzd2g9ffXq3cU",
+  "sort": 5100000,
+  "_key": "!items!MA1hzd2g9ffXq3cU"
+}

--- a/src/packs/items/general/miscellaneous_Suspended_Rod_zmWjD1F8u5kxfIzX.json
+++ b/src/packs/items/general/miscellaneous_Suspended_Rod_zmWjD1F8u5kxfIzX.json
@@ -1,0 +1,31 @@
+{
+  "name": "Suspended Rod",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/suspended_rod.png",
+  "system": {
+    "description": "<p>This flat rod is inscribed with runes. When you activate the rod, it is immediately suspended in place. Until the rod is deactivated, it can’t move, doesn’t abide by the rules of gravity, and remains in place.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009078369,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "zmWjD1F8u5kxfIzX",
+  "sort": 4900000,
+  "_key": "!items!zmWjD1F8u5kxfIzX"
+}

--- a/src/packs/items/general/miscellaneous_Valorstone_jVeqaaFSpxbdZ7ZT.json
+++ b/src/packs/items/general/miscellaneous_Valorstone_jVeqaaFSpxbdZ7ZT.json
@@ -1,0 +1,31 @@
+{
+  "name": "Valorstone",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/valorstone.png",
+  "system": {
+    "description": "<p>You can attach this stone to armor that doesn’t already have a feature. The armor gains the following feature.</p><p><strong>Resilient</strong>: Before you mark your last Armor Slot, roll a [[d6]]. On a result of 6, reduce the severity by one threshold without marking an Armor Slot.</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009077415,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "jVeqaaFSpxbdZ7ZT",
+  "sort": 4800000,
+  "_key": "!items!jVeqaaFSpxbdZ7ZT"
+}

--- a/src/packs/items/general/miscellaneous_Vial_of_Darksmoke_Recipe_ZJ8sWwXyNdEeEIV9.json
+++ b/src/packs/items/general/miscellaneous_Vial_of_Darksmoke_Recipe_ZJ8sWwXyNdEeEIV9.json
@@ -1,0 +1,31 @@
+{
+  "name": "Vial of Darksmoke Recipe",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/vial_of_darksmoke_recipe.png",
+  "system": {
+    "description": "<p>As a downtime move, you can mark a Stress to craft a @Consumables(Vial of Darksmoke).</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009076500,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "ZJ8sWwXyNdEeEIV9",
+  "sort": 4700000,
+  "_key": "!items!ZJ8sWwXyNdEeEIV9"
+}

--- a/src/packs/items/general/miscellaneous_Woven_Net_nQAlliOvdz1cgira.json
+++ b/src/packs/items/general/miscellaneous_Woven_Net_nQAlliOvdz1cgira.json
@@ -1,0 +1,31 @@
+{
+  "name": "Woven Net",
+  "type": "miscellaneous",
+  "img": "systems/daggerheart/assets/icons/loot/woven_net.png",
+  "system": {
+    "description": "<p>You can make a Finesse Roll using this net to trap a small creature. A trapped target can break free with a successful Attack Roll (16).</p>",
+    "quantity": 1
+  },
+  "effects": [],
+  "folder": null,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009075110,
+    "modifiedTime": 1748009143602,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "_id": "nQAlliOvdz1cgira",
+  "sort": 4600000,
+  "_key": "!items!nQAlliOvdz1cgira"
+}

--- a/src/packs/items/weapons/tier1/weapon_Arcane_Gauntlets_sZXALjdKu3HQ8hQE.json
+++ b/src/packs/items/weapons/tier1/weapon_Arcane_Gauntlets_sZXALjdKu3HQ8hQE.json
@@ -1,0 +1,41 @@
+{
+  "name": "Arcane Gauntlets",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_1/magical/arcane_gauntlets.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+3",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009471341,
+    "modifiedTime": 1748009471341,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "sZXALjdKu3HQ8hQE",
+  "sort": 0,
+  "_key": "!items!sZXALjdKu3HQ8hQE"
+}

--- a/src/packs/items/weapons/tier1/weapon_Battleaxe_27Kmwjycfn1De9ig.json
+++ b/src/packs/items/weapons/tier1/weapon_Battleaxe_27Kmwjycfn1De9ig.json
@@ -1,0 +1,41 @@
+{
+  "name": "Battleaxe",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_1/physical/battleaxe.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+3",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009469760,
+    "modifiedTime": 1748009469760,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "27Kmwjycfn1De9ig",
+  "sort": 0,
+  "_key": "!items!27Kmwjycfn1De9ig"
+}

--- a/src/packs/items/weapons/tier1/weapon_Broadsword_k4cXJtgvlPzOKJ4s.json
+++ b/src/packs/items/weapons/tier1/weapon_Broadsword_k4cXJtgvlPzOKJ4s.json
@@ -1,0 +1,42 @@
+{
+  "name": "Broadsword",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_1/physical/broadsword.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "melee",
+    "burden": "oneHanded",
+    "feature": "reliable"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009468771,
+    "modifiedTime": 1748009468771,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "k4cXJtgvlPzOKJ4s",
+  "sort": 0,
+  "_key": "!items!k4cXJtgvlPzOKJ4s"
+}

--- a/src/packs/items/weapons/tier1/weapon_Crossbow_GXdE6NaEGgiwUNEs.json
+++ b/src/packs/items/weapons/tier1/weapon_Crossbow_GXdE6NaEGgiwUNEs.json
@@ -1,0 +1,41 @@
+{
+  "name": "Crossbow",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_1/physical/crossbow.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+1",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "far",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009467966,
+    "modifiedTime": 1748009467975,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "GXdE6NaEGgiwUNEs",
+  "sort": 300000,
+  "_key": "!items!GXdE6NaEGgiwUNEs"
+}

--- a/src/packs/items/weapons/tier1/weapon_Cutlass_2qe0ilpRfBuVYbDo.json
+++ b/src/packs/items/weapons/tier1/weapon_Cutlass_2qe0ilpRfBuVYbDo.json
@@ -1,0 +1,41 @@
+{
+  "name": "Cutlass",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_1/physical/cutlass.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+1",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "presence",
+    "range": "melee",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009467172,
+    "modifiedTime": 1748009467975,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "2qe0ilpRfBuVYbDo",
+  "sort": 800000,
+  "_key": "!items!2qe0ilpRfBuVYbDo"
+}

--- a/src/packs/items/weapons/tier1/weapon_Dagger_Rz8lyl0B2rS3gBTP.json
+++ b/src/packs/items/weapons/tier1/weapon_Dagger_Rz8lyl0B2rS3gBTP.json
@@ -1,0 +1,41 @@
+{
+  "name": "Dagger",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_1/physical/dagger.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+1",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "melee",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009466224,
+    "modifiedTime": 1748009467975,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "Rz8lyl0B2rS3gBTP",
+  "sort": 700000,
+  "_key": "!items!Rz8lyl0B2rS3gBTP"
+}

--- a/src/packs/items/weapons/tier1/weapon_Dualstaff_GTEiHJ5Qvn99m4Os.json
+++ b/src/packs/items/weapons/tier1/weapon_Dualstaff_GTEiHJ5Qvn99m4Os.json
@@ -1,0 +1,41 @@
+{
+  "name": "Dualstaff",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_1/magical/dualstaff.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+3",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "range": "far",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009462631,
+    "modifiedTime": 1748009467975,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "GTEiHJ5Qvn99m4Os",
+  "sort": 600000,
+  "_key": "!items!GTEiHJ5Qvn99m4Os"
+}

--- a/src/packs/items/weapons/tier1/weapon_Glowing_Rings_vRQGEHauOXXVhsjX.json
+++ b/src/packs/items/weapons/tier1/weapon_Glowing_Rings_vRQGEHauOXXVhsjX.json
@@ -1,0 +1,41 @@
+{
+  "name": "Glowing Rings",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_1/magical/glowing_rings.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+1",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "veryClose",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009461747,
+    "modifiedTime": 1748009467975,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "vRQGEHauOXXVhsjX",
+  "sort": 500000,
+  "_key": "!items!vRQGEHauOXXVhsjX"
+}

--- a/src/packs/items/weapons/tier1/weapon_Greatstaff_GRZIvEb2ZFmYw50B.json
+++ b/src/packs/items/weapons/tier1/weapon_Greatstaff_GRZIvEb2ZFmYw50B.json
@@ -1,0 +1,42 @@
+{
+  "name": "Greatstaff",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_1/magical/greatstaff.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "knowledge",
+    "range": "veryFar",
+    "burden": "twoHanded",
+    "feature": "powerful"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009460779,
+    "modifiedTime": 1748009467975,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "GRZIvEb2ZFmYw50B",
+  "sort": 400000,
+  "_key": "!items!GRZIvEb2ZFmYw50B"
+}

--- a/src/packs/items/weapons/tier1/weapon_Greatsword_9Vy0YJHNVee1tYvN.json
+++ b/src/packs/items/weapons/tier1/weapon_Greatsword_9Vy0YJHNVee1tYvN.json
@@ -1,0 +1,42 @@
+{
+  "name": "Greatsword",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_1/physical/greatsword.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+3",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "twoHanded",
+    "feature": "massive"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009459689,
+    "modifiedTime": 1748009467975,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "9Vy0YJHNVee1tYvN",
+  "sort": 200000,
+  "_key": "!items!9Vy0YJHNVee1tYvN"
+}

--- a/src/packs/items/weapons/tier1/weapon_Halberd_SCi1BGjkp85nrCah.json
+++ b/src/packs/items/weapons/tier1/weapon_Halberd_SCi1BGjkp85nrCah.json
@@ -1,0 +1,42 @@
+{
+  "name": "Halberd",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_1/physical/halberd.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+2",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "veryClose",
+    "burden": "twoHanded",
+    "feature": "cumbersome"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009457587,
+    "modifiedTime": 1748009467975,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "SCi1BGjkp85nrCah",
+  "sort": 100000,
+  "_key": "!items!SCi1BGjkp85nrCah"
+}

--- a/src/packs/items/weapons/tier1/weapon_Hallowed_Axe_s6dHJKCQdS6QPKsf.json
+++ b/src/packs/items/weapons/tier1/weapon_Hallowed_Axe_s6dHJKCQdS6QPKsf.json
@@ -1,0 +1,41 @@
+{
+  "name": "Hallowed Axe",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_1/magical/hallowed_axe.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+1",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009456582,
+    "modifiedTime": 1748009467975,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "s6dHJKCQdS6QPKsf",
+  "sort": 1200000,
+  "_key": "!items!s6dHJKCQdS6QPKsf"
+}

--- a/src/packs/items/weapons/tier1/weapon_Hand_Runes_JUCgEbB0PRyViFMc.json
+++ b/src/packs/items/weapons/tier1/weapon_Hand_Runes_JUCgEbB0PRyViFMc.json
@@ -1,0 +1,41 @@
+{
+  "name": "Hand Runes",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_1/magical/hand_runes.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "range": "veryClose",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009455636,
+    "modifiedTime": 1748009467975,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "JUCgEbB0PRyViFMc",
+  "sort": 1600000,
+  "_key": "!items!JUCgEbB0PRyViFMc"
+}

--- a/src/packs/items/weapons/tier1/weapon_Longbow_z6TTwLScjmMOn7yX.json
+++ b/src/packs/items/weapons/tier1/weapon_Longbow_z6TTwLScjmMOn7yX.json
@@ -1,0 +1,42 @@
+{
+  "name": "Longbow",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_1/physical/longbow.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+3",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "veryFar",
+    "burden": "twoHanded",
+    "feature": "cumbersome"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009454814,
+    "modifiedTime": 1748009467975,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "z6TTwLScjmMOn7yX",
+  "sort": 1500000,
+  "_key": "!items!z6TTwLScjmMOn7yX"
+}

--- a/src/packs/items/weapons/tier1/weapon_Longsword_MzM4Xp8WoYmJImp7.json
+++ b/src/packs/items/weapons/tier1/weapon_Longsword_MzM4Xp8WoYmJImp7.json
@@ -1,0 +1,41 @@
+{
+  "name": "Longsword",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_1/physical/longsword.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+3",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "melee",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009453846,
+    "modifiedTime": 1748009467975,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "MzM4Xp8WoYmJImp7",
+  "sort": 1400000,
+  "_key": "!items!MzM4Xp8WoYmJImp7"
+}

--- a/src/packs/items/weapons/tier1/weapon_Mace_5PfnAoO12JXH8KSV.json
+++ b/src/packs/items/weapons/tier1/weapon_Mace_5PfnAoO12JXH8KSV.json
@@ -1,0 +1,41 @@
+{
+  "name": "Mace",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_1/physical/mace.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+1",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009452909,
+    "modifiedTime": 1748009467975,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "5PfnAoO12JXH8KSV",
+  "sort": 1300000,
+  "_key": "!items!5PfnAoO12JXH8KSV"
+}

--- a/src/packs/items/weapons/tier1/weapon_Quarterstaff_2jUxZEBhFX60Mbll.json
+++ b/src/packs/items/weapons/tier1/weapon_Quarterstaff_2jUxZEBhFX60Mbll.json
@@ -1,0 +1,41 @@
+{
+  "name": "Quarterstaff",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_1/physical/quarterstaff.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+3",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "range": "melee",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009452101,
+    "modifiedTime": 1748009467975,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "2jUxZEBhFX60Mbll",
+  "sort": 1100000,
+  "_key": "!items!2jUxZEBhFX60Mbll"
+}

--- a/src/packs/items/weapons/tier1/weapon_Rapier_79kmSUqnjHPmUrhQ.json
+++ b/src/packs/items/weapons/tier1/weapon_Rapier_79kmSUqnjHPmUrhQ.json
@@ -1,0 +1,42 @@
+{
+  "name": "Rapier",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_1/physical/rapier.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "presence",
+    "range": "melee",
+    "burden": "oneHanded",
+    "feature": "quick"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009451166,
+    "modifiedTime": 1748009467975,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "79kmSUqnjHPmUrhQ",
+  "sort": 1000000,
+  "_key": "!items!79kmSUqnjHPmUrhQ"
+}

--- a/src/packs/items/weapons/tier1/weapon_Returning_Blade_VZ1IzrGqoco0S1FH.json
+++ b/src/packs/items/weapons/tier1/weapon_Returning_Blade_VZ1IzrGqoco0S1FH.json
@@ -1,0 +1,42 @@
+{
+  "name": "Returning Blade",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_1/magical/returning_blade.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "<p><strong>Returning</strong>: When this weapon is thrown within its</p><p>range, it appears in your hand immediately after the</p><p>attack.</p>",
+    "trait": "finesse",
+    "range": "close",
+    "burden": "oneHanded",
+    "feature": "retrieve"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009450291,
+    "modifiedTime": 1748009467975,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "VZ1IzrGqoco0S1FH",
+  "sort": 900000,
+  "_key": "!items!VZ1IzrGqoco0S1FH"
+}

--- a/src/packs/items/weapons/tier1/weapon_Scepter_teDiNLXxtTYzFVaX.json
+++ b/src/packs/items/weapons/tier1/weapon_Scepter_teDiNLXxtTYzFVaX.json
@@ -1,0 +1,42 @@
+{
+  "name": "Scepter",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_1/magical/scepter.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "presence",
+    "range": "far",
+    "burden": "twoHanded",
+    "feature": "versatile"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009449461,
+    "modifiedTime": 1748009467975,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "teDiNLXxtTYzFVaX",
+  "sort": 1800000,
+  "_key": "!items!teDiNLXxtTYzFVaX"
+}

--- a/src/packs/items/weapons/tier1/weapon_Shortbow_7PMPT9r312jr5Vuu.json
+++ b/src/packs/items/weapons/tier1/weapon_Shortbow_7PMPT9r312jr5Vuu.json
@@ -1,0 +1,41 @@
+{
+  "name": "Shortbow",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_1/physical/shortbow.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+3",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "far",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009448691,
+    "modifiedTime": 1748009467975,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "7PMPT9r312jr5Vuu",
+  "sort": 1900000,
+  "_key": "!items!7PMPT9r312jr5Vuu"
+}

--- a/src/packs/items/weapons/tier1/weapon_Shortstaff_m6qCbG7WQ9fy3jhT.json
+++ b/src/packs/items/weapons/tier1/weapon_Shortstaff_m6qCbG7WQ9fy3jhT.json
@@ -1,0 +1,41 @@
+{
+  "name": "Shortstaff",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_1/magical/shortstaff.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+1",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "range": "close",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009447942,
+    "modifiedTime": 1748009467975,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "m6qCbG7WQ9fy3jhT",
+  "sort": 1700000,
+  "_key": "!items!m6qCbG7WQ9fy3jhT"
+}

--- a/src/packs/items/weapons/tier1/weapon_Spear_weKCJX4KfbaL26W4.json
+++ b/src/packs/items/weapons/tier1/weapon_Spear_weKCJX4KfbaL26W4.json
@@ -1,0 +1,42 @@
+{
+  "name": "Spear",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_1/physical/spear.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+2",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "veryClose",
+    "burden": "twoHanded",
+    "feature": "cumbersome"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009446966,
+    "modifiedTime": 1748009467975,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "weKCJX4KfbaL26W4",
+  "sort": 2100000,
+  "_key": "!items!weKCJX4KfbaL26W4"
+}

--- a/src/packs/items/weapons/tier1/weapon_Wand_95kiAjBsDA4aYgCJ.json
+++ b/src/packs/items/weapons/tier1/weapon_Wand_95kiAjBsDA4aYgCJ.json
@@ -1,0 +1,41 @@
+{
+  "name": "Wand",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_1/magical/wand.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+1",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "knowledge",
+    "range": "far",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009445897,
+    "modifiedTime": 1748009467975,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "95kiAjBsDA4aYgCJ",
+  "sort": 2200000,
+  "_key": "!items!95kiAjBsDA4aYgCJ"
+}

--- a/src/packs/items/weapons/tier1/weapon_Warhammer_EUUq7W9U7XOCvc0Z.json
+++ b/src/packs/items/weapons/tier1/weapon_Warhammer_EUUq7W9U7XOCvc0Z.json
@@ -1,0 +1,42 @@
+{
+  "name": "Warhammer",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_1/physical/warhammer.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d12+3",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "twoHanded",
+    "feature": "heavy"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009445078,
+    "modifiedTime": 1748009467975,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "EUUq7W9U7XOCvc0Z",
+  "sort": 2000000,
+  "_key": "!items!EUUq7W9U7XOCvc0Z"
+}

--- a/src/packs/items/weapons/tier2/weapon_Bladed_Whip_3YR4qTSUT5TAzSNs.json
+++ b/src/packs/items/weapons/tier2/weapon_Bladed_Whip_3YR4qTSUT5TAzSNs.json
@@ -1,0 +1,42 @@
+{
+  "name": "Bladed Whip",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/physical/bladed_whip.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+3",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "veryClose",
+    "burden": "oneHanded",
+    "feature": "quick"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009546888,
+    "modifiedTime": 1748009546888,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "3YR4qTSUT5TAzSNs",
+  "sort": 0,
+  "_key": "!items!3YR4qTSUT5TAzSNs"
+}

--- a/src/packs/items/weapons/tier2/weapon_Blunderbuss_OUH7FtPwrvhyRGfg.json
+++ b/src/packs/items/weapons/tier2/weapon_Blunderbuss_OUH7FtPwrvhyRGfg.json
@@ -1,0 +1,42 @@
+{
+  "name": "Blunderbuss",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/physical/blunderbuss.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+6",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "close",
+    "burden": "twoHanded",
+    "feature": "reloading"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009546083,
+    "modifiedTime": 1748009546083,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "OUH7FtPwrvhyRGfg",
+  "sort": 0,
+  "_key": "!items!OUH7FtPwrvhyRGfg"
+}

--- a/src/packs/items/weapons/tier2/weapon_Casting_Sword_MtJNIBRq4CaXEfQj.json
+++ b/src/packs/items/weapons/tier2/weapon_Casting_Sword_MtJNIBRq4CaXEfQj.json
@@ -1,0 +1,42 @@
+{
+  "name": "Casting Sword",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/magical/casting_sword.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+4",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "twoHanded",
+    "feature": "versatile"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009543885,
+    "modifiedTime": 1748009543885,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "MtJNIBRq4CaXEfQj",
+  "sort": 0,
+  "_key": "!items!MtJNIBRq4CaXEfQj"
+}

--- a/src/packs/items/weapons/tier2/weapon_Devouring_Dagger_CBXVCc2YKUhofHBg.json
+++ b/src/packs/items/weapons/tier2/weapon_Devouring_Dagger_CBXVCc2YKUhofHBg.json
@@ -1,0 +1,42 @@
+{
+  "name": "Devouring Dagger",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/magical/devouring_dagger.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+4",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "melee",
+    "burden": "oneHanded",
+    "feature": "scary"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009543021,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "CBXVCc2YKUhofHBg",
+  "sort": 300000,
+  "_key": "!items!CBXVCc2YKUhofHBg"
+}

--- a/src/packs/items/weapons/tier2/weapon_Ego_Blade_v2x2UxypzWdGpxeI.json
+++ b/src/packs/items/weapons/tier2/weapon_Ego_Blade_v2x2UxypzWdGpxeI.json
@@ -1,0 +1,42 @@
+{
+  "name": "Ego Blade",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/magical/ego_blade.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d12+4",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "melee",
+    "burden": "oneHanded",
+    "feature": "pompous"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009542183,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "v2x2UxypzWdGpxeI",
+  "sort": 600000,
+  "_key": "!items!v2x2UxypzWdGpxeI"
+}

--- a/src/packs/items/weapons/tier2/weapon_Elder_Bow_6YGoaFlUgzLZ7h7v.json
+++ b/src/packs/items/weapons/tier2/weapon_Elder_Bow_6YGoaFlUgzLZ7h7v.json
@@ -1,0 +1,42 @@
+{
+  "name": "Elder Bow",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/magical/elder_bow.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+4",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "range": "far",
+    "burden": "twoHanded",
+    "feature": "powerful"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009541351,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "6YGoaFlUgzLZ7h7v",
+  "sort": 500000,
+  "_key": "!items!6YGoaFlUgzLZ7h7v"
+}

--- a/src/packs/items/weapons/tier2/weapon_Finehair_Bow_7pALPrsv0dqzRGCV.json
+++ b/src/packs/items/weapons/tier2/weapon_Finehair_Bow_7pALPrsv0dqzRGCV.json
@@ -1,0 +1,42 @@
+{
+  "name": "Finehair Bow",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/physical/finehair_bow.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+5",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "veryFar",
+    "burden": "twoHanded",
+    "feature": "reliable"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009540474,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "7pALPrsv0dqzRGCV",
+  "sort": 400000,
+  "_key": "!items!7pALPrsv0dqzRGCV"
+}

--- a/src/packs/items/weapons/tier2/weapon_Gilded_Falchion_Pp2tAzb5hOip0zyi.json
+++ b/src/packs/items/weapons/tier2/weapon_Gilded_Falchion_Pp2tAzb5hOip0zyi.json
@@ -1,0 +1,42 @@
+{
+  "name": "Gilded Falchion",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/physical/gilded_falchion.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+4",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "oneHanded",
+    "feature": "powerful"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009539372,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "Pp2tAzb5hOip0zyi",
+  "sort": 200000,
+  "_key": "!items!Pp2tAzb5hOip0zyi"
+}

--- a/src/packs/items/weapons/tier2/weapon_Greatbow_yNZ6ZqtGKtPvqPxu.json
+++ b/src/packs/items/weapons/tier2/weapon_Greatbow_yNZ6ZqtGKtPvqPxu.json
@@ -1,0 +1,42 @@
+{
+  "name": "Greatbow",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/physical/greatbow.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+6",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "far",
+    "burden": "twoHanded",
+    "feature": "powerful"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009537355,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "yNZ6ZqtGKtPvqPxu",
+  "sort": 100000,
+  "_key": "!items!yNZ6ZqtGKtPvqPxu"
+}

--- a/src/packs/items/weapons/tier2/weapon_Hammer_of_Exota_X1DHoD7sHb9v27p0.json
+++ b/src/packs/items/weapons/tier2/weapon_Hammer_of_Exota_X1DHoD7sHb9v27p0.json
@@ -1,0 +1,42 @@
+{
+  "name": "Hammer of Exota",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/magical/hammer_of_exota.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+6",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "range": "melee",
+    "burden": "twoHanded",
+    "feature": "eruptive"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009536388,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "X1DHoD7sHb9v27p0",
+  "sort": 900000,
+  "_key": "!items!X1DHoD7sHb9v27p0"
+}

--- a/src/packs/items/weapons/tier2/weapon_Improved_Arcane_Gauntlets_GZ6OxXjA4OBPxV1F.json
+++ b/src/packs/items/weapons/tier2/weapon_Improved_Arcane_Gauntlets_GZ6OxXjA4OBPxV1F.json
@@ -1,0 +1,41 @@
+{
+  "name": "Improved Arcane Gauntlets",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/magical/improved_arcane_gauntlets.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+6",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009535552,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "GZ6OxXjA4OBPxV1F",
+  "sort": 1200000,
+  "_key": "!items!GZ6OxXjA4OBPxV1F"
+}

--- a/src/packs/items/weapons/tier2/weapon_Improved_Battleaxe_vCBROhfmKwXzgY9G.json
+++ b/src/packs/items/weapons/tier2/weapon_Improved_Battleaxe_vCBROhfmKwXzgY9G.json
@@ -1,0 +1,41 @@
+{
+  "name": "Improved Battleaxe",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/physical/improved_battleaxe.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+6",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009534822,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "vCBROhfmKwXzgY9G",
+  "sort": 1100000,
+  "_key": "!items!vCBROhfmKwXzgY9G"
+}

--- a/src/packs/items/weapons/tier2/weapon_Improved_Broadsword_h6KrDyeyEGwZYm4z.json
+++ b/src/packs/items/weapons/tier2/weapon_Improved_Broadsword_h6KrDyeyEGwZYm4z.json
@@ -1,0 +1,42 @@
+{
+  "name": "Improved Broadsword",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/physical/improved_broadsword.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+3",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "melee",
+    "burden": "oneHanded",
+    "feature": "reliable"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009534024,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "h6KrDyeyEGwZYm4z",
+  "sort": 1000000,
+  "_key": "!items!h6KrDyeyEGwZYm4z"
+}

--- a/src/packs/items/weapons/tier2/weapon_Improved_Crossbow_Me2aEKQzEHMl5CiG.json
+++ b/src/packs/items/weapons/tier2/weapon_Improved_Crossbow_Me2aEKQzEHMl5CiG.json
@@ -1,0 +1,41 @@
+{
+  "name": "Improved Crossbow",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/physical/improved_crossbow.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+4",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "far",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009532416,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "Me2aEKQzEHMl5CiG",
+  "sort": 800000,
+  "_key": "!items!Me2aEKQzEHMl5CiG"
+}

--- a/src/packs/items/weapons/tier2/weapon_Improved_Cutlass_qswhdn7ncrLwpJ4I.json
+++ b/src/packs/items/weapons/tier2/weapon_Improved_Cutlass_qswhdn7ncrLwpJ4I.json
@@ -1,0 +1,41 @@
+{
+  "name": "Improved Cutlass",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/physical/improved_cutlass.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+4",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "presence",
+    "range": "melee",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009531622,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "qswhdn7ncrLwpJ4I",
+  "sort": 700000,
+  "_key": "!items!qswhdn7ncrLwpJ4I"
+}

--- a/src/packs/items/weapons/tier2/weapon_Improved_Dagger_aBM1qoaOGCTmytB8.json
+++ b/src/packs/items/weapons/tier2/weapon_Improved_Dagger_aBM1qoaOGCTmytB8.json
@@ -1,0 +1,41 @@
+{
+  "name": "Improved Dagger",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/physical/improved_dagger.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+4",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "melee",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009530754,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "aBM1qoaOGCTmytB8",
+  "sort": 1600000,
+  "_key": "!items!aBM1qoaOGCTmytB8"
+}

--- a/src/packs/items/weapons/tier2/weapon_Improved_Dualstaff_ft68IExN2tPWiP87.json
+++ b/src/packs/items/weapons/tier2/weapon_Improved_Dualstaff_ft68IExN2tPWiP87.json
@@ -1,0 +1,41 @@
+{
+  "name": "Improved Dualstaff",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/magical/improved_dualstaff.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+6",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "range": "far",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009529809,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "ft68IExN2tPWiP87",
+  "sort": 2000000,
+  "_key": "!items!ft68IExN2tPWiP87"
+}

--- a/src/packs/items/weapons/tier2/weapon_Improved_Glowing_Rings_82pBMYukFn0rqvRc.json
+++ b/src/packs/items/weapons/tier2/weapon_Improved_Glowing_Rings_82pBMYukFn0rqvRc.json
@@ -1,0 +1,41 @@
+{
+  "name": "Improved Glowing Rings",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/magical/improved_glowing_rings.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+5",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "veryClose",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009527917,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "82pBMYukFn0rqvRc",
+  "sort": 1900000,
+  "_key": "!items!82pBMYukFn0rqvRc"
+}

--- a/src/packs/items/weapons/tier2/weapon_Improved_Greatstaff_b5g5jR7aH2I2krs1.json
+++ b/src/packs/items/weapons/tier2/weapon_Improved_Greatstaff_b5g5jR7aH2I2krs1.json
@@ -1,0 +1,42 @@
+{
+  "name": "Improved Greatstaff",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/magical/improved_greatstaff.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+3",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "knowledge",
+    "range": "veryClose",
+    "burden": "twoHanded",
+    "feature": "powerful"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009526945,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "b5g5jR7aH2I2krs1",
+  "sort": 1800000,
+  "_key": "!items!b5g5jR7aH2I2krs1"
+}

--- a/src/packs/items/weapons/tier2/weapon_Improved_Greatsword_aMYQY7T7nJpTHOjy.json
+++ b/src/packs/items/weapons/tier2/weapon_Improved_Greatsword_aMYQY7T7nJpTHOjy.json
@@ -1,0 +1,42 @@
+{
+  "name": "Improved Greatsword",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/physical/improved_greatsword.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+6",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "twoHanded",
+    "feature": "massive"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009526175,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "aMYQY7T7nJpTHOjy",
+  "sort": 1700000,
+  "_key": "!items!aMYQY7T7nJpTHOjy"
+}

--- a/src/packs/items/weapons/tier2/weapon_Improved_Halberd_9rhJEWn4xSTcerRq.json
+++ b/src/packs/items/weapons/tier2/weapon_Improved_Halberd_9rhJEWn4xSTcerRq.json
@@ -1,0 +1,42 @@
+{
+  "name": "Improved Halberd",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/physical/improved_halberd.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+5",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "veryClose",
+    "burden": "twoHanded",
+    "feature": "cumbersome"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009525423,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "9rhJEWn4xSTcerRq",
+  "sort": 1500000,
+  "_key": "!items!9rhJEWn4xSTcerRq"
+}

--- a/src/packs/items/weapons/tier2/weapon_Improved_Hallowed_Axe_Z3IziiiimIDR88wg.json
+++ b/src/packs/items/weapons/tier2/weapon_Improved_Hallowed_Axe_Z3IziiiimIDR88wg.json
@@ -1,0 +1,41 @@
+{
+  "name": "Improved Hallowed Axe",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/magical/improved_hallowed_axe.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+4",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009524364,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "Z3IziiiimIDR88wg",
+  "sort": 1400000,
+  "_key": "!items!Z3IziiiimIDR88wg"
+}

--- a/src/packs/items/weapons/tier2/weapon_Improved_Hand_Runes_RSxE3zlycp4UMGs5.json
+++ b/src/packs/items/weapons/tier2/weapon_Improved_Hand_Runes_RSxE3zlycp4UMGs5.json
@@ -1,0 +1,41 @@
+{
+  "name": "Improved Hand Runes",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/magical/improved_hand_runes.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+3",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "range": "veryClose",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009522783,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "RSxE3zlycp4UMGs5",
+  "sort": 1300000,
+  "_key": "!items!RSxE3zlycp4UMGs5"
+}

--- a/src/packs/items/weapons/tier2/weapon_Improved_Longbow_W8PjOiQwZbL86YO4.json
+++ b/src/packs/items/weapons/tier2/weapon_Improved_Longbow_W8PjOiQwZbL86YO4.json
@@ -1,0 +1,42 @@
+{
+  "name": "Improved Longbow",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/physical/improved_longbow.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+6",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "veryFar",
+    "burden": "twoHanded",
+    "feature": "cumbersome"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009520552,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "W8PjOiQwZbL86YO4",
+  "sort": 2400000,
+  "_key": "!items!W8PjOiQwZbL86YO4"
+}

--- a/src/packs/items/weapons/tier2/weapon_Improved_Longsword_H5DuWNbmfUmdgxgk.json
+++ b/src/packs/items/weapons/tier2/weapon_Improved_Longsword_H5DuWNbmfUmdgxgk.json
@@ -1,0 +1,41 @@
+{
+  "name": "Improved Longsword",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/physical/improved_longsword.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+6",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "melee",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009519715,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "H5DuWNbmfUmdgxgk",
+  "sort": 2700000,
+  "_key": "!items!H5DuWNbmfUmdgxgk"
+}

--- a/src/packs/items/weapons/tier2/weapon_Improved_Mace_NUFPD3bBflCztTw6.json
+++ b/src/packs/items/weapons/tier2/weapon_Improved_Mace_NUFPD3bBflCztTw6.json
@@ -1,0 +1,41 @@
+{
+  "name": "Improved Mace",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/physical/improved_mace.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+4",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009518795,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "NUFPD3bBflCztTw6",
+  "sort": 2600000,
+  "_key": "!items!NUFPD3bBflCztTw6"
+}

--- a/src/packs/items/weapons/tier2/weapon_Improved_Quarterstaff_HxqNhfekSKGZ5lER.json
+++ b/src/packs/items/weapons/tier2/weapon_Improved_Quarterstaff_HxqNhfekSKGZ5lER.json
@@ -1,0 +1,41 @@
+{
+  "name": "Improved Quarterstaff",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/physical/improved_quarterstaff.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+6",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "range": "melee",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009517603,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "HxqNhfekSKGZ5lER",
+  "sort": 2500000,
+  "_key": "!items!HxqNhfekSKGZ5lER"
+}

--- a/src/packs/items/weapons/tier2/weapon_Improved_Rapier_llBQI4DjfJAadtE8.json
+++ b/src/packs/items/weapons/tier2/weapon_Improved_Rapier_llBQI4DjfJAadtE8.json
@@ -1,0 +1,42 @@
+{
+  "name": "Improved Rapier",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/physical/improved_rapier.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+3",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "presence",
+    "range": "melee",
+    "burden": "oneHanded",
+    "feature": "quick"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009515586,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "llBQI4DjfJAadtE8",
+  "sort": 2300000,
+  "_key": "!items!llBQI4DjfJAadtE8"
+}

--- a/src/packs/items/weapons/tier2/weapon_Improved_Returning_Blade_G812F19Q4iK4Qmj6.json
+++ b/src/packs/items/weapons/tier2/weapon_Improved_Returning_Blade_G812F19Q4iK4Qmj6.json
@@ -1,0 +1,42 @@
+{
+  "name": "Improved Returning Blade",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/magical/improved_returning_blade.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+3",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "close",
+    "burden": "oneHanded",
+    "feature": "retractable"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009514599,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "G812F19Q4iK4Qmj6",
+  "sort": 2200000,
+  "_key": "!items!G812F19Q4iK4Qmj6"
+}

--- a/src/packs/items/weapons/tier2/weapon_Improved_Scepter_v93pZH1JNWfGzgVB.json
+++ b/src/packs/items/weapons/tier2/weapon_Improved_Scepter_v93pZH1JNWfGzgVB.json
@@ -1,0 +1,42 @@
+{
+  "name": "Improved Scepter",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/magical/improved_scepter.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+3",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "presence",
+    "range": "far",
+    "burden": "twoHanded",
+    "feature": "versatile"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009513614,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "v93pZH1JNWfGzgVB",
+  "sort": 2100000,
+  "_key": "!items!v93pZH1JNWfGzgVB"
+}

--- a/src/packs/items/weapons/tier2/weapon_Improved_Shortbow_i27H7xSpYaMOnyTE.json
+++ b/src/packs/items/weapons/tier2/weapon_Improved_Shortbow_i27H7xSpYaMOnyTE.json
@@ -1,0 +1,41 @@
+{
+  "name": "Improved Shortbow",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/physical/improved_shortbow.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+6",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "far",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009512488,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "i27H7xSpYaMOnyTE",
+  "sort": 3100000,
+  "_key": "!items!i27H7xSpYaMOnyTE"
+}

--- a/src/packs/items/weapons/tier2/weapon_Improved_Shortstaff_tyKBNpIhrJrTJam5.json
+++ b/src/packs/items/weapons/tier2/weapon_Improved_Shortstaff_tyKBNpIhrJrTJam5.json
@@ -1,0 +1,41 @@
+{
+  "name": "Improved Shortstaff",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/magical/improved_shortstaff.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+4",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "range": "close",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009511367,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "tyKBNpIhrJrTJam5",
+  "sort": 3700000,
+  "_key": "!items!tyKBNpIhrJrTJam5"
+}

--- a/src/packs/items/weapons/tier2/weapon_Improved_Spear_88DGrDCZcCUU9uwy.json
+++ b/src/packs/items/weapons/tier2/weapon_Improved_Spear_88DGrDCZcCUU9uwy.json
@@ -1,0 +1,42 @@
+{
+  "name": "Improved Spear",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/physical/improved_spear.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+5",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "veryClose",
+    "burden": "twoHanded",
+    "feature": "cumbersome"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009510256,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "88DGrDCZcCUU9uwy",
+  "sort": 3600000,
+  "_key": "!items!88DGrDCZcCUU9uwy"
+}

--- a/src/packs/items/weapons/tier2/weapon_Improved_Wand_NvCk3CHdyf7ZSwMd.json
+++ b/src/packs/items/weapons/tier2/weapon_Improved_Wand_NvCk3CHdyf7ZSwMd.json
@@ -1,0 +1,41 @@
+{
+  "name": "Improved Wand",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/magical/improved_wand.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+4",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "knowledge",
+    "range": "far",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009509283,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "NvCk3CHdyf7ZSwMd",
+  "sort": 3500000,
+  "_key": "!items!NvCk3CHdyf7ZSwMd"
+}

--- a/src/packs/items/weapons/tier2/weapon_Improved_Warhammer_kxqaACQb9VQEbc9S.json
+++ b/src/packs/items/weapons/tier2/weapon_Improved_Warhammer_kxqaACQb9VQEbc9S.json
@@ -1,0 +1,42 @@
+{
+  "name": "Improved Warhammer",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/physical/improved_warhammer.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d12+6",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "twoHanded",
+    "feature": "heavy"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009508360,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "kxqaACQb9VQEbc9S",
+  "sort": 3400000,
+  "_key": "!items!kxqaACQb9VQEbc9S"
+}

--- a/src/packs/items/weapons/tier2/weapon_Keeper_s_Staff_LlpGDvN6cd0rVZ9p.json
+++ b/src/packs/items/weapons/tier2/weapon_Keeper_s_Staff_LlpGDvN6cd0rVZ9p.json
@@ -1,0 +1,42 @@
+{
+  "name": "Keeper's Staff",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/magical/keepers_staff.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+4",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "knowledge",
+    "range": "far",
+    "burden": "twoHanded",
+    "feature": "reliable"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009507308,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "LlpGDvN6cd0rVZ9p",
+  "sort": 3300000,
+  "_key": "!items!LlpGDvN6cd0rVZ9p"
+}

--- a/src/packs/items/weapons/tier2/weapon_Knuckle_Blades_hzyIf7akuGl7jYlo.json
+++ b/src/packs/items/weapons/tier2/weapon_Knuckle_Blades_hzyIf7akuGl7jYlo.json
@@ -1,0 +1,42 @@
+{
+  "name": "Knuckle Blades",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/physical/knuckle_blades.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+6",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "twoHanded",
+    "feature": "brutal"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009506432,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "hzyIf7akuGl7jYlo",
+  "sort": 3200000,
+  "_key": "!items!hzyIf7akuGl7jYlo"
+}

--- a/src/packs/items/weapons/tier2/weapon_Scepter_of_Elias_N5nXkW5NBN2UYawJ.json
+++ b/src/packs/items/weapons/tier2/weapon_Scepter_of_Elias_N5nXkW5NBN2UYawJ.json
@@ -1,0 +1,42 @@
+{
+  "name": "Scepter of Elias",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/magical/scepter_of_elias.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+3",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "presence",
+    "range": "far",
+    "burden": "oneHanded",
+    "feature": "invigorating"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009505571,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "N5nXkW5NBN2UYawJ",
+  "sort": 3000000,
+  "_key": "!items!N5nXkW5NBN2UYawJ"
+}

--- a/src/packs/items/weapons/tier2/weapon_Steelforged_Halberd_vSixA7cq1nQYxvCH.json
+++ b/src/packs/items/weapons/tier2/weapon_Steelforged_Halberd_vSixA7cq1nQYxvCH.json
@@ -1,0 +1,42 @@
+{
+  "name": "Steelforged Halberd",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/physical/steelforged_halberd.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+4",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "veryClose",
+    "burden": "twoHanded",
+    "feature": "scary"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009504802,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "vSixA7cq1nQYxvCH",
+  "sort": 2900000,
+  "_key": "!items!vSixA7cq1nQYxvCH"
+}

--- a/src/packs/items/weapons/tier2/weapon_Urok_Broadsword_RpTkQgMbI3KlAXB6.json
+++ b/src/packs/items/weapons/tier2/weapon_Urok_Broadsword_RpTkQgMbI3KlAXB6.json
@@ -1,0 +1,42 @@
+{
+  "name": "Urok Broadsword",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/physical/urok_broadsword.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+3",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "melee",
+    "burden": "oneHanded",
+    "feature": "devastating"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009504025,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "RpTkQgMbI3KlAXB6",
+  "sort": 2800000,
+  "_key": "!items!RpTkQgMbI3KlAXB6"
+}

--- a/src/packs/items/weapons/tier2/weapon_Wand_of_Enthrallment_ME6aDBfBjecVkdoZ.json
+++ b/src/packs/items/weapons/tier2/weapon_Wand_of_Enthrallment_ME6aDBfBjecVkdoZ.json
@@ -1,0 +1,42 @@
+{
+  "name": "Wand of Enthrallment",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/magical/wand_of_enthrallment.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+4",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "presence",
+    "range": "far",
+    "burden": "oneHanded",
+    "feature": "persuasive"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009503226,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "ME6aDBfBjecVkdoZ",
+  "sort": 3900000,
+  "_key": "!items!ME6aDBfBjecVkdoZ"
+}

--- a/src/packs/items/weapons/tier2/weapon_War_Scythe_EidEr900k7AatPed.json
+++ b/src/packs/items/weapons/tier2/weapon_War_Scythe_EidEr900k7AatPed.json
@@ -1,0 +1,42 @@
+{
+  "name": "War Scythe",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/physical/war_scythe.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+5",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "veryClose",
+    "burden": "twoHanded",
+    "feature": "reliable"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009502355,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "EidEr900k7AatPed",
+  "sort": 4000000,
+  "_key": "!items!EidEr900k7AatPed"
+}

--- a/src/packs/items/weapons/tier2/weapon_Yutari_Bloodbow_YAeJexbo14oCp8SF.json
+++ b/src/packs/items/weapons/tier2/weapon_Yutari_Bloodbow_YAeJexbo14oCp8SF.json
@@ -1,0 +1,42 @@
+{
+  "name": "Yutari Bloodbow",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_2/magical/yutari_bloodbow.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+4",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "far",
+    "burden": "twoHanded",
+    "feature": "brutal"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009501453,
+    "modifiedTime": 1748009543035,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "YAeJexbo14oCp8SF",
+  "sort": 3800000,
+  "_key": "!items!YAeJexbo14oCp8SF"
+}

--- a/src/packs/items/weapons/tier3/weapon_Advanced_Arcane_Gauntlets_f1v9t1oDs4c9TI2K.json
+++ b/src/packs/items/weapons/tier3/weapon_Advanced_Arcane_Gauntlets_f1v9t1oDs4c9TI2K.json
@@ -1,0 +1,41 @@
+{
+  "name": "Advanced Arcane Gauntlets",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/advanced_arcane_gauntlets.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+9",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009726670,
+    "modifiedTime": 1748009726670,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "f1v9t1oDs4c9TI2K",
+  "sort": 0,
+  "_key": "!items!f1v9t1oDs4c9TI2K"
+}

--- a/src/packs/items/weapons/tier3/weapon_Advanced_Battleaxe_55kmkScxSwAGXSdN.json
+++ b/src/packs/items/weapons/tier3/weapon_Advanced_Battleaxe_55kmkScxSwAGXSdN.json
@@ -1,0 +1,41 @@
+{
+  "name": "Advanced Battleaxe",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_battleaxe.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+9",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009725955,
+    "modifiedTime": 1748009725955,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "55kmkScxSwAGXSdN",
+  "sort": 0,
+  "_key": "!items!55kmkScxSwAGXSdN"
+}

--- a/src/packs/items/weapons/tier3/weapon_Advanced_Broadsword_6iBBqlwCA1xBpEkz.json
+++ b/src/packs/items/weapons/tier3/weapon_Advanced_Broadsword_6iBBqlwCA1xBpEkz.json
@@ -1,0 +1,42 @@
+{
+  "name": "Advanced Broadsword",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_broadsword.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+6",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "melee",
+    "burden": "oneHanded",
+    "feature": "reliable"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009724319,
+    "modifiedTime": 1748009724319,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "6iBBqlwCA1xBpEkz",
+  "sort": 0,
+  "_key": "!items!6iBBqlwCA1xBpEkz"
+}

--- a/src/packs/items/weapons/tier3/weapon_Advanced_Crossbow_CwRGALuF4o0NJe3y.json
+++ b/src/packs/items/weapons/tier3/weapon_Advanced_Crossbow_CwRGALuF4o0NJe3y.json
@@ -1,0 +1,41 @@
+{
+  "name": "Advanced Crossbow",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_crossbow.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+7",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "far",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009723452,
+    "modifiedTime": 1748009723452,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "CwRGALuF4o0NJe3y",
+  "sort": 0,
+  "_key": "!items!CwRGALuF4o0NJe3y"
+}

--- a/src/packs/items/weapons/tier3/weapon_Advanced_Cutlass_rVoF4pXluLGXbAlk.json
+++ b/src/packs/items/weapons/tier3/weapon_Advanced_Cutlass_rVoF4pXluLGXbAlk.json
@@ -1,0 +1,41 @@
+{
+  "name": "Advanced Cutlass",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_cutlass.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+7",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "presence",
+    "range": "melee",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009721740,
+    "modifiedTime": 1748009721740,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "rVoF4pXluLGXbAlk",
+  "sort": 0,
+  "_key": "!items!rVoF4pXluLGXbAlk"
+}

--- a/src/packs/items/weapons/tier3/weapon_Advanced_Dagger_HoBYwjE8G9OTqISk.json
+++ b/src/packs/items/weapons/tier3/weapon_Advanced_Dagger_HoBYwjE8G9OTqISk.json
@@ -1,0 +1,41 @@
+{
+  "name": "Advanced Dagger",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_dagger.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+7",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "melee",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009720844,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "HoBYwjE8G9OTqISk",
+  "sort": 400000,
+  "_key": "!items!HoBYwjE8G9OTqISk"
+}

--- a/src/packs/items/weapons/tier3/weapon_Advanced_Dualstaff_Jtzvg4VmTzQyEvgw.json
+++ b/src/packs/items/weapons/tier3/weapon_Advanced_Dualstaff_Jtzvg4VmTzQyEvgw.json
@@ -1,0 +1,41 @@
+{
+  "name": "Advanced Dualstaff",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/advanced_dualstaff.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+9",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "range": "far",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009719957,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "Jtzvg4VmTzQyEvgw",
+  "sort": 700000,
+  "_key": "!items!Jtzvg4VmTzQyEvgw"
+}

--- a/src/packs/items/weapons/tier3/weapon_Advanced_Glowing_Rings_tiF1InKThXGrG5A5.json
+++ b/src/packs/items/weapons/tier3/weapon_Advanced_Glowing_Rings_tiF1InKThXGrG5A5.json
@@ -1,0 +1,41 @@
+{
+  "name": "Advanced Glowing Rings",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/advanced_glowing_rings.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+8",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "veryClose",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009719025,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "tiF1InKThXGrG5A5",
+  "sort": 600000,
+  "_key": "!items!tiF1InKThXGrG5A5"
+}

--- a/src/packs/items/weapons/tier3/weapon_Advanced_Greatstaff_lIk92ZPvryDQrtrm.json
+++ b/src/packs/items/weapons/tier3/weapon_Advanced_Greatstaff_lIk92ZPvryDQrtrm.json
@@ -1,0 +1,42 @@
+{
+  "name": "Advanced Greatstaff",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/advanced_greatstaff.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+6",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "knowledge",
+    "range": "veryFar",
+    "burden": "twoHanded",
+    "feature": "powerful"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009717363,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "lIk92ZPvryDQrtrm",
+  "sort": 500000,
+  "_key": "!items!lIk92ZPvryDQrtrm"
+}

--- a/src/packs/items/weapons/tier3/weapon_Advanced_Greatsword_dYFKPIujOvDH2sEx.json
+++ b/src/packs/items/weapons/tier3/weapon_Advanced_Greatsword_dYFKPIujOvDH2sEx.json
@@ -1,0 +1,42 @@
+{
+  "name": "Advanced Greatsword",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_greatsword.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+9",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "twoHanded",
+    "feature": "massive"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009716491,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "dYFKPIujOvDH2sEx",
+  "sort": 300000,
+  "_key": "!items!dYFKPIujOvDH2sEx"
+}

--- a/src/packs/items/weapons/tier3/weapon_Advanced_Halberd_hX3CM1pvIfeebF2g.json
+++ b/src/packs/items/weapons/tier3/weapon_Advanced_Halberd_hX3CM1pvIfeebF2g.json
@@ -1,0 +1,42 @@
+{
+  "name": "Advanced Halberd",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_halberd.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+8",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "veryClose",
+    "burden": "twoHanded",
+    "feature": "cumbersome"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009715670,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "hX3CM1pvIfeebF2g",
+  "sort": 200000,
+  "_key": "!items!hX3CM1pvIfeebF2g"
+}

--- a/src/packs/items/weapons/tier3/weapon_Advanced_Hallowed_Axe_Gf7I4j8skD862SU0.json
+++ b/src/packs/items/weapons/tier3/weapon_Advanced_Hallowed_Axe_Gf7I4j8skD862SU0.json
@@ -1,0 +1,41 @@
+{
+  "name": "Advanced Hallowed Axe",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/advanced_hallowed_axe.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+7",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009714741,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "Gf7I4j8skD862SU0",
+  "sort": 100000,
+  "_key": "!items!Gf7I4j8skD862SU0"
+}

--- a/src/packs/items/weapons/tier3/weapon_Advanced_Hand_Runes_uuZTjjTN73zXYVxE.json
+++ b/src/packs/items/weapons/tier3/weapon_Advanced_Hand_Runes_uuZTjjTN73zXYVxE.json
@@ -1,0 +1,41 @@
+{
+  "name": "Advanced Hand Runes",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/advanced_hand_runes.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+6",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "range": "veryClose",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009712990,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "uuZTjjTN73zXYVxE",
+  "sort": 1100000,
+  "_key": "!items!uuZTjjTN73zXYVxE"
+}

--- a/src/packs/items/weapons/tier3/weapon_Advanced_Longbow_wDsxrxhkuJwFEw8q.json
+++ b/src/packs/items/weapons/tier3/weapon_Advanced_Longbow_wDsxrxhkuJwFEw8q.json
@@ -1,0 +1,42 @@
+{
+  "name": "Advanced Longbow",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_longbow.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+9",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "veryFar",
+    "burden": "twoHanded",
+    "feature": "cumbersome"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009712027,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "wDsxrxhkuJwFEw8q",
+  "sort": 1300000,
+  "_key": "!items!wDsxrxhkuJwFEw8q"
+}

--- a/src/packs/items/weapons/tier3/weapon_Advanced_Longsword_ohLQbYRlQx4ivJMl.json
+++ b/src/packs/items/weapons/tier3/weapon_Advanced_Longsword_ohLQbYRlQx4ivJMl.json
@@ -1,0 +1,41 @@
+{
+  "name": "Advanced Longsword",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_longsword.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+9",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "melee",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009711161,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "ohLQbYRlQx4ivJMl",
+  "sort": 1200000,
+  "_key": "!items!ohLQbYRlQx4ivJMl"
+}

--- a/src/packs/items/weapons/tier3/weapon_Advanced_Mace_d0SqlcuhkKufJScF.json
+++ b/src/packs/items/weapons/tier3/weapon_Advanced_Mace_d0SqlcuhkKufJScF.json
@@ -1,0 +1,41 @@
+{
+  "name": "Advanced Mace",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_mace.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+7",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009710185,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "d0SqlcuhkKufJScF",
+  "sort": 1000000,
+  "_key": "!items!d0SqlcuhkKufJScF"
+}

--- a/src/packs/items/weapons/tier3/weapon_Advanced_Quarterstaff_w3Hze7ailRPQh4kc.json
+++ b/src/packs/items/weapons/tier3/weapon_Advanced_Quarterstaff_w3Hze7ailRPQh4kc.json
@@ -1,0 +1,41 @@
+{
+  "name": "Advanced Quarterstaff",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_quarterstaff.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+9",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "range": "melee",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009708527,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "w3Hze7ailRPQh4kc",
+  "sort": 900000,
+  "_key": "!items!w3Hze7ailRPQh4kc"
+}

--- a/src/packs/items/weapons/tier3/weapon_Advanced_Rapier_JEQZMzrlsoU2Pjd0.json
+++ b/src/packs/items/weapons/tier3/weapon_Advanced_Rapier_JEQZMzrlsoU2Pjd0.json
@@ -1,0 +1,42 @@
+{
+  "name": "Advanced Rapier",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_rapier.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+7",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "presence",
+    "range": "melee",
+    "burden": "oneHanded",
+    "feature": "quick"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009707684,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "JEQZMzrlsoU2Pjd0",
+  "sort": 800000,
+  "_key": "!items!JEQZMzrlsoU2Pjd0"
+}

--- a/src/packs/items/weapons/tier3/weapon_Advanced_Returning_Blade_fcLmPt9wFqM1xojl.json
+++ b/src/packs/items/weapons/tier3/weapon_Advanced_Returning_Blade_fcLmPt9wFqM1xojl.json
@@ -1,0 +1,42 @@
+{
+  "name": "Advanced Returning Blade",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/advanced_returning_blade.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+6",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "close",
+    "burden": "oneHanded",
+    "feature": "retrieve"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009706817,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "fcLmPt9wFqM1xojl",
+  "sort": 1600000,
+  "_key": "!items!fcLmPt9wFqM1xojl"
+}

--- a/src/packs/items/weapons/tier3/weapon_Advanced_Scepter_BqYoefSRnoQVpC2Q.json
+++ b/src/packs/items/weapons/tier3/weapon_Advanced_Scepter_BqYoefSRnoQVpC2Q.json
@@ -1,0 +1,42 @@
+{
+  "name": "Advanced Scepter",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/advanced_scepter.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+6",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "presence",
+    "range": "far",
+    "burden": "twoHanded",
+    "feature": "versatile"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009706027,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "BqYoefSRnoQVpC2Q",
+  "sort": 2000000,
+  "_key": "!items!BqYoefSRnoQVpC2Q"
+}

--- a/src/packs/items/weapons/tier3/weapon_Advanced_Shortbow_HLdn8xNWmDkdtFL7.json
+++ b/src/packs/items/weapons/tier3/weapon_Advanced_Shortbow_HLdn8xNWmDkdtFL7.json
@@ -1,0 +1,41 @@
+{
+  "name": "Advanced Shortbow",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_shortbow.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+9",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "far",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009702575,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "HLdn8xNWmDkdtFL7",
+  "sort": 1800000,
+  "_key": "!items!HLdn8xNWmDkdtFL7"
+}

--- a/src/packs/items/weapons/tier3/weapon_Advanced_Shortstaff_1OgEUTyTwP63JuWE.json
+++ b/src/packs/items/weapons/tier3/weapon_Advanced_Shortstaff_1OgEUTyTwP63JuWE.json
@@ -1,0 +1,41 @@
+{
+  "name": "Advanced Shortstaff",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/advanced_shortstaff.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+7",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "range": "close",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009703303,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "1OgEUTyTwP63JuWE",
+  "sort": 1900000,
+  "_key": "!items!1OgEUTyTwP63JuWE"
+}

--- a/src/packs/items/weapons/tier3/weapon_Advanced_Spear_ZZWf8dSIs9m2PH2h.json
+++ b/src/packs/items/weapons/tier3/weapon_Advanced_Spear_ZZWf8dSIs9m2PH2h.json
@@ -1,0 +1,42 @@
+{
+  "name": "Advanced Spear",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_spear.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+8",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "veryClose",
+    "burden": "twoHanded",
+    "feature": "cumbersome"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009701007,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "ZZWf8dSIs9m2PH2h",
+  "sort": 1700000,
+  "_key": "!items!ZZWf8dSIs9m2PH2h"
+}

--- a/src/packs/items/weapons/tier3/weapon_Advanced_Wand_tAEIzS7BlPz9D7xy.json
+++ b/src/packs/items/weapons/tier3/weapon_Advanced_Wand_tAEIzS7BlPz9D7xy.json
@@ -1,0 +1,41 @@
+{
+  "name": "Advanced Wand",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/advanced_wand.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+7",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "knowledge",
+    "range": "far",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009700097,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "tAEIzS7BlPz9D7xy",
+  "sort": 1500000,
+  "_key": "!items!tAEIzS7BlPz9D7xy"
+}

--- a/src/packs/items/weapons/tier3/weapon_Advanced_Warhammer_IV3HYPjJ5uRaq80h.json
+++ b/src/packs/items/weapons/tier3/weapon_Advanced_Warhammer_IV3HYPjJ5uRaq80h.json
@@ -1,0 +1,42 @@
+{
+  "name": "Advanced Warhammer",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/advanced_warhammer.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d12+9",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "twoHanded",
+    "feature": "heavy"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009697372,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "IV3HYPjJ5uRaq80h",
+  "sort": 1400000,
+  "_key": "!items!IV3HYPjJ5uRaq80h"
+}

--- a/src/packs/items/weapons/tier3/weapon_Axe_of_Fortunis_X1pTuQSSPm7PBPi0.json
+++ b/src/packs/items/weapons/tier3/weapon_Axe_of_Fortunis_X1pTuQSSPm7PBPi0.json
@@ -1,0 +1,42 @@
+{
+  "name": "Axe of Fortunis",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/axe_of_fortunis.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+8",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "twoHanded",
+    "feature": "lucky"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009696541,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "X1pTuQSSPm7PBPi0",
+  "sort": 2300000,
+  "_key": "!items!X1pTuQSSPm7PBPi0"
+}

--- a/src/packs/items/weapons/tier3/weapon_Black_Powder_Revolver_POHACCee5wa92XD1.json
+++ b/src/packs/items/weapons/tier3/weapon_Black_Powder_Revolver_POHACCee5wa92XD1.json
@@ -1,0 +1,42 @@
+{
+  "name": "Black Powder Revolver",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/black_powder_revolver.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+8",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "far",
+    "burden": "oneHanded",
+    "feature": "reloading"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009695686,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "POHACCee5wa92XD1",
+  "sort": 2600000,
+  "_key": "!items!POHACCee5wa92XD1"
+}

--- a/src/packs/items/weapons/tier3/weapon_Blessed_Anlace_p0oeyqhAIRdAQv6k.json
+++ b/src/packs/items/weapons/tier3/weapon_Blessed_Anlace_p0oeyqhAIRdAQv6k.json
@@ -1,0 +1,42 @@
+{
+  "name": "Blessed Anlace",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/blessed_anlace.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+6",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "range": "melee",
+    "burden": "oneHanded",
+    "feature": "healing"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009694614,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "p0oeyqhAIRdAQv6k",
+  "sort": 2500000,
+  "_key": "!items!p0oeyqhAIRdAQv6k"
+}

--- a/src/packs/items/weapons/tier3/weapon_Bravesword_1qE6NDSlN8bHVNLE.json
+++ b/src/packs/items/weapons/tier3/weapon_Bravesword_1qE6NDSlN8bHVNLE.json
@@ -1,0 +1,42 @@
+{
+  "name": "Bravesword",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/bravesword.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d12+7",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "twoHanded",
+    "feature": "barrier"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009692041,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "1qE6NDSlN8bHVNLE",
+  "sort": 2400000,
+  "_key": "!items!1qE6NDSlN8bHVNLE"
+}

--- a/src/packs/items/weapons/tier3/weapon_Double_Flail_tRqpSGHIIDCBS7sN.json
+++ b/src/packs/items/weapons/tier3/weapon_Double_Flail_tRqpSGHIIDCBS7sN.json
@@ -1,0 +1,42 @@
+{
+  "name": "Double Flail",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/double_flail.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+8",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "veryClose",
+    "burden": "twoHanded",
+    "feature": "powerful"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009691193,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "tRqpSGHIIDCBS7sN",
+  "sort": 2200000,
+  "_key": "!items!tRqpSGHIIDCBS7sN"
+}

--- a/src/packs/items/weapons/tier3/weapon_Firestaff_jeLL7YLCvzDo2MyT.json
+++ b/src/packs/items/weapons/tier3/weapon_Firestaff_jeLL7YLCvzDo2MyT.json
@@ -1,0 +1,42 @@
+{
+  "name": "Firestaff",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/firestaff.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+7",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "range": "far",
+    "burden": "twoHanded",
+    "feature": "burn"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009689947,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "jeLL7YLCvzDo2MyT",
+  "sort": 2100000,
+  "_key": "!items!jeLL7YLCvzDo2MyT"
+}

--- a/src/packs/items/weapons/tier3/weapon_Flickerfly_Blade_QTvf9KZeK567PClS.json
+++ b/src/packs/items/weapons/tier3/weapon_Flickerfly_Blade_QTvf9KZeK567PClS.json
@@ -1,0 +1,42 @@
+{
+  "name": "Flickerfly Blade",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/flickerfly_blade.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+5",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "melee",
+    "burden": "oneHanded",
+    "feature": "sheltering"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009688811,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "QTvf9KZeK567PClS",
+  "sort": 2900000,
+  "_key": "!items!QTvf9KZeK567PClS"
+}

--- a/src/packs/items/weapons/tier3/weapon_Ghostblade_yAszCKtIlBieTuth.json
+++ b/src/packs/items/weapons/tier3/weapon_Ghostblade_yAszCKtIlBieTuth.json
@@ -1,0 +1,42 @@
+{
+  "name": "Ghostblade",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/ghostblade.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+7",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "presence",
+    "range": "melee",
+    "burden": "oneHanded",
+    "feature": "otherwordly"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009688005,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "yAszCKtIlBieTuth",
+  "sort": 3300000,
+  "_key": "!items!yAszCKtIlBieTuth"
+}

--- a/src/packs/items/weapons/tier3/weapon_Gilded_Bow_mqtFoVo5umeCJ3g4.json
+++ b/src/packs/items/weapons/tier3/weapon_Gilded_Bow_mqtFoVo5umeCJ3g4.json
@@ -1,0 +1,42 @@
+{
+  "name": "Gilded Bow",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/guilded_bow.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+7",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "far",
+    "burden": "twoHanded",
+    "feature": "selfCorrecting"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009687074,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "mqtFoVo5umeCJ3g4",
+  "sort": 3200000,
+  "_key": "!items!mqtFoVo5umeCJ3g4"
+}

--- a/src/packs/items/weapons/tier3/weapon_Hammer_of_Wrath_g9EKWZaHZfuU5Yha.json
+++ b/src/packs/items/weapons/tier3/weapon_Hammer_of_Wrath_g9EKWZaHZfuU5Yha.json
@@ -1,0 +1,42 @@
+{
+  "name": "Hammer of Wrath",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/hammer_of_wrath.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+7",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "twoHanded",
+    "feature": "devastating"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009686240,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "g9EKWZaHZfuU5Yha",
+  "sort": 3100000,
+  "_key": "!items!g9EKWZaHZfuU5Yha"
+}

--- a/src/packs/items/weapons/tier3/weapon_Ilmari_s_Rifle_zVMZvitG5ESNBxjm.json
+++ b/src/packs/items/weapons/tier3/weapon_Ilmari_s_Rifle_zVMZvitG5ESNBxjm.json
@@ -1,0 +1,42 @@
+{
+  "name": "Ilmari's Rifle",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/ilmaris_rifle.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+6",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "veryFar",
+    "burden": "oneHanded",
+    "feature": "reloading"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009685440,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "zVMZvitG5ESNBxjm",
+  "sort": 3000000,
+  "_key": "!items!zVMZvitG5ESNBxjm"
+}

--- a/src/packs/items/weapons/tier3/weapon_Labrys_Axe_VkxSrdGjlWW6tUvO.json
+++ b/src/packs/items/weapons/tier3/weapon_Labrys_Axe_VkxSrdGjlWW6tUvO.json
@@ -1,0 +1,42 @@
+{
+  "name": "Labrys Axe",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/labrys_axe.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+7",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "range": "melee",
+    "burden": "twoHanded",
+    "feature": "protective"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009684684,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "VkxSrdGjlWW6tUvO",
+  "sort": 2800000,
+  "_key": "!items!VkxSrdGjlWW6tUvO"
+}

--- a/src/packs/items/weapons/tier3/weapon_Mage_Orb_LuZBjH3QvsEOkcVM.json
+++ b/src/packs/items/weapons/tier3/weapon_Mage_Orb_LuZBjH3QvsEOkcVM.json
@@ -1,0 +1,42 @@
+{
+  "name": "Mage Orb",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/mage_orb.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+7",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "knowledge",
+    "range": "far",
+    "burden": "oneHanded",
+    "feature": "powerful"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009683824,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "LuZBjH3QvsEOkcVM",
+  "sort": 2700000,
+  "_key": "!items!LuZBjH3QvsEOkcVM"
+}

--- a/src/packs/items/weapons/tier3/weapon_Meridian_Cutlass_grOsR6ArQQR4OBzX.json
+++ b/src/packs/items/weapons/tier3/weapon_Meridian_Cutlass_grOsR6ArQQR4OBzX.json
@@ -1,0 +1,42 @@
+{
+  "name": "Meridian Cutlass",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/meridian_cutlass.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+5",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "presence",
+    "range": "melee",
+    "burden": "oneHanded",
+    "feature": "doubleDuty"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009682959,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "grOsR6ArQQR4OBzX",
+  "sort": 3500000,
+  "_key": "!items!grOsR6ArQQR4OBzX"
+}

--- a/src/packs/items/weapons/tier3/weapon_Retractable_Saber_sXyasH1B078wvaSQ.json
+++ b/src/packs/items/weapons/tier3/weapon_Retractable_Saber_sXyasH1B078wvaSQ.json
@@ -1,0 +1,42 @@
+{
+  "name": "Retractable Saber",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/retractable_saber.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+7",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "presence",
+    "range": "melee",
+    "burden": "oneHanded",
+    "feature": "retractable"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009682132,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "sXyasH1B078wvaSQ",
+  "sort": 3600000,
+  "_key": "!items!sXyasH1B078wvaSQ"
+}

--- a/src/packs/items/weapons/tier3/weapon_Runes_of_Ruination_HEcvQ9sX8NlqWuKN.json
+++ b/src/packs/items/weapons/tier3/weapon_Runes_of_Ruination_HEcvQ9sX8NlqWuKN.json
@@ -1,0 +1,42 @@
+{
+  "name": "Runes of Ruination",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/runes_of_ruination.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d20+4",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "knowledge",
+    "range": "veryClose",
+    "burden": "oneHanded",
+    "feature": "painful"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009681254,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "HEcvQ9sX8NlqWuKN",
+  "sort": 3400000,
+  "_key": "!items!HEcvQ9sX8NlqWuKN"
+}

--- a/src/packs/items/weapons/tier3/weapon_Spiked_Bow_UF2AEiCmIftqllAB.json
+++ b/src/packs/items/weapons/tier3/weapon_Spiked_Bow_UF2AEiCmIftqllAB.json
@@ -1,0 +1,42 @@
+{
+  "name": "Spiked Bow",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/spiked_bow.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+7",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "range": "veryFar",
+    "burden": "twoHanded",
+    "feature": "versatile"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009680484,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "UF2AEiCmIftqllAB",
+  "sort": 3800000,
+  "_key": "!items!UF2AEiCmIftqllAB"
+}

--- a/src/packs/items/weapons/tier3/weapon_Talon_Blades_32DXoEEDbV3J8amu.json
+++ b/src/packs/items/weapons/tier3/weapon_Talon_Blades_32DXoEEDbV3J8amu.json
@@ -1,0 +1,42 @@
+{
+  "name": "Talon Blades",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/physical/talon_blades.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+7",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "range": "close",
+    "burden": "twoHanded",
+    "feature": "brutal"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009679650,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "32DXoEEDbV3J8amu",
+  "sort": 3900000,
+  "_key": "!items!32DXoEEDbV3J8amu"
+}

--- a/src/packs/items/weapons/tier3/weapon_Widogast_Pendant_MIvqgdCV9IbQ3gdm.json
+++ b/src/packs/items/weapons/tier3/weapon_Widogast_Pendant_MIvqgdCV9IbQ3gdm.json
@@ -1,0 +1,42 @@
+{
+  "name": "Widogast Pendant",
+  "type": "weapon",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_3/magical/widogast_pendant.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+5",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "knowledge",
+    "range": "close",
+    "burden": "oneHanded",
+    "feature": "timebender"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3,
+    "JKaKJsbixtjbUa07": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748009678700,
+    "modifiedTime": 1748009720858,
+    "lastModifiedBy": "JKaKJsbixtjbUa07"
+  },
+  "_id": "MIvqgdCV9IbQ3gdm",
+  "sort": 3700000,
+  "_key": "!items!MIvqgdCV9IbQ3gdm"
+}

--- a/src/packs/items/weapons/tier4/weapon_Aantari_Bow_9SVzLUWdp7ZeSqH5.json
+++ b/src/packs/items/weapons/tier4/weapon_Aantari_Bow_9SVzLUWdp7ZeSqH5.json
@@ -1,0 +1,41 @@
+{
+  "name": "Aantari Bow",
+  "type": "weapon",
+  "_id": "9SVzLUWdp7ZeSqH5",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/physical/aanatari_bow.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+11",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "feature": "reliable",
+    "range": "far",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748036207567,
+    "modifiedTime": 1748036227740,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!9SVzLUWdp7ZeSqH5"
+}

--- a/src/packs/items/weapons/tier4/weapon_Bloodstaff_LWYvJXHStsyNaYBR.json
+++ b/src/packs/items/weapons/tier4/weapon_Bloodstaff_LWYvJXHStsyNaYBR.json
@@ -1,0 +1,41 @@
+{
+  "name": "Bloodstaff",
+  "type": "weapon",
+  "_id": "LWYvJXHStsyNaYBR",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/magical/bloodstaff.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d20+7",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "feature": "painful",
+    "range": "far",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748038067989,
+    "modifiedTime": 1748038098782,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!LWYvJXHStsyNaYBR"
+}

--- a/src/packs/items/weapons/tier4/weapon_Curved_Dagger_sbKB1f2i7bQCR1i8.json
+++ b/src/packs/items/weapons/tier4/weapon_Curved_Dagger_sbKB1f2i7bQCR1i8.json
@@ -1,0 +1,41 @@
+{
+  "name": "Curved Dagger",
+  "type": "weapon",
+  "_id": "sbKB1f2i7bQCR1i8",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/physical/curved_dagger.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+9",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "feature": "serrated",
+    "range": "melee",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748035972954,
+    "modifiedTime": 1748035994504,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!sbKB1f2i7bQCR1i8"
+}

--- a/src/packs/items/weapons/tier4/weapon_Dual_Ended_Sword_kmSom1Srz8I3CXsh.json
+++ b/src/packs/items/weapons/tier4/weapon_Dual_Ended_Sword_kmSom1Srz8I3CXsh.json
@@ -1,0 +1,41 @@
+{
+  "name": "Dual-Ended Sword",
+  "type": "weapon",
+  "_id": "kmSom1Srz8I3CXsh",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/physical/dual-ended_sword.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+9",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "feature": "quick",
+    "range": "melee",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748035869264,
+    "modifiedTime": 1748035890591,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!kmSom1Srz8I3CXsh"
+}

--- a/src/packs/items/weapons/tier4/weapon_Extended_Polearm_cIc4kCK0qET1ilvM.json
+++ b/src/packs/items/weapons/tier4/weapon_Extended_Polearm_cIc4kCK0qET1ilvM.json
@@ -1,0 +1,41 @@
+{
+  "name": "Extended Polearm",
+  "type": "weapon",
+  "_id": "cIc4kCK0qET1ilvM",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/physical/extended_polearm.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+10",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "feature": "long",
+    "range": "veryClose",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748036008663,
+    "modifiedTime": 1748036132678,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!cIc4kCK0qET1ilvM"
+}

--- a/src/packs/items/weapons/tier4/weapon_Floating_Bladeshards_1HBqL3gwZNSwCBFL.json
+++ b/src/packs/items/weapons/tier4/weapon_Floating_Bladeshards_1HBqL3gwZNSwCBFL.json
@@ -1,0 +1,41 @@
+{
+  "name": "Floating Bladeshards",
+  "type": "weapon",
+  "_id": "1HBqL3gwZNSwCBFL",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/magical/floating_bladeshards.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+9",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "feature": "powerful",
+    "range": "close",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748037994398,
+    "modifiedTime": 1748038014447,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!1HBqL3gwZNSwCBFL"
+}

--- a/src/packs/items/weapons/tier4/weapon_Fusion_Gloves_XcJce4ZCzXkhirza.json
+++ b/src/packs/items/weapons/tier4/weapon_Fusion_Gloves_XcJce4ZCzXkhirza.json
@@ -1,0 +1,41 @@
+{
+  "name": "Fusion Gloves",
+  "type": "weapon",
+  "_id": "XcJce4ZCzXkhirza",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/magical/fusion_gloves.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+9",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "knowledge",
+    "feature": "bonded",
+    "range": "veryFar",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748038283403,
+    "modifiedTime": 1748038307993,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!XcJce4ZCzXkhirza"
+}

--- a/src/packs/items/weapons/tier4/weapon_Hand_Cannon_R8xE9WZ9iPV6Z1gX.json
+++ b/src/packs/items/weapons/tier4/weapon_Hand_Cannon_R8xE9WZ9iPV6Z1gX.json
@@ -1,0 +1,41 @@
+{
+  "name": "Hand Cannon",
+  "type": "weapon",
+  "_id": "R8xE9WZ9iPV6Z1gX",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/physical/hand_cannon.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+12",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "feature": "reloading",
+    "range": "veryFar",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748036236804,
+    "modifiedTime": 1748036255361,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!R8xE9WZ9iPV6Z1gX"
+}

--- a/src/packs/items/weapons/tier4/weapon_Impact_Gauntlet_kI8Fw82maQYBiuKO.json
+++ b/src/packs/items/weapons/tier4/weapon_Impact_Gauntlet_kI8Fw82maQYBiuKO.json
@@ -1,0 +1,41 @@
+{
+  "name": "Impact Gauntlet",
+  "type": "weapon",
+  "_id": "kI8Fw82maQYBiuKO",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/physical/impact_gauntlet.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+11",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "feature": "concussive",
+    "range": "melee",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748035900679,
+    "modifiedTime": 1748035920680,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!kI8Fw82maQYBiuKO"
+}

--- a/src/packs/items/weapons/tier4/weapon_Legendary_Arcane_Gauntlets_sI23YidfmazUWSd5.json
+++ b/src/packs/items/weapons/tier4/weapon_Legendary_Arcane_Gauntlets_sI23YidfmazUWSd5.json
@@ -1,0 +1,41 @@
+{
+  "name": "Legendary Arcane Gauntlets",
+  "type": "weapon",
+  "_id": "sI23YidfmazUWSd5",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/magical/legendary_arcane_gauntlets.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+12",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "feature": "",
+    "range": "melee",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748036278482,
+    "modifiedTime": 1748036298386,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!sI23YidfmazUWSd5"
+}

--- a/src/packs/items/weapons/tier4/weapon_Legendary_Battleaxe_30V01DlHo5rrVfJT.json
+++ b/src/packs/items/weapons/tier4/weapon_Legendary_Battleaxe_30V01DlHo5rrVfJT.json
@@ -1,0 +1,41 @@
+{
+  "name": "Legendary Battleaxe",
+  "type": "weapon",
+  "_id": "30V01DlHo5rrVfJT",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/physical/legendary_battleaxe.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+12",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "feature": "",
+    "range": "melee",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748035381150,
+    "modifiedTime": 1748035402533,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!30V01DlHo5rrVfJT"
+}

--- a/src/packs/items/weapons/tier4/weapon_Legendary_Broadsword_a3j8NNUEUmfOXFZQ.json
+++ b/src/packs/items/weapons/tier4/weapon_Legendary_Broadsword_a3j8NNUEUmfOXFZQ.json
@@ -1,0 +1,41 @@
+{
+  "name": "Legendary Broadsword",
+  "type": "weapon",
+  "_id": "a3j8NNUEUmfOXFZQ",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/physical/legendary_broadsword.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+9",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "feature": "reliable",
+    "range": "melee",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748035124153,
+    "modifiedTime": 1748035160291,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!a3j8NNUEUmfOXFZQ"
+}

--- a/src/packs/items/weapons/tier4/weapon_Legendary_Crossbow_zT0lfEzzay3Pfjai.json
+++ b/src/packs/items/weapons/tier4/weapon_Legendary_Crossbow_zT0lfEzzay3Pfjai.json
@@ -1,0 +1,41 @@
+{
+  "name": "Legendary Crossbow",
+  "type": "weapon",
+  "_id": "zT0lfEzzay3Pfjai",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/physical/legendary_crossbow.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+10",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "feature": "",
+    "range": "far",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748035809338,
+    "modifiedTime": 1748035823146,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!zT0lfEzzay3Pfjai"
+}

--- a/src/packs/items/weapons/tier4/weapon_Legendary_Cutlass_5tYEYizBM6IS9bHH.json
+++ b/src/packs/items/weapons/tier4/weapon_Legendary_Cutlass_5tYEYizBM6IS9bHH.json
@@ -1,0 +1,41 @@
+{
+  "name": "Legendary Cutlass",
+  "type": "weapon",
+  "_id": "5tYEYizBM6IS9bHH",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/physical/legendary_cutlass.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+10",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "presence",
+    "feature": "",
+    "range": "melee",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748035596682,
+    "modifiedTime": 1748035618015,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!5tYEYizBM6IS9bHH"
+}

--- a/src/packs/items/weapons/tier4/weapon_Legendary_Dagger_KtFWQLwrDT1eAXfW.json
+++ b/src/packs/items/weapons/tier4/weapon_Legendary_Dagger_KtFWQLwrDT1eAXfW.json
@@ -1,0 +1,41 @@
+{
+  "name": "Legendary Dagger",
+  "type": "weapon",
+  "_id": "KtFWQLwrDT1eAXfW",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/physical/legendary_dagger.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+10",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "feature": "",
+    "range": "melee",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748035511214,
+    "modifiedTime": 1748035543656,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!KtFWQLwrDT1eAXfW"
+}

--- a/src/packs/items/weapons/tier4/weapon_Legendary_Dualstaff_8IiuOpspImJXxd3M.json
+++ b/src/packs/items/weapons/tier4/weapon_Legendary_Dualstaff_8IiuOpspImJXxd3M.json
@@ -1,0 +1,41 @@
+{
+  "name": "Legendary Dualstaff",
+  "type": "weapon",
+  "_id": "8IiuOpspImJXxd3M",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/magical/legendary_dualstaff.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+12",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "feature": "",
+    "range": "far",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748036876318,
+    "modifiedTime": 1748036899738,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!8IiuOpspImJXxd3M"
+}

--- a/src/packs/items/weapons/tier4/weapon_Legendary_Glowing_Rings_o2YogWivkfQN5uiO.json
+++ b/src/packs/items/weapons/tier4/weapon_Legendary_Glowing_Rings_o2YogWivkfQN5uiO.json
@@ -1,0 +1,41 @@
+{
+  "name": "Legendary Glowing Rings",
+  "type": "weapon",
+  "_id": "o2YogWivkfQN5uiO",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/magical/legendary_glowing_rings.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+11",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "feature": "",
+    "range": "veryClose",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748036340614,
+    "modifiedTime": 1748036668101,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!o2YogWivkfQN5uiO"
+}

--- a/src/packs/items/weapons/tier4/weapon_Legendary_Greatstaff_6yHpOErxja3ORXR3.json
+++ b/src/packs/items/weapons/tier4/weapon_Legendary_Greatstaff_6yHpOErxja3ORXR3.json
@@ -1,0 +1,41 @@
+{
+  "name": "Legendary Greatstaff",
+  "type": "weapon",
+  "_id": "6yHpOErxja3ORXR3",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/magical/legendary_greatstaff.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+9",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "knowledge",
+    "feature": "powerful",
+    "range": "veryClose",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748037493547,
+    "modifiedTime": 1748037516990,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!6yHpOErxja3ORXR3"
+}

--- a/src/packs/items/weapons/tier4/weapon_Legendary_Greatsword_bocnpC5X34s9DJ84.json
+++ b/src/packs/items/weapons/tier4/weapon_Legendary_Greatsword_bocnpC5X34s9DJ84.json
@@ -1,0 +1,41 @@
+{
+  "name": "Legendary Greatsword",
+  "type": "weapon",
+  "_id": "bocnpC5X34s9DJ84",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/physical/legendary_greatsword.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+12",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "feature": "massive",
+    "range": "melee",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748035411406,
+    "modifiedTime": 1748035426315,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!bocnpC5X34s9DJ84"
+}

--- a/src/packs/items/weapons/tier4/weapon_Legendary_Halberd_KIzmmRZCRnlfy398.json
+++ b/src/packs/items/weapons/tier4/weapon_Legendary_Halberd_KIzmmRZCRnlfy398.json
@@ -1,0 +1,41 @@
+{
+  "name": "Legendary Halberd",
+  "type": "weapon",
+  "_id": "KIzmmRZCRnlfy398",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/physical/legendary_halberd.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+11",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "feature": "cumbersome",
+    "range": "veryClose",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748035694823,
+    "modifiedTime": 1748035717710,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!KIzmmRZCRnlfy398"
+}

--- a/src/packs/items/weapons/tier4/weapon_Legendary_Hallowed_Axe_TxhLOsmk5CGbOXtl.json
+++ b/src/packs/items/weapons/tier4/weapon_Legendary_Hallowed_Axe_TxhLOsmk5CGbOXtl.json
@@ -1,0 +1,41 @@
+{
+  "name": "Legendary Hallowed Axe",
+  "type": "weapon",
+  "_id": "TxhLOsmk5CGbOXtl",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/magical/legendary_hallowed_axe.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+10",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "feature": "",
+    "range": "melee",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748036308494,
+    "modifiedTime": 1748036324619,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!TxhLOsmk5CGbOXtl"
+}

--- a/src/packs/items/weapons/tier4/weapon_Legendary_Hand_Runes_VoERob9158dndnz0.json
+++ b/src/packs/items/weapons/tier4/weapon_Legendary_Hand_Runes_VoERob9158dndnz0.json
@@ -1,0 +1,41 @@
+{
+  "name": "Legendary Hand Runes",
+  "type": "weapon",
+  "_id": "VoERob9158dndnz0",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/magical/legendary_hand_runes.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+9",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "feature": "",
+    "range": "veryClose",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748036679767,
+    "modifiedTime": 1748036698804,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!VoERob9158dndnz0"
+}

--- a/src/packs/items/weapons/tier4/weapon_Legendary_Longbow_72WaOMvPburJGcSV.json
+++ b/src/packs/items/weapons/tier4/weapon_Legendary_Longbow_72WaOMvPburJGcSV.json
@@ -1,0 +1,41 @@
+{
+  "name": "Legendary Longbow",
+  "type": "weapon",
+  "_id": "72WaOMvPburJGcSV",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/physical/legendary_longbow.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+12",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "feature": "cumbersome",
+    "range": "veryFar",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748035834991,
+    "modifiedTime": 1748035854361,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!72WaOMvPburJGcSV"
+}

--- a/src/packs/items/weapons/tier4/weapon_Legendary_Longsword_UaAZOEco3yrUMF2R.json
+++ b/src/packs/items/weapons/tier4/weapon_Legendary_Longsword_UaAZOEco3yrUMF2R.json
@@ -1,0 +1,41 @@
+{
+  "name": "Legendary Longsword",
+  "type": "weapon",
+  "_id": "UaAZOEco3yrUMF2R",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/physical/legendary_longsword.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+12",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "feature": "",
+    "range": "melee",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748035241283,
+    "modifiedTime": 1748035262092,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!UaAZOEco3yrUMF2R"
+}

--- a/src/packs/items/weapons/tier4/weapon_Legendary_Mace_Q3zGz4BWGPwThNhK.json
+++ b/src/packs/items/weapons/tier4/weapon_Legendary_Mace_Q3zGz4BWGPwThNhK.json
@@ -1,0 +1,41 @@
+{
+  "name": "Legendary Mace",
+  "type": "weapon",
+  "_id": "Q3zGz4BWGPwThNhK",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/physical/legendary_mace.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+10",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "feature": "",
+    "range": "melee",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748035444280,
+    "modifiedTime": 1748035462669,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!Q3zGz4BWGPwThNhK"
+}

--- a/src/packs/items/weapons/tier4/weapon_Legendary_Quarterstaff_iEXntwy16qcBXVjy.json
+++ b/src/packs/items/weapons/tier4/weapon_Legendary_Quarterstaff_iEXntwy16qcBXVjy.json
@@ -1,0 +1,41 @@
+{
+  "name": "Legendary Quarterstaff",
+  "type": "weapon",
+  "_id": "iEXntwy16qcBXVjy",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/physical/legendary_quarterstaff.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+12",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "feature": "",
+    "range": "melee",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748035558663,
+    "modifiedTime": 1748035588193,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!iEXntwy16qcBXVjy"
+}

--- a/src/packs/items/weapons/tier4/weapon_Legendary_Rapier_P1xXyWvYCLR02b5l.json
+++ b/src/packs/items/weapons/tier4/weapon_Legendary_Rapier_P1xXyWvYCLR02b5l.json
@@ -1,0 +1,41 @@
+{
+  "name": "Legendary Rapier",
+  "type": "weapon",
+  "_id": "P1xXyWvYCLR02b5l",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/physical/legendary_rapier.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+9",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "presence",
+    "feature": "quick",
+    "range": "melee",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748035626405,
+    "modifiedTime": 1748035684846,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!P1xXyWvYCLR02b5l"
+}

--- a/src/packs/items/weapons/tier4/weapon_Legendary_Returning_Blade_FEDXHLxkC3UK7ZEM.json
+++ b/src/packs/items/weapons/tier4/weapon_Legendary_Returning_Blade_FEDXHLxkC3UK7ZEM.json
@@ -1,0 +1,41 @@
+{
+  "name": "Legendary Returning Blade",
+  "type": "weapon",
+  "_id": "FEDXHLxkC3UK7ZEM",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/magical/legendary_returning_blade.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+9",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "feature": "retrieve",
+    "range": "close",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748036711181,
+    "modifiedTime": 1748036774931,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!FEDXHLxkC3UK7ZEM"
+}

--- a/src/packs/items/weapons/tier4/weapon_Legendary_Scepter_UruA4MYOIblYgCDt.json
+++ b/src/packs/items/weapons/tier4/weapon_Legendary_Scepter_UruA4MYOIblYgCDt.json
@@ -1,0 +1,41 @@
+{
+  "name": "Legendary Scepter",
+  "type": "weapon",
+  "_id": "UruA4MYOIblYgCDt",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/magical/legendary_scepter.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+9",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "presence",
+    "feature": "versatile",
+    "range": "far",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748037404434,
+    "modifiedTime": 1748037453330,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!UruA4MYOIblYgCDt"
+}

--- a/src/packs/items/weapons/tier4/weapon_Legendary_Shortbow_4LJ3n3dXQeaUkSQo.json
+++ b/src/packs/items/weapons/tier4/weapon_Legendary_Shortbow_4LJ3n3dXQeaUkSQo.json
@@ -1,0 +1,41 @@
+{
+  "name": "Legendary Shortbow",
+  "type": "weapon",
+  "_id": "4LJ3n3dXQeaUkSQo",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/physical/legendary_shortbow.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+12",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "feature": "",
+    "range": "far",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748035780892,
+    "modifiedTime": 1748035798511,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!4LJ3n3dXQeaUkSQo"
+}

--- a/src/packs/items/weapons/tier4/weapon_Legendary_Shortstaff_tNAcnWoed7WEZ9p0.json
+++ b/src/packs/items/weapons/tier4/weapon_Legendary_Shortstaff_tNAcnWoed7WEZ9p0.json
@@ -1,0 +1,41 @@
+{
+  "name": "Legendary Shortstaff",
+  "type": "weapon",
+  "_id": "tNAcnWoed7WEZ9p0",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/magical/legendary_shortstaff.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+10",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "feature": "",
+    "range": "close",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748036751087,
+    "modifiedTime": 1748036765881,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!tNAcnWoed7WEZ9p0"
+}

--- a/src/packs/items/weapons/tier4/weapon_Legendary_Spear_DI75wSq10QSF5sFM.json
+++ b/src/packs/items/weapons/tier4/weapon_Legendary_Spear_DI75wSq10QSF5sFM.json
@@ -1,0 +1,41 @@
+{
+  "name": "Legendary Spear",
+  "type": "weapon",
+  "_id": "DI75wSq10QSF5sFM",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/physical/legendary_spear.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+11",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "feature": "cumbersome",
+    "range": "veryClose",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748035729969,
+    "modifiedTime": 1748036865195,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!DI75wSq10QSF5sFM"
+}

--- a/src/packs/items/weapons/tier4/weapon_Legendary_Wand_2FiMSztRSxvl2OWN.json
+++ b/src/packs/items/weapons/tier4/weapon_Legendary_Wand_2FiMSztRSxvl2OWN.json
@@ -1,0 +1,41 @@
+{
+  "name": "Legendary Wand",
+  "type": "weapon",
+  "_id": "2FiMSztRSxvl2OWN",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/magical/legendary_wand.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+10",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "knowledge",
+    "feature": "",
+    "range": "far",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748037462942,
+    "modifiedTime": 1748037481379,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!2FiMSztRSxvl2OWN"
+}

--- a/src/packs/items/weapons/tier4/weapon_Legendary_Warhammer_9CCfQYb9s7fWVEjh.json
+++ b/src/packs/items/weapons/tier4/weapon_Legendary_Warhammer_9CCfQYb9s7fWVEjh.json
@@ -1,0 +1,41 @@
+{
+  "name": "Legendary Warhammer",
+  "type": "weapon",
+  "_id": "9CCfQYb9s7fWVEjh",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/physical/legendary_warhammer.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d12+12",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "feature": "heavy",
+    "range": "melee",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748035473288,
+    "modifiedTime": 1748035493376,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!9CCfQYb9s7fWVEjh"
+}

--- a/src/packs/items/weapons/tier4/weapon_Magus_Revolver_h4BHRl3Ji6NAmOd4.json
+++ b/src/packs/items/weapons/tier4/weapon_Magus_Revolver_h4BHRl3Ji6NAmOd4.json
@@ -1,0 +1,41 @@
+{
+  "name": "Magus Revolver",
+  "type": "weapon",
+  "_id": "h4BHRl3Ji6NAmOd4",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/magical/magus_revolver.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+13",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "finesse",
+    "feature": "reloading",
+    "range": "veryFar",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748038246368,
+    "modifiedTime": 1748038271449,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!h4BHRl3Ji6NAmOd4"
+}

--- a/src/packs/items/weapons/tier4/weapon_Midas_Scythe_cpK9iWwesVYUFyXO.json
+++ b/src/packs/items/weapons/tier4/weapon_Midas_Scythe_cpK9iWwesVYUFyXO.json
@@ -1,0 +1,41 @@
+{
+  "name": "Midas Scythe",
+  "type": "weapon",
+  "_id": "cpK9iWwesVYUFyXO",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/magical/midas_scythe.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+9",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "knowledge",
+    "feature": "greedy",
+    "range": "melee",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748037954420,
+    "modifiedTime": 1748037972671,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!cpK9iWwesVYUFyXO"
+}

--- a/src/packs/items/weapons/tier4/weapon_Ricochet_Axes_9Eqdt9BDUGjfP6Lx.json
+++ b/src/packs/items/weapons/tier4/weapon_Ricochet_Axes_9Eqdt9BDUGjfP6Lx.json
@@ -1,0 +1,41 @@
+{
+  "name": "Ricochet Axes",
+  "type": "weapon",
+  "_id": "9Eqdt9BDUGjfP6Lx",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/physical/ricochet_axes.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+11",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "agility",
+    "feature": "bouncing",
+    "range": "far",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748036183658,
+    "modifiedTime": 1748036197458,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!9Eqdt9BDUGjfP6Lx"
+}

--- a/src/packs/items/weapons/tier4/weapon_Siphoning_Gauntlets_sVAw2DRc5goXxFVk.json
+++ b/src/packs/items/weapons/tier4/weapon_Siphoning_Gauntlets_sVAw2DRc5goXxFVk.json
@@ -1,0 +1,41 @@
+{
+  "name": "Siphoning Gauntlets",
+  "type": "weapon",
+  "_id": "sVAw2DRc5goXxFVk",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/magical/siphoning_gauntlets.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+9",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "presence",
+    "feature": "lifestealing",
+    "range": "melee",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748037919641,
+    "modifiedTime": 1748037941422,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!sVAw2DRc5goXxFVk"
+}

--- a/src/packs/items/weapons/tier4/weapon_Sledge_Axe_ltCk06bPulLKwMs0.json
+++ b/src/packs/items/weapons/tier4/weapon_Sledge_Axe_ltCk06bPulLKwMs0.json
@@ -1,0 +1,41 @@
+{
+  "name": "Sledge Axe",
+  "type": "weapon",
+  "_id": "ltCk06bPulLKwMs0",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/physical/sledge_axe.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d12+13",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "feature": "destructive",
+    "range": "melee",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748035931856,
+    "modifiedTime": 1748035964268,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!ltCk06bPulLKwMs0"
+}

--- a/src/packs/items/weapons/tier4/weapon_Swinging_Ropeblade_n3KjqDGkTteA0akJ.json
+++ b/src/packs/items/weapons/tier4/weapon_Swinging_Ropeblade_n3KjqDGkTteA0akJ.json
@@ -1,0 +1,41 @@
+{
+  "name": "Swinging Ropeblade",
+  "type": "weapon",
+  "_id": "n3KjqDGkTteA0akJ",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/physical/swinging_ropeblade.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+9",
+      "type": "physical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "presence",
+    "feature": "grappling",
+    "range": "close",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748036149445,
+    "modifiedTime": 1748036170107,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!n3KjqDGkTteA0akJ"
+}

--- a/src/packs/items/weapons/tier4/weapon_Sword_of_Light___Flame_rgWjQGvUvgbk1h7d.json
+++ b/src/packs/items/weapons/tier4/weapon_Sword_of_Light___Flame_rgWjQGvUvgbk1h7d.json
@@ -1,0 +1,41 @@
+{
+  "name": "Sword of Light & Flame",
+  "type": "weapon",
+  "_id": "rgWjQGvUvgbk1h7d",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/magical/sword_of_light_flame.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d10+11",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "strength",
+    "feature": "chargedAttack",
+    "range": "melee",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748037560954,
+    "modifiedTime": 1748037607118,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!rgWjQGvUvgbk1h7d"
+}

--- a/src/packs/items/weapons/tier4/weapon_Thistlebow_oOhEjWqxLlAIcKjX.json
+++ b/src/packs/items/weapons/tier4/weapon_Thistlebow_oOhEjWqxLlAIcKjX.json
@@ -1,0 +1,41 @@
+{
+  "name": "Thistlebow",
+  "type": "weapon",
+  "_id": "oOhEjWqxLlAIcKjX",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/magical/thistlebow.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d6+13",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "instinct",
+    "feature": "reliable",
+    "range": "far",
+    "burden": "twoHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748038319940,
+    "modifiedTime": 1748038336938,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!oOhEjWqxLlAIcKjX"
+}

--- a/src/packs/items/weapons/tier4/weapon_Wand_of_Essek_mp8s5umPvk4Vw25q.json
+++ b/src/packs/items/weapons/tier4/weapon_Wand_of_Essek_mp8s5umPvk4Vw25q.json
@@ -1,0 +1,41 @@
+{
+  "name": "Wand of Essek",
+  "type": "weapon",
+  "_id": "mp8s5umPvk4Vw25q",
+  "img": "systems/daggerheart/assets/icons/weapons/primary/tier_4/magical/wand_of_essek.png",
+  "system": {
+    "active": false,
+    "inventoryWeapon": null,
+    "secondary": false,
+    "damage": {
+      "value": "d8+13",
+      "type": "magical"
+    },
+    "quantity": 1,
+    "description": "",
+    "trait": "knowledge",
+    "feature": "timebender",
+    "range": "far",
+    "burden": "oneHanded"
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "ei8OkswTzyDp4IGC": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1748038190876,
+    "modifiedTime": 1748038227799,
+    "lastModifiedBy": "ei8OkswTzyDp4IGC"
+  },
+  "_key": "!items!mp8s5umPvk4Vw25q"
+}

--- a/src/packs/subclasses/subclass_Troubadour_T1iBO8i0xRF5c8Q2.json
+++ b/src/packs/subclasses/subclass_Troubadour_T1iBO8i0xRF5c8Q2.json
@@ -1,66 +1,66 @@
 {
-    "name": "Troubadour",
-    "type": "subclass",
-    "_id": "T1iBO8i0xRF5c8Q2",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "description": "<p>Play the Troubadour if you want to play music to bolster your allies.</p>",
-        "spellcastingTrait": "presence",
-        "foundationFeature": {
-            "description": "<p><strong>Gifted Performer:</strong> Describe how you perform for others. You can play each song once per long rest:</p><p>• <strong>Relaxing Song:</strong> You and all allies within Close range clear a Hit Point.</p><p>• <strong>Epic Song:</strong> Make a target within Close range temporarily Vulnerable.</p><p>• <strong>Heartbreaking Song:</strong> You and all allies within Close range gain a Hope.</p>",
-            "abilities": [
-                {
-                    "actionType": "passive",
-                    "featureType": {
-                        "type": "normal",
-                        "data": {
-                            "property": "spellcastingTrait",
-                            "max": 1,
-                            "numbers": {}
-                        }
-                    },
-                    "refreshData": null,
-                    "multiclass": null,
-                    "disabled": false,
-                    "description": "<p>You are among the greatest of your craft and your skill is boundless. You can perform each of your “Gifted Performer” feature’s songs twice instead of once per long rest.</p>",
-                    "effects": {},
-                    "actions": [],
-                    "type": "subclass"
-                }
-            ]
-        },
-        "specializationFeature": {
-            "unlocked": false,
-            "tier": null,
-            "description": "",
-            "abilities": []
-        },
-        "masteryFeature": {
-            "unlocked": false,
-            "tier": null,
-            "description": "",
-            "abilities": []
-        },
-        "multiclass": null
+  "name": "Troubadour",
+  "type": "subclass",
+  "_id": "T1iBO8i0xRF5c8Q2",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": "<p>Play the Troubadour if you want to play music to bolster your allies.</p>",
+    "spellcastingTrait": "presence",
+    "foundationFeature": {
+      "description": "<p><strong>Gifted Performer:</strong> Describe how you perform for others. You can play each song once per long rest:</p><p>• <strong>Relaxing Song:</strong> You and all allies within Close range clear a Hit Point.</p><p>• <strong>Epic Song:</strong> Make a target within Close range temporarily Vulnerable.</p><p>• <strong>Heartbreaking Song:</strong> You and all allies within Close range gain a Hope.</p>",
+      "abilities": [
+        {
+          "actionType": "passive",
+          "featureType": {
+            "type": "normal",
+            "data": {
+              "property": "spellcastingTrait",
+              "max": 1,
+              "numbers": {}
+            }
+          },
+          "refreshData": null,
+          "multiclass": null,
+          "disabled": false,
+          "description": "<p>You are among the greatest of your craft and your skill is boundless. You can perform each of your “Gifted Performer” feature’s songs twice instead of once per long rest.</p>",
+          "effects": {},
+          "actions": [],
+          "type": "subclass"
+        }
+      ]
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3
+    "specializationFeature": {
+      "unlocked": false,
+      "tier": null,
+      "description": "",
+      "abilities": []
     },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1747991594334,
-        "modifiedTime": 1747991866434,
-        "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+    "masteryFeature": {
+      "unlocked": false,
+      "tier": null,
+      "description": "",
+      "abilities": []
     },
-    "_key": "!items!T1iBO8i0xRF5c8Q2"
+    "multiclass": null
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747991594334,
+    "modifiedTime": 1747991866434,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!T1iBO8i0xRF5c8Q2"
 }

--- a/src/packs/subclasses/subclass_Wordsmith_FXT65YDVWFy85EI0.json
+++ b/src/packs/subclasses/subclass_Wordsmith_FXT65YDVWFy85EI0.json
@@ -1,47 +1,47 @@
 {
-    "name": "Wordsmith",
-    "type": "subclass",
-    "_id": "FXT65YDVWFy85EI0",
-    "img": "icons/svg/item-bag.svg",
-    "system": {
-        "description": "<p>Play the Wordsmith if you want to use clever wordplay and captivate crowds.</p>",
-        "spellcastingTrait": "presence",
-        "foundationFeature": {
-            "description": "",
-            "abilities": []
-        },
-        "specializationFeature": {
-            "unlocked": false,
-            "tier": null,
-            "description": "",
-            "abilities": []
-        },
-        "masteryFeature": {
-            "unlocked": false,
-            "tier": null,
-            "description": "",
-            "abilities": []
-        },
-        "multiclass": null
+  "name": "Wordsmith",
+  "type": "subclass",
+  "_id": "FXT65YDVWFy85EI0",
+  "img": "icons/svg/item-bag.svg",
+  "system": {
+    "description": "<p>Play the Wordsmith if you want to use clever wordplay and captivate crowds.</p>",
+    "spellcastingTrait": "presence",
+    "foundationFeature": {
+      "description": "",
+      "abilities": []
     },
-    "effects": [],
-    "folder": null,
-    "sort": 0,
-    "ownership": {
-        "default": 0,
-        "NqO2eQGMjrvUO6v9": 3
+    "specializationFeature": {
+      "unlocked": false,
+      "tier": null,
+      "description": "",
+      "abilities": []
     },
-    "flags": {},
-    "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "exportSource": null,
-        "coreVersion": "13.344",
-        "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1747991988842,
-        "modifiedTime": 1747992014955,
-        "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+    "masteryFeature": {
+      "unlocked": false,
+      "tier": null,
+      "description": "",
+      "abilities": []
     },
-    "_key": "!items!FXT65YDVWFy85EI0"
+    "multiclass": null
+  },
+  "effects": [],
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "NqO2eQGMjrvUO6v9": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.344",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1747991988842,
+    "modifiedTime": 1747992014955,
+    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+  },
+  "_key": "!items!FXT65YDVWFy85EI0"
 }

--- a/styles/daggerheart.css
+++ b/styles/daggerheart.css
@@ -8,3149 +8,2625 @@
 /* Inputs */
 @import '../node_modules/@yaireo/tagify/dist/tagify.css';
 .daggerheart.sheet.class .editor {
-    height: 500px;
+  height: 500px;
 }
 .daggerheart.sheet.pc {
-    width: 810px !important;
+  width: 810px !important;
 }
 .daggerheart.sheet.pc div[data-application-part] {
-    display: flex;
-    flex-direction: column;
+  display: flex;
+  flex-direction: column;
 }
 .daggerheart.sheet.pc div[data-application-part] .pc-sheet-header {
-    display: flex;
-    gap: 4px;
-    height: 120px;
-    margin-bottom: 4px;
+  display: flex;
+  gap: 4px;
+  height: 120px;
+  margin-bottom: 4px;
 }
 .daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .portrait {
-    border: 0;
-    border-right: 1px solid var(--color-underline-header);
+  border: 0;
+  border-right: 1px solid var(--color-underline-header);
 }
 .daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .class-info {
-    flex: 1;
-    background: #778899;
+  flex: 1;
+  background: #778899;
 }
 .daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .class-info .portrait {
-    max-width: 120px;
+  max-width: 120px;
 }
 .daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .class-info .class-title {
-    text-align: center;
-    display: flex;
-    justify-content: space-between;
+  text-align: center;
+  display: flex;
+  justify-content: space-between;
 }
 .daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .class-info .class-title span:hover {
-    filter: drop-shadow(0px 0px 3px red);
-    cursor: pointer;
+  filter: drop-shadow(0px 0px 3px red);
+  cursor: pointer;
 }
 .daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .class-info .class-title .domain-container {
-    margin-left: 4px;
+  margin-left: 4px;
 }
 .daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .class-info .class-add-container {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    flex: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  flex: 0;
 }
 .daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .class-info .class-add-container button {
-    height: 22px;
-    width: 22px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-left: 4px;
-    background: #778899;
+  height: 22px;
+  width: 22px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 4px;
+  background: #778899;
 }
 .daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .class-info .domain-title {
-    text-transform: uppercase;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    line-height: 23px;
-    font-weight: bold;
-    font-style: italic;
+  text-transform: uppercase;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  line-height: 23px;
+  font-weight: bold;
+  font-style: italic;
 }
 .daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .class-info .domain-image {
-    height: 30px;
-    flex: 0;
+  height: 30px;
+  flex: 0;
 }
 .daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .general-info {
-    flex: 2;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
+  flex: 2;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 .daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .general-info .general-input {
-    position: relative;
+  position: relative;
 }
 .daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .general-info .general-input .general-title {
-    position: absolute;
-    left: 4px;
-    text-align: center;
-    font-weight: bold;
-    text-transform: uppercase;
+  position: absolute;
+  left: 4px;
+  text-align: center;
+  font-weight: bold;
+  text-transform: uppercase;
 }
 .daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .general-info .pc-tabs {
-    flex: 1;
-    margin: 0;
+  flex: 1;
+  margin: 0;
 }
 .daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .general-info .rest-container {
-    flex-wrap: nowrap;
-    display: flex;
-    height: var(--form-field-height);
-    flex: 0;
+  flex-wrap: nowrap;
+  display: flex;
+  height: var(--form-field-height);
+  flex: 0;
 }
 .daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .general-info .rest-container button {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 50%;
-    width: var(--form-field-height);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  width: var(--form-field-height);
 }
 .daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .general-info .rest-container button i {
-    font-size: 13px;
+  font-size: 13px;
 }
 .daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .general-info .level-container {
-    position: relative;
-    bottom: 4px;
-    flex: none;
-    width: 40px;
-    border: none;
-    outline: none;
-    margin-left: 8px;
+  position: relative;
+  bottom: 4px;
+  flex: none;
+  width: 40px;
+  border: none;
+  outline: none;
+  margin-left: 8px;
 }
 .daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .general-info .level-container.levelup {
-    filter: drop-shadow(0px 0px 3px gold);
+  filter: drop-shadow(0px 0px 3px gold);
 }
 .daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .general-info .level-container img {
-    height: 40px;
-    width: 40px;
-    border: none;
+  height: 40px;
+  width: 40px;
+  border: none;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .pc-sheet-header
-    .general-info
-    .level-container
-    .level-value-container {
-    width: 48px;
-    position: absolute;
-    top: calc(50% - 17px);
-    left: calc(50% - 23px);
+.daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .general-info .level-container .level-value-container {
+  width: 48px;
+  position: absolute;
+  top: calc(50% - 17px);
+  left: calc(50% - 23px);
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .pc-sheet-header
-    .general-info
-    .level-container
-    .level-value-container
-    .level-value {
-    font-weight: bold;
-    font-size: 20px;
-    text-align: center;
+.daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .general-info .level-container .level-value-container .level-value {
+  font-weight: bold;
+  font-size: 20px;
+  text-align: center;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .pc-sheet-header
-    .general-info
-    .level-container
-    .level-value-container
-    .level-value:not(:hover),
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .pc-sheet-header
-    .general-info
-    .level-container
-    .level-value-container
-    .level-value:not(:focus) {
-    border: none;
+.daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .general-info .level-container .level-value-container .level-value:not(:hover),
+.daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .general-info .level-container .level-value-container .level-value:not(:focus) {
+  border: none;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .pc-sheet-header
-    .general-info
-    .level-container
-    .level-value-container
-    .levelup-marker {
-    position: absolute;
-    top: 0;
-    right: calc(50% - 12px);
-    color: gold;
-    filter: drop-shadow(0px 0px 3px black);
+.daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .general-info .level-container .level-value-container .levelup-marker {
+  position: absolute;
+  top: 0;
+  right: calc(50% - 12px);
+  color: gold;
+  filter: drop-shadow(0px 0px 3px black);
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .pc-sheet-header
-    .general-info
-    .level-container
-    .level-value-container
-    .levelup-marker.double-digit {
-    right: calc(50% - 20px);
+.daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .general-info .level-container .level-value-container .levelup-marker.double-digit {
+  right: calc(50% - 20px);
 }
 .daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .general-info .level-container .level-title {
-    position: absolute;
-    bottom: 2px;
-    width: 42px;
-    background-color: black;
-    color: white;
-    left: calc(50% - 21px);
-    text-align: center;
-    border-radius: 5px;
-    font-size: 12px;
+  position: absolute;
+  bottom: 2px;
+  width: 42px;
+  background-color: black;
+  color: white;
+  left: calc(50% - 21px);
+  text-align: center;
+  border-radius: 5px;
+  font-size: 12px;
 }
 .daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .general-info .level-container .level-title.levelup {
-    color: gold;
-    filter: drop-shadow(0px 0px 3px orange);
-    font-weight: bold;
-    cursor: pointer;
+  color: gold;
+  filter: drop-shadow(0px 0px 3px orange);
+  font-weight: bold;
+  cursor: pointer;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .pc-sheet-header
-    .general-info
-    .level-container
-    .level-title.levelup:hover {
-    background-color: aliceblue;
+.daggerheart.sheet.pc div[data-application-part] .pc-sheet-header .general-info .level-container .level-title.levelup:hover {
+  background-color: aliceblue;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .tab-container {
-    height: 100%;
-    display: flex;
-    flex-direction: column;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .tab-container .tab-inner-container {
-    flex: 1;
+  flex: 1;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .tab-container .tab-inner-container .body-section {
-    display: flex;
-    flex-direction: column;
+  display: flex;
+  flex-direction: column;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .tab-container
-    .tab-inner-container
-    .body-section
-    fieldset {
-    flex: 0;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .tab-container .tab-inner-container .body-section fieldset {
+  flex: 0;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .system-info {
-    font-size: 12px;
-    font-style: italic;
-    font-weight: bold;
-    margin-top: -4px;
-    flex: 0;
+  font-size: 12px;
+  font-style: italic;
+  font-weight: bold;
+  margin-top: -4px;
+  flex: 0;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .feature-sheet-body {
-    gap: 4px;
+  gap: 4px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-container {
-    position: relative;
-    display: flex;
-    flex-wrap: wrap;
-    border-radius: 6px;
-    padding-left: 0;
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  border-radius: 6px;
+  padding-left: 0;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-container legend {
-    margin-left: auto;
-    margin-right: auto;
-    font-weight: bold;
-    text-transform: uppercase;
-    padding: 0 8px;
-    position: relative;
+  margin-left: auto;
+  margin-right: auto;
+  font-weight: bold;
+  text-transform: uppercase;
+  padding: 0 8px;
+  position: relative;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-container .attributes-menu {
-    position: absolute;
-    bottom: calc(50% - 12px);
-    font-size: 24px;
-    left: -8px;
+  position: absolute;
+  bottom: calc(50% - 12px);
+  font-size: 24px;
+  left: -8px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-container .attribute {
-    position: relative;
-    padding: 0 0 4px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    flex-basis: 33.33%;
+  position: relative;
+  padding: 0 0 4px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex-basis: 33.33%;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-container .attribute .attribute-banner {
-    position: relative;
-    top: 8px;
-    z-index: 2;
-    background: black;
-    color: white;
-    text-transform: uppercase;
-    padding: 2px;
-    border-radius: 6px;
-    display: flex;
-    align-items: center;
-    overflow: hidden;
-    min-width: 96px;
+  position: relative;
+  top: 8px;
+  z-index: 2;
+  background: black;
+  color: white;
+  text-transform: uppercase;
+  padding: 2px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  min-width: 96px;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .abilities-container
-    .attribute
-    .attribute-banner
-    .attribute-roll {
-    position: absolute;
-    width: 16px;
-    transition: transform 0.2s;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-container .attribute .attribute-banner .attribute-roll {
+  position: absolute;
+  width: 16px;
+  transition: transform 0.2s;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .abilities-container
-    .attribute
-    .attribute-banner
-    .attribute-roll:hover {
-    transform: rotate(30deg);
-    filter: drop-shadow(0px 0px 3px red);
-    cursor: pointer;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-container .attribute .attribute-banner .attribute-roll:hover {
+  transform: rotate(30deg);
+  filter: drop-shadow(0px 0px 3px red);
+  cursor: pointer;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .abilities-container
-    .attribute
-    .attribute-banner
-    .attribute-text {
-    width: 100%;
-    margin-left: 16px;
-    font-size: 12px;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-container .attribute .attribute-banner .attribute-text {
+  width: 100%;
+  margin-left: 16px;
+  font-size: 12px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-container .attribute .attribute-mark {
-    height: 23px;
-    width: 23px;
-    position: absolute;
-    right: -5px;
-    top: 6px;
-    border: 2px solid black;
-    border-radius: 50%;
-    background: white;
-    z-index: 2;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  height: 23px;
+  width: 23px;
+  position: absolute;
+  right: -5px;
+  top: 6px;
+  border: 2px solid black;
+  border-radius: 50%;
+  background: white;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .abilities-container
-    .attribute
-    .attribute-mark.selectable {
-    border-color: gold;
-    filter: drop-shadow(0 0 3px black);
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-container .attribute .attribute-mark.selectable {
+  border-color: gold;
+  filter: drop-shadow(0 0 3px black);
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .abilities-container
-    .attribute
-    .attribute-mark.selectable:hover
-    i {
-    opacity: 0.3;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-container .attribute .attribute-mark.selectable:hover i {
+  opacity: 0.3;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-container .attribute .attribute-mark i.selected,
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .abilities-container
-    .attribute
-    .attribute-mark:hover
-    i.selected {
-    color: green;
-    opacity: 1;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-container .attribute .attribute-mark:hover i.selected {
+  color: green;
+  opacity: 1;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-container .attribute .attribute-mark i {
-    color: black;
-    font-size: 17px;
-    opacity: 0;
+  color: black;
+  font-size: 17px;
+  opacity: 0;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-container .attribute .attribute-image {
-    position: relative;
-    width: fit-content;
-    display: flex;
+  position: relative;
+  width: fit-content;
+  display: flex;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-container .attribute .attribute-image img {
-    height: 80px;
-    width: 80px;
-    border: none;
+  height: 80px;
+  width: 80px;
+  border: none;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .abilities-container
-    .attribute
-    .attribute-image
-    .attribute-value {
-    width: 55px;
-    padding-right: 10px;
-    position: absolute;
-    top: calc(50% - 18px);
-    left: calc(50% - 24px);
-    font-weight: bold;
-    font-size: 30px;
-    line-height: 30px;
-    text-align: center;
-    border: none;
-    appearance: none;
-    -moz-appearance: none;
-    -webkit-appearance: none;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-container .attribute .attribute-image .attribute-value {
+  width: 55px;
+  padding-right: 10px;
+  position: absolute;
+  top: calc(50% - 18px);
+  left: calc(50% - 24px);
+  font-weight: bold;
+  font-size: 30px;
+  line-height: 30px;
+  text-align: center;
+  border: none;
+  appearance: none;
+  -moz-appearance: none;
+  -webkit-appearance: none;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .abilities-container
-    .attribute
-    .attribute-image
-    .attribute-value.negative {
-    left: calc(50% - 29px);
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-container .attribute .attribute-image .attribute-value.negative {
+  left: calc(50% - 29px);
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .abilities-container
-    .attribute
-    .attribute-image
-    .attribute-value.unselected {
-    filter: drop-shadow(0 0 3px gold);
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-container .attribute .attribute-image .attribute-value.unselected {
+  filter: drop-shadow(0 0 3px gold);
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .abilities-container
-    .attribute
-    .attribute-image
-    .attribute-text {
-    width: 47px;
-    position: absolute;
-    top: calc(50% - 22px);
-    left: calc(50% - 24px);
-    font-weight: bold;
-    font-size: 30px;
-    text-align: center;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-container .attribute .attribute-image .attribute-text {
+  width: 47px;
+  position: absolute;
+  top: calc(50% - 22px);
+  left: calc(50% - 24px);
+  font-weight: bold;
+  font-size: 30px;
+  text-align: center;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .abilities-container
-    .attribute
-    .attribute-image
-    .attribute-text.negative {
-    left: calc(50% - 29px);
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-container .attribute .attribute-image .attribute-text.negative {
+  left: calc(50% - 29px);
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-container .attribute .attribute-verb {
-    font-variant: petite-caps;
+  font-variant: petite-caps;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .defense-row {
-    height: 100%;
-    width: 100%;
-    display: flex;
-    align-items: baseline;
-    justify-content: space-evenly;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-evenly;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .defense-row .defense-section {
-    display: flex;
-    align-items: center;
-    margin-right: 8px;
+  display: flex;
+  align-items: center;
+  margin-right: 8px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .defense-row .defense-section .defense-container {
-    position: relative;
-    padding: 4px;
-    max-width: 100px;
+  position: relative;
+  padding: 4px;
+  max-width: 100px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .defense-row .defense-section .defense-container img {
-    border: none;
-    max-width: 80px;
+  border: none;
+  max-width: 80px;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .defense-row
-    .defense-section
-    .defense-container
-    .defense-value {
-    width: 47px;
-    position: absolute;
-    top: calc(50% - 22px);
-    left: calc(50% - 24px);
-    font-weight: bold;
-    font-size: 30px;
-    text-align: center;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .defense-row .defense-section .defense-container .defense-value {
+  width: 47px;
+  position: absolute;
+  top: calc(50% - 22px);
+  left: calc(50% - 24px);
+  font-weight: bold;
+  font-size: 30px;
+  text-align: center;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .defense-row
-    .defense-section
-    .defense-container
-    .defense-value:not(:hover),
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .defense-row
-    .defense-section
-    .defense-container
-    .defense-value:not(:focus) {
-    border: none;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .defense-row .defense-section .defense-container .defense-value:not(:hover),
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .defense-row .defense-section .defense-container .defense-value:not(:focus) {
+  border: none;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .defense-row
-    .defense-section
-    .defense-container
-    .defense-banner {
-    position: absolute;
-    bottom: 20px;
-    left: calc(50% - 42px);
-    z-index: 2;
-    background-color: black;
-    color: white;
-    width: 84px;
-    text-align: center;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .defense-row .defense-section .defense-container .defense-banner {
+  position: absolute;
+  bottom: 20px;
+  left: calc(50% - 42px);
+  z-index: 2;
+  background-color: black;
+  color: white;
+  width: 84px;
+  text-align: center;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .defense-row .armor-marks {
-    max-width: 67px;
-    padding: 4px;
-    align-self: end;
-    margin-left: 4px;
+  max-width: 67px;
+  padding: 4px;
+  align-self: end;
+  margin-left: 4px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .defense-row .armor-marks .mark {
-    width: 16px;
-    height: 16px;
-    margin: 0px;
+  width: 16px;
+  height: 16px;
+  margin: 0px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .defense-row .armor-marks .disabled-mark {
-    opacity: 0.6;
+  opacity: 0.6;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .left-main-container {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    border-radius: 6px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  border-radius: 6px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .left-main-container .legend {
-    margin-left: auto;
-    margin-right: auto;
-    font-weight: bold;
-    text-transform: uppercase;
-    padding: 0 4px;
-    position: relative;
+  margin-left: auto;
+  margin-right: auto;
+  font-weight: bold;
+  text-transform: uppercase;
+  padding: 0 4px;
+  position: relative;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .weapon-section {
-    padding-top: 8px;
+  padding-top: 8px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .threshold-container {
-    position: relative;
-    display: flex;
-    align-items: center;
-    align-self: center;
+  position: relative;
+  display: flex;
+  align-items: center;
+  align-self: center;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .threshold-container .threshold-box {
-    position: relative;
-    width: 30px;
-    height: 30px;
-    border: 2px solid black;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 20px;
-    font-weight: bold;
+  position: relative;
+  width: 30px;
+  height: 30px;
+  border: 2px solid black;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  font-weight: bold;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .threshold-container .threshold-spacer {
-    position: relative;
-    z-index: 2;
-    width: 70px;
-    height: 18px;
-    background-color: darkgray;
-    color: white;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+  position: relative;
+  z-index: 2;
+  width: 70px;
+  height: 18px;
+  background-color: darkgray;
+  color: white;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .resource-label {
-    text-transform: uppercase;
-    font-weight: bold;
+  text-transform: uppercase;
+  font-weight: bold;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .death-save {
-    position: absolute;
-    right: -22px;
+  position: absolute;
+  right: -22px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .death-save:hover:not(.disabled) {
-    filter: drop-shadow(0 0 3px red);
-    cursor: pointer;
+  filter: drop-shadow(0 0 3px red);
+  cursor: pointer;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .death-save.disabled {
-    opacity: 0.4;
+  opacity: 0.4;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .resource-box {
-    width: 20px;
-    height: 12px;
+  width: 20px;
+  height: 12px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .resource-box.stress:nth-child(even) {
-    position: relative;
-    right: 1px;
+  position: relative;
+  right: 1px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .resource-box .disabled {
-    opacity: 0.6;
+  opacity: 0.6;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .hope-text {
-    font-size: 11.7px;
-    margin-right: 6px;
+  font-size: 11.7px;
+  margin-right: 6px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .hope-container {
-    background: darkgray;
-    border-radius: 6px;
-    display: flex;
-    padding: 2px 0px;
+  background: darkgray;
+  border-radius: 6px;
+  display: flex;
+  padding: 2px 0px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .hope-container .vertical-separator {
-    border-left: 2px solid white;
-    height: auto;
-    margin: 4px 0;
-    flex: 0;
+  border-left: 2px solid white;
+  height: auto;
+  margin: 4px 0;
+  flex: 0;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .hope-container .hope-inner-container {
-    position: relative;
+  position: relative;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .hope-container .hope-inner-container .hope-value {
-    width: 16px;
-    height: 16px;
+  width: 16px;
+  height: 16px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .hope-container .hope-inner-container .hope-scar {
-    position: absolute;
-    top: calc(50% - 6px);
-    left: calc(50% - 7px);
-    opacity: 0.4;
-    font-size: 12px;
-    -webkit-transform: scaleX(-1);
-    transform: scaleX(-1);
+  position: absolute;
+  top: calc(50% - 6px);
+  left: calc(50% - 7px);
+  opacity: 0.4;
+  font-size: 12px;
+  -webkit-transform: scaleX(-1);
+  transform: scaleX(-1);
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .experience-row {
-    width: 100%;
-    display: flex;
-    align-items: flex-end;
+  width: 100%;
+  display: flex;
+  align-items: flex-end;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .experience-row .experience-selector {
-    font-size: 18px;
-    cursor: pointer;
-    margin-right: 4px;
-    opacity: 0.5;
+  font-size: 18px;
+  cursor: pointer;
+  margin-right: 4px;
+  opacity: 0.5;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .experience-row .experience-selector:hover:not(.selected) {
-    filter: drop-shadow(0 0 3px gold);
+  filter: drop-shadow(0 0 3px gold);
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .experience-row .experience-selector.selected {
-    filter: drop-shadow(0 0 3px gold);
-    opacity: 1;
+  filter: drop-shadow(0 0 3px gold);
+  opacity: 1;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .experience-row .experience-value {
-    margin-left: 8px;
-    width: 30px;
-    border-bottom: 2px solid black;
-    border-radius: 4px;
-    text-align: center;
-    font-weight: bold;
+  margin-left: 8px;
+  width: 30px;
+  border-bottom: 2px solid black;
+  border-radius: 4px;
+  text-align: center;
+  font-weight: bold;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .experience-row .experience-value.empty {
-    border: 0;
+  border: 0;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .experience-row .disabled-experience {
-    border: 1px solid #7a7971;
-    background: rgba(0, 0, 0, 0.2);
+  border: 1px solid #7a7971;
+  background: rgba(0, 0, 0, 0.2);
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .gold-section {
-    width: calc(100% - 8px);
-    display: flex;
-    justify-content: space-between;
+  width: calc(100% - 8px);
+  display: flex;
+  justify-content: space-between;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .gold-section fieldset.gold-fieldset {
-    padding-right: 0;
-    padding-left: 0;
-    padding-bottom: 4px;
+  padding-right: 0;
+  padding-left: 0;
+  padding-bottom: 4px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .gold-section fieldset.gold-fieldset legend {
-    margin-left: auto;
-    margin-right: auto;
-    font-size: 15px;
-    font-variant: all-petite-caps;
-    font-weight: bold;
+  margin-left: auto;
+  margin-right: auto;
+  font-size: 15px;
+  font-variant: all-petite-caps;
+  font-weight: bold;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .gold-section fieldset.gold-fieldset .gold-column {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-    gap: 4px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: 4px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .gold-section fieldset.gold-fieldset .gold-row {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0 4px;
-    gap: 2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 4px;
+  gap: 2px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .gold-section fieldset.gold-fieldset .gold-row img,
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .gold-section fieldset.gold-fieldset .gold-column img {
-    min-width: 14px;
-    min-height: 14px;
-    height: 14px;
-    border: 0;
-    filter: invert(0%) sepia(100%) saturate(0%) hue-rotate(21deg) brightness(17%) contrast(103%);
+  min-width: 14px;
+  min-height: 14px;
+  height: 14px;
+  border: 0;
+  filter: invert(0%) sepia(100%) saturate(0%) hue-rotate(21deg) brightness(17%) contrast(103%);
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .gold-section fieldset.gold-fieldset .gold-row img:hover,
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .gold-section
-    fieldset.gold-fieldset
-    .gold-column
-    img:hover {
-    cursor: pointer;
-    filter: invert(0%) sepia(100%) saturate(0%) hue-rotate(21deg) brightness(17%) contrast(103%)
-        drop-shadow(0 0 3px red);
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .gold-section fieldset.gold-fieldset .gold-column img:hover {
+  cursor: pointer;
+  filter: invert(0%) sepia(100%) saturate(0%) hue-rotate(21deg) brightness(17%) contrast(103%) drop-shadow(0 0 3px red);
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .gold-section fieldset.gold-fieldset .gold-row i:hover,
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .gold-section fieldset.gold-fieldset .gold-column i:hover {
-    cursor: pointer;
-    filter: drop-shadow(0 0 3px red);
+  cursor: pointer;
+  filter: drop-shadow(0 0 3px red);
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .gold-section
-    fieldset.gold-fieldset
-    .gold-row
-    img:not(.owned),
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .gold-section
-    fieldset.gold-fieldset
-    .gold-column
-    img:not(.owned),
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .gold-section
-    fieldset.gold-fieldset
-    .gold-row
-    i:not(.owned),
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .gold-section
-    fieldset.gold-fieldset
-    .gold-column
-    i:not(.owned) {
-    opacity: 0.4;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .gold-section fieldset.gold-fieldset .gold-row img:not(.owned),
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .gold-section fieldset.gold-fieldset .gold-column img:not(.owned),
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .gold-section fieldset.gold-fieldset .gold-row i:not(.owned),
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .gold-section fieldset.gold-fieldset .gold-column i:not(.owned) {
+  opacity: 0.4;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .health-category {
-    text-transform: uppercase;
+  text-transform: uppercase;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .class-feature-selectable {
-    cursor: pointer;
+  cursor: pointer;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .class-feature-selectable:hover {
-    filter: drop-shadow(0 0 3px red);
+  filter: drop-shadow(0 0 3px red);
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .class-feature-selectable.inactive {
-    opacity: 0.5;
+  opacity: 0.5;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .features-container {
-    width: 100%;
-    min-height: 136px;
+  width: 100%;
+  min-height: 136px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .features-container .feature-container {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 4px;
-    margin-bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px;
+  margin-bottom: 0;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .features-container .feature-container .feature-img {
-    max-width: 42px;
+  max-width: 42px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .features-container .feature-container .feature-label {
-    font-weight: bold;
-    font-size: 30px;
+  font-weight: bold;
+  font-size: 30px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .features-container .feature-container button {
-    flex: 0;
+  flex: 0;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .features-container .feature-tick-container {
-    flex: 0;
-    min-width: 56px;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    margin: 0 24px;
+  flex: 0;
+  min-width: 56px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0 24px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .features-container .feature-tick-container .feature-tick {
-    position: relative;
-    border: 2px solid #7a7971;
-    height: 24px;
-    border-radius: 50%;
-    width: 24px;
-    background: rgba(0, 0, 0, 0.05);
-    display: flex;
-    justify-content: center;
+  position: relative;
+  border: 2px solid #7a7971;
+  height: 24px;
+  border-radius: 50%;
+  width: 24px;
+  background: rgba(0, 0, 0, 0.05);
+  display: flex;
+  justify-content: center;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .features-container
-    .feature-tick-container
-    .feature-tick:hover:not(.disabled):not(.used) {
-    cursor: pointer;
-    filter: drop-shadow(0 0 3px red);
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .features-container .feature-tick-container .feature-tick:hover:not(.disabled):not(.used) {
+  cursor: pointer;
+  filter: drop-shadow(0 0 3px red);
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .features-container
-    .feature-tick-container
-    .feature-tick.disabled {
-    opacity: 0.3;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .features-container .feature-tick-container .feature-tick.disabled {
+  opacity: 0.3;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .features-container
-    .feature-tick-container
-    .feature-tick
-    img {
-    border: 0;
-    width: 24px;
-    height: 24px;
-    filter: invert(17%) sepia(0%) saturate(0%) hue-rotate(19deg) brightness(102%) contrast(84%);
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .features-container .feature-tick-container .feature-tick img {
+  border: 0;
+  width: 24px;
+  height: 24px;
+  filter: invert(17%) sepia(0%) saturate(0%) hue-rotate(19deg) brightness(102%) contrast(84%);
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .features-container
-    .feature-tick-container
-    .feature-tick
-    .feature-dice-value {
-    font-size: 18px;
-    align-self: center;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .features-container .feature-tick-container .feature-tick .feature-dice-value {
+  font-size: 18px;
+  align-self: center;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .features-container
-    .feature-tick-container
-    .feature-tick.used::after {
-    position: absolute;
-    content: '/';
-    color: #7a7971;
-    font-weight: 700;
-    font-size: 1.7em;
-    left: 4px;
-    top: -5px;
-    transform: rotate(25deg);
-    font-size: 24.5px;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .features-container .feature-tick-container .feature-tick.used::after {
+  position: absolute;
+  content: '/';
+  color: #7a7971;
+  font-weight: 700;
+  font-size: 1.7em;
+  left: 4px;
+  top: -5px;
+  transform: rotate(25deg);
+  font-size: 24.5px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .feature-input {
-    border: 0;
-    border-bottom: 1px solid #7a7971;
-    text-align: center;
-    height: min-content;
-    background: inherit;
-    font-size: 20px;
-    position: relative;
-    bottom: 3px;
+  border: 0;
+  border-bottom: 1px solid #7a7971;
+  text-align: center;
+  height: min-content;
+  background: inherit;
+  font-size: 20px;
+  position: relative;
+  bottom: 3px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .editor {
-    height: 400px;
-    width: 100%;
+  height: 400px;
+  width: 100%;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .weapons-title {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .weapons-title .proficiency-container {
-    width: 176px;
-    height: 20px;
-    position: absolute;
-    bottom: -15px;
-    left: calc(50% - 88px);
-    text-transform: uppercase;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 1;
-    clip-path: polygon(11% 100%, 89% 100%, 100% 0%, 0% 0%);
-    font-size: 10px;
+  width: 176px;
+  height: 20px;
+  position: absolute;
+  bottom: -15px;
+  left: calc(50% - 88px);
+  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
+  clip-path: polygon(11% 100%, 89% 100%, 100% 0%, 0% 0%);
+  font-size: 10px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .weapons-title .proficiency-container span {
-    margin-right: 2px;
+  margin-right: 2px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .weapons-title .proficiency-container .proficiency-dot {
-    background: white;
-    color: white;
-    font-size: 10px;
-    padding: 1px;
-    border-radius: 50%;
+  background: white;
+  color: white;
+  font-size: 10px;
+  padding: 1px;
+  border-radius: 50%;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .weapons-title
-    .proficiency-container
-    .proficiency-dot.marked {
-    color: black;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .weapons-title .proficiency-container .proficiency-dot.marked {
+  color: black;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .weapons-title
-    .proficiency-container
-    .proficiency-dot:not(:last-of-type) {
-    margin-right: 2px;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .weapons-title .proficiency-container .proficiency-dot:not(:last-of-type) {
+  margin-right: 2px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .weapons-burden {
-    position: absolute;
-    top: -4px;
-    right: -56px;
-    display: flex;
-    align-items: center;
+  position: absolute;
+  top: -4px;
+  right: -56px;
+  display: flex;
+  align-items: center;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .weapons-burden .weapons-burden-icon {
-    color: white;
-    font-size: 22px;
-    -webkit-text-stroke-width: 1px;
-    -webkit-text-stroke-color: black;
+  color: white;
+  font-size: 22px;
+  -webkit-text-stroke-width: 1px;
+  -webkit-text-stroke-color: black;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .weapons-burden .weapons-burden-icon.active {
-    -webkit-text-stroke-color: rgba(0, 0, 0, 0.05);
-    color: black;
+  -webkit-text-stroke-color: rgba(0, 0, 0, 0.05);
+  color: black;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .weapons-burden .weapons-burden-icon.left {
-    -webkit-transform: scaleX(-1) rotate(20deg);
-    transform: scaleX(-1) rotate(20deg);
-    margin-right: 4px;
+  -webkit-transform: scaleX(-1) rotate(20deg);
+  transform: scaleX(-1) rotate(20deg);
+  margin-right: 4px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .weapons-burden .weapons-burden-icon.right {
-    transform: rotate(20deg);
+  transform: rotate(20deg);
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .armor-container {
-    display: flex;
-    align-items: center;
+  display: flex;
+  align-items: center;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .armor-container .active-item-label-chip {
-    margin-left: 4px;
+  margin-left: 4px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .item-section .active-item-container {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    padding: 2px 0px;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding: 2px 0px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .item-section .active-item-container .weapons-label-row {
-    display: flex;
-    align-items: center;
+  display: flex;
+  align-items: center;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .item-section
-    .active-item-container
-    .weapons-label-row
-    .damage-roll {
-    width: 24px;
-    border: none;
-    margin-left: 4px;
-    transition: transform 0.2s;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .item-section .active-item-container .weapons-label-row .damage-roll {
+  width: 24px;
+  border: none;
+  margin-left: 4px;
+  transition: transform 0.2s;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .item-section
-    .active-item-container
-    .weapons-label-row
-    .damage-roll:hover {
-    transform: rotate(30deg);
-    filter: drop-shadow(0px 0px 3px red);
-    cursor: pointer;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .item-section .active-item-container .weapons-label-row .damage-roll:hover {
+  transform: rotate(30deg);
+  filter: drop-shadow(0px 0px 3px red);
+  cursor: pointer;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .item-section .active-item-label-chip {
-    width: 62px;
-    border: 2px solid black;
-    border-radius: 6px;
-    background-color: #778899;
-    display: flex;
-    align-items: center;
-    justify-content: space-around;
-    margin-left: 4px;
+  width: 62px;
+  border: 2px solid black;
+  border-radius: 6px;
+  background-color: #778899;
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  margin-left: 4px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .item-section .active-item-label-chip img {
-    height: 20px;
+  height: 20px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .item-section .active-item-label-chip button {
-    height: 17px;
-    width: 17px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: #7a7971;
-    border-color: black;
-    margin: 0;
+  height: 17px;
+  width: 17px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #7a7971;
+  border-color: black;
+  margin: 0;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .item-section .active-item-label-chip button:hover {
-    background: red;
+  background: red;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .item-section .active-item-label-chip button i {
-    font-size: 10px;
-    color: black;
+  font-size: 10px;
+  color: black;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-armor-section,
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-weapon-section {
-    width: 100%;
-    margin-bottom: 8px;
-    text-transform: uppercase;
+  width: 100%;
+  margin-bottom: 8px;
+  text-transform: uppercase;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-armor-section h2,
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-weapon-section h2 {
-    width: 100%;
-    display: flex;
-    align-items: center;
+  width: 100%;
+  display: flex;
+  align-items: center;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-legend {
-    display: flex;
-    align-items: center;
-    margin-bottom: 4px;
+  display: flex;
+  align-items: center;
+  margin-bottom: 4px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-legend .page-selector {
-    margin-left: 4px;
-    display: flex;
-    align-items: center;
+  margin-left: 4px;
+  display: flex;
+  align-items: center;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-legend .page-selector i:hover:not(.disabled) {
-    cursor: pointer;
-    filter: drop-shadow(0px 0px 3px red);
+  cursor: pointer;
+  filter: drop-shadow(0px 0px 3px red);
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-legend .page-selector i.disabled {
-    opacity: 0.4;
+  opacity: 0.4;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-add-button {
-    position: absolute;
-    border-radius: 50%;
-    height: 15px;
-    width: 15px;
-    top: -20px;
-    background: grey;
-    border-color: black;
-    right: 6px;
-    display: flex;
-    font-size: 13px;
-    align-items: center;
-    justify-content: center;
+  position: absolute;
+  border-radius: 50%;
+  height: 15px;
+  width: 15px;
+  top: -20px;
+  background: grey;
+  border-color: black;
+  right: 6px;
+  display: flex;
+  font-size: 13px;
+  align-items: center;
+  justify-content: center;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory {
-    width: 100%;
+  width: 100%;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory .inventory-row {
-    height: 26px;
-    border-bottom: 1px solid #7a7971;
-    display: flex;
-    margin-bottom: 8px;
-    border-radius: 8px;
+  height: 26px;
+  border-bottom: 1px solid #7a7971;
+  display: flex;
+  margin-bottom: 8px;
+  border-radius: 8px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory .inventory-row .item-container {
-    flex-basis: 25%;
-    margin: 0 4px 8px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    cursor: pointer;
+  flex-basis: 25%;
+  margin: 0 4px 8px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory .inventory-row .item-container:hover {
-    filter: drop-shadow(0px 0px 3px red);
+  filter: drop-shadow(0px 0px 3px red);
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory .inventory-row .item-container .inventory-item {
-    background: #778899;
-    padding: 4px;
-    border: 1px solid black;
-    border-radius: 6px;
-    display: flex;
-    align-items: center;
+  background: #778899;
+  padding: 4px;
+  border: 1px solid black;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .inventory
-    .inventory-row
-    .item-container
-    .inventory-item
-    .inventory-item-text {
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    flex: 1;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory .inventory-row .item-container .inventory-item .inventory-item-text {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  flex: 1;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .inventory
-    .inventory-row
-    .item-container
-    .inventory-item
-    button {
-    height: 16px;
-    width: 16px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex: 0;
-    background: #7a7971;
-    border-color: black;
-    margin-left: 4px;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory .inventory-row .item-container .inventory-item button {
+  height: 16px;
+  width: 16px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0;
+  background: #7a7971;
+  border-color: black;
+  margin-left: 4px;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .inventory
-    .inventory-row
-    .item-container
-    .inventory-item
-    button
-    i {
-    font-size: 12px;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory .inventory-row .item-container .inventory-item button i {
+  font-size: 12px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory .editor {
-    height: 100px;
+  height: 100px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-items {
-    width: 100%;
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
+  width: 100%;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .domain-card-tab {
-    flex: 1;
+  flex: 1;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .domain-card-tab .domain-card-body {
-    height: 100%;
-    width: 100%;
-    padding: 8px;
-    display: flex;
-    flex-direction: column;
+  height: 100%;
+  width: 100%;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .domain-card-tab .domain-card-body .card-row {
-    flex: 1;
-    display: flex;
+  flex: 1;
+  display: flex;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .domain-card-tab .domain-card-body .domain-card {
-    flex: 0;
-    flex-basis: 33.33%;
-    margin: 8px;
+  flex: 0;
+  flex-basis: 33.33%;
+  margin: 8px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .domain-card-tab .domain-card-body .loadout-body {
-    flex: 1;
+  flex: 1;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .domain-card-tab
-    .domain-card-body
-    .loadout-body
-    .loadout-container {
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .domain-card-tab .domain-card-body .loadout-body .loadout-container {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .domain-card-tab
-    .domain-card-body
-    .loadout-body
-    .loadout-container
-    .top-card-row {
-    flex: 1;
-    display: flex;
-    justify-content: space-around;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .domain-card-tab .domain-card-body .loadout-body .loadout-container .top-card-row {
+  flex: 1;
+  display: flex;
+  justify-content: space-around;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .domain-card-tab
-    .domain-card-body
-    .loadout-body
-    .loadout-container
-    .domain-card.outlined {
-    border: 2px dotted black;
-    padding: 0;
-    margin: 8px;
-    height: calc(100% - 16px);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: space-evenly;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .domain-card-tab .domain-card-body .loadout-body .loadout-container .domain-card.outlined {
+  border: 2px dotted black;
+  padding: 0;
+  margin: 8px;
+  height: calc(100% - 16px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-evenly;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .domain-card-tab .domain-card-body .vault-container {
-    display: flex;
-    flex-wrap: wrap;
-    overflow-y: auto;
-    height: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  overflow-y: auto;
+  height: 100%;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .domain-card-tab
-    .domain-card-body
-    .vault-container
-    .vault-card {
-    flex: 0;
-    flex-basis: calc(33.33% - 16px);
-    margin: 8px;
-    height: calc(50% - 16px);
-    min-height: calc(50% - 16px);
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .domain-card-tab .domain-card-body .vault-container .vault-card {
+  flex: 0;
+  flex-basis: calc(33.33% - 16px);
+  margin: 8px;
+  height: calc(50% - 16px);
+  min-height: calc(50% - 16px);
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .domain-card-tab .domain-card-body .domain-card-menu {
-    flex: 0;
-    width: 120px;
-    height: 100%;
-    border-width: 2px 0 2px 2px;
-    border-color: black;
-    border-style: solid;
+  flex: 0;
+  width: 120px;
+  height: 100%;
+  border-width: 2px 0 2px 2px;
+  border-color: black;
+  border-style: solid;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .domain-card-tab
-    .domain-card-body
-    .domain-card-menu
-    button {
-    margin-bottom: 2px;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .domain-card-tab .domain-card-body .domain-card-menu button {
+  margin-bottom: 2px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .loadout-tabs {
-    border-top: 1px solid #b5b3a4;
-    border-bottom: 1px solid #b5b3a4;
+  border-top: 1px solid #b5b3a4;
+  border-bottom: 1px solid #b5b3a4;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-card {
-    position: relative;
-    border: 4px solid #708090;
-    border-radius: 6px;
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    font-size: 14px;
+  position: relative;
+  border: 4px solid #708090;
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  font-size: 14px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-card .abilities-card-image-container {
-    position: relative;
+  position: relative;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-card .abilities-card-image {
-    width: 100%;
-    height: 100%;
-    aspect-ratio: 2;
+  width: 100%;
+  height: 100%;
+  aspect-ratio: 2;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-card .abilities-text-container {
-    flex: 1;
-    position: relative;
-    height: 50%;
-    display: flex;
-    flex-direction: column;
-    overflow-y: auto;
-    padding: 12px 4px 4px;
+  flex: 1;
+  position: relative;
+  height: 50%;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  padding: 12px 4px 4px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-card .abilities-card-level {
-    position: absolute;
-    top: 0;
-    left: 12px;
-    color: black;
-    height: 60px;
-    border: 2px solid orange;
-    border-top-width: 0;
-    width: 30px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: space-evenly;
-    background: grey;
-    font-size: 20px;
-    font-weight: bold;
+  position: absolute;
+  top: 0;
+  left: 12px;
+  color: black;
+  height: 60px;
+  border: 2px solid orange;
+  border-top-width: 0;
+  width: 30px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-evenly;
+  background: grey;
+  font-size: 20px;
+  font-weight: bold;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-card .abilities-card-level img {
-    border: 0;
-    width: 20px;
+  border: 0;
+  width: 20px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-card .abilities-card-refresh-cost {
-    position: absolute;
-    top: 12px;
-    right: 12px;
-    color: white;
-    width: 30px;
-    height: 30px;
-    border: 2px solid orange;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: black;
-    font-size: 14px;
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  color: white;
+  width: 30px;
+  height: 30px;
+  border: 2px solid orange;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: black;
+  font-size: 14px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-card .abilities-card-refresh-cost i {
-    font-size: 11px;
+  font-size: 11px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-card .abilities-card-type {
-    flex: 0;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    font-weight: bold;
-    position: absolute;
-    left: 0;
-    text-align: center;
-    width: 100%;
-    bottom: -9px;
-    z-index: 1;
+  flex: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: bold;
+  position: absolute;
+  left: 0;
+  text-align: center;
+  width: 100%;
+  bottom: -9px;
+  z-index: 1;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .abilities-card
-    .abilities-card-type
-    .abilities-card-type-text {
-    padding: 0px 4px;
-    border: 1px solid black;
-    border-radius: 6px;
-    background: gold;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-card .abilities-card-type .abilities-card-type-text {
+  padding: 0px 4px;
+  border: 1px solid black;
+  border-radius: 6px;
+  background: gold;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-card .abilities-card-title {
-    flex: 0;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    font-weight: bold;
-    font-size: 18px;
+  flex: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: bold;
+  font-size: 18px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-card .abilities-card-sub-title {
-    flex: 0;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    font-style: italic;
-    font-size: 12px;
+  flex: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-style: italic;
+  font-size: 12px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-card .abilities-card-spellcast {
-    flex: 0;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    text-transform: uppercase;
-    font-size: 12px;
+  flex: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-transform: uppercase;
+  font-size: 12px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-card .abilities-card-spellcast .title {
-    font-weight: bold;
+  font-weight: bold;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-card .abilities-card-description {
-    flex: 0;
-    font-size: 12px;
-    margin-bottom: 4px;
+  flex: 0;
+  font-size: 12px;
+  margin-bottom: 4px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-card .abilities-card-effect {
-    cursor: pointer;
+  cursor: pointer;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-card .abilities-card-effect:hover {
-    background: rgba(47, 79, 79, 0.25);
+  background: rgba(47, 79, 79, 0.25);
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-card .abilities-card-effect > * {
-    margin-top: 0;
-    margin-bottom: 0;
+  margin-top: 0;
+  margin-bottom: 0;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-card .abilities-card-abilities {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .abilities-card
-    .abilities-card-abilities
-    .abilities-card-ability {
-    font-size: 12px;
-    cursor: pointer;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-card .abilities-card-abilities .abilities-card-ability {
+  font-size: 12px;
+  cursor: pointer;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .abilities-card
-    .abilities-card-abilities
-    .abilities-card-ability:hover {
-    background: rgba(47, 79, 79, 0.25);
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-card .abilities-card-abilities .abilities-card-ability:hover {
+  background: rgba(47, 79, 79, 0.25);
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .abilities-card
-    .abilities-card-abilities
-    .abilities-card-ability
-    > * {
-    margin: 0;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-card .abilities-card-abilities .abilities-card-ability > * {
+  margin: 0;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-card:hover .abilities-card-menu {
-    height: 40px;
-    left: 0px;
+  height: 40px;
+  left: 0px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-card .abilities-card-menu {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 0;
-    transition: height 0.2s;
-    overflow: hidden;
-    position: absolute;
-    bottom: 0;
-    z-index: 2;
-    width: 100%;
-    background: grey;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 0;
+  transition: height 0.2s;
+  overflow: hidden;
+  position: absolute;
+  bottom: 0;
+  z-index: 2;
+  width: 100%;
+  background: grey;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .abilities-card .abilities-card-menu button {
-    font-weight: bold;
+  font-weight: bold;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .heritage-container {
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .heritage-container .card-row {
-    height: 50%;
-    display: flex;
-    justify-content: space-around;
+  height: 50%;
+  display: flex;
+  justify-content: space-around;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .heritage-container .heritage-card {
-    flex-basis: 33.33%;
-    margin: 8px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  flex-basis: 33.33%;
+  margin: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .heritage-container .heritage-card.outlined {
-    border: 2px dotted black;
-    font-size: 25px;
+  border: 2px dotted black;
+  font-size: 25px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .empty-ability-container {
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    font-size: 25px;
-    opacity: 0.7;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 25px;
+  opacity: 0.7;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .empty-ability-container .empty-ability-inner-container {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .empty-ability-container .empty-ability-inner-container i {
-    font-size: 48px;
+  font-size: 48px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .story-container {
-    gap: 16px;
+  gap: 16px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .story-container .story-fieldset {
-    border-radius: 6px;
+  border-radius: 6px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .story-container .story-legend {
-    margin-left: auto;
-    margin-right: auto;
-    padding: 0 8px;
-    font-size: 30px;
-    font-weight: bold;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 0 8px;
+  font-size: 30px;
+  font-weight: bold;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .story-container .scars-container .editor {
-    height: 240px;
+  height: 240px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-container {
-    height: 100%;
-    overflow: auto;
+  height: 100%;
+  overflow: auto;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-container .inventory-item-list {
-    list-style-type: none;
-    padding: 0 8px;
-    margin-top: 0;
+  list-style-type: none;
+  padding: 0 8px;
+  margin-top: 0;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .inventory-container
-    .inventory-item-list.inventory-item-header {
-    margin-bottom: 0;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-container .inventory-item-list.inventory-item-header {
+  margin-bottom: 0;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .inventory-container
-    .inventory-item-list
-    .inventory-title-row-container {
-    display: flex;
-    align-items: center;
-    width: 100%;
-    border-bottom: 4px ridge slategrey;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-container .inventory-item-list .inventory-title-row-container {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  border-bottom: 4px ridge slategrey;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .inventory-container
-    .inventory-item-list
-    .inventory-title-row-container
-    .inventory-title-row {
-    justify-content: space-between;
-    flex: 1;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-container .inventory-item-list .inventory-title-row-container .inventory-title-row {
+  justify-content: space-between;
+  flex: 1;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .inventory-container
-    .inventory-item-list
-    .inventory-title-row-container
-    .inventory-item-title-container {
-    flex: 1;
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-container .inventory-item-list .inventory-title-row-container .inventory-item-title-container {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .inventory-container
-    .inventory-item-list
-    .inventory-title-row-container
-    .inventory-item-quantity {
-    width: 48px;
-    display: flex;
-    align-items: center;
-    margin-right: 96px;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-container .inventory-item-list .inventory-title-row-container .inventory-item-quantity {
+  width: 48px;
+  display: flex;
+  align-items: center;
+  margin-right: 96px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-container .inventory-item-list .inventory-item {
-    background: crimson;
+  background: crimson;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .inventory-container
-    .inventory-item-list
-    .inventory-item:not(:last-of-type) {
-    border-bottom: 2px ridge slategrey;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-container .inventory-item-list .inventory-item:not(:last-of-type) {
+  border-bottom: 2px ridge slategrey;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .inventory-container
-    .inventory-item-list
-    .inventory-item
-    .inventory-item-title-container {
-    flex: 1;
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-container .inventory-item-list .inventory-item .inventory-item-title-container {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .inventory-container
-    .inventory-item-list
-    .inventory-item
-    .inventory-item-title-container
-    .inventory-item-title {
-    display: flex;
-    align-items: center;
-    cursor: pointer;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-container .inventory-item-list .inventory-item .inventory-item-title-container .inventory-item-title {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .inventory-container
-    .inventory-item-list
-    .inventory-item
-    .inventory-item-title-container
-    .inventory-item-title:hover {
-    filter: drop-shadow(0 0 3px gold);
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-container .inventory-item-list .inventory-item .inventory-item-title-container .inventory-item-title:hover {
+  filter: drop-shadow(0 0 3px gold);
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .inventory-container
-    .inventory-item-list
-    .inventory-item
-    .inventory-item-quantity {
-    width: 48px;
-    display: flex;
-    align-items: center;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-container .inventory-item-list .inventory-item .inventory-item-quantity {
+  width: 48px;
+  display: flex;
+  align-items: center;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .inventory-container
-    .inventory-item-list
-    .inventory-item
-    .inventory-item-quantity.spaced {
-    margin-right: 56px;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-container .inventory-item-list .inventory-item .inventory-item-quantity.spaced {
+  margin-right: 56px;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .inventory-container
-    .inventory-item-list
-    .inventory-item
-    .inventory-item-quantity
-    input {
-    margin: 0 2px;
-    border: 0;
-    border-bottom: 2px solid black;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-container .inventory-item-list .inventory-item .inventory-item-quantity input {
+  margin: 0 2px;
+  border: 0;
+  border-bottom: 2px solid black;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .inventory-container
-    .inventory-item-list
-    .inventory-item
-    .inventory-item-quantity
-    i {
-    font-size: 20px;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-container .inventory-item-list .inventory-item .inventory-item-quantity i {
+  font-size: 20px;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .inventory-container
-    .inventory-item-list
-    .inventory-title-row {
-    font-size: 20px;
-    font-weight: bold;
-    display: flex;
-    align-items: center;
-    padding: 0 4px;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-container .inventory-item-list .inventory-title-row {
+  font-size: 20px;
+  font-weight: bold;
+  display: flex;
+  align-items: center;
+  padding: 0 4px;
 }
 .daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-container .inventory-item-list .inventory-row {
-    display: flex;
-    align-items: center;
-    padding: 4px;
-    font-size: 24px;
+  display: flex;
+  align-items: center;
+  padding: 4px;
+  font-size: 24px;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .inventory-container
-    .inventory-item-list
-    .inventory-row
-    .row-icon {
-    margin-left: 4px;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-container .inventory-item-list .inventory-row .row-icon {
+  margin-left: 4px;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .inventory-container
-    .inventory-item-list
-    .inventory-row
-    .active-item {
-    position: absolute;
-    font-size: 16px;
-    left: calc(50% - 8px);
-    top: calc(50% - 8px);
-    margin-left: 2px;
-    color: crimson;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-container .inventory-item-list .inventory-row .active-item {
+  position: absolute;
+  font-size: 16px;
+  left: calc(50% - 8px);
+  top: calc(50% - 8px);
+  margin-left: 2px;
+  color: crimson;
 }
-.daggerheart.sheet.pc
-    div[data-application-part]
-    .sheet-body
-    .inventory-container
-    .inventory-item-list
-    .inventory-row
-    img {
-    width: 32px;
+.daggerheart.sheet.pc div[data-application-part] .sheet-body .inventory-container .inventory-item-list .inventory-row img {
+  width: 32px;
 }
 .combat-sidebar .encounter-gm-resources {
-    flex: 0;
-    display: flex;
-    justify-content: center;
-    padding: 8px 0;
+  flex: 0;
+  display: flex;
+  justify-content: center;
+  padding: 8px 0;
 }
 .combat-sidebar .encounter-gm-resources .gm-resource-controls {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 0 4px;
-    justify-content: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0 4px;
+  justify-content: center;
 }
 .combat-sidebar .encounter-gm-resources .gm-resource-tools {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    padding: 0 5px 0 4px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 0 5px 0 4px;
 }
 .combat-sidebar .encounter-gm-resources .gm-resource-tools i {
-    margin: 0 2px;
-    font-size: 16px;
+  margin: 0 2px;
+  font-size: 16px;
 }
 .combat-sidebar .encounter-gm-resources .gm-resource-tools i.disabled {
-    opacity: 0.6;
+  opacity: 0.6;
 }
 .combat-sidebar .encounter-gm-resources .gm-resource-tools i:hover:not(.disabled) {
-    cursor: pointer;
-    filter: drop-shadow(0 0 3px red);
+  cursor: pointer;
+  filter: drop-shadow(0 0 3px red);
 }
 .combat-sidebar .encounter-gm-resources .gm-resource {
-    background: rgba(255, 255, 255, 0.1);
-    padding: 4px;
-    border-radius: 8px;
-    border: 2px solid black;
-    font-size: 20px;
+  background: rgba(255, 255, 255, 0.1);
+  padding: 4px;
+  border-radius: 8px;
+  border: 2px solid black;
+  font-size: 20px;
 }
 .combat-sidebar .token-action-tokens {
-    flex: 0 0 48px;
-    text-align: center;
+  flex: 0 0 48px;
+  text-align: center;
 }
 .combat-sidebar .token-action-tokens .use-action-token.disabled {
-    opacity: 0.6;
+  opacity: 0.6;
 }
 .combat-sidebar .icon-button.spaced {
-    margin-left: 4px;
+  margin-left: 4px;
 }
 .combat-sidebar .icon-button.disabled {
-    opacity: 0.6;
+  opacity: 0.6;
 }
 .combat-sidebar .icon-button:hover:not(.disabled) {
-    cursor: pointer;
-    filter: drop-shadow(0 0 3px red);
+  cursor: pointer;
+  filter: drop-shadow(0 0 3px red);
 }
 .daggerheart.chat.downtime {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 .daggerheart.chat.downtime .downtime-title-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 .daggerheart.chat.downtime .downtime-title-container .downtime-subtitle {
-    font-size: 17px;
+  font-size: 17px;
 }
 .daggerheart.chat.downtime .downtime-image {
-    width: 80px;
+  width: 80px;
 }
 .daggerheart.chat.downtime .downtime-refresh-container {
-    margin-top: 8px;
-    width: 100%;
+  margin-top: 8px;
+  width: 100%;
 }
 .daggerheart.chat.downtime .downtime-refresh-container .refresh-title {
-    font-weight: bold;
+  font-weight: bold;
 }
 .daggerheart.chat.roll .dice-flavor {
-    text-align: center;
-    font-weight: bold;
+  text-align: center;
+  font-weight: bold;
 }
 .daggerheart.chat.roll .dice-tooltip .dice-rolls.duality {
-    display: flex;
-    align-items: center;
+  display: flex;
+  align-items: center;
 }
 .daggerheart.chat.roll .dice-tooltip .dice-rolls.duality .dice-hope-container {
-    display: flex;
+  display: flex;
 }
 .daggerheart.chat.roll .dice-tooltip .dice-rolls.duality .dice-hope-container .roll.die:not(:last-of-type) {
-    margin-right: 8px;
+  margin-right: 8px;
 }
 .daggerheart.chat.roll .dice-tooltip .dice-rolls.duality .modifiers-container {
-    display: flex;
+  display: flex;
 }
 .daggerheart.chat.roll .dice-tooltip .dice-rolls.duality .modifiers-container .modifier-value:not(:last-of-type) {
-    margin-right: 8px;
+  margin-right: 8px;
 }
 .daggerheart.chat.roll .dice-tooltip .dice-rolls.duality .roll.die.hope {
-    color: white;
-    -webkit-text-stroke-color: #008080;
-    -webkit-text-stroke-width: 1.5px;
-    font-weight: 400;
+  color: white;
+  -webkit-text-stroke-color: #008080;
+  -webkit-text-stroke-width: 1.5px;
+  font-weight: 400;
 }
 .daggerheart.chat.roll .dice-tooltip .dice-rolls.duality .roll.die.hope:not(.discarded) {
-    filter: none;
+  filter: none;
 }
 .daggerheart.chat.roll .dice-tooltip .dice-rolls.duality .roll.die.fear {
-    color: white;
-    -webkit-text-stroke-color: #430070;
-    -webkit-text-stroke-width: 1.5px;
-    font-weight: 400;
+  color: white;
+  -webkit-text-stroke-color: #430070;
+  -webkit-text-stroke-width: 1.5px;
+  font-weight: 400;
 }
 .daggerheart.chat.roll .dice-tooltip .dice-rolls.duality .roll.die.fear:not(.discarded) {
-    filter: none;
+  filter: none;
 }
 .daggerheart.chat.roll .dice-tooltip .dice-rolls.duality .roll.die.disadvantage {
-    color: white;
-    -webkit-text-stroke-color: #b30000;
-    -webkit-text-stroke-width: 1.5px;
-    font-weight: 400;
+  color: white;
+  -webkit-text-stroke-color: #b30000;
+  -webkit-text-stroke-width: 1.5px;
+  font-weight: 400;
 }
 .daggerheart.chat.roll .dice-tooltip .dice-rolls.duality .roll.die.advantage {
-    color: white;
-    -webkit-text-stroke-color: green;
-    -webkit-text-stroke-width: 1.5px;
-    font-weight: 400;
+  color: white;
+  -webkit-text-stroke-color: green;
+  -webkit-text-stroke-width: 1.5px;
+  font-weight: 400;
 }
 .daggerheart.chat.roll .dice-tooltip .dice-rolls.duality .roll.die.unused {
-    opacity: 0.3;
+  opacity: 0.3;
 }
 .daggerheart.chat.roll .dice-tooltip .dice-rolls.duality .modifier-value {
-    text-align: center;
-    font-weight: bold;
-    font-size: 16px;
+  text-align: center;
+  font-weight: bold;
+  font-size: 16px;
 }
 .daggerheart.chat.roll .dice-tooltip .attack-roll-advantage-container {
-    text-align: end;
-    font-weight: bold;
+  text-align: end;
+  font-weight: bold;
 }
 .daggerheart.chat.roll .dice-total .dice-total-value .hope {
-    color: #008080;
+  color: #008080;
 }
 .daggerheart.chat.roll .dice-total .dice-total-value .fear {
-    color: #430070;
+  color: #430070;
 }
 .daggerheart.chat.roll .dice-total .dice-total-value .critical {
-    color: #ffd700;
+  color: #ffd700;
 }
 .daggerheart.chat.roll .dice-total-label {
-    font-size: 12px;
-    font-weight: bold;
-    font-variant: all-small-caps;
-    margin: -8px 0;
+  font-size: 12px;
+  font-weight: bold;
+  font-variant: all-small-caps;
+  margin: -8px 0;
 }
 .daggerheart.chat.roll .target-section {
-    margin-top: 5px;
+  margin-top: 5px;
 }
 .daggerheart.chat.roll .target-section .target-container {
-    display: flex;
-    transition: all 0.2s ease-in-out;
+  display: flex;
+  transition: all 0.2s ease-in-out;
 }
 .daggerheart.chat.roll .target-section .target-container:hover {
-    filter: drop-shadow(0 0 3px gold);
-    border-color: gold;
+  filter: drop-shadow(0 0 3px gold);
+  border-color: gold;
 }
 .daggerheart.chat.roll .target-section .target-container.hidden {
-    display: none;
-    border: 0;
+  display: none;
+  border: 0;
 }
 .daggerheart.chat.roll .target-section .target-container.hit {
-    background: #008000;
+  background: #008000;
 }
 .daggerheart.chat.roll .target-section .target-container.miss {
-    background: #ff0000;
+  background: #ff0000;
 }
 .daggerheart.chat.roll .target-section .target-container img {
-    flex: 0;
-    width: 22px;
-    height: 22px;
-    margin-left: 8px;
-    align-self: center;
-    border-color: transparent;
+  flex: 0;
+  width: 22px;
+  height: 22px;
+  margin-left: 8px;
+  align-self: center;
+  border-color: transparent;
 }
 .daggerheart.chat.roll .target-section .target-container .target-inner-container {
-    flex: 1;
-    display: flex;
-    justify-content: center;
-    margin-right: 32px;
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  margin-right: 32px;
 }
 .daggerheart.chat.roll .dice-actions {
-    display: flex;
-    gap: 4px;
+  display: flex;
+  gap: 4px;
 }
 .daggerheart.chat.roll .dice-actions button {
-    flex: 1;
+  flex: 1;
 }
 .daggerheart.chat.roll .dice-result .roll-damage-button,
 .daggerheart.chat.roll .dice-result .damage-button {
-    margin-top: 5px;
+  margin-top: 5px;
 }
 .daggerheart.chat.domain-card {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 .daggerheart.chat.domain-card .domain-card-title {
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 .daggerheart.chat.domain-card .domain-card-title div {
-    font-size: 20px;
-    font-variant: small-caps;
-    font-weight: bold;
+  font-size: 20px;
+  font-variant: small-caps;
+  font-weight: bold;
 }
 .daggerheart.chat.domain-card .domain-card-title h2 {
-    width: 100%;
-    text-align: center;
+  width: 100%;
+  text-align: center;
 }
 .daggerheart.chat.domain-card .ability-card-footer {
-    display: flex;
-    width: 100%;
-    margin-top: 8px;
-    flex-wrap: wrap;
+  display: flex;
+  width: 100%;
+  margin-top: 8px;
+  flex-wrap: wrap;
 }
 .daggerheart.chat.domain-card .ability-card-footer button {
-    border-radius: 6px;
-    background: #699969;
-    border-color: black;
-    flex-basis: calc(50% - 2px);
+  border-radius: 6px;
+  background: #699969;
+  border-color: black;
+  flex-basis: calc(50% - 2px);
 }
 .daggerheart.chat.domain-card .ability-card-footer button:nth-of-type(n + 3) {
-    margin-top: 2px;
+  margin-top: 2px;
 }
 .daggerheart.chat.domain-card img {
-    width: 80px;
+  width: 80px;
 }
 .daggerheart.sheet.feature {
-    background-color: red;
+  background-color: red;
 }
 .daggerheart.sheet.feature .editable {
-    display: flex;
-    flex-direction: column;
+  display: flex;
+  flex-direction: column;
 }
 .daggerheart.sheet.feature .sheet-body {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
 }
 .daggerheart.sheet.feature .feature-description {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
 }
 .daggerheart.sheet.class .class-feature {
-    display: flex;
+  display: flex;
 }
 .daggerheart.sheet.class .class-feature img {
-    width: 40px;
+  width: 40px;
 }
 .daggerheart.sheet.class .class-feature button {
-    width: 40px;
+  width: 40px;
 }
 .daggerheart.sheet .domain-card-description .editor {
-    height: 300px;
+  height: 300px;
 }
 .daggerheart.sheet .item-container {
-    margin-top: 4px;
-    gap: 4px;
-    align-items: baseline;
+  margin-top: 4px;
+  gap: 4px;
+  align-items: baseline;
 }
 .daggerheart.sheet .item-sidebar {
-    border-right: 1px groove darkgray;
-    min-width: 160px;
-    flex: 0;
-    padding: 4px;
+  border-right: 1px groove darkgray;
+  min-width: 160px;
+  flex: 0;
+  padding: 4px;
 }
 .daggerheart.sheet .item-sidebar label {
-    margin-right: 8px;
-    font-weight: bold;
+  margin-right: 8px;
+  font-weight: bold;
 }
 .daggerheart.sheet .item-sidebar input[type='checkbox'] {
-    margin: 0;
+  margin: 0;
 }
 form.daggerheart.views.downtime {
-    height: auto !important;
+  height: auto !important;
 }
 div.daggerheart.views.death-move {
-    height: auto !important;
+  height: auto !important;
 }
 div.daggerheart.views.multiclass {
-    height: auto !important;
+  height: auto !important;
 }
 .daggerheart.views.levelup .levelup-title-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    font-size: 32px;
-    margin-bottom: 4px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-size: 32px;
+  margin-bottom: 4px;
 }
 .daggerheart.views.levelup .levelup-title-container .level-title {
-    text-decoration: underline;
+  text-decoration: underline;
 }
 .daggerheart.views.levelup .levelup-title-container .level-display {
-    display: flex;
-    align-items: center;
+  display: flex;
+  align-items: center;
 }
 .daggerheart.views.levelup .levelup-title-container .level-display i {
-    margin: 0 4px;
+  margin: 0 4px;
 }
 .daggerheart.views.levelup .levelup-section {
-    display: flex;
-    align-items: flex-start;
-    margin-bottom: 8px;
-    font-size: 11px;
+  display: flex;
+  align-items: flex-start;
+  margin-bottom: 8px;
+  font-size: 11px;
 }
 .daggerheart.views.levelup .levelup-section .levelup-container {
-    flex: 1;
+  flex: 1;
 }
 .daggerheart.views.levelup .levelup-section .levelup-container:nth-of-type(2) {
-    padding: 0 4px;
+  padding: 0 4px;
 }
 .daggerheart.views.levelup .levelup-section .levelup-container.disabled {
-    opacity: 0.2;
+  opacity: 0.2;
 }
 .daggerheart.views.levelup .levelup-section .levelup-container .levelup-inner-container {
-    height: 700px;
-    padding: 24px 58px 0;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    position: relative;
+  height: 700px;
+  padding: 24px 58px 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
 }
 .daggerheart.views.levelup .levelup-section .levelup-container .levelup-inner-container .levelup-legend {
-    margin-left: auto;
-    margin-right: auto;
-    font-weight: bold;
-    z-index: 1;
+  margin-left: auto;
+  margin-right: auto;
+  font-weight: bold;
+  z-index: 1;
 }
 .daggerheart.views.levelup .levelup-section .levelup-container .levelup-inner-container .levelup-info {
-    background: #778899;
-    width: 100%;
-    text-align: center;
-    position: absolute;
-    top: -6px;
-    padding: 8px 0;
+  background: #778899;
+  width: 100%;
+  text-align: center;
+  position: absolute;
+  top: -6px;
+  padding: 8px 0;
 }
 .daggerheart.views.levelup .levelup-section .levelup-container .levelup-inner-container .levelup-pretext {
-    padding: 8px 0;
+  padding: 8px 0;
 }
 .daggerheart.views.levelup .levelup-section .levelup-container .levelup-inner-container .levelup-body {
-    display: flex;
-    flex-direction: column;
+  display: flex;
+  flex-direction: column;
 }
-.daggerheart.views.levelup
-    .levelup-section
-    .levelup-container
-    .levelup-inner-container
-    .levelup-body
-    .levelup-choice-row {
-    display: flex;
-    align-items: center;
-    padding: 4px;
+.daggerheart.views.levelup .levelup-section .levelup-container .levelup-inner-container .levelup-body .levelup-choice-row {
+  display: flex;
+  align-items: center;
+  padding: 4px;
 }
-.daggerheart.views.levelup
-    .levelup-section
-    .levelup-container
-    .levelup-inner-container
-    .levelup-body
-    .levelup-choice-row
-    .levelup-choice-row-inner {
-    display: flex;
-    align-items: center;
+.daggerheart.views.levelup .levelup-section .levelup-container .levelup-inner-container .levelup-body .levelup-choice-row .levelup-choice-row-inner {
+  display: flex;
+  align-items: center;
 }
-.daggerheart.views.levelup
-    .levelup-section
-    .levelup-container
-    .levelup-inner-container
-    .levelup-body
-    .levelup-choice-row
-    .levelup-choice-input-container {
-    position: relative;
-    display: flex;
-    align-items: center;
+.daggerheart.views.levelup .levelup-section .levelup-container .levelup-inner-container .levelup-body .levelup-choice-row .levelup-choice-input-container {
+  position: relative;
+  display: flex;
+  align-items: center;
 }
-.daggerheart.views.levelup
-    .levelup-section
-    .levelup-container
-    .levelup-inner-container
-    .levelup-body
-    .levelup-choice-row
-    .levelup-choice-input-container
-    input:disabled:checked::before {
-    opacity: 0.4;
-    color: var(--color-warm-1);
+.daggerheart.views.levelup .levelup-section .levelup-container .levelup-inner-container .levelup-body .levelup-choice-row .levelup-choice-input-container input:disabled:checked::before {
+  opacity: 0.4;
+  color: var(--color-warm-1);
 }
-.daggerheart.views.levelup
-    .levelup-section
-    .levelup-container
-    .levelup-inner-container
-    .levelup-body
-    .levelup-choice-row
-    .levelup-choice-input-container
-    i.fa-link {
-    transform: rotate(45deg);
-    position: relative;
-    top: 2px;
-    margin: 0 -3px;
+.daggerheart.views.levelup .levelup-section .levelup-container .levelup-inner-container .levelup-body .levelup-choice-row .levelup-choice-input-container i.fa-link {
+  transform: rotate(45deg);
+  position: relative;
+  top: 2px;
+  margin: 0 -3px;
 }
-.daggerheart.views.levelup
-    .levelup-section
-    .levelup-container
-    .levelup-inner-container
-    .levelup-body
-    .levelup-choice-row
-    .levelup-choice-input-container
-    i.fa-lock {
-    position: absolute;
-    top: 0;
-    left: 0;
-    font-size: 8px;
+.daggerheart.views.levelup .levelup-section .levelup-container .levelup-inner-container .levelup-body .levelup-choice-row .levelup-choice-input-container i.fa-lock {
+  position: absolute;
+  top: 0;
+  left: 0;
+  font-size: 8px;
 }
 .daggerheart.views.levelup .levelup-section .levelup-container .levelup-inner-container .levelup-posttext {
-    padding: 8px 0;
+  padding: 8px 0;
 }
 .daggerheart.views .downtime-container .activity-container {
-    display: flex;
-    align-items: center;
-    padding: 8px;
+  display: flex;
+  align-items: center;
+  padding: 8px;
 }
 .daggerheart.views .downtime-container .activity-container .activity-title {
-    flex: 1;
-    display: flex;
-    align-items: center;
+  flex: 1;
+  display: flex;
+  align-items: center;
 }
 .daggerheart.views .downtime-container .activity-container .activity-title .activity-title-text {
-    font-size: 24px;
-    font-weight: bold;
+  font-size: 24px;
+  font-weight: bold;
 }
 .daggerheart.views .downtime-container .activity-container .activity-title .activity-image {
-    width: 120px;
-    border: 2px solid black;
-    border-radius: 50%;
-    margin-right: 8px;
-    cursor: pointer;
+  width: 120px;
+  border: 2px solid black;
+  border-radius: 50%;
+  margin-right: 8px;
+  cursor: pointer;
 }
 .daggerheart.views .downtime-container .activity-container .activity-title .activity-image:hover,
 .daggerheart.views .downtime-container .activity-container .activity-title .activity-image.selected {
-    filter: drop-shadow(0 0 6px gold);
+  filter: drop-shadow(0 0 6px gold);
 }
 .daggerheart.views .downtime-container .activity-container .activity-title .custom-name-input {
-    font-size: 24px;
-    font-weight: bold;
-    padding: 0;
-    background: transparent;
-    color: #efe6d8;
+  font-size: 24px;
+  font-weight: bold;
+  padding: 0;
+  background: transparent;
+  color: #efe6d8;
 }
 .daggerheart.views .downtime-container .activity-container .activity-body {
-    flex: 1;
-    font-style: italic;
+  flex: 1;
+  font-style: italic;
 }
 .daggerheart.views.downtime .activity-text-area {
-    resize: none;
+  resize: none;
 }
 .daggerheart.views .range-reset {
-    flex: 0;
-    width: 21px;
-    height: 21px;
-    margin: 3px 4px;
-    border: 1px solid black;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  flex: 0;
+  width: 21px;
+  height: 21px;
+  margin: 3px 4px;
+  border: 1px solid black;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 .daggerheart.views.roll-selection .roll-selection-container i {
-    filter: invert(0%) sepia(100%) saturate(0%) hue-rotate(21deg) brightness(17%) contrast(103%);
+  filter: invert(0%) sepia(100%) saturate(0%) hue-rotate(21deg) brightness(17%) contrast(103%);
 }
 .daggerheart.views.roll-selection .roll-dialog-container .disadvantage,
 .daggerheart.views.roll-selection .roll-dialog-container .advantage {
-    border: 2px solid #708090;
-    border-radius: 6px;
-    display: flex;
-    align-items: center;
-    padding: 4px;
-    margin-bottom: 6px;
+  border: 2px solid #708090;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  padding: 4px;
+  margin-bottom: 6px;
 }
 .daggerheart.views.roll-selection .roll-dialog-container .disadvantage.selected,
 .daggerheart.views.roll-selection .roll-dialog-container .advantage.selected {
-    filter: drop-shadow(0px 0px 3px red);
+  filter: drop-shadow(0px 0px 3px red);
 }
 .daggerheart.views.roll-selection .roll-dialog-container .disadvantage input,
 .daggerheart.views.roll-selection .roll-dialog-container .advantage input {
-    border: 0;
+  border: 0;
 }
 .daggerheart.views.roll-selection .roll-dialog-container .disadvantage button,
 .daggerheart.views.roll-selection .roll-dialog-container .advantage button {
-    flex: 0;
-    border-radius: 50%;
-    height: 20px;
-    width: 20px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin: 2px 0 2px 4px;
-    padding: 12px;
+  flex: 0;
+  border-radius: 50%;
+  height: 20px;
+  width: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 2px 0 2px 4px;
+  padding: 12px;
 }
 .daggerheart.views.roll-selection .roll-dialog-container .disadvantage button i,
 .daggerheart.views.roll-selection .roll-dialog-container .advantage button i {
-    margin: 0;
+  margin: 0;
 }
 .daggerheart.views.roll-selection .roll-dialog-container .roll-dialog-experience-container {
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 4px;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
 }
 .daggerheart.views.roll-selection .roll-dialog-container .roll-dialog-experience-container .roll-dialog-chip {
-    border: 1px solid black;
-    border-radius: 6px;
-    min-width: calc(33% - 2px);
-    flex: 1;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 4px;
-    cursor: pointer;
-    padding: 4px;
-    background: grey;
-    overflow: hidden;
-    font-weight: bold;
+  border: 1px solid black;
+  border-radius: 6px;
+  min-width: calc(33% - 2px);
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  cursor: pointer;
+  padding: 4px;
+  background: grey;
+  overflow: hidden;
+  font-weight: bold;
 }
 .daggerheart.views.roll-selection .roll-dialog-container .roll-dialog-experience-container .roll-dialog-chip.hover {
-    filter: drop-shadow(0 0 3px red);
+  filter: drop-shadow(0 0 3px red);
 }
 .daggerheart.views.roll-selection .roll-dialog-container .roll-dialog-experience-container .roll-dialog-chip span {
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 .daggerheart.views.roll-selection .roll-dialog-container .roll-dialog-experience-container .roll-dialog-chip.selected {
-    background: green;
+  background: green;
 }
-.daggerheart.views.roll-selection
-    .roll-dialog-container
-    .roll-dialog-experience-container
-    .roll-dialog-chip.selected
-    span {
-    filter: drop-shadow(0 0 3px gold);
+.daggerheart.views.roll-selection .roll-dialog-container .roll-dialog-experience-container .roll-dialog-chip.selected span {
+  filter: drop-shadow(0 0 3px gold);
 }
 .daggerheart.views.roll-selection .roll-dialog-container .hope-container {
-    display: flex;
-    gap: 8px;
-    align-items: center;
-    font-size: 18px;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  font-size: 18px;
 }
 .daggerheart.views.npc-roll-selection .npc-roll-dialog-container {
-    display: flex;
-    flex-direction: column;
+  display: flex;
+  flex-direction: column;
 }
 .daggerheart.views.npc-roll-selection .npc-roll-dialog-container .selection-container {
-    display: flex;
-    align-items: center;
-    margin-bottom: 8px;
-    gap: 16px;
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+  gap: 16px;
 }
 .daggerheart.views.npc-roll-selection .npc-roll-dialog-container .selection-container .dice-container {
-    display: flex;
-    align-items: center;
-    flex: 1;
+  display: flex;
+  align-items: center;
+  flex: 1;
 }
-.daggerheart.views.npc-roll-selection
-    .npc-roll-dialog-container
-    .selection-container
-    .dice-container
-    .dice-inner-container {
-    position: relative;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+.daggerheart.views.npc-roll-selection .npc-roll-dialog-container .selection-container .dice-container .dice-inner-container {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
-.daggerheart.views.npc-roll-selection
-    .npc-roll-dialog-container
-    .selection-container
-    .dice-container
-    .dice-inner-container
-    i {
-    font-size: 18px;
+.daggerheart.views.npc-roll-selection .npc-roll-dialog-container .selection-container .dice-container .dice-inner-container i {
+  font-size: 18px;
 }
-.daggerheart.views.npc-roll-selection
-    .npc-roll-dialog-container
-    .selection-container
-    .dice-container
-    .dice-inner-container
-    img {
-    border: 0;
-    position: relative;
-    left: 1px;
+.daggerheart.views.npc-roll-selection .npc-roll-dialog-container .selection-container .dice-container .dice-inner-container img {
+  border: 0;
+  position: relative;
+  left: 1px;
 }
-.daggerheart.views.npc-roll-selection
-    .npc-roll-dialog-container
-    .selection-container
-    .dice-container
-    .dice-inner-container
-    .dice-number {
-    position: absolute;
-    font-size: 24px;
-    font-weight: bold;
+.daggerheart.views.npc-roll-selection .npc-roll-dialog-container .selection-container .dice-container .dice-inner-container .dice-number {
+  position: absolute;
+  font-size: 24px;
+  font-weight: bold;
 }
-.daggerheart.views.npc-roll-selection
-    .npc-roll-dialog-container
-    .selection-container
-    .dice-container
-    .advantage-container {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    flex: 1;
+.daggerheart.views.npc-roll-selection .npc-roll-dialog-container .selection-container .dice-container .advantage-container {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
 }
-.daggerheart.views.npc-roll-selection
-    .npc-roll-dialog-container
-    .selection-container
-    .dice-container
-    .advantage-container
-    .advantage-button.active,
-.daggerheart.views.npc-roll-selection
-    .npc-roll-dialog-container
-    .selection-container
-    .dice-container
-    .advantage-container
-    .advantage-button:hover {
-    background: var(--button-hover-background-color);
+.daggerheart.views.npc-roll-selection .npc-roll-dialog-container .selection-container .dice-container .advantage-container .advantage-button.active,
+.daggerheart.views.npc-roll-selection .npc-roll-dialog-container .selection-container .dice-container .advantage-container .advantage-button:hover {
+  background: var(--button-hover-background-color);
 }
 .daggerheart.views.npc-roll-selection .npc-roll-dialog-container .roll-dialog-experience-container {
-    display: flex;
-    align-items: flex-start;
-    flex-wrap: wrap;
-    gap: 4px;
-    flex: 1;
-    height: 100%;
+  display: flex;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 4px;
+  flex: 1;
+  height: 100%;
 }
 .daggerheart.views.npc-roll-selection .npc-roll-dialog-container .roll-dialog-experience-container .experience-chip {
-    opacity: 0.6;
-    border-radius: 16px;
-    width: calc(50% - 4px);
-    white-space: nowrap;
+  opacity: 0.6;
+  border-radius: 16px;
+  width: calc(50% - 4px);
+  white-space: nowrap;
 }
-.daggerheart.views.npc-roll-selection
-    .npc-roll-dialog-container
-    .roll-dialog-experience-container
-    .experience-chip.active,
-.daggerheart.views.npc-roll-selection
-    .npc-roll-dialog-container
-    .roll-dialog-experience-container
-    .experience-chip:hover {
-    opacity: 1;
-    background: var(--button-hover-background-color);
+.daggerheart.views.npc-roll-selection .npc-roll-dialog-container .roll-dialog-experience-container .experience-chip.active,
+.daggerheart.views.npc-roll-selection .npc-roll-dialog-container .roll-dialog-experience-container .experience-chip:hover {
+  opacity: 1;
+  background: var(--button-hover-background-color);
 }
 .daggerheart.views.multiclass .multiclass-container {
-    margin-bottom: 16px;
+  margin-bottom: 16px;
 }
 .daggerheart.views.multiclass .multiclass-container .multiclass-category-title {
-    margin-top: 16px;
+  margin-top: 16px;
 }
 .daggerheart.views.multiclass .multiclass-container .multiclass-class-choices {
-    display: flex;
-    width: 100%;
-    height: 100%;
-    flex-wrap: wrap;
+  display: flex;
+  width: 100%;
+  height: 100%;
+  flex-wrap: wrap;
 }
 .daggerheart.views.multiclass .multiclass-container .multiclass-spaced-choices {
-    display: flex;
-    justify-content: space-around;
-    width: 100%;
-    height: 100%;
+  display: flex;
+  justify-content: space-around;
+  width: 100%;
+  height: 100%;
 }
 .daggerheart.views.multiclass .multiclass-container .multiclass-class-choice {
-    display: flex;
-    align-items: center;
-    flex-basis: 33.33%;
-    font-weight: bold;
-    font-size: 24px;
-    cursor: pointer;
+  display: flex;
+  align-items: center;
+  flex-basis: 33.33%;
+  font-weight: bold;
+  font-size: 24px;
+  cursor: pointer;
 }
 .daggerheart.views.multiclass .multiclass-container .multiclass-class-choice.selected:not(.disabled),
 .daggerheart.views.multiclass .multiclass-container .multiclass-class-choice:hover:not(.disabled) {
-    filter: drop-shadow(0 0 3px gold);
+  filter: drop-shadow(0 0 3px gold);
 }
 .daggerheart.views.multiclass .multiclass-container .multiclass-class-choice.inactive,
 .daggerheart.views.multiclass .multiclass-container .multiclass-class-choice.disabled {
-    cursor: initial;
-    opacity: 0.4;
+  cursor: initial;
+  opacity: 0.4;
 }
 .daggerheart.views.multiclass .multiclass-container .multiclass-class-choice img {
-    width: 80px;
-    height: 80px;
-    margin-right: 16px;
+  width: 80px;
+  height: 80px;
+  margin-right: 16px;
 }
 .daggerheart.views.damage-selection .hope-container {
-    display: flex;
-    gap: 8px;
-    align-items: center;
-    font-size: 18px;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  font-size: 18px;
 }
 .daggerheart.views.action .action-category {
-    display: flex;
-    flex-direction: column;
+  display: flex;
+  flex-direction: column;
 }
 .daggerheart.views.action .action-category .action-category-label {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    border-radius: 6px;
-    cursor: pointer;
-    padding: 0 4px;
-    margin: 0 auto 4px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-radius: 6px;
+  cursor: pointer;
+  padding: 0 4px;
+  margin: 0 auto 4px;
 }
 .daggerheart.views.action .action-category .action-category-label:hover {
-    background-color: darkgray;
+  background-color: darkgray;
 }
 .daggerheart.views.action .action-category .action-category-data {
-    max-height: 0;
-    transition: max-height 0.2s ease-in-out;
-    overflow: hidden;
+  max-height: 0;
+  transition: max-height 0.2s ease-in-out;
+  overflow: hidden;
 }
 .daggerheart.views.action .action-category .action-category-data.open {
-    max-height: initial;
+  max-height: initial;
 }
 .daggerheart.views.ancestry-selection .ancestry-section {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    margin-bottom: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 8px;
 }
 .daggerheart.views.ancestry-selection .ancestry-section .ancestry-container {
-    width: 100%;
-    display: flex;
-    flex-wrap: wrap;
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
 }
 .daggerheart.views.ancestry-selection .ancestry-section .ancestry-container .ancestry-inner-container {
-    flex-basis: 25%;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  flex-basis: 25%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
-.daggerheart.views.ancestry-selection
-    .ancestry-section
-    .ancestry-container
-    .ancestry-inner-container
-    .image-container
-    img {
-    width: 120px;
-    border: 4px solid black;
-    border-radius: 50%;
+.daggerheart.views.ancestry-selection .ancestry-section .ancestry-container .ancestry-inner-container .image-container img {
+  width: 120px;
+  border: 4px solid black;
+  border-radius: 50%;
 }
-.daggerheart.views.ancestry-selection
-    .ancestry-section
-    .ancestry-container
-    .ancestry-inner-container
-    .image-container
-    img.selected {
-    border-color: gold;
+.daggerheart.views.ancestry-selection .ancestry-section .ancestry-container .ancestry-inner-container .image-container img.selected {
+  border-color: gold;
 }
-.daggerheart.views.ancestry-selection
-    .ancestry-section
-    .ancestry-container
-    .ancestry-inner-container
-    .image-container
-    img:hover:not(.selected) {
-    filter: drop-shadow(0 0 3px gold);
+.daggerheart.views.ancestry-selection .ancestry-section .ancestry-container .ancestry-inner-container .image-container img:hover:not(.selected) {
+  filter: drop-shadow(0 0 3px gold);
 }
-.daggerheart.views.ancestry-selection
-    .ancestry-section
-    .ancestry-container
-    .ancestry-inner-container
-    .image-container
-    img.disabled {
-    opacity: 0.3;
+.daggerheart.views.ancestry-selection .ancestry-section .ancestry-container .ancestry-inner-container .image-container img.disabled {
+  opacity: 0.3;
 }
-.daggerheart.views.ancestry-selection
-    .ancestry-section
-    .ancestry-container
-    .ancestry-inner-container
-    .name-container
-    div {
-    font-size: 18px;
-    font-weight: bold;
-    cursor: help;
+.daggerheart.views.ancestry-selection .ancestry-section .ancestry-container .ancestry-inner-container .name-container div {
+  font-size: 18px;
+  font-weight: bold;
+  cursor: help;
 }
 .daggerheart.views.ancestry-selection .ancestry-section .mixed-ancestry-container {
-    width: 100%;
-    display: flex;
-    gap: 8px;
+  width: 100%;
+  display: flex;
+  gap: 8px;
 }
 .daggerheart.views.ancestry-selection .ancestry-section .mixed-ancestry-container > div {
-    flex: 1;
+  flex: 1;
 }
 .daggerheart.views.ancestry-selection .ancestry-section .mixed-ancestry-container .mixed-ancestry-name {
-    text-align: center;
+  text-align: center;
 }
 .daggerheart.views.ancestry-selection .ancestry-section .mixed-ancestry-container .mixed-ancestry-name div {
-    font-size: 24px;
+  font-size: 24px;
 }
 .daggerheart.views.ancestry-selection .ancestry-section .mixed-ancestry-container .mixed-ancestry-images {
-    display: flex;
-    align-items: center;
-    gap: 4px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
-.daggerheart.views.ancestry-selection
-    .ancestry-section
-    .mixed-ancestry-container
-    .mixed-ancestry-images
-    .mixed-ancestry-image {
-    position: relative;
-    max-width: 33%;
+.daggerheart.views.ancestry-selection .ancestry-section .mixed-ancestry-container .mixed-ancestry-images .mixed-ancestry-image {
+  position: relative;
+  max-width: 33%;
 }
-.daggerheart.views.ancestry-selection
-    .ancestry-section
-    .mixed-ancestry-container
-    .mixed-ancestry-images
-    .mixed-ancestry-image:hover
-    i {
-    opacity: 1;
+.daggerheart.views.ancestry-selection .ancestry-section .mixed-ancestry-container .mixed-ancestry-images .mixed-ancestry-image:hover i {
+  opacity: 1;
 }
-.daggerheart.views.ancestry-selection
-    .ancestry-section
-    .mixed-ancestry-container
-    .mixed-ancestry-images
-    .mixed-ancestry-image
-    i {
-    position: absolute;
-    font-size: 32px;
-    top: calc(50% - 20px);
-    left: calc(50% - 20px);
-    padding: 4px;
-    background-color: grey;
-    opacity: 0;
-    cursor: pointer;
+.daggerheart.views.ancestry-selection .ancestry-section .mixed-ancestry-container .mixed-ancestry-images .mixed-ancestry-image i {
+  position: absolute;
+  font-size: 32px;
+  top: calc(50% - 20px);
+  left: calc(50% - 20px);
+  padding: 4px;
+  background-color: grey;
+  opacity: 0;
+  cursor: pointer;
 }
-.daggerheart.views.ancestry-selection
-    .ancestry-section
-    .mixed-ancestry-container
-    .mixed-ancestry-images
-    .mixed-ancestry-image
-    i:hover {
-    filter: drop-shadow(0 0 3px gold);
+.daggerheart.views.ancestry-selection .ancestry-section .mixed-ancestry-container .mixed-ancestry-images .mixed-ancestry-image i:hover {
+  filter: drop-shadow(0 0 3px gold);
 }
-.daggerheart.views.ancestry-selection
-    .ancestry-section
-    .mixed-ancestry-container
-    .mixed-ancestry-images
-    .mixed-ancestry-image
-    img {
-    max-width: 100%;
+.daggerheart.views.ancestry-selection .ancestry-section .mixed-ancestry-container .mixed-ancestry-images .mixed-ancestry-image img {
+  max-width: 100%;
 }
 .daggerheart.views.ancestry-selection .ancestry-section .mixed-ancestry-container .mixed-ancestry-images img {
-    max-width: 33%;
-    border: 4px solid black;
-    border-radius: 50%;
+  max-width: 33%;
+  border: 4px solid black;
+  border-radius: 50%;
 }
 .daggerheart.views.ancestry-selection .ancestry-section .mixed-ancestry-container .mixed-ancestry-images img.selected {
-    border-color: gold;
+  border-color: gold;
 }
 .daggerheart.sheet.heritage .editor {
-    height: 200px;
+  height: 200px;
 }
 .daggerheart.sheet.class .guide .guide-section {
-    gap: 8px;
+  gap: 8px;
 }
 .daggerheart.sheet.class .guide .drop-section {
-    width: 100%;
+  width: 100%;
 }
 .daggerheart.sheet.class .guide .drop-section legend {
-    margin-left: auto;
-    margin-right: auto;
-    font-size: 12px;
+  margin-left: auto;
+  margin-right: auto;
+  font-size: 12px;
 }
 .daggerheart.sheet.class .guide .drop-section .drop-section-body {
-    min-height: 40px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  min-height: 40px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 .daggerheart.sheet.class .guide .trait-input {
-    text-align: center;
-    min-width: 24px;
+  text-align: center;
+  min-width: 24px;
 }
 .daggerheart.sheet.class .guide .suggested-item {
-    padding: 2px 4px;
-    border-radius: 6px;
-    border: 1px solid black;
-    background: #778899;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
+  padding: 2px 4px;
+  border-radius: 6px;
+  border: 1px solid black;
+  background: #778899;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
 }
 .daggerheart.sheet.class .guide .suggested-item:not(:last-child) {
-    margin: 4px;
+  margin: 4px;
 }
 .daggerheart.sheet.class .guide .suggested-item img {
-    width: 30px;
+  width: 30px;
 }
 .daggerheart.sheet.class .guide .suggested-item div {
-    text-align: center;
+  text-align: center;
 }
 .daggerheart.sheet.class .guide .suggested-item i {
-    border-radius: 50%;
-    margin-right: 4px;
-    font-size: 11px;
+  border-radius: 50%;
+  margin-right: 4px;
+  font-size: 11px;
 }
 .daggerheart.sheet.class .guide .extra-section {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 .daggerheart.sheet.class .guide .extra-section .extra-title {
-    font-size: 14px;
-    font-weight: bold;
+  font-size: 14px;
+  font-weight: bold;
 }
 .daggerheart.sheet.class .guide .extra-section .extra-input {
-    margin-bottom: 4px;
+  margin-bottom: 4px;
 }
 .daggerheart.sheet.class .guide-section-title-centered {
-    font-weight: bold;
-    font-size: 18px;
+  font-weight: bold;
+  font-size: 18px;
 }
 .daggerheart.sheet.class .inventory-section {
-    width: 100%;
-    border: 2px solid black;
-    border-style: dotted;
-    min-height: 80px;
+  width: 100%;
+  border: 2px solid black;
+  border-style: dotted;
+  min-height: 80px;
 }
 .daggerheart.sheet.class .inventory-section .inventory-title {
-    font-weight: bold;
-    font-size: 14px;
-    text-align: center;
+  font-weight: bold;
+  font-size: 14px;
+  text-align: center;
 }
 .daggerheart.sheet.class .tagify {
-    background: var(--color-light-1);
-    border: 1px solid var(--color-border);
-    height: 34px;
-    width: 100%;
-    border-radius: 3px;
-    margin-right: 1px;
+  background: var(--color-light-1);
+  border: 1px solid var(--color-border);
+  height: 34px;
+  width: 100%;
+  border-radius: 3px;
+  margin-right: 1px;
 }
 .daggerheart.sheet.class .tagify tag div {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    height: 22px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 22px;
 }
 .daggerheart.sheet.class .tagify tag div span {
-    font-weight: 400;
+  font-weight: 400;
 }
 .daggerheart.sheet.class .tagify tag div img {
-    margin-left: 8px;
-    height: 20px;
-    width: 20px;
+  margin-left: 8px;
+  height: 20px;
+  width: 20px;
 }
 .daggerheart.sheet.adversary .adversary-header-container {
-    position: relative;
-    background-color: grey;
-    display: flex;
+  position: relative;
+  background-color: grey;
+  display: flex;
 }
 .daggerheart.sheet.adversary .adversary-header-container .adversary-header {
-    flex: 1;
+  flex: 1;
 }
 .daggerheart.sheet.adversary .adversary-header-container .adversary-header img {
-    height: 60px;
-    width: 60px;
+  height: 60px;
+  width: 60px;
 }
 .daggerheart.sheet.adversary .adversary-header-container .adversary-header .adversary-title {
-    display: flex;
-    align-items: center;
-    text-align: center;
-    font-size: 28px;
+  display: flex;
+  align-items: center;
+  text-align: center;
+  font-size: 28px;
 }
 .daggerheart.sheet.adversary .adversary-header-container .adversary-header .adversary-title .title-text {
-    width: 100%;
+  width: 100%;
 }
 .daggerheart.sheet.adversary .adversary-header-container .adversary-header .adversary-title input {
-    font-size: 28px;
-    border: 0;
-    height: 100%;
+  font-size: 28px;
+  border: 0;
+  height: 100%;
 }
 .daggerheart.sheet.adversary .adversary-header-container .adversary-toggle {
-    position: absolute;
-    top: 0;
-    right: 0;
-    background-color: white;
-    color: black;
-    flex: 0;
+  position: absolute;
+  top: 0;
+  right: 0;
+  background-color: white;
+  color: black;
+  flex: 0;
 }
 .daggerheart.sheet.adversary .motive-container {
-    background: lightgrey;
-    margin-bottom: 8px;
-    padding-bottom: 4px;
+  background: lightgrey;
+  margin-bottom: 8px;
+  padding-bottom: 4px;
 }
 .daggerheart.sheet.adversary .motive-container .motive-title {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
 }
 .daggerheart.sheet.adversary .motive-container .motive-title .motive-title-base {
-    font-size: 21px;
+  font-size: 21px;
 }
 .daggerheart.sheet.adversary .motive-container .motive-title .motive-title-value {
-    font-style: italic;
-    position: relative;
-    top: 2px;
+  font-style: italic;
+  position: relative;
+  top: 2px;
 }
 .daggerheart.sheet.adversary .motive-container .motive-title i {
-    margin-left: 4px;
-    cursor: pointer;
+  margin-left: 4px;
+  cursor: pointer;
 }
 .daggerheart.sheet.adversary .motive-container .motive-title i:hover {
-    filter: drop-shadow(0 0 3px red);
+  filter: drop-shadow(0 0 3px red);
 }
 .daggerheart.sheet.adversary .adversary-content-container {
-    display: flex;
-    align-items: baseline;
+  display: flex;
+  align-items: baseline;
 }
 .daggerheart.sheet.adversary .adversary-statistics-container {
-    flex: 1;
-    margin-right: 24px;
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
+  flex: 1;
+  margin-right: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 .daggerheart.sheet.adversary .adversary-statistics-container .statistic-title {
-    flex: 0;
-    white-space: nowrap;
-    font-weight: bold;
+  flex: 0;
+  white-space: nowrap;
+  font-weight: bold;
 }
 .daggerheart.sheet.adversary .adversary-statistics-container .statistic-row {
-    display: flex;
-    align-items: center;
+  display: flex;
+  align-items: center;
 }
 .daggerheart.sheet.adversary .adversary-statistics-container .statistic-row .statistic-value {
-    flex: 0;
-    white-space: nowrap;
-    margin-left: 4px;
+  flex: 0;
+  white-space: nowrap;
+  margin-left: 4px;
 }
 .daggerheart.sheet.adversary .adversary-statistics-container .statistic-row .adversary-roll {
-    border: 0;
-    width: 16px;
-    margin-left: 4px;
-    align-self: baseline;
-    transition: transform 0.2s;
+  border: 0;
+  width: 16px;
+  margin-left: 4px;
+  align-self: baseline;
+  transition: transform 0.2s;
 }
 .daggerheart.sheet.adversary .adversary-statistics-container .statistic-row .adversary-roll:hover {
-    transform: rotate(30deg);
-    filter: drop-shadow(0px 0px 3px red);
-    cursor: pointer;
+  transform: rotate(30deg);
+  filter: drop-shadow(0px 0px 3px red);
+  cursor: pointer;
 }
 .daggerheart.sheet.adversary .adversary-statistics-container .statistic-resource-container {
-    display: flex;
-    align-items: center;
+  display: flex;
+  align-items: center;
 }
 .daggerheart.sheet.adversary .adversary-statistics-container .statistic-resource-container label {
-    min-width: 44px;
+  min-width: 44px;
 }
-.daggerheart.sheet.adversary
-    .adversary-statistics-container
-    .statistic-resource-container
-    .statistic-resource-inner-container {
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 4px;
+.daggerheart.sheet.adversary .adversary-statistics-container .statistic-resource-container .statistic-resource-inner-container {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
 }
 .daggerheart.sheet.adversary .adversary-statistics-container .statistic-resource-container .resource-title {
-    align-self: center;
-    font-weight: bold;
+  align-self: center;
+  font-weight: bold;
 }
 .daggerheart.sheet.adversary .adversary-statistics-container .statistic-resource-container .statistic-resource-input {
-    margin: 0;
-    flex: 0;
-    min-width: 16px;
+  margin: 0;
+  flex: 0;
+  min-width: 16px;
 }
 .daggerheart.sheet.adversary .adversary-statistics-container .attack-container {
-    border: 1px solid black dotted;
+  border: 1px solid black dotted;
 }
 .daggerheart.sheet.adversary .adversary-statistics-container .experience-row {
-    display: flex;
+  display: flex;
 }
 .daggerheart.sheet.adversary .adversary-statistics-container .experience-row * {
-    flex: 0;
-    white-space: nowrap;
+  flex: 0;
+  white-space: nowrap;
 }
 .daggerheart.sheet.adversary .adversary-statistics-container .experience-container i {
-    margin-left: 4px;
-    cursor: pointer;
+  margin-left: 4px;
+  cursor: pointer;
 }
 .daggerheart.sheet.adversary .adversary-statistics-container .experience-container i:hover {
-    filter: drop-shadow(0 0 3px red);
+  filter: drop-shadow(0 0 3px red);
 }
 .daggerheart.sheet.adversary .adversary-statistics-container .experience-chip {
-    border: 2px solid #708090;
-    border-radius: 6px;
-    display: flex;
-    align-items: center;
-    padding: 4px;
-    margin-bottom: 6px;
+  border: 2px solid #708090;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  padding: 4px;
+  margin-bottom: 6px;
 }
 .daggerheart.sheet.adversary .adversary-statistics-container .experience-chip .experience-text {
-    flex: 1;
+  flex: 1;
 }
 .daggerheart.sheet.adversary .adversary-statistics-container .experience-chip .experience-value {
-    flex: 0;
-    min-width: 26px;
-    margin: 0 4px;
+  flex: 0;
+  min-width: 26px;
+  margin: 0 4px;
 }
 .daggerheart.sheet.adversary .adversary-statistics-container .experience-chip .experience-button {
-    flex: 0;
-    border-radius: 50%;
-    height: 20px;
-    width: 20px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 12px;
+  flex: 0;
+  border-radius: 50%;
+  height: 20px;
+  width: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px;
 }
 .daggerheart.sheet.adversary .adversary-damage-threshold-container input {
-    min-width: 26px;
+  min-width: 26px;
 }
 .daggerheart.sheet.adversary .adversary-moves-container {
-    flex: 2.5;
+  flex: 2.5;
 }
 .daggerheart.sheet.adversary .adversary-moves-container .moves-title {
-    text-decoration: underline;
-    font-weight: bold;
+  text-decoration: underline;
+  font-weight: bold;
 }
 .daggerheart.sheet.adversary .adversary-moves-container .move-container {
-    cursor: pointer;
+  cursor: pointer;
 }
 .daggerheart.sheet.adversary .adversary-moves-container .move-container:hover {
-    background: #2f4f4f40;
+  background: #2f4f4f40;
 }
 .daggerheart.sheet.adversary .adversary-moves-container .move-container .moves-name {
-    font-weight: bold;
-    text-decoration: none;
+  font-weight: bold;
+  text-decoration: none;
 }
 .daggerheart.sheet.adversary .adversary-moves-container .move-container .move-description p {
-    margin-top: 0;
+  margin-top: 0;
 }
 .daggerheart.sheet.adversary .adversary-moves-container .moves-edit-container i {
-    margin-left: 4px;
-    cursor: pointer;
+  margin-left: 4px;
+  cursor: pointer;
 }
 .daggerheart.sheet.adversary .adversary-moves-container .moves-edit-container i:hover {
-    filter: drop-shadow(0 0 3px red);
+  filter: drop-shadow(0 0 3px red);
 }
 .daggerheart.sheet.adversary .chip-container {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    background: #778899;
-    padding: 8px;
-    border: 2px solid black;
-    border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: #778899;
+  padding: 8px;
+  border: 2px solid black;
+  border-radius: 6px;
 }
 .daggerheart.sheet.adversary .chip-container:not(:last-child) {
-    margin-bottom: 8px;
+  margin-bottom: 8px;
 }
 .daggerheart.sheet.adversary .chip-container .chip-inner-container {
-    display: flex;
-    align-items: center;
+  display: flex;
+  align-items: center;
 }
 .daggerheart.sheet.adversary .chip-container .chip-inner-container img {
-    height: 40px;
-    width: 40px;
-    margin-right: 8px;
+  height: 40px;
+  width: 40px;
+  margin-right: 8px;
 }
 .daggerheart.sheet.adversary .chip-container .chip-inner-container .chip-title {
-    font-size: 22px;
-    font-weight: bold;
-    font-style: italic;
+  font-size: 22px;
+  font-weight: bold;
+  font-style: italic;
 }
 .daggerheart.sheet.adversary .chip-container button {
-    height: 40px;
-    width: 40px;
-    background: white;
+  height: 40px;
+  width: 40px;
+  background: white;
 }
 .daggerheart.sheet .title-container {
-    display: flex;
-    gap: 8px;
+  display: flex;
+  gap: 8px;
 }
 .daggerheart.sheet .title-container div {
-    flex: 1;
-    align-items: baseline;
+  flex: 1;
+  align-items: baseline;
 }
 .daggerheart.sheet .editor-form-group {
-    display: flex;
-    flex-direction: column;
+  display: flex;
+  flex-direction: column;
 }
 .daggerheart.sheet .editor-form-group label {
-    font-weight: bold;
-    text-align: center;
+  font-weight: bold;
+  text-align: center;
 }
 .daggerheart.sheet .option-select {
-    position: absolute;
-    top: calc(50% - 10px);
-    right: 8px;
-    height: 20px;
-    width: 20px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 8px;
+  position: absolute;
+  top: calc(50% - 10px);
+  right: 8px;
+  height: 20px;
+  width: 20px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
 }
 .daggerheart.sheet .option-select.deeper {
-    right: 32px;
+  right: 32px;
 }
 .daggerheart.sheet .option-select:hover:not(:disabled) {
-    filter: drop-shadow(0px 0px 3px red);
-    cursor: pointer;
+  filter: drop-shadow(0px 0px 3px red);
+  cursor: pointer;
 }
 .daggerheart.sheet .option-select i {
-    margin: 0;
-    font-size: 11px;
+  margin: 0;
+  font-size: 11px;
 }
 .daggerheart.sheet .ability-title {
-    width: 100%;
-    display: flex;
+  width: 100%;
+  display: flex;
 }
 .daggerheart.sheet .ability-title h2 {
-    flex: 1;
+  flex: 1;
 }
 .daggerheart.sheet .ability-title i {
-    cursor: pointer;
+  cursor: pointer;
 }
 .daggerheart.sheet .ability-title i:hover {
-    filter: drop-shadow(0px 0px 3px red);
+  filter: drop-shadow(0px 0px 3px red);
 }
 .daggerheart.sheet .ability-choices {
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
 }
 .daggerheart.sheet .ability-chip {
-    border: 2px solid #708090;
-    border-radius: 6px;
-    display: flex;
-    align-items: center;
-    padding: 4px;
-    margin-bottom: 6px;
-    flex: calc(33% - 4px);
-    max-width: calc(33% - 4px);
+  border: 2px solid #708090;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  padding: 4px;
+  margin-bottom: 6px;
+  flex: calc(33% - 4px);
+  max-width: calc(33% - 4px);
 }
 .daggerheart.sheet .ability-chip.selected {
-    filter: drop-shadow(0px 0px 3px red);
+  filter: drop-shadow(0px 0px 3px red);
 }
 .daggerheart.sheet .ability-chip:nth-of-type(3n-1) {
-    margin-left: 6px;
-    margin-right: 6px;
+  margin-left: 6px;
+  margin-right: 6px;
 }
 .daggerheart.sheet .ability-chip input {
-    border: 0;
+  border: 0;
 }
 .daggerheart.sheet .ability-chip button {
-    flex: 0;
-    border-radius: 50%;
-    height: 20px;
-    width: 20px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin: 2px 0 2px 4px;
-    padding: 12px;
+  flex: 0;
+  border-radius: 50%;
+  height: 20px;
+  width: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 2px 0 2px 4px;
+  padding: 12px;
 }
 .daggerheart.sheet .ability-chip button i {
-    margin: 0;
+  margin: 0;
 }
 .daggerheart.sheet .object-select-display {
-    position: relative;
-    width: calc(100% - 2px);
-    background: rgba(0, 0, 0, 0.05);
-    height: var(--form-field-height);
-    display: flex;
-    border: 1px solid #7a7971;
-    border-radius: 3px;
+  position: relative;
+  width: calc(100% - 2px);
+  background: rgba(0, 0, 0, 0.05);
+  height: var(--form-field-height);
+  display: flex;
+  border: 1px solid #7a7971;
+  border-radius: 3px;
 }
 .daggerheart.sheet .object-select-display .object-select-title {
-    position: absolute;
-    left: 4px;
-    text-align: center;
-    font-weight: bold;
-    text-transform: uppercase;
+  position: absolute;
+  left: 4px;
+  text-align: center;
+  font-weight: bold;
+  text-transform: uppercase;
 }
 .daggerheart.sheet .object-select-display .object-select-text {
-    align-self: center;
+  align-self: center;
 }
 .daggerheart.sheet .object-select-display .object-select-item {
-    cursor: pointer;
+  cursor: pointer;
 }
 .daggerheart.sheet .object-select-display .object-select-item:hover {
-    filter: drop-shadow(0px 0px 3px red);
+  filter: drop-shadow(0px 0px 3px red);
 }
 .daggerheart.sheet .feature-container {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    background: #778899;
-    padding: 8px;
-    border: 2px solid black;
-    border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: #778899;
+  padding: 8px;
+  border: 2px solid black;
+  border-radius: 6px;
 }
 .daggerheart.sheet .feature-container:not(:last-child) {
-    margin-bottom: 8px;
+  margin-bottom: 8px;
 }
 .daggerheart.sheet .feature-container .feature-inner-container {
-    display: flex;
-    align-items: center;
+  display: flex;
+  align-items: center;
 }
 .daggerheart.sheet .feature-container .feature-inner-container img {
-    height: 40px;
-    width: 40px;
-    margin-right: 8px;
+  height: 40px;
+  width: 40px;
+  margin-right: 8px;
 }
 .daggerheart.sheet .feature-container .feature-inner-container .feature-title {
-    font-size: 22px;
-    font-weight: bold;
-    font-style: italic;
+  font-size: 22px;
+  font-weight: bold;
+  font-style: italic;
 }
 .daggerheart.sheet .feature-container button {
-    height: 40px;
-    width: 40px;
-    background: inherit;
-    border: 0;
+  height: 40px;
+  width: 40px;
+  background: inherit;
+  border: 0;
 }
 .slider-container {
-    position: relative;
-    background: lightslategray;
+  position: relative;
+  background: lightslategray;
 }
 .slider-container .slider-inner-container {
-    position: absolute;
-    top: 1px;
-    left: -60px;
-    background-color: inherit;
-    color: inherit;
-    border-radius: 30px;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    height: 20px;
-    width: 40px;
-    padding: 0 4px;
-    border: 1px solid black;
+  position: absolute;
+  top: 1px;
+  left: -60px;
+  background-color: inherit;
+  color: inherit;
+  border-radius: 30px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  height: 20px;
+  width: 40px;
+  padding: 0 4px;
+  border: 1px solid black;
 }
 .slider-container .slider-inner-container:hover {
-    filter: drop-shadow(0 0 3px red);
+  filter: drop-shadow(0 0 3px red);
 }
 .slider-container .slider-inner-container input:checked {
-    opacity: 0;
-    width: 0;
-    height: 0;
+  opacity: 0;
+  width: 0;
+  height: 0;
 }
 .slider-container .slider-inner-container input:checked + .slider-icon {
-    transform: translateX(17px);
-    transition: 1s;
+  transform: translateX(17px);
+  transition: 1s;
 }
 .slider-container .slider-inner-container .slider-icon {
-    position: absolute;
-    left: 4px;
-    height: 15px;
-    width: 15px;
-    border-radius: 50%;
-    transition: 1s;
-    transform: translateX(0);
+  position: absolute;
+  left: 4px;
+  height: 15px;
+  width: 15px;
+  border-radius: 50%;
+  transition: 1s;
+  transform: translateX(0);
 }
 .item-button.checked {
-    background: green;
+  background: green;
 }
 .item-button .item-icon {
-    opacity: 0;
-    transition: opacity 0.2s;
+  opacity: 0;
+  transition: opacity 0.2s;
 }
 .item-button .item-icon.checked {
-    opacity: 1;
+  opacity: 1;
 }
 #logo {
-    content: url(../assets/DaggerheartLogo.webp);
-    height: 50px;
-    width: 50px;
-    position: relative;
-    left: 25px;
+  content: url(../assets/DaggerheartLogo.webp);
+  height: 50px;
+  width: 50px;
+  position: relative;
+  left: 25px;
 }
 .daggerheart {
-    /* Flex */
-    /****/
+  /* Flex */
+  /****/
 }
 .daggerheart .vertical-separator {
-    border-left: 2px solid black;
-    height: 56px;
-    flex: 0;
-    align-self: center;
+  border-left: 2px solid black;
+  height: 56px;
+  flex: 0;
+  align-self: center;
 }
 .daggerheart .flex-centered {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 .daggerheart .flex-col-centered {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 .daggerheart .flex-spaced {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
 }
 .daggerheart .flex-min {
-    display: flex;
-    flex: 0;
+  display: flex;
+  flex: 0;
 }
 .daggerheart img[data-edit='img'] {
-    min-width: 64px;
-    min-height: 64px;
+  min-width: 64px;
+  min-height: 64px;
 }
 .daggerheart .editor {
-    height: 200px;
+  height: 200px;
 }
 .daggerheart button i {
-    margin: 0;
+  margin: 0;
 }
 .daggerheart .icon-button.spaced {
-    margin-left: 4px;
+  margin-left: 4px;
 }
 .daggerheart .icon-button.active {
-    filter: drop-shadow(0 0 3px red);
+  filter: drop-shadow(0 0 3px red);
 }
 .daggerheart .icon-button.active.secondary {
-    filter: drop-shadow(0 0 3px gold);
+  filter: drop-shadow(0 0 3px gold);
 }
 .daggerheart .icon-button.disabled {
-    opacity: 0.6;
+  opacity: 0.6;
 }
 .daggerheart .icon-button:hover:not(.disabled) {
-    cursor: pointer;
-    filter: drop-shadow(0 0 3px red);
+  cursor: pointer;
+  filter: drop-shadow(0 0 3px red);
 }
 .daggerheart .icon-button:hover:not(.disabled).secondary {
-    filter: drop-shadow(0 0 3px gold);
+  filter: drop-shadow(0 0 3px gold);
 }
 #players h3 {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    flex-wrap: nowrap;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: nowrap;
 }
 #players h3 .players-container {
-    display: flex;
-    align-items: center;
+  display: flex;
+  align-items: center;
 }
 #players h3 .fear-control {
-    font-size: 10px;
+  font-size: 10px;
 }
 #players h3 .fear-control.disabled {
-    opacity: 0.4;
+  opacity: 0.4;
 }
 #players h3 .fear-control:hover:not(.disabled) {
-    cursor: pointer;
-    filter: drop-shadow(0 0 3px red);
+  cursor: pointer;
+  filter: drop-shadow(0 0 3px red);
 }

--- a/tools/pullYMLtoLDB.mjs
+++ b/tools/pullYMLtoLDB.mjs
@@ -4,9 +4,28 @@ import { promises as fs } from 'fs';
 const MODULE_ID = process.cwd();
 const yaml = false;
 
-const packs = await fs.readdir('./src/packs');
+const packs = await deepGetDirectories('./packs');
+console.log(packs);
 for (const pack of packs) {
     if (pack === '.gitattributes') continue;
     console.log('Packing ' + pack);
-    await compilePack(`${MODULE_ID}/src/packs/${pack}`, `${MODULE_ID}/packs/${pack}`, { yaml });
+    await compilePack(`${MODULE_ID}/src/${pack}`, `${MODULE_ID}/${pack}`, { yaml });
+}
+
+async function deepGetDirectories(distPath) {
+    const dirr = await fs.readdir('src/' + distPath);
+    const dirrsWithSub = [];
+    for (let file of dirr) {
+        const stat = await fs.stat('src/' + distPath + '/' + file);
+        if (stat.isDirectory()) {
+            const deeper = await deepGetDirectories(distPath + '/' + file);
+            if (deeper.length > 0) {
+                dirrsWithSub.push(...deeper);
+            } else {
+                dirrsWithSub.push(distPath + '/' + file);
+            }
+        }
+    }
+
+    return dirrsWithSub;
 }

--- a/tools/pushLDBtoYML.mjs
+++ b/tools/pushLDBtoYML.mjs
@@ -5,11 +5,13 @@ import path from 'path';
 const MODULE_ID = process.cwd();
 const yaml = false;
 
-const packs = await fs.readdir('./packs');
+// const packs = await fs.readdir('./packs');
+const packs = await deepGetDirectories('./packs');
+console.log(packs);
 for (const pack of packs) {
     if (pack === '.gitattributes') continue;
     console.log('Unpacking ' + pack);
-    const directory = `./src/packs/${pack}`;
+    const directory = `./src/${pack}`;
     try {
         for (const file of await fs.readdir(directory)) {
             await fs.unlink(path.join(directory, file));
@@ -18,7 +20,7 @@ for (const pack of packs) {
         if (error.code === 'ENOENT') console.log('No files inside of ' + pack);
         else console.log(error);
     }
-    await extractPack(`${MODULE_ID}/packs/${pack}`, `${MODULE_ID}/src/packs/${pack}`, {
+    await extractPack(`${MODULE_ID}/${pack}`, `${MODULE_ID}/src/${pack}`, {
         yaml,
         transformName
     });
@@ -33,4 +35,24 @@ function transformName(doc) {
     const prefix = ['actors', 'items'].includes(type) ? doc.type : type;
 
     return `${doc.name ? `${prefix}_${safeFileName}_${doc._id}` : doc._id}.${yaml ? 'yml' : 'json'}`;
+}
+
+async function deepGetDirectories(distPath) {
+    const dirr = await fs.readdir(distPath);
+    const dirrsWithSub = [];
+    for (let file of dirr) {
+        const stat = await fs.stat(distPath + '/' + file);
+        if (stat.isDirectory()) {
+            if (file === 'packs') continue;
+
+            const deeper = await deepGetDirectories(distPath + '/' + file);
+            if (deeper.length > 0) {
+                dirrsWithSub.push(...deeper);
+            } else {
+                dirrsWithSub.push(distPath + '/' + file);
+            }
+        }
+    }
+
+    return dirrsWithSub;
 }


### PR DESCRIPTION
A lot of compendium entries that had been added weren't being saved into JSON format for github. 
This was because `pushLDBtoYML` and `pullYMLtoLDB` were only looking one level down in `Packs`. I changed it so that they recursively go through all folders.

I'm bringing this one in right away so compendium work isn't blocked. It also contains cptn-cosmo's work on items :smile: