### PR TITLE
Fixed Firefox progress bar (HP/Stress)

### DIFF
--- a/styles/less/actors/adversary/sidebar.less
+++ b/styles/less/actors/adversary/sidebar.less
@@ -170,6 +170,7 @@
                         border: 1px solid light-dark(@dark-blue, @golden);
                         border-radius: 6px;
                         z-index: 1;
+                        background: @dark-blue;
 
                         &::-webkit-progress-bar {
                             border: none;
@@ -184,13 +185,9 @@
                             background: @gradient-stress;
                             border-radius: 6px;
                         }
-                        &::-moz-progress-value,
-                        &::-moz-progress-bar {
-                            border-radius: 6px;
-                        }
-
                         &::-moz-progress-bar {
                             background: @gradient-hp;
+                            border-radius: 6px;
                         }
                         &.stress-color::-moz-progress-bar {
                             background: @gradient-stress;

--- a/styles/less/actors/character/sidebar.less
+++ b/styles/less/actors/character/sidebar.less
@@ -128,6 +128,7 @@
                         border: 1px solid light-dark(@dark-blue, @golden);
                         border-radius: 6px;
                         z-index: 1;
+                        background: @dark-blue;
 
                         &::-webkit-progress-bar {
                             border: none;
@@ -142,13 +143,9 @@
                             background: @gradient-stress;
                             border-radius: 6px;
                         }
-                        &::-moz-progress-value,
-                        &::-moz-progress-bar {
-                            border-radius: 6px;
-                        }
-
                         &::-moz-progress-bar {
                             background: @gradient-hp;
+                            border-radius: 6px;
                         }
                         &.stress-color::-moz-progress-bar {
                             background: @gradient-stress;


### PR DESCRIPTION
## Description

Due to some minor errors in the CSS for the HP and Stress progress bars, Fiefox users couldn't read their max HP/Stress (see screenshots below).

## Type of Change

Please check the relevant options:

- [x] Bug fix
- [ ] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

Manually tested in Firefox and Edge.

- [x] Manual testing
- [ ] Other:

## Screenshots (if applicable)

### Firefox
Before:
![firefox_before](https://github.com/user-attachments/assets/dc10e668-2cb1-43dd-8262-573557e57d57)
After:
![firefox_after](https://github.com/user-attachments/assets/3afb468c-0960-4037-93b9-f18f4270a335)

### Chromium (no visible changes)
Before:
![chromium_before](https://github.com/user-attachments/assets/bb80c33a-fdda-4f8d-871e-9bcea967cc1e)
After:
![chromium_after](https://github.com/user-attachments/assets/1ca6468e-0ce6-49f2-b5c6-ed7fe481c726)

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [ ] New and existing tests pass locally with my changes

## Additional Comments

As is visible in the screenshots, there are still other (less urgent?) style differences between Firefox and Chromium; I could look deeper into these as well if wanted/needed.

---

> Thank you for your contribution! 🎉
