### PR TITLE
fix sheet instance issue

### DIFF
--- a/module/applications/levelup.mjs
+++ b/module/applications/levelup.mjs
@@ -18,7 +18,6 @@ export default class DhpLevelup extends HandlebarsApplicationMixin(ApplicationV2
     }
 
     static DEFAULT_OPTIONS = {
-        id: 'daggerheart-levelup',
         classes: ['daggerheart', 'views', 'levelup'],
         position: { width: 1200, height: 'auto' },
         window: {

--- a/module/applications/npcRollSelectionDialog.mjs
+++ b/module/applications/npcRollSelectionDialog.mjs
@@ -19,7 +19,6 @@ export default class NpcRollSelectionDialog extends HandlebarsApplicationMixin(A
 
     static DEFAULT_OPTIONS = {
         tag: 'form',
-        id: 'roll-selection',
         classes: ['daggerheart', 'views', 'npc-roll-selection'],
         position: { width: '500', height: 'auto' },
         actions: {

--- a/module/applications/rollSelectionDialog.mjs
+++ b/module/applications/rollSelectionDialog.mjs
@@ -33,6 +33,7 @@ export default class RollSelectionDialog extends HandlebarsApplicationMixin(Appl
 
     static DEFAULT_OPTIONS = {
         tag: 'form',
+        id: 'roll-selection', //Having an id causes a new instance to overwrite previous.
         classes: ['daggerheart', 'views', 'roll-selection'],
         position: {
             width: 400,

--- a/module/applications/sheets/adversary.mjs
+++ b/module/applications/sheets/adversary.mjs
@@ -205,7 +205,6 @@ export default class AdversarySheet extends DaggerheartSheet(ActorSheetV2) {
 
     static DEFAULT_OPTIONS = {
         tag: 'form',
-        id: 'daggerheart-adversary',
         classes: ['daggerheart', 'sheet', 'adversary'],
         position: { width: 600 },
         actions: {

--- a/module/applications/sheets/ancestry.mjs
+++ b/module/applications/sheets/ancestry.mjs
@@ -61,7 +61,6 @@ const { ItemSheetV2 } = foundry.applications.sheets;
 export default class AncestrySheet extends DaggerheartSheet(ItemSheetV2) {
     static DEFAULT_OPTIONS = {
         tag: 'form',
-        id: 'daggerheart-ancestry',
         classes: ['daggerheart', 'sheet', 'heritage'],
         position: { width: 600 },
         actions: {

--- a/module/applications/sheets/armor.mjs
+++ b/module/applications/sheets/armor.mjs
@@ -31,7 +31,6 @@ const { ItemSheetV2 } = foundry.applications.sheets;
 export default class ArmorSheet extends DaggerheartSheet(ItemSheetV2) {
     static DEFAULT_OPTIONS = {
         tag: 'form',
-        id: 'daggerheart-armor',
         classes: ['daggerheart', 'sheet', 'armor'],
         position: { width: 400 },
         form: {

--- a/module/applications/sheets/class.mjs
+++ b/module/applications/sheets/class.mjs
@@ -217,7 +217,6 @@ const { TextEditor } = foundry.applications.ux;
 export default class ClassSheet extends DaggerheartSheet(ItemSheetV2) {
     static DEFAULT_OPTIONS = {
         tag: 'form',
-        id: 'daggerheart-class',
         classes: ['daggerheart', 'sheet', 'class'],
         position: { width: 600 },
         actions: {

--- a/module/applications/sheets/community.mjs
+++ b/module/applications/sheets/community.mjs
@@ -61,7 +61,6 @@ const { ItemSheetV2 } = foundry.applications.sheets;
 export default class CommunitySheet extends DaggerheartSheet(ItemSheetV2) {
     static DEFAULT_OPTIONS = {
         tag: 'form',
-        id: 'daggerheart-community',
         classes: ['daggerheart', 'sheet', 'heritage'],
         position: { width: 600 },
         actions: {

--- a/module/applications/sheets/consumable.mjs
+++ b/module/applications/sheets/consumable.mjs
@@ -26,7 +26,6 @@ const { ItemSheetV2 } = foundry.applications.sheets;
 export default class ConsumableSheet extends DaggerheartSheet(ItemSheetV2) {
     static DEFAULT_OPTIONS = {
         tag: 'form',
-        id: 'daggerheart-consumable',
         classes: ['daggerheart', 'sheet', 'consumable'],
         position: { width: 480 },
         form: {

--- a/module/applications/sheets/domainCard.mjs
+++ b/module/applications/sheets/domainCard.mjs
@@ -38,7 +38,6 @@ const { ItemSheetV2 } = foundry.applications.sheets;
 export default class DomainCardSheet extends DaggerheartSheet(ItemSheetV2) {
     static DEFAULT_OPTIONS = {
         tag: 'form',
-        id: 'daggerheart-domainCard',
         classes: ['daggerheart', 'sheet', 'domain-card'],
         position: { width: 600, height: 600 },
         actions: {

--- a/module/applications/sheets/feature.mjs
+++ b/module/applications/sheets/feature.mjs
@@ -12,7 +12,6 @@ export default class FeatureSheet extends DaggerheartSheet(ItemSheetV2) {
 
     static DEFAULT_OPTIONS = {
         tag: 'form',
-        id: 'daggerheart-feature',
         classes: ['daggerheart', 'sheet', 'feature'],
         position: { width: 600, height: 600 },
         actions: {

--- a/module/applications/sheets/miscellaneous.mjs
+++ b/module/applications/sheets/miscellaneous.mjs
@@ -26,7 +26,6 @@ const { ItemSheetV2 } = foundry.applications.sheets;
 export default class MiscellaneousSheet extends DaggerheartSheet(ItemSheetV2) {
     static DEFAULT_OPTIONS = {
         tag: 'form',
-        id: 'daggerheart-miscellaneous',
         classes: ['daggerheart', 'sheet', 'miscellaneous'],
         position: { width: 400 },
         form: {

--- a/module/applications/sheets/pc.mjs
+++ b/module/applications/sheets/pc.mjs
@@ -23,7 +23,6 @@ export default class PCSheet extends DaggerheartSheet(ActorSheetV2) {
 
     static DEFAULT_OPTIONS = {
         tag: 'form',
-        id: 'daggerheart-pc',
         classes: ['daggerheart', 'sheet', 'pc'],
         position: { width: 810, height: 1080 },
         actions: {

--- a/module/applications/sheets/subclass.mjs
+++ b/module/applications/sheets/subclass.mjs
@@ -79,7 +79,6 @@ const { ItemSheetV2 } = foundry.applications.sheets;
 export default class SubclassSheet extends DaggerheartSheet(ItemSheetV2) {
     static DEFAULT_OPTIONS = {
         tag: 'form',
-        id: 'daggerheart-subclass',
         classes: ['daggerheart', 'sheet', 'subclass'],
         position: { width: 600 },
         actions: {

--- a/module/applications/sheets/weapon.mjs
+++ b/module/applications/sheets/weapon.mjs
@@ -32,7 +32,6 @@ const { ItemSheetV2 } = foundry.applications.sheets;
 export default class WeaponSheet extends DaggerheartSheet(ItemSheetV2) {
     static DEFAULT_OPTIONS = {
         tag: 'form',
-        id: 'daggerheart-weapon',
         classes: ['daggerheart', 'sheet', 'weapon'],
         position: { width: 400 },
         form: {


### PR DESCRIPTION
remove id from sheets to allow multiple sheets of same type to be open. Added id to roll selection so only a single roll modal will be open. No more spawning infinite dice rollers by click the roll icon on a PC sheet.  It's possible this was causing other weirdness as well.