### PR TITLE
Daggerheart.css changing line-endings on start/checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text eol=crlf


### PR DESCRIPTION
It's line endings that keep being changed because GIT changes them to Linux format.
I added git settings to always keep it in windows format. Someone who runs on Linux will have to tell us if they get the issue now or not :laugh: