### PR TITLE
Issue 73 - Update Community features. Remove bad abilty from Troubadour

### DIFF
--- a/src/packs/communities/community_Highborne_8AcV556QwoIzkkea.json
+++ b/src/packs/communities/community_Highborne_8AcV556QwoIzkkea.json
@@ -9,7 +9,7 @@
       {
         "img": "icons/svg/item-bag.svg",
         "name": "Privilege",
-        "uuid": "Compendium.world.community-features.Item.WoMZCTnDcK8GPSh1"
+        "uuid": "Compendium.daggerheart.community-features.Item.AgJiUvad5tgeam57"
       }
     ]
   },
@@ -29,8 +29,8 @@
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1747940320728,
-    "modifiedTime": 1747990568291,
-    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+    "modifiedTime": 1748487208088,
+    "lastModifiedBy": "c3xaFsDtL56heKoi"
   },
   "_key": "!items!8AcV556QwoIzkkea"
 }

--- a/src/packs/communities/community_Loreborne_fgJHuCdoyXX4Q84O.json
+++ b/src/packs/communities/community_Loreborne_fgJHuCdoyXX4Q84O.json
@@ -9,7 +9,7 @@
       {
         "img": "icons/svg/item-bag.svg",
         "name": "Well-Read",
-        "uuid": "Compendium.world.community-features.Item.MUfVlf8hoJ3HZidv"
+        "uuid": "Compendium.daggerheart.community-features.Item.n2RA9iZNiVbGlxco"
       }
     ]
   },
@@ -29,8 +29,8 @@
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1747940300210,
-    "modifiedTime": 1747990671092,
-    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+    "modifiedTime": 1748487185921,
+    "lastModifiedBy": "c3xaFsDtL56heKoi"
   },
   "_key": "!items!fgJHuCdoyXX4Q84O"
 }

--- a/src/packs/communities/community_Orderborne_Cg39GoSa6lxhXndW.json
+++ b/src/packs/communities/community_Orderborne_Cg39GoSa6lxhXndW.json
@@ -9,7 +9,7 @@
       {
         "img": "icons/svg/item-bag.svg",
         "name": "Dedicated",
-        "uuid": "Compendium.world.community-features.Item.b7LmL7ti1gL5kfGq"
+        "uuid": "Compendium.daggerheart.community-features.Item.ZiBpJxtDSsh6wY3h"
       }
     ]
   },
@@ -29,8 +29,8 @@
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1747940332147,
-    "modifiedTime": 1747990820386,
-    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+    "modifiedTime": 1748487117035,
+    "lastModifiedBy": "c3xaFsDtL56heKoi"
   },
   "_key": "!items!Cg39GoSa6lxhXndW"
 }

--- a/src/packs/communities/community_Ridgeborne_DAQoNvVlc9w7NmZd.json
+++ b/src/packs/communities/community_Ridgeborne_DAQoNvVlc9w7NmZd.json
@@ -9,7 +9,7 @@
       {
         "img": "icons/svg/item-bag.svg",
         "name": "Steady",
-        "uuid": "Compendium.world.community-features.Item.hKGv54dst9crq3Sw"
+        "uuid": "Compendium.daggerheart.community-features.Item.Oky51ziMZp6bbuUQ"
       }
     ]
   },
@@ -29,8 +29,8 @@
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1747940346633,
-    "modifiedTime": 1747990891669,
-    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+    "modifiedTime": 1748487238072,
+    "lastModifiedBy": "c3xaFsDtL56heKoi"
   },
   "_key": "!items!DAQoNvVlc9w7NmZd"
 }

--- a/src/packs/communities/community_Seaborne_ivrXToGxyuVdqZtG.json
+++ b/src/packs/communities/community_Seaborne_ivrXToGxyuVdqZtG.json
@@ -9,7 +9,7 @@
       {
         "img": "icons/svg/item-bag.svg",
         "name": "Know the Tide",
-        "uuid": "Compendium.world.community-features.Item.coBcBEFpXgtxD1Jt"
+        "uuid": "Compendium.daggerheart.community-features.Item.0mdoYz7uZNWCcK5Z"
       }
     ]
   },
@@ -29,8 +29,8 @@
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1747940375520,
-    "modifiedTime": 1747990980804,
-    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+    "modifiedTime": 1748487248881,
+    "lastModifiedBy": "c3xaFsDtL56heKoi"
   },
   "_key": "!items!ivrXToGxyuVdqZtG"
 }

--- a/src/packs/communities/community_Slyborne_rwsUCLenOkE9CS7v.json
+++ b/src/packs/communities/community_Slyborne_rwsUCLenOkE9CS7v.json
@@ -9,7 +9,7 @@
       {
         "img": "icons/svg/item-bag.svg",
         "name": "Scoundrel",
-        "uuid": "Compendium.world.community-features.Item.p2PipVUiMt0Cy0ws"
+        "uuid": "Compendium.daggerheart.community-features.Item.5BUCiSPswsiB0RDW"
       }
     ]
   },
@@ -29,8 +29,8 @@
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1747940388725,
-    "modifiedTime": 1747991089836,
-    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+    "modifiedTime": 1748487260950,
+    "lastModifiedBy": "c3xaFsDtL56heKoi"
   },
   "_key": "!items!rwsUCLenOkE9CS7v"
 }

--- a/src/packs/communities/community_Underborne_CXQN2zcQUIjUOx1i.json
+++ b/src/packs/communities/community_Underborne_CXQN2zcQUIjUOx1i.json
@@ -9,7 +9,7 @@
       {
         "img": "icons/svg/item-bag.svg",
         "name": "Low-Light Living",
-        "uuid": "Compendium.world.community-features.Item.p12Le1M3DPWXa0vh"
+        "uuid": "Compendium.daggerheart.community-features.Item.hX85YvTQcMzc25hW"
       }
     ]
   },
@@ -29,8 +29,8 @@
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1747940403160,
-    "modifiedTime": 1747991158174,
-    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+    "modifiedTime": 1748487269990,
+    "lastModifiedBy": "c3xaFsDtL56heKoi"
   },
   "_key": "!items!CXQN2zcQUIjUOx1i"
 }

--- a/src/packs/communities/community_Wanderborne_DHB5uSzbBeJCJuvC.json
+++ b/src/packs/communities/community_Wanderborne_DHB5uSzbBeJCJuvC.json
@@ -9,7 +9,7 @@
       {
         "img": "icons/svg/item-bag.svg",
         "name": "Nomadic Pack",
-        "uuid": "Compendium.world.community-features.Item.NeuBdFDpV0HTzOIM"
+        "uuid": "Compendium.daggerheart.community-features.Item.o3Q88Rws9Eb5ae5D"
       }
     ]
   },
@@ -29,8 +29,8 @@
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1747940414913,
-    "modifiedTime": 1747991238462,
-    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+    "modifiedTime": 1748487280155,
+    "lastModifiedBy": "c3xaFsDtL56heKoi"
   },
   "_key": "!items!DHB5uSzbBeJCJuvC"
 }

--- a/src/packs/communities/community_Wildborne_jUzXIVyBx0mlIFWa.json
+++ b/src/packs/communities/community_Wildborne_jUzXIVyBx0mlIFWa.json
@@ -9,7 +9,7 @@
       {
         "img": "icons/svg/item-bag.svg",
         "name": "Lightfoot",
-        "uuid": "Compendium.world.community-features.Item.4VaugxNAouI7SKKz"
+        "uuid": "Compendium.daggerheart.community-features.Item.LY9c4DCgMcB1uEiv"
       }
     ]
   },
@@ -29,8 +29,8 @@
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1747940432585,
-    "modifiedTime": 1747991300734,
-    "lastModifiedBy": "NqO2eQGMjrvUO6v9"
+    "modifiedTime": 1748487285826,
+    "lastModifiedBy": "c3xaFsDtL56heKoi"
   },
   "_key": "!items!jUzXIVyBx0mlIFWa"
 }

--- a/src/packs/subclasses/subclass_Troubadour_T1iBO8i0xRF5c8Q2.json
+++ b/src/packs/subclasses/subclass_Troubadour_T1iBO8i0xRF5c8Q2.json
@@ -8,26 +8,7 @@
     "spellcastingTrait": "presence",
     "foundationFeature": {
       "description": "<p><strong>Gifted Performer:</strong> Describe how you perform for others. You can play each song once per long rest:</p><p>• <strong>Relaxing Song:</strong> You and all allies within Close range clear a Hit Point.</p><p>• <strong>Epic Song:</strong> Make a target within Close range temporarily Vulnerable.</p><p>• <strong>Heartbreaking Song:</strong> You and all allies within Close range gain a Hope.</p>",
-      "abilities": [
-        {
-          "actionType": "passive",
-          "featureType": {
-            "type": "normal",
-            "data": {
-              "property": "spellcastingTrait",
-              "max": 1,
-              "numbers": {}
-            }
-          },
-          "refreshData": null,
-          "multiclass": null,
-          "disabled": false,
-          "description": "<p>You are among the greatest of your craft and your skill is boundless. You can perform each of your “Gifted Performer” feature’s songs twice instead of once per long rest.</p>",
-          "effects": {},
-          "actions": [],
-          "type": "subclass"
-        }
-      ]
+      "abilities": []
     },
     "specializationFeature": {
       "unlocked": false,


### PR DESCRIPTION
Update the Community to use the Community Features from the daggerheart system rather than world. Removed a bad action from the Troubadour subclass. These features and subclass should now be usable on the PC sheet. 