### PR TITLE
finding and fixing bugs.

### DIFF
--- a/module/data/abilityUse.mjs
+++ b/module/data/abilityUse.mjs
@@ -4,11 +4,12 @@ export default class DhpAbilityUse extends foundry.abstract.TypeDataModel {
 
         return {
             title: new fields.StringField({}),
+            origin: new fields.StringField({}),
             img: new fields.StringField({}),
             name: new fields.StringField({}),
             description: new fields.StringField({}),
             actions: new fields.ArrayField(
-                new fields.SchemaField({
+                new fields.ObjectField({
                     name: new fields.StringField({}),
                     damage: new fields.SchemaField({
                         type: new fields.StringField({}),
@@ -19,11 +20,11 @@ export default class DhpAbilityUse extends foundry.abstract.TypeDataModel {
                         value: new fields.StringField({})
                     }),
                     cost: new fields.SchemaField({
-                        type: new fields.StringField({ nullable: true }),
-                        value: new fields.NumberField({ nullable: true })
+                        type: new fields.StringField({}),
+                        value: new fields.NumberField({})
                     }),
                     target: new fields.SchemaField({
-                        type: new fields.StringField({})
+                        type: new fields.StringField({ nullable: true })
                     })
                 })
             )

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -307,10 +307,20 @@ export default class DhpActor extends Actor {
         let update = {};
         switch (type) {
             case SYSTEM.GENERAL.healingTypes.health.id:
-                update = { 'system.resources.health.value': Math.max(this.system.resources.health.value - healing, 0) };
+                update = {
+                    'system.resources.health.value': Math.min(
+                        this.system.resources.health.value + healing,
+                        this.system.resources.health.max
+                    )
+                };
                 break;
             case SYSTEM.GENERAL.healingTypes.stress.id:
-                update = { 'system.resources.stress.value': Math.max(this.system.resources.stress.value - healing, 0) };
+                update = {
+                    'system.resources.stress.value': Math.min(
+                        this.system.resources.stress.value + healing,
+                        this.system.resources.stress.max
+                    )
+                };
                 break;
         }
 
@@ -343,7 +353,10 @@ export default class DhpActor extends Actor {
         }
 
         if (action.cost.type != null && action.cost.value != null) {
-            if (this.system.resources[action.cost.type].value < action.cost.value - 1) {
+            if (
+                this.system.resources[action.cost.type].value - action.cost.value <=
+                this.system.resources[action.cost.type].min
+            ) {
                 ui.notifications.error(game.i18n.localize(`Insufficient ${action.cost.type} to use this ability`));
                 return;
             }

--- a/module/ui/chatLog.mjs
+++ b/module/ui/chatLog.mjs
@@ -36,7 +36,7 @@ export default class DhpChatLog extends foundry.applications.sidebar.tabs.ChatLo
             element.addEventListener('click', event => this.selectAdvantage.bind(this)(event, data.message))
         );
         html.querySelectorAll('.ability-use-button').forEach(element =>
-            element.addEventListener('click', this.abilityUseButton.bind(this)(event, data.message))
+            element.addEventListener('click', event => this.abilityUseButton.bind(this)(event, data.message))
         );
     };
 
@@ -134,6 +134,7 @@ export default class DhpChatLog extends foundry.applications.sidebar.tabs.ChatLo
         event.stopPropagation();
 
         const action = message.system.actions[Number.parseInt(event.currentTarget.dataset.index)];
-        await game.user.character.useAction(action);
+        const actor = game.actors.get(message.system.origin);
+        await actor.useAction(action);
     };
 }

--- a/styles/chat.less
+++ b/styles/chat.less
@@ -547,6 +547,11 @@
                     margin-top: @tinyMargin;
                 }
             }
+
+            .ability-card-action-cost {
+                margin: auto;
+                font-size: 1.5em;
+            }
         }
 
         img {

--- a/styles/daggerheart.css
+++ b/styles/daggerheart.css
@@ -1770,6 +1770,10 @@
 .daggerheart.chat.domain-card .ability-card-footer button:nth-of-type(n + 3) {
   margin-top: 2px;
 }
+.daggerheart.chat.domain-card .ability-card-footer .ability-card-action-cost {
+  margin: auto;
+  font-size: 1.5em;
+}
 .daggerheart.chat.domain-card img {
   width: 80px;
 }

--- a/templates/chat/ability-use.hbs
+++ b/templates/chat/ability-use.hbs
@@ -10,6 +10,7 @@
             <button class="ability-use-button" data-index="{{index}}">
                 {{action.name}}
             </button>
+            {{#if action.cost.value}}<div class="ability-card-action-cost">{{action.cost.value}} {{action.cost.type}}</div>{{/if}}            
         {{/each}}
     </footer>
 </div>

--- a/templates/sheets/parts/domainCard.hbs
+++ b/templates/sheets/parts/domainCard.hbs
@@ -16,6 +16,7 @@
         </div>  
     </div>
     <div class="abilities-text-container domain">
+        <div ><i data-action="removeCard" data-type="{{card.type}}" data-key="{{card.uuid}}" class="fas fa-trash icon-button row-icon"></i></div>
         <div class="abilities-card-title">{{card.name}}</div>
         {{#if inVault}}
             <div class="abilities-card-description">{{{card.system.effect}}}</div>


### PR DESCRIPTION
Fixed cards not being able to swap between loadout and vault. 
Added a delete icon on the loadout/vault cards (I didn't bother with styles since this is about to be updated) and set it up so only domain cards can be removed.
Fixed where the abilityUse chat message wasn't passing the actions properly. (changed SchemaField to ObjectField, otherwise the clean function of the Chatmessage was wiping out the actions).
Fixed healing so it actually heals, rather than damages the target. 
On action-use Chat Messages, added a cost next to the action button if a cost exists. Since we don't automate the reduction of resources on cast, it's probably better to have a reminder. Otherwise it looks like it's free. 


close #87 