### PR TITLE
fix: remove unnecessary negation in takeHealing method

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -477,7 +477,6 @@ export default class DhpActor extends Actor {
     }
 
     async takeHealing(resources) {
-        resources.forEach(r => (r.value *= -1));
         await this.modifyResource(resources);
     }
 


### PR DESCRIPTION
## Description

Healing action incorrectly negated the resource, causing damage instead of healing

before:

https://github.com/user-attachments/assets/92d5079e-eb9f-4958-a842-b3b76bcad404

after:

https://github.com/user-attachments/assets/43f47f19-1d4a-4584-b809-50cc957af952



- Fixes #(issue)
- Closes #(issue)

## Type of Change

Please check the relevant options:

- [ x] Bug fix

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [ x] Manual testing
- [ ] Other:

## Screenshots (if applicable)

Include screenshots or GIFs to help explain your changes visually.

## Checklist

- [x ] My code follows the project style guidelines
- [ x] I have performed a self-review of my code
- [ x] I have commented my code where necessary
- [x ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings or errors
- [] I have added tests that prove my fix or feature works
- [] New and existing tests pass locally with my changes

## Additional Comments

Add any other context or questions here.

---

> Thank you for your contribution! 🎉
