### PR TITLE
Css Complication Fix

### DIFF
--- a/styles/daggerheart.css
+++ b/styles/daggerheart.css
@@ -3205,6 +3205,7 @@ div.daggerheart.views.multiclass {
   width: 100%;
   object-fit: cover;
   mask-image: linear-gradient(0deg, transparent 0%, black 10%);
+  cursor: pointer;
 }
 .application.sheet.daggerheart.dh-style .item-card-header .item-icons-list {
   position: absolute;

--- a/styles/daggerheart.less
+++ b/styles/daggerheart.less
@@ -13,7 +13,6 @@
 
 // new styles imports
 @import './less/items/feature.less';
-@import './less/items/ancestry.less';
 @import './less/items/domainCard.less';
 
 @import './less/utils/colors.less';


### PR DESCRIPTION
A non-existant import had misstakenly been left in. This prevented gulp from compiling changes to `daggerheart.css`. 