### PR TITLE
Irk/83 homebrew currency

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -101,6 +101,7 @@
                     "traitArray": { "label": "Initial Trait Modifiers" }
                 },
                 "Currency": {
+                    "enabled": "Enable Overrides",
                     "title": "Currency Overrides",
                     "currencyName": "Currency Name",
                     "coinName": "Coin Name",

--- a/lang/en.json
+++ b/lang/en.json
@@ -102,6 +102,7 @@
                 },
                 "Currency": {
                     "title": "Currency Overrides",
+                    "currencyName": "Currency Name",
                     "coinName": "Coin Name",
                     "handfullName": "Handfull Name",
                     "bagName": "Bag Name",

--- a/lang/en.json
+++ b/lang/en.json
@@ -99,6 +99,13 @@
                 "FIELDS": {
                     "maxFear": { "label": "Max Fear" },
                     "traitArray": { "label": "Initial Trait Modifiers" }
+                },
+                "Currency": {
+                    "title": "Currency Overrides",
+                    "coinName": "Coin Name",
+                    "handfullName": "Handfull Name",
+                    "bagName": "Bag Name",
+                    "chestName": "Chest Name"
                 }
             },
             "Resources": {

--- a/module/applications/settings/homebrewSettings.mjs
+++ b/module/applications/settings/homebrewSettings.mjs
@@ -1,6 +1,5 @@
 import { DhHomebrew } from '../../data/settings/_module.mjs';
 import DhSettingsActionView from './components/settingsActionsView.mjs';
-import { defaultRestOptions } from '../../config/generalConfig.mjs';
 
 const { HandlebarsApplicationMixin, ApplicationV2 } = foundry.applications.api;
 
@@ -159,10 +158,9 @@ export default class DhHomebrewSettings extends HandlebarsApplicationMixin(Appli
     }
 
     static async reset() {
-        //For some reason this doesn't seem to localize any of the strings, so calling a recursive call to localize all strings. ¯\_(ツ)_/¯
         const resetSettings = new DhHomebrew();
         let localizedSettings = this.localizeObject(resetSettings);
-        await this.settings.updateSource(localizedSettings);
+        this.settings.updateSource(localizedSettings);
         this.render();
     }
 
@@ -175,7 +173,6 @@ export default class DhHomebrewSettings extends HandlebarsApplicationMixin(Appli
                 } else {
                     if (typeof value === 'string' && value.startsWith('DAGGERHEART.')) {
                         obj[key] = game.i18n.localize(value);
-                        console.log(obj[key]);
                     }
                 }
             }

--- a/module/applications/settings/homebrewSettings.mjs
+++ b/module/applications/settings/homebrewSettings.mjs
@@ -171,9 +171,11 @@ export default class DhHomebrewSettings extends HandlebarsApplicationMixin(Appli
             if (obj.hasOwnProperty(key)) {
                 const value = obj[key];
                 if (typeof value === 'object' && value !== null) {
+                    obj[key] = this.localizeObject(value);
                 } else {
                     if (typeof value === 'string' && value.startsWith('DAGGERHEART.')) {
                         obj[key] = game.i18n.localize(value);
+                        console.log(obj[key]);
                     }
                 }
             }

--- a/module/applications/settings/homebrewSettings.mjs
+++ b/module/applications/settings/homebrewSettings.mjs
@@ -1,5 +1,6 @@
 import { DhHomebrew } from '../../data/settings/_module.mjs';
 import DhSettingsActionView from './components/settingsActionsView.mjs';
+import { defaultRestOptions } from '../../config/generalConfig.mjs';
 
 const { HandlebarsApplicationMixin, ApplicationV2 } = foundry.applications.api;
 
@@ -24,14 +25,16 @@ export default class DhHomebrewSettings extends HandlebarsApplicationMixin(Appli
             editItem: this.editItem,
             removeItem: this.removeItem,
             resetMoves: this.resetMoves,
-            save: this.save
+            save: this.save,
+            reset: this.reset
         },
         form: { handler: this.updateData, submitOnChange: true }
     };
 
     static PARTS = {
         main: {
-            template: 'systems/daggerheart/templates/settings/homebrew-settings.hbs'
+            template: 'systems/daggerheart/templates/settings/homebrew-settings.hbs',
+            scrollable: ['']
         }
     };
 
@@ -153,5 +156,28 @@ export default class DhHomebrewSettings extends HandlebarsApplicationMixin(Appli
     static async save() {
         await game.settings.set(SYSTEM.id, SYSTEM.SETTINGS.gameSettings.Homebrew, this.settings.toObject());
         this.close();
+    }
+
+    static async reset() {
+        //For some reason this doesn't seem to localize any of the strings, so calling a recursive call to localize all strings. ¯\_(ツ)_/¯
+        const resetSettings = new DhHomebrew();
+        let localizedSettings = this.localizeObject(resetSettings);
+        await this.settings.updateSource(localizedSettings);
+        this.render();
+    }
+
+    localizeObject(obj) {
+        for (let key in obj) {
+            if (obj.hasOwnProperty(key)) {
+                const value = obj[key];
+                if (typeof value === 'object' && value !== null) {
+                } else {
+                    if (typeof value === 'string' && value.startsWith('DAGGERHEART.')) {
+                        obj[key] = game.i18n.localize(value);
+                    }
+                }
+            }
+        }
+        return obj;
     }
 }

--- a/module/applications/sheets/character.mjs
+++ b/module/applications/sheets/character.mjs
@@ -329,8 +329,19 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                 },
                 items: this.document.items.filter(x => x.type === 'armor')
             },
-            currency: game.settings.get(SYSTEM.id, SYSTEM.SETTINGS.gameSettings.Homebrew).currency
+            currency: {
+                title: game.i18n.localize('DAGGERHEART.Sheets.PC.Gold.Title'),
+                coins: game.i18n.localize('DAGGERHEART.Sheets.PC.Gold.Coins'),
+                handfulls: game.i18n.localize('DAGGERHEART.Sheets.PC.Gold.Handfulls'),
+                bags: game.i18n.localize('DAGGERHEART.Sheets.PC.Gold.Bags'),
+                chests: game.i18n.localize('DAGGERHEART.Sheets.PC.Gold.Chests')
+            }
         };
+
+        const homebrewCurrency = game.settings.get(SYSTEM.id, SYSTEM.SETTINGS.gameSettings.Homebrew).currency;
+        if (homebrewCurrency.enabled) {
+            context.inventory.currency = homebrewCurrency;
+        }
 
         if (context.inventory.length === 0) {
             context.inventory = Array(1).fill(Array(5).fill([]));

--- a/module/applications/sheets/character.mjs
+++ b/module/applications/sheets/character.mjs
@@ -328,7 +328,8 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                     quantity: game.i18n.localize('DAGGERHEART.Sheets.PC.InventoryTab.QuantityTitle')
                 },
                 items: this.document.items.filter(x => x.type === 'armor')
-            }
+            },
+            currency: game.settings.get(SYSTEM.id, SYSTEM.SETTINGS.gameSettings.Homebrew).currency
         };
 
         if (context.inventory.length === 0) {

--- a/module/config/generalConfig.mjs
+++ b/module/config/generalConfig.mjs
@@ -153,13 +153,15 @@ export const defaultRestOptions = {
             id: 'repairArmor',
             name: game.i18n.localize('DAGGERHEART.Downtime.ShortRest.RepairArmor.Name'),
             img: 'icons/skills/trades/smithing-anvil-silver-red.webp',
-            description: game.i18n.localize('DAGGERHEART.Downtime.ShortRest.RepairArmor.Description')
+            description: game.i18n.localize('DAGGERHEART.Downtime.ShortRest.RepairArmor.Description'),
+            actions: []
         },
         prepare: {
             id: 'prepare',
             name: game.i18n.localize('DAGGERHEART.Downtime.ShortRest.Prepare.Name'),
             img: 'icons/skills/trades/academics-merchant-scribe.webp',
-            description: game.i18n.localize('DAGGERHEART.Downtime.ShortRest.Prepare.Description')
+            description: game.i18n.localize('DAGGERHEART.Downtime.ShortRest.Prepare.Description'),
+            actions: []
         }
     }),
     longRest: () => ({
@@ -167,31 +169,36 @@ export const defaultRestOptions = {
             id: 'tendToWounds',
             name: game.i18n.localize('DAGGERHEART.Downtime.LongRest.TendToWounds.Name'),
             img: 'icons/magic/life/cross-worn-green.webp',
-            description: game.i18n.localize('DAGGERHEART.Downtime.LongRest.TendToWounds.Description')
+            description: game.i18n.localize('DAGGERHEART.Downtime.LongRest.TendToWounds.Description'),
+            actions: []
         },
         clearStress: {
             id: 'clearStress',
             name: game.i18n.localize('DAGGERHEART.Downtime.LongRest.ClearStress.Name'),
             img: 'icons/magic/perception/eye-ringed-green.webp',
-            description: game.i18n.localize('DAGGERHEART.Downtime.LongRest.ClearStress.Description')
+            description: game.i18n.localize('DAGGERHEART.Downtime.LongRest.ClearStress.Description'),
+            actions: []
         },
         repairArmor: {
             id: 'repairArmor',
             name: game.i18n.localize('DAGGERHEART.Downtime.LongRest.RepairArmor.Name'),
             img: 'icons/skills/trades/smithing-anvil-silver-red.webp',
-            description: game.i18n.localize('DAGGERHEART.Downtime.LongRest.RepairArmor.Description')
+            description: game.i18n.localize('DAGGERHEART.Downtime.LongRest.RepairArmor.Description'),
+            actions: []
         },
         prepare: {
             id: 'prepare',
             name: game.i18n.localize('DAGGERHEART.Downtime.LongRest.Prepare.Name'),
             img: 'icons/skills/trades/academics-merchant-scribe.webp',
-            description: game.i18n.localize('DAGGERHEART.Downtime.LongRest.Prepare.Description')
+            description: game.i18n.localize('DAGGERHEART.Downtime.LongRest.Prepare.Description'),
+            actions: []
         },
         workOnAProject: {
             id: 'workOnAProject',
             name: game.i18n.localize('DAGGERHEART.Downtime.LongRest.WorkOnAProject.Name'),
             img: 'icons/skills/social/thumbsup-approval-like.webp',
-            description: game.i18n.localize('DAGGERHEART.Downtime.LongRest.WorkOnAProject.Description')
+            description: game.i18n.localize('DAGGERHEART.Downtime.LongRest.WorkOnAProject.Description'),
+            actions: []
         }
     }),
     custom: {

--- a/module/data/settings/Homebrew.mjs
+++ b/module/data/settings/Homebrew.mjs
@@ -17,6 +17,11 @@ export default class DhHomebrew extends foundry.abstract.DataModel {
                 initial: () => [2, 1, 1, 0, 0, -1]
             }),
             currency: new fields.SchemaField({
+                enabled: new fields.BooleanField({
+                    required: true,
+                    initial: false,
+                    label: 'DAGGERHEART.Settings.Homebrew.Currency.enabled'
+                }),
                 title: new fields.StringField({
                     required: true,
                     initial: 'Gold',

--- a/module/data/settings/Homebrew.mjs
+++ b/module/data/settings/Homebrew.mjs
@@ -16,6 +16,28 @@ export default class DhHomebrew extends foundry.abstract.DataModel {
             traitArray: new fields.ArrayField(new fields.NumberField({ required: true, integer: true }), {
                 initial: () => [2, 1, 1, 0, 0, -1]
             }),
+            currency: new fields.SchemaField({
+                coins: new fields.StringField({
+                    required: true,
+                    initial: game.i18n.localize('DAGGERHEART.Sheets.PC.Gold.Coins'),
+                    label: 'DAGGERHEART.Settings.Homebrew.Currency.coinName'
+                }),
+                handfulls: new fields.StringField({
+                    required: true,
+                    initial: game.i18n.localize('DAGGERHEART.Sheets.PC.Gold.Handfulls'),
+                    label: 'DAGGERHEART.Settings.Homebrew.Currency.handfullName'
+                }),
+                bags: new fields.StringField({
+                    required: true,
+                    initial: game.i18n.localize('DAGGERHEART.Sheets.PC.Gold.Bags'),
+                    label: 'DAGGERHEART.Settings.Homebrew.Currency.bagName'
+                }),
+                chests: new fields.StringField({
+                    required: true,
+                    initial: game.i18n.localize('DAGGERHEART.Sheets.PC.Gold.Chests'),
+                    label: 'DAGGERHEART.Settings.Homebrew.Currency.chestName'
+                })
+            }),
             restMoves: new fields.SchemaField({
                 longRest: new fields.SchemaField({
                     nrChoices: new fields.NumberField({ required: true, integer: true, min: 1, initial: 2 }),

--- a/module/data/settings/Homebrew.mjs
+++ b/module/data/settings/Homebrew.mjs
@@ -17,24 +17,29 @@ export default class DhHomebrew extends foundry.abstract.DataModel {
                 initial: () => [2, 1, 1, 0, 0, -1]
             }),
             currency: new fields.SchemaField({
+                title: new fields.StringField({
+                    required: true,
+                    initial: 'Gold',
+                    label: 'DAGGERHEART.Settings.Homebrew.Currency.currencyName'
+                }),
                 coins: new fields.StringField({
                     required: true,
-                    initial: game.i18n.localize('DAGGERHEART.Sheets.PC.Gold.Coins'),
+                    initial: 'Coins',
                     label: 'DAGGERHEART.Settings.Homebrew.Currency.coinName'
                 }),
                 handfulls: new fields.StringField({
                     required: true,
-                    initial: game.i18n.localize('DAGGERHEART.Sheets.PC.Gold.Handfulls'),
+                    initial: 'Handfulls',
                     label: 'DAGGERHEART.Settings.Homebrew.Currency.handfullName'
                 }),
                 bags: new fields.StringField({
                     required: true,
-                    initial: game.i18n.localize('DAGGERHEART.Sheets.PC.Gold.Bags'),
+                    initial: 'Bags',
                     label: 'DAGGERHEART.Settings.Homebrew.Currency.bagName'
                 }),
                 chests: new fields.StringField({
                     required: true,
-                    initial: game.i18n.localize('DAGGERHEART.Sheets.PC.Gold.Chests'),
+                    initial: 'Chests',
                     label: 'DAGGERHEART.Settings.Homebrew.Currency.chestName'
                 })
             }),

--- a/templates/settings/homebrew-settings.hbs
+++ b/templates/settings/homebrew-settings.hbs
@@ -15,6 +15,7 @@
         <legend>
             {{localize "DAGGERHEART.Settings.Homebrew.Currency.title"}} 
         </legend>
+        {{formGroup settingFields.schema.fields.currency.fields.title value=settingFields._source.currency.title localize=true}}
         {{formGroup settingFields.schema.fields.currency.fields.coins value=settingFields._source.currency.coins localize=true}}
         {{formGroup settingFields.schema.fields.currency.fields.handfulls value=settingFields._source.currency.handfulls localize=true}}
         {{formGroup settingFields.schema.fields.currency.fields.bags value=settingFields._source.currency.bags localize=true}}

--- a/templates/settings/homebrew-settings.hbs
+++ b/templates/settings/homebrew-settings.hbs
@@ -15,6 +15,7 @@
         <legend>
             {{localize "DAGGERHEART.Settings.Homebrew.Currency.title"}} 
         </legend>
+        {{formGroup settingFields.schema.fields.currency.fields.enabled value=settingFields._source.currency.enabled localize=true}}
         {{formGroup settingFields.schema.fields.currency.fields.title value=settingFields._source.currency.title localize=true}}
         {{formGroup settingFields.schema.fields.currency.fields.coins value=settingFields._source.currency.coins localize=true}}
         {{formGroup settingFields.schema.fields.currency.fields.handfulls value=settingFields._source.currency.handfulls localize=true}}

--- a/templates/settings/homebrew-settings.hbs
+++ b/templates/settings/homebrew-settings.hbs
@@ -1,4 +1,4 @@
-<div>
+<div class="scrollable">
     {{formGroup settingFields.schema.fields.maxFear value=settingFields._source.maxFear localize=true}}
 
     <h4>{{localize "DAGGERHEART.Settings.Homebrew.FIELDS.traitArray.label"}}</h4>
@@ -9,7 +9,18 @@
                 <input type="text" data-dtype="Number" name="{{concat "traitArray." index}}" value="{{this}}" />
             </div>
         {{/each}}
-    </div>
+</div>   
+
+    <fieldset>
+        <legend>
+            {{localize "DAGGERHEART.Settings.Homebrew.Currency.title"}} 
+        </legend>
+        {{formGroup settingFields.schema.fields.currency.fields.coins value=settingFields._source.currency.coins localize=true}}
+        {{formGroup settingFields.schema.fields.currency.fields.handfulls value=settingFields._source.currency.handfulls localize=true}}
+        {{formGroup settingFields.schema.fields.currency.fields.bags value=settingFields._source.currency.bags localize=true}}
+        {{formGroup settingFields.schema.fields.currency.fields.chests value=settingFields._source.currency.chests localize=true}}
+        
+    </fieldset>
 
     <fieldset class="two-columns even">
         <legend>{{localize "DAGGERHEART.Settings.Homebrew.DowntimeMoves"}}</legend>

--- a/templates/sheets/actors/character/inventory.hbs
+++ b/templates/sheets/actors/character/inventory.hbs
@@ -21,20 +21,21 @@
     </div>
 
     <div class="currency-section">
+        {{log this}}
         <div class="input">
-            <span>{{localize "DAGGERHEART.Sheets.PC.Gold.Coins"}}</span>
+            <span>{{this.inventory.currency.coins}}</span>
             {{formInput systemFields.gold.fields.coins value=source.system.gold.coins enriched=source.system.gold.coins localize=true toggled=true}}
         </div>
         <div class="input">
-            <span>{{localize "DAGGERHEART.Sheets.PC.Gold.Handfulls"}}</span>
+            <span>{{this.inventory.currency.handfulls}}</span>
             {{formInput systemFields.gold.fields.handfulls value=source.system.gold.handfulls enriched=source.system.gold.handfulls localize=true toggled=true}}
         </div>
         <div class="input">
-            <span>{{localize "DAGGERHEART.Sheets.PC.Gold.Bags"}}</span>
+            <span>{{this.inventory.currency.bags}}</span>
             {{formInput systemFields.gold.fields.bags value=source.system.gold.bags enriched=source.system.gold.bags localize=true toggled=true}}
         </div>
         <div class="input">
-            <span>{{localize "DAGGERHEART.Sheets.PC.Gold.Chests"}}</span>
+            <span>{{this.inventory.currency.chests}}</span>
             {{formInput systemFields.gold.fields.chests value=source.system.gold.chests enriched=source.system.gold.chests localize=true toggled=true}}
         </div>
     </div>

--- a/templates/sheets/actors/character/inventory.hbs
+++ b/templates/sheets/actors/character/inventory.hbs
@@ -12,7 +12,7 @@
         </div>
         <a><i class="fa-solid fa-filter"></i></a>
     </div>
-
+    
     <div class="items-section">
         {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'TYPES.Item.weapon') type='weapon' isGlassy=true}}
         {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'TYPES.Item.armor') type='armor' isGlassy=true}}
@@ -20,24 +20,23 @@
         {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'TYPES.Item.miscellaneous') type='miscellaneous' isGlassy=true}}
     </div>
 
-    <div class="currency-section">
-        {{log this}}
+    <div class="currency-section">       
         <div class="input">
-            <span>{{this.inventory.currency.coins}}</span>
+            <span>{{localize this.inventory.currency.coins}}</span>
             {{formInput systemFields.gold.fields.coins value=source.system.gold.coins enriched=source.system.gold.coins localize=true toggled=true}}
         </div>
         <div class="input">
-            <span>{{this.inventory.currency.handfulls}}</span>
+            <span>{{localize this.inventory.currency.handfulls}}</span>
             {{formInput systemFields.gold.fields.handfulls value=source.system.gold.handfulls enriched=source.system.gold.handfulls localize=true toggled=true}}
         </div>
         <div class="input">
-            <span>{{this.inventory.currency.bags}}</span>
+            <span>{{localize this.inventory.currency.bags}}</span>
             {{formInput systemFields.gold.fields.bags value=source.system.gold.bags enriched=source.system.gold.bags localize=true toggled=true}}
         </div>
         <div class="input">
-            <span>{{this.inventory.currency.chests}}</span>
+            <span>{{localize this.inventory.currency.chests}}</span>
             {{formInput systemFields.gold.fields.chests value=source.system.gold.chests enriched=source.system.gold.chests localize=true toggled=true}}
         </div>
+        
     </div>
-
 </section>

--- a/templates/sheets/parts/gold.hbs
+++ b/templates/sheets/parts/gold.hbs
@@ -1,10 +1,12 @@
+
+{{log this}}
 <fieldset class="left-main-container" style="padding-top: 0; margin-top: 8px;">
-    <legend class="legend" style="line-height: 2px;">{{localize "DAGGERHEART.Sheets.PC.Gold.Title"}}</legend>
+    <legend class="legend" style="line-height: 2px;">{{localize this.inventory.currency.title}}</legend>
 
     <div class="gold-section">
         <fieldset class="gold-fieldset">
             <legend>
-                {{localize "DAGGERHEART.Sheets.PC.Gold.Coins"}}
+                {{localize this.inventory.currency.coins}}
             </legend>
             <div class="gold-column">
                 <div class="gold-row">
@@ -27,7 +29,7 @@
         </fieldset>
         <fieldset class="gold-fieldset">
             <legend>
-                {{localize "DAGGERHEART.Sheets.PC.Gold.Handfulls"}}
+                {{localize this.inventory.currency.handfulls}}
             </legend>
             <div class="gold-column">
                 <div class="gold-row">
@@ -50,7 +52,7 @@
         </fieldset>
         <fieldset class="gold-fieldset">
             <legend>
-                {{localize "DAGGERHEART.Sheets.PC.Gold.Bags"}}
+                {{localize this.inventory.currency.bags}}
             </legend>
             <div class="gold-column">
                 <div class="gold-row">
@@ -76,7 +78,7 @@
         </fieldset>
         <fieldset class="gold-fieldset" style="min-width: 56px;">
             <legend>
-                {{localize "DAGGERHEART.Sheets.PC.Gold.Chests"}}
+                {{localize this.inventory.currency.chests}}
             </legend>
 
             <div class="gold-column">

--- a/templates/sheets/parts/gold.hbs
+++ b/templates/sheets/parts/gold.hbs
@@ -1,5 +1,3 @@
-
-{{log this}}
 <fieldset class="left-main-container" style="padding-top: 0; margin-top: 8px;">
     <legend class="legend" style="line-height: 2px;">{{localize this.inventory.currency.title}}</legend>
 


### PR DESCRIPTION
Should now be able to change the default name categories for currency. 

For some reason on the reset function of the homebrew settings it didn't want to localize all the strings, so I have it call a recursive function to localize any strings that need it. 

Not sure if we actually need or plan to use the gold.hbs anymore, but just in case I updated it as well. 

close #83 