### PR TITLE
Language Organization

### DIFF
--- a/daggerheart.mjs
+++ b/daggerheart.mjs
@@ -190,7 +190,7 @@ Hooks.on('chatMessage', (_, message) => {
     if (message.startsWith('/dr')) {
         const rollCommand = rollCommandToJSON(message.replace(/\/dr\s?/, ''));
         if (!rollCommand) {
-            ui.notifications.error(game.i18n.localize('DAGGERHEART.Notification.Error.DualityParsing'));
+            ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.dualityParsing'));
             return false;
         }
 
@@ -203,16 +203,16 @@ Hooks.on('chatMessage', (_, message) => {
             new Promise(async (resolve, reject) => {
                 const trait = target ? target.system.traits[traitValue] : undefined;
                 if (traitValue && !trait) {
-                    ui.notifications.error(game.i18n.localize('DAGGERHEART.Notification.Error.AttributeFaulty'));
+                    ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.attributeFaulty'));
                     reject();
                     return;
                 }
 
                 const title = traitValue
-                    ? game.i18n.format('DAGGERHEART.Chat.DualityRoll.AbilityCheckTitle', {
+                    ? game.i18n.format('DAGGERHEART.UI.Chat.dualityRoll.abilitychecktitle', {
                           ability: game.i18n.localize(SYSTEM.ACTOR.abilities[traitValue].label)
                       })
-                    : game.i18n.localize('DAGGERHEART.General.Duality');
+                    : game.i18n.localize('DAGGERHEART.General.duality');
 
                 const config = {
                     title: title,
@@ -247,8 +247,8 @@ Hooks.on('renderJournalDirectory', async (tab, html, _, options) => {
         if (options.parts && !options.parts.includes('footer')) return;
 
         const buttons = tab.element.querySelector('.directory-footer.action-buttons');
-        const title = game.i18n.format('DAGGERHEART.Countdown.Title', {
-            type: game.i18n.localize('DAGGERHEART.Countdown.Types.narrative')
+        const title = game.i18n.format('DAGGERHEART.Applications.Countdown.title', {
+            type: game.i18n.localize('DAGGERHEART.Applications.Countdown.types.narrative')
         });
         buttons.insertAdjacentHTML(
             'afterbegin',

--- a/daggerheart.mjs
+++ b/daggerheart.mjs
@@ -212,7 +212,7 @@ Hooks.on('chatMessage', (_, message) => {
                     ? game.i18n.format('DAGGERHEART.UI.Chat.dualityRoll.abilitychecktitle', {
                           ability: game.i18n.localize(SYSTEM.ACTOR.abilities[traitValue].label)
                       })
-                    : game.i18n.localize('DAGGERHEART.General.duality');
+                    : game.i18n.localize('DAGGERHEART.GENERAL.duality');
 
                 const config = {
                     title: title,
@@ -247,8 +247,8 @@ Hooks.on('renderJournalDirectory', async (tab, html, _, options) => {
         if (options.parts && !options.parts.includes('footer')) return;
 
         const buttons = tab.element.querySelector('.directory-footer.action-buttons');
-        const title = game.i18n.format('DAGGERHEART.Applications.Countdown.title', {
-            type: game.i18n.localize('DAGGERHEART.Applications.Countdown.types.narrative')
+        const title = game.i18n.format('DAGGERHEART.APPLICATIONS.Countdown.title', {
+            type: game.i18n.localize('DAGGERHEART.APPLICATIONS.Countdown.types.narrative')
         });
         buttons.insertAdjacentHTML(
             'afterbegin',

--- a/lang/en.json
+++ b/lang/en.json
@@ -21,322 +21,706 @@
         }
     },
     "DAGGERHEART": {
-        "UI": {
-            "notifications": {
-                "adversaryMissing": "The linked adversary doesn't exist in the world.",
-                "beastformInapplicable": "A beastform can only be applied to a Character.",
-                "beastformAlreadyApplied": "The character already has a beastform applied!",
-                "featureIsMissing": "The feature doesn't exist. You should remove it.",
-                "featureIsFull": "You can only have 1 entry of this feature"
+        "Actors": {
+            "Adversary": {
+                "FIELDS": {
+                    "tier": { "label": "Tier" },
+                    "type": { "label": "Type" },
+                    "description": { "label": "Description" },
+                    "motivesAndTactics": { "label": "Motives & Tactics" },
+                    "difficulty": { "label": "Difficulty" },
+                    "damageThresholds": {
+                        "major": { "label": "Major" },
+                        "severe": { "label": "Severe" }
+                    },
+                    "resources": {
+                        "hitPoints": {
+                            "value": { "label": "Current" },
+                            "max": { "label": "Max" }
+                        },
+                        "stress": {
+                            "value": { "label": "Current" },
+                            "max": { "label": "Max" }
+                        }
+                    },
+                    "experiences": {
+                        "element": {
+                            "name": { "label": "Name" },
+                            "value": { "label": "Modifier" }
+                        }
+                    },
+                    "attack": {
+                        "name": { "label": "Name" },
+                        "modifier": { "label": "Modifier" },
+                        "range": { "label": "Range" },
+                        "damage": {
+                            "value": { "label": "Damage" },
+                            "type": { "label": "Damage Type" }
+                        }
+                    }
+                },
+                "horderHp": "Horde/HP"
+            },
+            "Character": {
+                "pronouns": "Pronouns",
+                "age": "Age",
+                "faith": "Faith",
+                "levelUp": "You can level up",
+                "companionFeatures": "Companion Features",
+                "contextMenu": {
+                    "equip": "Equip",
+                    "unequip": "Unequip",
+                    "toLoadout": "Send to Loadout",
+                    "toVault": "Send to Vault",
+                    "consume": "Consume Item",
+                    "sendToChat": "Send To Chat"
+                },
+                "story": {
+                    "backgroundTitle": "Background",
+                    "connectionsTitle": "Connections",
+                    "characteristics": "Characteristics"
+                }
+            },
+            "Environment": {
+                "FIELDS": {
+                    "tier": {
+                        "label": "Tier"
+                    },
+                    "type": {
+                        "label": "Type"
+                    },
+                    "difficulty": {
+                        "label": "Difficulty"
+                    },
+                    "impulses": {
+                        "label": "Impulses"
+                    },
+                    "description": {
+                        "label": "Description"
+                    }
+                },
+                "newAdversary": "New Adversary"
+            },
+            "Companion": {
+                "FIELDS": {
+                    "partner": { "label": "Partner" },
+                    "evasion": {
+                        "value": { "label": "Evasion" }
+                    },
+                    "resources": {
+                        "stress": {
+                            "value": { "label": "Stress" }
+                        }
+                    },
+                    "attack": {
+                        "name": { "label": "Attack Name" }
+                    }
+                },
+                "noPartner": "No Partner selected"
             }
         },
-        "Settings": {
-            "Menu": {
-                "Automation": {
-                    "Name": "Automation Settings",
-                    "Label": "Configure Automation",
-                    "Hint": "Various settings automating resource management and more"
-                },
-                "Homebrew": {
-                    "Name": "Homebrew Settings",
-                    "Label": "Configure Homebrew",
-                    "Hint": "Various settings allowing extensions to types or altered game rules",
-                    "AbilityArrayLabel": "Ability Array"
-                },
-                "Range": {
-                    "Name": "Range Settings",
-                    "Label": "Configure Range Handling",
-                    "Hint": "System ruler setup for displaying ranges in Daggerheart"
-                },
-                "Appearance": {
-                    "title": "Appearance Settings",
-                    "label": "Appearance Settings",
-                    "hint": "Modify the look of various parts of the system",
-                    "name": "Appearance Settings",
-                    "duality": "Duality Rolls",
-                    "DiceSoNice": {
-                        "title": "Dice So Nice",
-                        "hint": "Coloration of Hope and Fear dice if the Dice So Nice module is used.",
-                        "foreground": "Foreground",
-                        "background": "Background",
-                        "outline": "Outline",
-                        "edge": "Edge"
-                    }
-                },
-                "VariantRules": {
-                    "title": "Variant Rules",
-                    "label": "Variant Rules",
-                    "hint": "Apply variant rules from the Daggerheart system",
-                    "name": "Variant Rules",
-                    "actionTokens": "Action Tokens"
+        "Items": {
+            "Consumable": {
+                "consumeOnUse": "Consume On Use"
+            },
+            "Subclass": {
+                "spellcastingTrait": "Spellcasting Trait"
+            },
+            "Weapon": {
+                "primaryWeapon": "Primary Weapon",
+                "secondaryWeapon": "Secondary Weapon"
+            },
+            "Armor": {
+                "baseScore": "Base Score",
+                "baseThresholds": {
+                    "base": "Base Thresholds",
+                    "major": "Major Threshold",
+                    "severe": "Severe Threshold"
                 }
             },
-            "Appearance": {
-                "FIELDS": {
-                    "displayFear": { "label": "Fear Display" }
-                },
-                "FearDisplay": {
-                    "Token": "Tokens",
-                    "Bar": "Bar",
-                    "Hide": "Hide"
-                }
-            },
-            "Automation": {
-                "Fear": {
-                    "Name": "Fear",
-                    "Hint": "Automatically increase the GM's fear pool on a fear duality roll result."
-                },
-                "FIELDS": {
-                    "hope": {
-                        "label": "Hope",
-                        "hint": "Automatically increase a character's hope on a hope duality roll result."
-                    },
-                    "actionPoints": {
-                        "label": "Action Points",
-                        "hint": "Automatically give and take Action Points as combatants take their turns."
-                    },
-                    "countdowns": {
-                        "label": "Countdowns",
-                        "hint": "Automatically progress non-custom countdowns"
+            "Class": {
+                "hopeFeatures": "Hope Features",
+                "classFeatures": "Class Features",
+                "guide": {
+                    "suggestedEquipment": "Suggested Equipments",
+                    "suggestedPrimaryWeaponTitle": "Primary Weapon",
+                    "suggestedSecondaryWeaponTitle": "Secondary Weapon",
+                    "suggestedArmorTitle": "Armor",
+                    "inventory": {
+                        "thenChoose": "Then Choose Between",
+                        "andEither": "And Either"
                     }
                 }
             },
-            "Homebrew": {
-                "NewDowntimeMove": "Downtime Move",
-                "DowntimeMoves": "Downtime Moves",
-                "NrChoices": "# Moves Per Rest",
-                "ResetMovesTitle": "Reset {type} Downtime Moves",
-                "ResetMovesText": "Are you sure you want to reset?",
+            "Beastform": {
                 "FIELDS": {
-                    "maxFear": { "label": "Max Fear" },
-                    "traitArray": { "label": "Initial Trait Modifiers" }
-                },
-                "Currency": {
-                    "enabled": "Enable Overrides",
-                    "title": "Currency Overrides",
-                    "currencyName": "Currency Name",
-                    "coinName": "Coin Name",
-                    "handfullName": "Handfull Name",
-                    "bagName": "Bag Name",
-                    "chestName": "Chest Name"
-                }
-            },
-            "Resources": {
-                "Fear": {
-                    "Name": "Fear",
-                    "Hint": "The Fear pool of the GM."
-                },
-                "MaxFear": {
-                    "Name": "Maximum amount of Fear",
-                    "Hint": "The maximum amount of Fear the GM can get."
-                },
-                "DisplayFear": {
-                    "Name": "Fear display style",
-                    "Hint": "Change how the GM Fear count should be displayed."
-                }
-            },
-            "General": {
-                "AbilityArray": {
-                    "Name": "Ability Score Array",
-                    "Hint": "The starting distribution of Ability Scores for a character."
-                },
-                "RangeMeasurement": {
-                    "Name": "Enable Range Measurement",
-                    "Hint": "Enable measuring of ranges with the ruler according to set distances."
-                }
-            },
-            "VariantRules": {
-                "ActionTokens": {
-                    "label": "Action Tokens",
-                    "hint": "Give each player action tokens to use in combat"
-                },
-                "FIELDS": {
-                    "actionTokens": {
-                        "enabled": { "label": "Enabled" },
-                        "tokens": { "label": "Tokens" }
-                    },
-                    "useCoins": {
-                        "label": "Use Coins",
-                        "hint": "test"
+                    "tier": { "label": "Tier" },
+                    "examples": { "label": "Examples" },
+                    "advantageOn": { "label": "Gain Advantage On" },
+                    "tokenImg": { "label": "Token Image" },
+                    "tokenSize": {
+                        "placeholder": "Using character dimensions",
+                        "height": { "label": "Height" },
+                        "width": { "label": "Width" }
                     }
+                },
+                "dialogTitle": "Beastform Selection",
+                "tokenTitle": "Beastform Token",
+                "transform": "Transform",
+                "beastformEffect": "Beastform Transformation"
+            },
+            "DomainCard": {
+                "type": "Type",
+                "foundation": "Foundation",
+                "recallCost": "Recall Cost",
+                "specializationTitle": "Specialization",
+                "masteryTitle": "Mastery"
+            }
+        },
+        "Effects": {
+            "Duration": {
+                "passive": "Passive",
+                "temporary": "Temporary"
+            },
+            "Types": {
+                "hitPoints": {
+                    "name": "Hit Points"
+                },
+                "stress": {
+                    "name": "Stress"
+                },
+                "reach": {
+                    "name": "Reach"
+                },
+                "damage": {
+                    "name": "Damage"
                 }
             },
-            "DualityRollColor": {
-                "Name": "Duality Roll Colour Scheme",
-                "Hint": "The display type for Duality Rolls",
-                "Options": {
-                    "Colorful": "Colorful",
-                    "Normal": "Normal"
+            "ApplyLocations": {
+                "attackRoll": {
+                    "name": "Attack Roll"
+                },
+                "damageRoll": {
+                    "name": "Damage Roll"
                 }
             }
         },
-        "Notification": {
-            "Info": {
-                "ClassCanOnlyHaveTwoDomains": "A class can only have 2 domains!",
-                "NoTargetsSelected": "No targets are selected.",
-                "SelectClassBeforeSubclass": "Select a Class before selecting a Subclass.",
-                "SubclassNotOfClass": "This Subclass doesn't belong to your current Class.",
-                "AttackTargetDoesNotExist": "The target token no longer exists"
+        "Actions": {
+            "Types": {
+                "attack": {
+                    "name": "Attack"
+                },
+                "damage": {
+                    "name": "Damage"
+                },
+                "healing": {
+                    "name": "Healing"
+                },
+                "summon": {
+                    "name": "Summon"
+                },
+                "effect": {
+                    "name": "Effect"
+                },
+                "macro": {
+                    "name": "Macro"
+                },
+                "beastform": {
+                    "name": "Beastform"
+                }
             },
-            "Error": {
-                "ActionRequiresTarget": "The action requires at least one target",
-                "NoAssignedPlayerCharacter": "You have no assigned character.",
-                "NoSelectedToken": "You have no selected token",
-                "OnlyUseableByPC": "This can only be used with a PC token",
-                "DualityParsing": "Duality roll not properly formated",
-                "AttributeFaulty": "The supplied Attribute doesn't exist"
+            "Settings": {
+                "resultBased": {
+                    "label": "Formula based on Hope/Fear result."
+                }
+            },
+            "Config": {
+                "beastform": {
+                    "label": "Beastform",
+                    "exact": "Beastform Max Tier",
+                    "exactHint": "The Character's Tier is used if empty"
+                }
             }
         },
         "General": {
-            "Name": "Name",
-            "Hope": "Hope",
-            "Fear": "Fear",
-            "Duality": "Duality",
-            "Check": "{check} Check",
-            "CriticalSuccess": "Critical Success",
-            "Advantage": {
-                "Full": "Advantage",
-                "Short": "Adv"
+            "Tiers": {
+                "singular": "Tier",
+                "tier1": "Tier 1",
+                "tier2": "Tier 2",
+                "tier3": "Tier 3",
+                "tier4": "Tier 4"
             },
-            "Disadvantage": {
-                "Full": "Disadvantage",
-                "Short": "Dis"
+            "Domain": {
+                "single": "Domain",
+                "plural": "Domains",
+                "arcana": {
+                    "label": "Arcana",
+                    "Description": "This is the domain of the innate or instinctual use of magic. Those who walk this path tap into the raw, enigmatic forces of the realms to manipulate both the elements and their own energy. Arcana offers wielders a volatile power, but it is incredibly potent when correctly channeled."
+                },
+                "blade": {
+                    "label": "Blade",
+                    "Description": "This is the domain of those who dedicate their lives to the mastery of weapons. Whether by blade, bow, or perhaps a more specialized arm, those who follow this path have the skill to cut short the lives of others. Blade requires study and dedication from its followers, in exchange for inexorable power over death."
+                },
+                "bone": {
+                    "label": "Bone",
+                    "Description": "This is the domain of mastery of swiftness and tactical mastery. Practitioners of this domain have an uncanny control over their own physical abilities, and an eye for predicting the behaviors of others in combat. Bone grants its adherents unparalleled understanding of bodies and their movements in exchange for diligent training."
+                },
+                "codex": {
+                    "label": "Codex",
+                    "Description": "This is the domain of intensive magical study. Those who seek magical knowledge turn to the recipes of power recorded in books, on scrolls, etched into walls, or tattooed on bodies. Codex offers a commanding and versatile understanding of magic to those devotees who are willing to seek beyond the common knowledge."
+                },
+                "grace": {
+                    "label": "Grace",
+                    "Description": "This is the domain of charisma. Through rapturous storytelling, clever charm, or a shroud of lies, those who channel this power define the realities of their adversaries, bending perception to their will. Grace offers its wielders raw magnetism and mastery over language."
+                },
+                "midnight": {
+                    "label": "Midnight",
+                    "Description": "This is the domain of shadows and secrecy. Whether by clever tricks, or cloak of night those who channel these forces are practiced in that art of obscurity and there is nothing hidden they cannot reach. Midnight offers practitioners the incredible power to control and create enigmas."
+                },
+                "sage": {
+                    "label": "Sage",
+                    "Description": "This is the domain of the natural world. Those who walk this path tap into the unfettered power of the earth and its creatures to unleash raw magic. Sage grants its adherents the vitality of a blooming flower and ferocity of a hungry predator."
+                },
+                "splendor": {
+                    "label": "Splendor",
+                    "Description": "This is the domain of life. Through this magic, followers gain the ability to heal, though such power also grants the wielder some control over death. Splendor offers its disciples the magnificent ability to both give and end life."
+                },
+                "valor": {
+                    "label": "Valor",
+                    "Description": "This is the domain of protection. Whether through attack or defense, those who choose this discipline channel formidable strength to protect their allies in battle. Valor offers great power to those who raise their shield in defense of others."
+                }
             },
-            "Neutral": {
-                "Full": "None",
-                "Short": "no"
-            },
-            "OK": "OK",
-            "Cancel": "Cancel",
-            "Or": "Or",
-            "Enabled": "Enabled",
-            "Description": "Description",
-            "Modifier": "Modifier",
-            "Features": "Features",
-            "proficiency": "Proficiency",
-            "unarmored": "Unarmored",
-            "Experience": {
-                "Single": "Experience",
-                "plural": "Experiences"
-            },
-            "Adversary": {
-                "Singular": "Adversary",
-                "Plural": "Adversaries"
-            },
-            "Character": {
-                "Singular": "Character",
-                "Plural": "Characters"
-            },
-            "RefreshType": {
-                "Session": "Session",
-                "Shortrest": "Short Rest",
-                "Longrest": "Long Rest"
-            },
-            "Damage": {
-                "Severe": "Severe",
-                "Major": "Major",
-                "Minor": "Minor",
-                "None": "None"
-            },
-            "tabs": {
+            "Tabs": {
                 "details": "Details",
                 "attack": "Attack",
                 "experiences": "Experiences",
                 "features": "Features",
                 "actions": "Actions",
                 "potentialAdversaries": "Potential Adversaries",
-                "adversaries": "Adversaries"
+                "adversaries": "Adversaries",
+                "advancement": "Level Advancement",
+                "selections": "Advancement Choices",
+                "summary": "Summary",
+                "effects": "Effects",
+                "settings": "Settings",
+                "description": "Description",
+                "main": "Data",
+                "information": "Information",
+                "notes": "Notes",
+                "inventory": "Inventory",
+                "loadout": "Loadout",
+                "vault": "Vault",
+                "heritage": "Heritage",
+                "story": "Story",
+                "biography": "Biography",
+                "general": "General",
+                "foundation": "Foundation",
+                "specialization": "Specialization",
+                "mastery": "Mastery",
+                "optional": "Optional",
+                "setup": "Setup",
+                "equipment": "Equipment"
+            },
+            "Action": {
+                "single": "Action",
+                "plural": "Actions"
+            },
+            "DamageThresholds": {
+                "title": "Damage Thresholds",
+                "minor": "Minor",
+                "major": "Major",
+                "severe": "Severe"
+            },
+            "Dice": {
+                "single": "Die",
+                "plural": "Dice"
+            },
+            "Effect": {
+                "single": "Effect",
+                "plural": "Effects"
+            },
+            "activeEffects": "Active Effects",
+            "inactiveEffects": "Inactive Effects",
+            "inventory": "Inventory",
+            "take": "Take",
+            "evasion": "Evasion",
+            "burden": "Burden",
+            "bonus": "Bonus",
+            "type": "Type",
+            "title": "Title",
+            "range": "Range",
+            "Trait": {
+                "single": "Trait",
+                "plural": "Traits"
+            },
+            "quantity": "Quantity",
+            "attack": "Attack",
+            "hitPoints": "Hit Points",
+            "stress": "Stress",
+            "level": "Level",
+            "features": "Features",
+            "multiclass": "Multiclass",
+            "use": "Use",
+            "hope": "Hope",
+            "fear": "Fear",
+            "duality": "Duality",
+            "check": "{check} Check",
+            "criticalSuccess": "Critical Success",
+            "Advantage": {
+                "full": "Advantage",
+                "short": "Adv"
+            },
+            "Disadvantage": {
+                "full": "Disadvantage",
+                "short": "Dis"
+            },
+            "Neutral": {
+                "full": "None",
+                "short": "no"
+            },
+            "enabled": "Enabled",
+            "description": "Description",
+            "modifier": "Modifier",
+            "unarmored": "Unarmored",
+            "Experience": {
+                "single": "Experience",
+                "plural": "Experiences"
+            },
+            "Adversary": {
+                "singular": "Adversary",
+                "plural": "Adversaries"
+            },
+            "Character": {
+                "singular": "Character",
+                "plural": "Characters"
+            },
+            "RefreshType": {
+                "session": "Session",
+                "shortrest": "Short Rest",
+                "longrest": "Long Rest"
+            },
+            "Damage": {
+                "severe": "Severe",
+                "major": "Major",
+                "minor": "Minor",
+                "none": "None"
             },
             "basics": "Basics",
             "dualityRoll": "Duality Roll"
         },
-        "ActionType": {
-            "passive": "Passive",
-            "action": "Action",
-            "reaction": "Reaction"
-        },
-        "Abilities": {
-            "agility": {
-                "name": "Agility",
-                "short": "AGI",
-                "verb": {
-                    "sprint": "Sprint",
-                    "leap": "Leap",
-                    "maneuver": "Maneuver"
-                }
+        "UI": {
+            "Tooltip": {
+                "openItemWorld": "Open Item World",
+                "openActorWorld": "Open Actor World",
+                "sendToChat": "Send to Chat",
+                "moreOptions": "More Options",
+                "equip": "Equip",
+                "unequip": "Unequip",
+                "sendToVault": "Send to Vault",
+                "sendToLoadout": "Send to Loadout",
+                "makeDeathMove": "Make a Death Move"
             },
-            "strength": {
-                "name": "Strength",
-                "short": "STR",
-                "verb": {
-                    "lift": "Lift",
-                    "smash": "Smash",
-                    "grapple": "Grapple"
-                }
+            "Notifications": {
+                "adversaryMissing": "The linked adversary doesn't exist in the world.",
+                "beastformInapplicable": "A beastform can only be applied to a Character.",
+                "beastformAlreadyApplied": "The character already has a beastform applied!",
+                "noTargetsSelected": "No targets are selected.",
+                "attackTargetDoesNotExist": "The target token no longer exists",
+                "insufficentAdvancements": "You don't have enough advancements left.",
+                "noAssignedPlayerCharacter": "You have no assigned character.",
+                "noSelectedToken": "You have no selected token",
+                "onlyUseableByPC": "This can only be used with a PC token",
+                "dualityParsing": "Duality roll not properly formated",
+                "attributeFaulty": "The supplied Attribute doesn't exist",
+                "domainCardWrongDomain": "You don't have access to that Domain",
+                "domainCardToHighLevel": "The Domain Card is too high level to be selected",
+                "domainCardDuplicate": "You already have that domain card!",
+                "noSelectionsLeft": "Nothing more to select!",
+                "alreadySelectedClass": "You already have that class!",
+                "classAlreadySelected": "The character already has a class",
+                "subclassAlreadySelected": "The character already has a subclass for that class.",
+                "noClassSelected": "Your character has no class selected!",
+                "lacksDomain": "Your character doesn't have the domain of the card!",
+                "duplicateDomainCard": "You already have a domain card with that name!",
+                "missingClassOrSubclass": "The character doesn't have a class and subclass",
+                "tooHighLevel": "You cannot raise the character level past the maximum",
+                "tooLowLevel": "You cannot lower the character level below starting level",
+                "subclassNotInClass": "This subclass does not belong to your selected class.",
+                "missingClass": "You don't have a class selected yet.",
+                "wrongDomain": "The card isn't from one of your class domains.",
+                "cardTooHighLevel": "The card is too high level!",
+                "duplicateCard": "You cannot select the same card more than once.",
+                "notPrimary": "The weapon is not a primary weapon!",
+                "notSecondary": "The weapon is not a secondary weapon!",
+                "itemTooHighTier": "The item must be from Tier1",
+                "primaryIsTwoHanded": "Cannot select a secondary weapon with a two-handed primary!",
+                "noMoreMoves": "You cannot select any more downtime moves",
+                "damageAlreadyNone": "The damage has already been reduced to none",
+                "noAvailableArmorMarks": "You have no more available armor marks",
+                "notEnoughStress": "You don't have enough stress",
+                "damageIgnore": "{character} did not take damage"
             },
-            "finesse": {
-                "name": "Finesse",
-                "short": "FIN",
-                "verb": {
-                    "control": "Control",
-                    "hide": "Hide",
-                    "tinker": "Tinker"
-                }
-            },
-            "instinct": {
-                "name": "Instinct",
-                "short": "INS",
-                "verb": {
-                    "perceive": "Perceive",
-                    "sense": "Sense",
-                    "navigate": "Navigate"
-                }
-            },
-            "presence": {
-                "name": "Presence",
-                "short": "PRE",
-                "verb": {
-                    "charm": "Charm",
-                    "perform": "Perform",
-                    "deceive": "Deceive"
-                }
-            },
-            "knowledge": {
-                "name": "Knowledge",
-                "short": "KNO",
-                "verb": {
-                    "recall": "Recall",
-                    "analyze": "Analyze",
-                    "comprehend": "Comprehend"
-                }
+            "Chat": {
+                "dualityRoll": {
+                    "abilityCheckTitle": "{ability} Check"
+                },
+                "attackRoll": {
+                    "title": "Attack - {attack}",
+                    "rollDamage": "Roll Damage",
+                    "rollHealing": "Roll Healing",
+                    "applyEffect": "Apply Effects"
+                },
+                "damageRoll": {
+                    "title": "Damage - {damage}",
+                    "dealDamageToTargets": "Damage Hit Targets",
+                    "dealDamage": "Deal Damage",
+                    "rollDamage": "Roll Damage",
+                    "hitTarget": "Hit Targets",
+                    "selectedTarget": "Selected"
+                },
+                "applyEffect": {
+                    "title": "Apply Effects - {name}"
+                },
+                "healingRoll": {
+                    "title": "Heal - {healing}",
+                    "heal": "Heal"
+                },
+                "deathMove": {
+                    "title": "Death Move"
+                },
+                "domainCard": {
+                    "title": "Domain Card"
+                },
+                "foundationCard": {
+                    "ancestryTitle": "Ancestry Card",
+                    "communityTitle": "Community Card",
+                    "subclassFeatureTitle": "Subclass Feature"
+                },
+                "featureTitle": "Class Feature"
             }
         },
-        "FeatureProperty": {
-            "SpellcastingTrait": "Spellcasting Trait"
-        },
-        "Condition": {
-            "vulnerable": {
-                "name": "Vulnerable",
-                "description": "While a creature is Vulnerable, all rolls targeting them have advantage.\nA creature who is already Vulnerable can’t be made to take the condition again."
+        "Applications": {
+            "CombatTracker": {
+                "giveSpotlight": "Give The Spotlight",
+                "requestSpotlight": "Request The Spotlight",
+                "requestingSpotlight": "Requesting The Spotlight",
+                "combatStarted": "Active"
             },
-            "hidden": {
-                "name": "Hidden",
-                "description": "While Hidden, attacks cannot be made directly targeting them nd any rolls against them are at disadvantage.\nWhen a Hidden creature moves or attacks, they are no longer Hidden. However, if a creature is Hidden when they begin making an attack, the roll has advantage; the Hidden condition isn’t cleared until after the attack is resolved."
+            "CharacterCreation": {
+                "title": "{actor} - Character Setup",
+                "traitIncreases": "Trait Increases",
+                "suggestedTraits": "Suggested Traits",
+                "initialExperiences": "Initial Experiences",
+                "heritage": "Heritage",
+                "selectAncestry": "Select Ancestry",
+                "selectCommunity": "Select Community",
+                "selectClass": "Select Class",
+                "selectSubclass": "Select Subclass",
+                "selectArmor": "Select Armor",
+                "selectPrimaryWeapon": "Select Primary Weapon",
+                "selectSecondaryWeapon": "Select Secondary Weapon",
+                "suggestedArmor": "Suggested Armor",
+                "suggestedWeapons": "Suggested Weapon",
+                "suggestedPrimaryWeapon": "Suggested Primary Weapon",
+                "suggestedSecondaryWeapon": "Suggested Secondary Weapon",
+                "startingItems": "Starting Items",
+                "choice": "Choice",
+                "newExperience": "New Experience..",
+                "finishCreation": "Finish Character Setup"
             },
-            "restrained": {
-                "name": "Restrained",
-                "description": "When an effect makes a creature Restrained, it means they cannot move until this condition is cleared.\nThey can still take actions from their current position."
+            "Levelup": {
+                "title": "{actor} Level Up",
+                "navigateLevel": "To Level {level}",
+                "navigateToLevelup": "Return To Levelup",
+                "navigateToSummary": "To Summary",
+                "takeLevelUp": "Finish Level Up",
+                "delevel": {
+                    "title": "Go back to previous level",
+                    "content": "Returning to the previous level selection will remove all selections made for this level. Do you want to proceed?"
+                },
+                "selections": {
+                    "emptyDomainCardHint": "{domain} level {level} or below",
+                    "viciousDamage": "Damage",
+                    "viciousRange": "Range"
+                },
+                "summary": {
+                    "levelAchievements": "Level Achievements",
+                    "levelAdvancements": "Level Advancements",
+                    "proficiencyIncrease": "Proficiency Increased: {proficiency}",
+                    "hpIncrease": "Hit Points Increased: {hitPoints}",
+                    "stressIncrease": "Stress Increased: {stress}",
+                    "evasionIncrease": "Evasion Increased: {evasion}",
+                    "damageThresholdMajorIncrease": "Major: {threshold}",
+                    "damageThresholdSevereIncrease": "Severe: {threshold}",
+                    "newExperiences": "New Experiences",
+                    "experiencePlaceholder": "A new experience..",
+                    "domainCards": "Domain Cards",
+                    "subclass": "Subclass",
+                    "multiclass": "Multiclass",
+                    "traits": "Increased Traits",
+                    "experienceIncreases": "Experience Increases",
+                    "damageThresholds": "Damage Thresholds",
+                    "vicious": "Vicious",
+                    "damageIncreased": "Damage Increased: {damage}",
+                    "rangeIncreased": "Range Increased: {range}",
+                    "simpleFeature": "Feature: {feature}"
+                },
+                "options": {
+                    "trait": "Gain a +1 bonus to two unmarked character traits and mark them.",
+                    "hitPoint": "Permanently gain one Hit Point slot.",
+                    "stress": "Permanently gain one Stress slot.",
+                    "experience": "Permanently gain a +1 bonus to two experiences.",
+                    "domainCard": "Choose an additional domain card of your level or lower from a domain you have access to (up to level {maxLevel})",
+                    "evasion": "Permanently gain a +1 bonus to your Evasion.",
+                    "subclass": "Take an upgraded subclass card. Then cross out the multiclass option for this tier.",
+                    "proficiency": "Increase your Proficiency by +1.",
+                    "multiclass": "Multiclass: Choose an additional class for your character, then cross out an unused “Take an upgraded subclass card” and the other multiclass option on this sheet.",
+                    "intelligent": "Your companion gains a permanent +1 bonus to a Companion Experience of your choice.",
+                    "lightInTheDark": "Gain an additional Hope slot for your character.",
+                    "creatureComfort": "Once per rest, when you take time during a quiet moment to give your companion love and attention, you can gain a Hope or you can both clear a Stress.",
+                    "armored": "When your companion takes damage, you can mark one of your Armor Slots instead of marking one of their Stress.",
+                    "vicious": "Increase your companion's damage dice or range by one step (d6 to d8, Close to Far, etc.)",
+                    "resilient": "Your companion gains an additional Stress slot.",
+                    "bonded": "When you mark your last Hit Point, your companion rushes to your side to comfort you. Roll a number of d6s equal to the unmarked Stress slots they have and mark them. If any roll a 6, your companion helps you up. Clear your last Hit Point and return to the scene.",
+                    "aware": "Your companion gains a permanent +2 bonus to their Evasion."
+                },
+                "actions": {
+                    "creatureComfort": {
+                        "name": "Creature Comfort",
+                        "description": "Once per rest, when you take time during a quiet moment to give your companion love and attention, you can gain a Hope or you can both clear a Stress."
+                    },
+                    "armored": {
+                        "name": "Armored",
+                        "description": "When your companion takes damage, you can mark one of your Armor Slots instead of marking one of their Stress."
+                    },
+                    "bonded": {
+                        "name": "Bonded",
+                        "description": "When you mark your last Hit Point, your companion rushes to your side to comfort you. Roll a number of d6s equal to the unmarked Stress slots they have and mark them. If any roll a 6, your companion helps you up. Clear your last Hit Point and return to the scene."
+                    }
+                },
+                "tier2": {
+                    "label": "Levels 2-4",
+                    "infoLabel": "At Level 2, gain an additional Experience at +2 and gain a +1 bonus to your Proficiency.",
+                    "pretext": "Choose two options from the list below",
+                    "posttext": "Take an additional domain card of your level or lower from a domain you have access to."
+                },
+                "tier3": {
+                    "label": "Levels 5-7",
+                    "infoLabel": "At Level 5, take an additional Experience and clear all marks on Character Traits.",
+                    "pretext": "When you level up, record it on your character sheet, then choose two from the list below or any unmarked from the previous tier.",
+                    "posttext": "Take an additional domain card of your level or lower from a domain you have access to."
+                },
+                "tier4": {
+                    "label": "Levels 8-10",
+                    "infoLabel": "At Level 8, take an additional Experience and clear all marks on Character Traits.",
+                    "pretext": "When you level up, record it on your character sheet, then choose two from the list below or any unmarked from the previous tier.",
+                    "posttext": "Take an additional domain card of your level or lower from a domain you have access to."
+                },
+                "choiceDescriptions": {
+                    "attributes": "Gain a +1 bonus to two unmarked character traits and mark them.",
+                    "hitPointSlots": "Permanently gain one Hit Point slot.",
+                    "stressSlots": "Permanently gain one Stress slot.",
+                    "experiences": "Permanently gain a +1 bonus to two experiences.",
+                    "domainCard": "Choose an additional domain card of your level or lower from a domain you have access to (up to level {maxLevel})",
+                    "evasion": "Permanently gain a +1 bonus to your Evasion.",
+                    "proficiency": "Increase your Proficiency by +1.",
+                    "subclass": "Take an upgraded subclass card. Then cross out the multiclass option for this tier.",
+                    "multiclass": "Multiclass: Choose an additional class for your character, then cross out an unused “Take an upgraded subclass card” and the other multiclass option on this sheet."
+                }
+            },
+            "Downtime": {
+                "downtimeHeader": "Downtime Moves ({current}/{max})",
+                "shortRest": {
+                    "title": "Short Rest",
+                    "tendToWounds": {
+                        "name": "Tend to Wounds",
+                        "description": "Describe how you hastily patch yourself up, then clear a number of Hit Points equal to 1d4 + your tier. You can do this to an ally instead."
+                    },
+                    "clearStress": {
+                        "name": "Clear Stress",
+                        "description": "Describe how you blow off steam or pull yourself together, then clear a number of Stress equal to 1d4 + your tier."
+                    },
+                    "repairArmor": {
+                        "name": "Repair Armor",
+                        "description": "Describe how you quickly repair your armor, then clear a number of Armor Slots equal to 1d4 + your tier. You can do this to an ally's armor instead."
+                    },
+                    "prepare": {
+                        "name": "Prepare",
+                        "description": "Describe how you prepare yourself for the path ahead, then gain a Hope. If you choose to Prepare with one or more members of your party, you each gain 2 Hope."
+                    }
+                },
+                "longRest": {
+                    "title": "Long Rest",
+                    "tendToWounds": {
+                        "name": "Tend to Wounds",
+                        "description": "Describe how you patch yourself up and remove all marked Hit Points. You may also do this on an ally instead."
+                    },
+                    "clearStress": {
+                        "name": "Clear Stress",
+                        "description": "Describe how you blow off steam or pull yourself together, and clear all marked Stress."
+                    },
+                    "repairArmor": {
+                        "name": "Repair Armor",
+                        "description": "Describe how you spend time repairing your armor and clear all of its Armor Slots. You may also do this to an ally's armor instead."
+                    },
+                    "prepare": {
+                        "name": "Prepare",
+                        "description": "Describe how you are preparing for the next day's adventure, then gain a Hope. If you choose to Prepare with one or more members of your party, you may each take two Hope."
+                    },
+                    "workOnAProject": {
+                        "name": "Work on a Project",
+                        "description": "Establish or continue work on a project."
+                    }
+                }
+            },
+            "DeathMove": {
+                "title": "{actor} - Death Move",
+                "takeMove": "Take Death Move"
+            },
+            "Countdown": {
+                "FIELDS": {
+                    "countdowns": {
+                        "element": {
+                            "name": { "label": "Name" },
+                            "progress": {
+                                "current": { "label": "Current" },
+                                "max": { "label": "Max" },
+                                "type": {
+                                    "value": { "label": "Value" },
+                                    "label": { "label": "Label", "hint": "Used for custom" }
+                                }
+                            }
+                        }
+                    }
+                },
+                "newCountdown": "New Countdown",
+                "addCountdown": "Add Countdown",
+                "removeCountdownTitle": "Remove Countdown",
+                "removeCountdownText": "Are you sure you want to remove the countdown: {name}?",
+                "openOwnership": "Edit Player Ownership",
+                "title": "{type} Countdowns",
+                "toggleSimple": "Toggle Simple View",
+                "types": {
+                    "narrative": "Narrative",
+                    "encounter": "Encounter"
+                }
+            },
+            "OwnershipSelection": {
+                "title": "Ownership Selection - {name}",
+                "default": "Default Ownership"
+            },
+            "DamageReduction": {
+                "title": "Damage Reduction",
+                "armorMarks": "Armor Marks",
+                "usedMarks": "Used Marks",
+                "stress": "Stress",
+                "armorWithStress": "Spend 1 stress to use an extra mark",
+                "unncessaryStress": "You don't need to expend stress",
+                "stressReduction": "Reduce By Stress"
             }
         },
-        "Tiers": {
-            "singular": "Tier",
-            "tier1": "Tier 1",
-            "tier2": "Tier 2",
-            "tier3": "Tier 3",
-            "tier4": "Tier 4"
-        },
-        "Adversary": {
-            "Type": {
+        "Config": {
+            "AdversaryType": {
                 "bruiser": {
                     "label": "Bruiser",
                     "description": "Tough adversaries with powerful attacks."
@@ -378,26 +762,34 @@
                     "description": "Enemies that enhance their allies and/or disrupt their opponents."
                 }
             },
-            "Trait": {
-                "Relentless": {
-                    "Name": "Relentless",
-                    "Description": "A foe with Relentless can activate up to X times during a GM move so long as there are enough action tokens.",
-                    "Tip": "The Relentless move is useful if you want an adversary you can activate more than once during a single GM move. This is often best for exceedingly fast or dangerous foes, or for adversaries who are likely to be battling the party on their own."
+            "CountdownType": {
+                "spotlight": "Spotlight",
+                "custom": "Custom",
+                "characterAttack": "Character Attack"
+            },
+            "DomainCardTypes": {
+                "ability": "Ability",
+                "spell": "Spell",
+                "grimoire": "Grimoire"
+            },
+            "AdversaryTrait": {
+                "relentless": {
+                    "name": "Relentless",
+                    "description": "A foe with Relentless can activate up to X times during a GM move so long as there are enough action tokens.",
+                    "tip": "The Relentless move is useful if you want an adversary you can activate more than once during a single GM move. This is often best for exceedingly fast or dangerous foes, or for adversaries who are likely to be battling the party on their own."
                 },
-                "Slow": {
-                    "Name": "Slow",
-                    "Description": "A foe with Slow costs X action tokens to activate.",
-                    "Tip": "The Slow move is useful if you want an adversary who narratively takes longer to act than others, like a slug creature or a massive ogre. This is usually most effective when that creature is very powerful when it does act, but eats up lots of action tokens to do it."
+                "slow": {
+                    "name": "Slow",
+                    "description": "A foe with Slow costs X action tokens to activate.",
+                    "tip": "The Slow move is useful if you want an adversary who narratively takes longer to act than others, like a slug creature or a massive ogre. This is usually most effective when that creature is very powerful when it does act, but eats up lots of action tokens to do it."
                 },
-                "Minion": {
-                    "Name": "Minion",
-                    "Description": "For every X damage a PC deals to this adversary, they also deal 1 HP to an additional minion within their attack’s range.",
-                    "Tip": "The Minion move is useful when you want to drop lots of small enemies into the battlefield, knowing the party can swing through them very easily. This move means that if a PC hits one minion and they do enough damage, they also hit a number of others that are in range for them. Because of this, it’s often best to have minions crowd a PC–it will feel overwhelming and dangerous until they’re able to make an attack against them. If you want that cinematic feeling of the PCs taking out waves of enemies with a single attack roll, minions are a great tool to make that happen."
+                "minion": {
+                    "name": "Minion",
+                    "description": "For every X damage a PC deals to this adversary, they also deal 1 HP to an additional minion within their attack’s range.",
+                    "tip": "The Minion move is useful when you want to drop lots of small enemies into the battlefield, knowing the party can swing through them very easily. This move means that if a PC hits one minion and they do enough damage, they also hit a number of others that are in range for them. Because of this, it’s often best to have minions crowd a PC–it will feel overwhelming and dangerous until they’re able to make an attack against them. If you want that cinematic feeling of the PCs taking out waves of enemies with a single attack roll, minions are a great tool to make that happen."
                 }
-            }
-        },
-        "Environment": {
-            "Type": {
+            },
+            "EnvironmentType": {
                 "exploration": {
                     "label": "Exploration",
                     "description": ""
@@ -414,1256 +806,565 @@
                     "label": "Event",
                     "description": ""
                 }
-            }
-        },
-        "Domains": {
-            "arcana": {
-                "label": "Arcana",
-                "Description": "This is the domain of the innate or instinctual use of magic. Those who walk this path tap into the raw, enigmatic forces of the realms to manipulate both the elements and their own energy. Arcana offers wielders a volatile power, but it is incredibly potent when correctly channeled."
             },
-            "blade": {
-                "label": "Blade",
-                "Description": "This is the domain of those who dedicate their lives to the mastery of weapons. Whether by blade, bow, or perhaps a more specialized arm, those who follow this path have the skill to cut short the lives of others. Blade requires study and dedication from its followers, in exchange for inexorable power over death."
+            "Gold": {
+                "title": "Gold",
+                "coins": "Coins",
+                "handfulls": "Handfulls",
+                "bags": "Bags",
+                "chests": "Chests"
             },
-            "bone": {
-                "label": "Bone",
-                "Description": "This is the domain of mastery of swiftness and tactical mastery. Practitioners of this domain have an uncanny control over their own physical abilities, and an eye for predicting the behaviors of others in combat. Bone grants its adherents unparalleled understanding of bodies and their movements in exchange for diligent training."
-            },
-            "codex": {
-                "label": "Codex",
-                "Description": "This is the domain of intensive magical study. Those who seek magical knowledge turn to the recipes of power recorded in books, on scrolls, etched into walls, or tattooed on bodies. Codex offers a commanding and versatile understanding of magic to those devotees who are willing to seek beyond the common knowledge."
-            },
-            "grace": {
-                "label": "Grace",
-                "Description": "This is the domain of charisma. Through rapturous storytelling, clever charm, or a shroud of lies, those who channel this power define the realities of their adversaries, bending perception to their will. Grace offers its wielders raw magnetism and mastery over language."
-            },
-            "midnight": {
-                "label": "Midnight",
-                "Description": "This is the domain of shadows and secrecy. Whether by clever tricks, or cloak of night those who channel these forces are practiced in that art of obscurity and there is nothing hidden they cannot reach. Midnight offers practitioners the incredible power to control and create enigmas."
-            },
-            "sage": {
-                "label": "Sage",
-                "Description": "This is the domain of the natural world. Those who walk this path tap into the unfettered power of the earth and its creatures to unleash raw magic. Sage grants its adherents the vitality of a blooming flower and ferocity of a hungry predator."
-            },
-            "splendor": {
-                "label": "Splendor",
-                "Description": "This is the domain of life. Through this magic, followers gain the ability to heal, though such power also grants the wielder some control over death. Splendor offers its disciples the magnificent ability to both give and end life."
-            },
-            "valor": {
-                "label": "Valor",
-                "Description": "This is the domain of protection. Whether through attack or defense, those who choose this discipline channel formidable strength to protect their allies in battle. Valor offers great power to those who raise their shield in defense of others."
-            }
-        },
-        "Domain": {
-            "CardTypes": {
-                "ability": "Ability",
-                "spell": "Spell",
-                "grimoire": "Grimoire"
-            }
-        },
-        "Combat": {
-            "giveSpotlight": "Give The Spotlight",
-            "requestSpotlight": "Request The Spotlight",
-            "requestingSpotlight": "Requesting The Spotlight",
-            "combatStarted": "Active"
-        },
-        "CharacterCreation": {
-            "Title": "{actor} - Character Setup",
-            "TraitIncreases": "Trait Increases",
-            "SuggestedTraits": "Suggested Traits",
-            "InitialExperiences": "Initial Experiences",
-            "Heritage": "Heritage",
-            "SelectAncestry": "Select Ancestry",
-            "SelectCommunity": "Select Community",
-            "SelectClass": "Select Class",
-            "SelectSubclass": "Select Subclass",
-            "SelectArmor": "Select Armor",
-            "SelectPrimaryWeapon": "Select Primary Weapon",
-            "SelectSecondaryWeapon": "Select Secondary Weapon",
-            "SuggestedArmor": "Suggested Armor",
-            "SuggestedWeapons": "Suggested Weapon",
-            "SuggestedPrimaryWeapon": "Suggested Primary Weapon",
-            "SuggestedSecondaryWeapon": "Suggested Secondary Weapon",
-            "StartingItems": "Starting Items",
-            "Choice": "Choice",
-            "NewExperience": "New Experience..",
-            "FinishCreation": "Finish Character Setup",
-            "Tabs": {
-                "Optional": "Optional",
-                "Setup": "Setup",
-                "Equipment": "Equipment",
-                "Story": "Story"
-            },
-            "Notifications": {
-                "SubclassNotInClass": "This subclass does not belong to your selected class.",
-                "MissingClass": "You don't have a class selected yet.",
-                "WrongDomain": "The card isn't from one of your class domains.",
-                "CardTooHighLevel": "The card is too high level!",
-                "DuplicateCard": "You cannot select the same card more than once.",
-                "NotPrimary": "The weapon is not a primary weapon!",
-                "NotSecondary": "The weapon is not a secondary weapon!",
-                "ItemTooHighTier": "The item must be from Tier1",
-                "PrimaryIsTwoHanded": "Cannot select a secondary weapon with a two-handed primary!"
-            }
-        },
-        "LevelUp": {
-            "Options": {
-                "trait": "Gain a +1 bonus to two unmarked character traits and mark them.",
-                "hitPoint": "Permanently gain one Hit Point slot.",
-                "stress": "Permanently gain one Stress slot.",
-                "experience": "Permanently gain a +1 bonus to two experiences.",
-                "domainCard": "Choose an additional domain card of your level or lower from a domain you have access to (up to level {maxLevel})",
-                "evasion": "Permanently gain a +1 bonus to your Evasion.",
-                "subclass": "Take an upgraded subclass card. Then cross out the multiclass option for this tier.",
-                "proficiency": "Increase your Proficiency by +1.",
-                "multiclass": "Multiclass: Choose an additional class for your character, then cross out an unused “Take an upgraded subclass card” and the other multiclass option on this sheet.",
-                "intelligent": "Your companion gains a permanent +1 bonus to a Companion Experience of your choice.",
-                "lightInTheDark": "Gain an additional Hope slot for your character.",
-                "creatureComfort": "Once per rest, when you take time during a quiet moment to give your companion love and attention, you can gain a Hope or you can both clear a Stress.",
-                "armored": "When your companion takes damage, you can mark one of your Armor Slots instead of marking one of their Stress.",
-                "vicious": "Increase your companion's damage dice or range by one step (d6 to d8, Close to Far, etc.)",
-                "resilient": "Your companion gains an additional Stress slot.",
-                "bonded": "When you mark your last Hit Point, your companion rushes to your side to comfort you. Roll a number of d6s equal to the unmarked Stress slots they have and mark them. If any roll a 6, your companion helps you up. Clear your last Hit Point and return to the scene.",
-                "aware": "Your companion gains a permanent +2 bonus to their Evasion."
-            },
-            "Actions": {
-                "CreatureComfort": {
-                    "Name": "Creature Comfort",
-                    "Description": "Once per rest, when you take time during a quiet moment to give your companion love and attention, you can gain a Hope or you can both clear a Stress."
+            "Traits": {
+                "agility": {
+                    "name": "Agility",
+                    "short": "AGI",
+                    "verb": {
+                        "sprint": "Sprint",
+                        "leap": "Leap",
+                        "maneuver": "Maneuver"
+                    }
                 },
-                "Armored": {
-                    "Name": "Armored",
-                    "Description": "When your companion takes damage, you can mark one of your Armor Slots instead of marking one of their Stress."
+                "strength": {
+                    "name": "Strength",
+                    "short": "STR",
+                    "verb": {
+                        "lift": "Lift",
+                        "smash": "Smash",
+                        "grapple": "Grapple"
+                    }
                 },
-                "Bonded": {
-                    "Name": "Bonded",
-                    "Description": "When you mark your last Hit Point, your companion rushes to your side to comfort you. Roll a number of d6s equal to the unmarked Stress slots they have and mark them. If any roll a 6, your companion helps you up. Clear your last Hit Point and return to the scene."
-                }
-            },
-            "Tier2": {
-                "Label": "Levels 2-4",
-                "InfoLabel": "At Level 2, gain an additional Experience at +2 and gain a +1 bonus to your Proficiency.",
-                "Pretext": "Choose two options from the list below",
-                "Posttext": "Take an additional domain card of your level or lower from a domain you have access to."
-            },
-            "Tier3": {
-                "Label": "Levels 5-7",
-                "InfoLabel": "At Level 5, take an additional Experience and clear all marks on Character Traits.",
-                "Pretext": "When you level up, record it on your character sheet, then choose two from the list below or any unmarked from the previous tier.",
-                "Posttext": "Take an additional domain card of your level or lower from a domain you have access to."
-            },
-            "Tier4": {
-                "Label": "Levels 8-10",
-                "InfoLabel": "At Level 8, take an additional Experience and clear all marks on Character Traits.",
-                "Pretext": "When you level up, record it on your character sheet, then choose two from the list below or any unmarked from the previous tier.",
-                "Posttext": "Take an additional domain card of your level or lower from a domain you have access to."
-            },
-            "ChoiceDescriptions": {
-                "Attributes": "Gain a +1 bonus to two unmarked character traits and mark them.",
-                "HitPointSlots": "Permanently gain one Hit Point slot.",
-                "StressSlots": "Permanently gain one Stress slot.",
-                "Experiences": "Permanently gain a +1 bonus to two experiences.",
-                "DomainCard": "Choose an additional domain card of your level or lower from a domain you have access to (up to level {maxLevel})",
-                "Evasion": "Permanently gain a +1 bonus to your Evasion.",
-                "Proficiency": "Increase your Proficiency by +1.",
-                "Subclass": "Take an upgraded subclass card. Then cross out the multiclass option for this tier.",
-                "Multiclass": "Multiclass: Choose an additional class for your character, then cross out an unused “Take an upgraded subclass card” and the other multiclass option on this sheet."
-            }
-        },
-        "Downtime": {
-            "DowntimeHeader": "Downtime Moves ({current}/{max})",
-            "ShortRest": {
-                "title": "Short Rest",
-                "TendToWounds": {
-                    "Name": "Tend to Wounds",
-                    "Description": "Describe how you hastily patch yourself up, then clear a number of Hit Points equal to 1d4 + your tier. You can do this to an ally instead."
+                "finesse": {
+                    "name": "Finesse",
+                    "short": "FIN",
+                    "verb": {
+                        "control": "Control",
+                        "hide": "Hide",
+                        "tinker": "Tinker"
+                    }
                 },
-                "ClearStress": {
-                    "Name": "Clear Stress",
-                    "Description": "Describe how you blow off steam or pull yourself together, then clear a number of Stress equal to 1d4 + your tier."
+                "instinct": {
+                    "name": "Instinct",
+                    "short": "INS",
+                    "verb": {
+                        "perceive": "Perceive",
+                        "sense": "Sense",
+                        "navigate": "Navigate"
+                    }
                 },
-                "RepairArmor": {
-                    "Name": "Repair Armor",
-                    "Description": "Describe how you quickly repair your armor, then clear a number of Armor Slots equal to 1d4 + your tier. You can do this to an ally's armor instead."
+                "presence": {
+                    "name": "Presence",
+                    "short": "PRE",
+                    "verb": {
+                        "charm": "Charm",
+                        "perform": "Perform",
+                        "deceive": "Deceive"
+                    }
                 },
-                "Prepare": {
-                    "Name": "Prepare",
-                    "Description": "Describe how you prepare yourself for the path ahead, then gain a Hope. If you choose to Prepare with one or more members of your party, you each gain 2 Hope."
-                }
-            },
-            "LongRest": {
-                "title": "Long Rest",
-                "TendToWounds": {
-                    "Name": "Tend to Wounds",
-                    "Description": "Describe how you patch yourself up and remove all marked Hit Points. You may also do this on an ally instead."
-                },
-                "ClearStress": {
-                    "Name": "Clear Stress",
-                    "Description": "Describe how you blow off steam or pull yourself together, and clear all marked Stress."
-                },
-                "RepairArmor": {
-                    "Name": "Repair Armor",
-                    "Description": "Describe how you spend time repairing your armor and clear all of its Armor Slots. You may also do this to an ally's armor instead."
-                },
-                "Prepare": {
-                    "Name": "Prepare",
-                    "Description": "Describe how you are preparing for the next day's adventure, then gain a Hope. If you choose to Prepare with one or more members of your party, you may each take two Hope."
-                },
-                "WorkOnAProject": {
-                    "Name": "Work on a Project",
-                    "Description": "Establish or continue work on a project."
-                }
-            },
-            "Notifications": {
-                "NoMoreMoves": "You cannot select any more downtime moves"
-            }
-        },
-        "DeathMoves": {
-            "AvoidDeath": {
-                "Name": "Avoid Death",
-                "Description": "You drop unconscious temporarily and work with the GM to describe how the situation gets much worse because of it. Then roll your Fear die; if its value is equal to or under your Level, take a Scar."
-            },
-            "RiskItAll": {
-                "Name": "Risk It All",
-                "Description": "Roll your Duality Dice. If Hope is higher, you stay on your feet and clear an amount of Hit Points and/or Stress equal to the value of the Hope die (divide the Hope die value up between these however you’d prefer). If your Fear die is higher, you cross through the veil of death. If the Duality Dice are tied, you stay on your feet and clear all Hit Points and Stress."
-            },
-            "BlazeOfGlory": {
-                "Name": "Blaze Of Glory",
-                "Description": "With Blaze of Glory, the player is accepting death for the character. Take one action (at GM discretion), which becomes an automatic critical success, then cross through the veil of death."
-            }
-        },
-        "Burden": {
-            "oneHanded": "One-Handed",
-            "twoHanded": "Two-Handed"
-        },
-        "Range": {
-            "self": {
-                "name": "Self",
-                "description": "means yourself."
-            },
-            "melee": {
-                "name": "Melee",
-                "description": "means a character is within touching distance of the target. PCs can generally touch targets up to a few feet away from them, but melee range may be greater for especially large NPCs."
-            },
-            "veryClose": {
-                "name": "Very Close",
-                "description": "means a distance where one can see fine details of a target- within moments of reaching, if need be. This is usually anywhere from about 5-10 feet away. While in danger, a PC can usually get to anything that’s very close as part of any other action they take. Anything on a battle map that is within the shortest length of a game card (~2-3 inches) can usually be considered very close."
-            },
-            "close": {
-                "name": "Close",
-                "description": "means a distance where one can see prominent details of a target-- across a room or to a neighboring market stall, generally about 10-30 feet away. While in danger, a PC can usually get to anything that’s close as part of any other action they take. Anything on a battle map that is within the length of a standard pen or pencil (~5-6 inches) can usually be considered close."
-            },
-            "far": {
-                "name": "Far",
-                "description": "means a distance where one can see the appearance of a person or object, but probably not in great detail-- across a small battlefield or down a large corridor. This is usually about 30-100 feet away. While under danger, a PC will likely have to make an Agility check to get here safely. Anything on a battle map that is within the length of a standard piece of paper (~10-11 inches) can usually be considered far."
-            },
-            "veryFar": {
-                "name": "Very Far",
-                "description": "means a distance where you can see the shape of a person or object, but probably not make outany details-- across a large battlefield or down a long street, generally about 100-300 feet away. While under danger, a PC likely has to make an Agility check to get here safely. Anything on a battle map that is beyond far distance, but still within sight of the characters can usually be considered very far."
-            }
-        },
-        "DamageType": {
-            "physical": {
-                "name": "Physical",
-                "abbreviation": "Phy"
-            },
-            "magical": {
-                "name": "Magical",
-                "abbreviation": "Mag"
-            }
-        },
-        "HealingType": {
-            "HitPoints": {
-                "Name": "Hit Points",
-                "Abbreviation": "HP"
-            },
-            "Stress": {
-                "Name": "Stress",
-                "Stress": "STR"
-            },
-            "Hope": {
-                "Name": "Hope",
-                "Abbreviation": "HO"
-            },
-            "ArmorStack": {
-                "Name": "Armor Stack",
-                "Stress": "AS"
-            }
-        },
-        "ArmorFeature": {
-            "Burning": {
-                "Name": "Burning",
-                "Description": "When an adversary attacks you within Melee range, they mark a Stress."
-            },
-            "Channeling": {
-                "Name": "Channeling",
-                "Description": "+1 to Spellcast Rolls"
-            },
-            "Difficult": {
-                "Name": "Difficult",
-                "Description": "-1 to all character traits and Evasion"
-            },
-            "Flexible": {
-                "Name": "Flexible",
-                "Description": "+1 to Evasion"
-            },
-            "Fortified": {
-                "Name": "Fortified",
-                "Description": "When you mark an Armor Slot, you reduce the severity of an attack by two thresholds instead of one."
-            },
-            "Gilded": {
-                "Name": "Gilded",
-                "Description": "+1 to Presence"
-            },
-            "Heavy": {
-                "Name": "Heavy",
-                "Description": "-1 to Evasion"
-            },
-            "Hopeful": {
-                "Name": "Hopeful",
-                "Description": "When you would spend a Hope, you can mark an Armor Slot instead."
-            },
-            "Impenetrable": {
-                "Name": "Impenetrable",
-                "Description": "Once per short rest, when you would mark your last Hit Point, you can instead mark a Stress."
-            },
-            "Magic": {
-                "Name": "Magic",
-                "Description": "You can't mark an Armor Slot to reduce physical damage."
-            },
-            "Painful": {
-                "Name": "Painful",
-                "Description": "Each time you mark an Armor Slot, you must mark a Stress."
-            },
-            "Physical": {
-                "Name": "Physical",
-                "Description": "You can't mark an Armor Slot to reduce magic damage."
-            },
-            "Quiet": {
-                "Name": "Quiet",
-                "Description": "You gain a +2 bonus to rolls you make to move silently."
-            },
-            "Reinforced": {
-                "Name": "Reinforced",
-                "Description": "When you mark your last Armor Slot, increase your damage thresholds by +2 until you clear at least 1 Armor Slot."
-            },
-            "Resilient": {
-                "Name": "Resilient",
-                "Description": "Before you mark your last Armor Slot, roll a d6. On a result of 6, reduce the severity by one threshold without marking an Armor Slot."
-            },
-            "Sharp": {
-                "Name": "Sharp",
-                "Description": "On a successful attack against a target within Melee range, add a d4 to the damage roll."
-            },
-            "Shifting": {
-                "Name": "Shifting",
-                "Description": "When you are targeted for an attack, you can mark an Armor Slot to give the attack roll against you disadvantage."
-            },
-            "Timeslowing": {
-                "Name": "Timeslowing",
-                "Description": "Mark an Armor Slot to roll a d4 and add its result as a bonus to your Evasion against an incoming attack."
-            },
-            "Truthseeking": {
-                "Name": "Truthseeking",
-                "Description": "This armor glows when another creature within Close range tells a lie."
-            },
-            "VeryHeavy": {
-                "Name": "Very Heavy",
-                "Description": "-2 to Evasion; -1 to Agility"
-            },
-            "Warded": {
-                "Name": "Warded",
-                "Description": "You reduce incoming magic damage by your Armor Score before applying it to your damage thresholds."
-            }
-        },
-        "WeaponFeature": {
-            "Barrier": {
-                "Name": "Barrier",
-                "Description": "+{armorScore} to Armor Score; -1 to Evasion"
-            },
-            "Bonded": {
-                "Name": "Bonded",
-                "Description": "Gain a bonus to your damage rolls equal to your level."
-            },
-            "Bouncing": {
-                "Name": "Bouncing",
-                "Description": "Mark 1 or more Stress to hit that many targets in range of the attack."
-            },
-            "Brave": {
-                "Name": "Brave",
-                "Description": "-1 to Evasion; +3 to Severe damage threshold"
-            },
-            "Brutal": {
-                "Name": "Brutal",
-                "Description": "When you roll the maximum value on a damage die, roll an additional damage die."
-            },
-            "Charged": {
-                "Name": "Charged",
-                "Description": "Mark a Stress to gain a +1 bonus to your Proficiency on a primary weapon attack."
-            },
-            "Concussive": {
-                "Name": "Concussive",
-                "Description": "On a successful attack, you can spend a Hope to knock the target back to Far range."
-            },
-            "Cumbersome": {
-                "Name": "Cumbersome",
-                "Description": "-1 to Finesse"
-            },
-            "Deadly": {
-                "Name": "Deadly",
-                "Description": "When you deal Severe damage, the target must mark an additional HP."
-            },
-            "Deflecting": {
-                "Name": "Deflecting",
-                "Description": "When you are attacked, you can mark an Armor Slot to gain a bonus to your Evasion equal to your Armor Score against the attack."
-            },
-            "Destructive": {
-                "Name": "Destructive",
-                "Description": "-1 to Agility; on a successful attack, all adversaries within Very Close range must mark a Stress."
-            },
-            "Devastating": {
-                "Name": "Devastating",
-                "Description": "Before you make an attack roll, you can mark a Stress to use a d20 as your damage die."
-            },
-            "DoubleDuty": {
-                "Name": "Double Duty",
-                "Description": "+1 to Armor Score; +1 to primary weapon damage within Melee range"
-            },
-            "DoubledUp": {
-                "Name": "Doubled Up",
-                "Description": "When you make an attack with your primary weapon, you can deal damage to another target within Melee range."
-            },
-            "Dueling": {
-                "Name": "Dueling",
-                "Description": "When there are no other creatures within Close range of the target, gain advantage on your attack roll against them."
-            },
-            "Eruptive": {
-                "Name": "Eruptive",
-                "Description": "On a successful attack against a target within Melee range, all other adversaries within Very Close range must succeed on a reaction roll (14) or take half damage."
-            },
-            "Grappling": {
-                "Name": "Grappling",
-                "Description": "On a successful attack, you can spend a Hope to Restrain the target or pull them into Melee range with you."
-            },
-            "Greedy": {
-                "Name": "Greedy",
-                "Description": "Spend a handful of gold to gain a +1 bonus to your Proficiency on a damage roll."
-            },
-            "Healing": {
-                "Name": "Healing",
-                "Description": "During downtime, automatically clear a Hit Point."
-            },
-            "Heavy": {
-                "Name": "Heavy",
-                "Description": "-1 to Evasion"
-            },
-            "Hooked": {
-                "Name": "Hooked",
-                "Description": "On a successful attack, you can pull the target into Melee range."
-            },
-            "Hot": {
-                "Name": "Hot",
-                "Description": "This weapon cuts through solid material."
-            },
-            "Invigorating": {
-                "Name": "Invigorating",
-                "Description": "On a successful attack, roll a d4. On a result of 4, clear a Stress."
-            },
-            "Lifestealing": {
-                "Name": "Lifestealing",
-                "Description": "On a successful attack, roll a d6. On a result of 6, clear a Hit Point or clear a Stress."
-            },
-            "LockedOn": {
-                "Name": "Locked On",
-                "Description": "On a successful attack, your next attack against the same target with your primary weapon automatically succeeds."
-            },
-            "Lucky": {
-                "Name": "Lucky",
-                "Description": "On a failed attack, you can mark a Stress to reroll your attack."
-            },
-            "Long": {
-                "Name": "Long",
-                "Description": "This weapon's attack targets all adversaries in a line within range."
-            },
-            "Massive": {
-                "Name": "Massive",
-                "Description": "-1 to Evasion; on a successful attack, roll an additional damage die and discard the lowest result."
-            },
-            "Painful": {
-                "Name": "Painful",
-                "Description": "Each time you make a successful attack, you must mark a Stress."
-            },
-            "Paired": {
-                "Name": "Paired",
-                "Description": "+{bonusDamage} to primary weapon damage to targets within Melee range"
-            },
-            "Parry": {
-                "Name": "Parry",
-                "Description": "When you are attacked, roll this weapon's damage dice. If any of the attacker's damage dice rolled the same value as your dice, the matching results are discarded from the attacker's damage dice before the damage you take is totaled."
-            },
-            "Persuasive": {
-                "Name": "Persuasive",
-                "Description": "Before you make a Presence Roll, you can mark a Stress to gain a +2 bonus to the result."
-            },
-            "Pompous": {
-                "Name": "Pompous",
-                "Description": "You must have a Presence of 0 or lower to use this weapon."
-            },
-            "Powerful": {
-                "Name": "Powerful",
-                "Description": "On a successful attack, roll an additional damage die and discard the lowest result."
-            },
-            "Protective": {
-                "Name": "Protective",
-                "Description": "+{tier} to Armor Score"
-            },
-            "Quick": {
-                "Name": "Quick",
-                "Description": "When you make an attack, you can mark a Stress to target another creature within range."
-            },
-            "Reliable": {
-                "Name": "Reliable",
-                "Description": "+1 to attack rolls"
-            },
-            "Reloading": {
-                "Name": "Reloading",
-                "Description": "After you make an attack, roll a d6. On a result of 1, you must mark a Stress to reload this weapon before you can fire it again."
-            },
-            "Retractable": {
-                "Name": "Retractable",
-                "Description": "The blade can be hidden in the hilt to avoid detection."
-            },
-            "Returning": {
-                "Name": "Returning",
-                "Description": "When this weapon is thrown within its range, it appears in your hand immediately after the attack."
-            },
-            "Scary": {
-                "Name": "Scary",
-                "Description": "On a successful attack, the target must mark a Stress."
-            },
-            "Serrated": {
-                "Name": "Serrated",
-                "Description": "When you roll a 1 on a damage die, it deals 8 damage instead."
-            },
-            "Sharpwing": {
-                "Name": "Sharpwing",
-                "Description": "Gain a bonus to your damage rolls equal to your Agility."
-            },
-            "Sheltering": {
-                "Name": "Sheltering",
-                "Description": "When you mark an Armor Slot, it reduces damage for you and all allies within Melee range of you who took the same damage."
-            },
-            "Startling": {
-                "Name": "Startling",
-                "Description": "Mark a Stress to crack the whip and force all adversaries within Melee range back to Close range."
-            },
-            "Timebending": {
-                "Name": "Timebending",
-                "Description": "You can choose the target of your attack after making your attack roll."
-            },
-            "Versatile": {
-                "Name": "Versatile",
-                "Description": "This weapon can also be used with these statistics—{characterTrait}, {range}, {damage}."
-            }
-        },
-        "Application": {
-            "Downtime": {
-                "TakeDowntime": "Take Downtime"
-            },
-            "LevelUp": {
-                "Title": "{actor} Level Up",
-                "Tabs": {
-                    "advancement": "Level Advancement",
-                    "selections": "Advancement Choices",
-                    "summary": "Summary"
-                },
-                "navigateLevel": "To Level {level}",
-                "navigateToLevelup": "Return To Levelup",
-                "navigateToSummary": "To Summary",
-                "TakeLevelUp": "Finish Level Up",
-                "Delevel": {
-                    "title": "Go back to previous level",
-                    "content": "Returning to the previous level selection will remove all selections made for this level. Do you want to proceed?"
-                },
-                "Selections": {
-                    "emptyDomainCardHint": "{domain} level {level} or below",
-                    "viciousDamage": "Damage",
-                    "viciousRange": "Range"
-                },
-                "summary": {
-                    "levelAchievements": "Level Achievements",
-                    "levelAdvancements": "Level Advancements",
-                    "proficiencyIncrease": "Proficiency Increased: {proficiency}",
-                    "hpIncrease": "Hit Points Increased: {hitPoints}",
-                    "stressIncrease": "Stress Increased: {stress}",
-                    "evasionIncrease": "Evasion Increased: {evasion}",
-                    "damageThresholdMajorIncrease": "Major: {threshold}",
-                    "damageThresholdSevereIncrease": "Severe: {threshold}",
-                    "newExperiences": "New Experiences",
-                    "experiencePlaceholder": "A new experience..",
-                    "domainCards": "Domain Cards",
-                    "subclass": "Subclass",
-                    "multiclass": "Multiclass",
-                    "traits": "Increased Traits",
-                    "experienceIncreases": "Experience Increases",
-                    "damageThresholds": "Damage Thresholds",
-                    "vicious": "Vicious",
-                    "damageIncreased": "Damage Increased: {damage}",
-                    "rangeIncreased": "Range Increased: {range}",
-                    "simpleFeature": "Feature: {feature}"
-                },
-                "notifications": {
-                    "info": {
-                        "insufficentAdvancements": "You don't have enough advancements left.",
-                        "insufficientTierAdvancements": "You have no available advancements for this tier."
-                    },
-                    "error": {
-                        "domainCardWrongDomain": "You don't have access to that Domain",
-                        "domainCardToHighLevel": "The Domain Card is too high level to be selected",
-                        "domainCardDuplicate": "You already have that domain card!",
-                        "noSelectionsLeft": "Nothing more to select!",
-                        "alreadySelectedClass": "You already have that class!"
+                "knowledge": {
+                    "name": "Knowledge",
+                    "short": "KNO",
+                    "verb": {
+                        "recall": "Recall",
+                        "analyze": "Analyze",
+                        "comprehend": "Comprehend"
                     }
                 }
             },
-            "DeathMove": {
-                "Title": "{actor} - Death Move",
-                "TakeMove": "Take Death Move"
-            },
-            "RollSelection": {
-                "Title": "Roll Options"
-            },
-            "Settings": {
-                "Title": "Daggerheart Settings"
-            },
-            "Multiclass": {
-                "ClassSection": {
-                    "Title": "Select Class"
-                },
-                "SubclassSection": {
-                    "Title": "Select Subclass"
-                },
-                "DomainSection": {
-                    "Title": "Select Domain"
-                },
-                "AlreadyOwnedDomain": "You already have this domain!",
-                "Finish": "Finish Multiclass",
-                "Close": "Cancel"
-            },
-            "Cancel": "Cancel"
-        },
-        "Chat": {
-            "DualityRoll": {
-                "AbilityCheckTitle": "{ability} Check"
-            },
-            "AttackRoll": {
-                "Title": "Attack - {attack}",
-                "RollDamage": "Roll Damage",
-                "RollHealing": "Roll Healing",
-                "ApplyEffect": "Apply Effects"
-            },
-            "DamageRoll": {
-                "Title": "Damage - {damage}",
-                "DealDamageToTargets": "Damage Hit Targets",
-                "DealDamage": "Deal Damage",
-                "RollDamage": "Roll Damage",
-                "HitTarget": "Hit Targets",
-                "SelectedTarget": "Selected"
-            },
-            "ApplyEffect": {
-                "Title": "Apply Effects - {name}"
-            },
-            "HealingRoll": {
-                "Title": "Heal - {healing}",
-                "Heal": "Heal"
-            },
-            "DeathMove": {
-                "Title": "Death Move"
-            },
-            "DomainCard": {
-                "Title": "Domain Card"
-            },
-            "FoundationCard": {
-                "AncestryTitle": "Ancestry Card",
-                "CommunityTitle": "Community Card",
-                "SubclassFeatureTitle": "Subclass Feature"
-            },
-            "FeatureTitle": "Class Feature",
-            "EnvironmentTitle": "Environment {actionType}",
-            "Downtime": {
-                "Title": "Downtime"
-            }
-        },
-        "Countdown": {
-            "FIELDS": {
-                "countdowns": {
-                    "element": {
-                        "name": { "label": "Name" },
-                        "progress": {
-                            "current": { "label": "Current" },
-                            "max": { "label": "Max" },
-                            "type": {
-                                "value": { "label": "Value" },
-                                "label": { "label": "Label", "hint": "Used for custom" }
-                            }
-                        }
-                    }
-                }
-            },
-            "Type": {
-                "Spotlight": "Spotlight",
-                "Custom": "Custom",
-                "CharacterAttack": "Character Attack"
-            },
-            "NewCountdown": "New Countdown",
-            "AddCountdown": "Add Countdown",
-            "RemoveCountdownTitle": "Remove Countdown",
-            "RemoveCountdownText": "Are you sure you want to remove the countdown: {name}?",
-            "OpenOwnership": "Edit Player Ownership",
-            "Title": "{type} Countdowns",
-            "ToggleSimple": "Toggle Simple View",
-            "Types": {
-                "narrative": "Narrative",
-                "encounter": "Encounter"
-            },
-            "Notifications": {
-                "LimitedOwnershipMaximise": "You don't have permission to enter edit view"
-            }
-        },
-        "OwnershipSelection": {
-            "Title": "Ownership Selection - {name}",
-            "Default": "Default Ownership"
-        },
-        "DamageReduction": {
-            "Title": "Damage Reduction",
-            "ArmorMarks": "Armor Marks",
-            "UsedMarks": "Used Marks",
-            "Stress": "Stress",
-            "ArmorWithStress": "Spend 1 stress to use an extra mark",
-            "UnncessaryStress": "You don't need to expend stress",
-            "StressReduction": "Reduce By Stress",
-            "Notifications": {
-                "DamageAlreadyNone": "The damage has already been reduced to none",
-                "NoAvailableArmorMarks": "You have no more available armor marks",
-                "NotEnoughStress": "You don't have enough stress",
-                "DamageIgnore": "{character} did not take damage"
-            }
-        },
-        "Sheets": {
-            "TABS": {
-                "features": "Features",
-                "effects": "Effects",
-                "settings": "Settings",
-                "actions": "Actions",
-                "description": "Description"
-            },
-            "PC": {
-                "Name": "Name",
-                "Pronouns": "Pronouns",
-                "age": "Age",
-                "faith": "Faith",
-                "ShortRest": "Take a Short Rest",
-                "LongRest": "Take a Long Rest",
-                "CharacterSetup": "Character setup isn't done yet",
-                "Level": "Level",
-                "LevelUp": "You can level up",
-                "Features": "Features",
-                "CompanionFeatures": "Companion Features",
-                "beastformFeatures": "Beastform Features",
-                "Tabs": {
-                    "Features": "Features",
-                    "Inventory": "Inventory",
-                    "Foundation": "Foundation",
-                    "Loadout": "Loadout",
-                    "Vault": "Vault",
-                    "Heritage": "Heritage",
-                    "Story": "Story",
-                    "biography": "Biography",
-                    "effects": "Effects"
-                },
-                "ContextMenu": {
-                    "UseItem": "Use",
-                    "Equip": "Equip",
-                    "Unequip": "Unequip",
-                    "Edit": "Edit",
-                    "Delete": "Delete",
-                    "ToLoadout": "Send to Loadout",
-                    "ToVault": "Send to Vault",
-                    "Consume": "Consume Item",
-                    "SendToChat": "Send To Chat"
-                },
-                "Armor": {
-                    "Title": "Active Armor"
-                },
-                "Attributes": {
-                    "AttributeBaseMenuTitle": "Edit starting attribute values"
-                },
-                "Defense": {
-                    "Evasion": "EVASION",
-                    "Armor": "ARMOR"
-                },
-                "DomainCard": {
-                    "Recall": "Recall",
-                    "ToVault": "To Vault",
-                    "AvailableDomainSlot": "Available Loadout Slot",
-                    "UnavailableDomainSlot": "Available at level {level}",
-                    "FoundationTitle": "Foundation",
-                    "SpecializationTitle": "Specialization",
-                    "MasteryTitle": "Mastery"
-                },
-                "Experience": {
-                    "Title": "Experience"
-                },
-                "Gold": {
-                    "Title": "Gold",
-                    "Coins": "Coins",
-                    "Handfulls": "Handfulls",
-                    "Bags": "Bags",
-                    "Chests": "Chests"
-                },
-                "Health": {
-                    "Title": "HIT POINTS & STRESS",
-                    "Minor": "Minor",
-                    "Major": "Major",
-                    "Severe": "Severe",
-                    "DeathMoveTooltip": "Make a Death Move",
-                    "HealthTitle": "HP",
-                    "StressTitle": "STRESS"
-                },
-                "Heritage": {
-                    "EmptyAncestry": "Ancestry Card",
-                    "EmptyAncestryTip": "(Select an Ancestry)",
-                    "EmptyCommunity": "Community Card",
-                    "EmptyCommunityTip": "(Select a Community)",
-                    "SubclassFoundation": "Subclass Foundation",
-                    "SubclassFoundationTip": "(Select a Subclass)",
-                    "Subclass": "Subclass Upgrade",
-                    "Multiclass": "Multiclass"
-                },
-                "Hope": {
-                    "Title": "Hope",
-                    "Description": "Spend Hope to use an experience or help an ally."
-                },
-                "Inventory": {
-                    "Title": "Inventory",
-                    "InventoryArmor": "Inventory Armor",
-                    "InventoryWeapon": "Inventory Weapon"
-                },
-                "InventoryTab": {
-                    "ConsumableTitle": "Consumables",
-                    "MiscellaneousTitle": "Miscellaneous",
-                    "WeaponsTitle": "Weapons",
-                    "ArmorsTitle": "Armors",
-                    "QuantityTitle": "Quantity"
-                },
-                "Weapons": {
-                    "Title": "Active Weapons",
-                    "ProficiencyTitle": "Proficiency",
-                    "PrimaryTitle": "PRIMARY",
-                    "SecondaryTitle": "SECONDARY"
-                },
-                "Story": {
-                    "BackgroundTitle": "Background",
-                    "AppearanceTitle": "Appearance",
-                    "ConnectionsTitle": "Connections",
-                    "characteristics": "Characteristics",
-                    "Scars": {
-                        "Title": "Scars"
-                    }
-                },
-                "NewItem": "New Item",
-                "NewScar": "New Scar",
-                "DeleteConfirmation": "Are you sure you want to delete the item - {item}?",
-                "Errors": {
-                    "missingClassOrSubclass": "The character doesn't have a class and subclass",
-                    "tooHighLevel": "You cannot raise the character level past the maximum",
-                    "tooLowLevel": "You cannot lower the character level below starting level"
-                }
-            },
-            "Companion": {
-                "FIELDS": {
-                    "partner": { "label": "Partner" },
-                    "evasion": {
-                        "value": { "label": "Evasion" }
-                    },
-                    "resources": {
-                        "stress": {
-                            "value": { "label": "Stress" }
-                        }
-                    },
-                    "attack": {
-                        "name": { "label": "Attack Name" }
-                    }
-                },
-                "Experiences": "Experiences",
-                "Level": "Level",
-                "noPartner": "No Partner selected"
-            },
-            "Adversary": {
-                "FIELDS": {
-                    "tier": { "label": "Tier" },
-                    "type": { "label": "Type" },
-                    "description": { "label": "Description" },
-                    "motivesAndTactics": { "label": "Motives & Tactics" },
-                    "difficulty": { "label": "Difficulty" },
-                    "damageThresholds": {
-                        "major": { "label": "Major" },
-                        "severe": { "label": "Severe" }
-                    },
-                    "resources": {
-                        "hitPoints": {
-                            "value": { "label": "Current" },
-                            "max": { "label": "Max" }
-                        },
-                        "stress": {
-                            "value": { "label": "Current" },
-                            "max": { "label": "Max" }
-                        }
-                    },
-                    "experiences": {
-                        "element": {
-                            "name": { "label": "Name" },
-                            "value": { "label": "Modifier" }
-                        }
-                    },
-                    "attack": {
-                        "name": { "label": "Name" },
-                        "modifier": { "label": "Modifier" },
-                        "range": { "label": "Range" },
-                        "damage": {
-                            "value": { "label": "Damage" },
-                            "type": { "label": "Damage Type" }
-                        }
-                    }
-                },
-                "Tabs": {
-                    "Main": "Data",
-                    "Information": "Information",
-                    "features": "Features",
-                    "notes": "Notes",
-                    "effects": "Effects"
-                },
-                "General": "General",
-                "DamageThresholds": "Damage Thresholds",
-                "HitPoints": "Hit Points",
-                "Stress": "Stress",
-                "Experiences": "Experiences",
-                "Attack": "Attack",
-                "horderHp": "Horde/HP"
-            },
-            "Environment": {
-                "FIELDS": {
-                    "tier": {
-                        "label": "Tier"
-                    },
-                    "type": {
-                        "label": "Type"
-                    },
-                    "difficulty": {
-                        "label": "Difficulty"
-                    },
-                    "impulses": {
-                        "label": "Impulses"
-                    },
-                    "description": {
-                        "label": "Description"
-                    }
-                },
-                "Tabs": {
-                    "Main": "Data",
-                    "Information": "Information"
-                },
-                "general": "General",
-                "newAdversary": "New Adversary",
-                "newFeature": "New feature",
-                "description": "Description",
-                "impulses": "Impulses",
-                "potentialAdversaries": {
-                    "label": "Potential Adversaries",
-                    "placeholder": "Optionally drag and drop adversaries here"
-                },
-                "features": {
-                    "label": "Features"
-                }
-            },
-            "Armor": {
-                "baseScore": "Base Score",
-                "feature": "Feature",
-                "description": "Description",
-                "baseThresholds": {
-                    "base": "Base Thresholds",
-                    "major": "Major Threshold",
-                    "severe": "Severe Threshold"
-                }
-            },
-            "Class": {
-                "Tabs": {
-                    "Features": "Features",
-                    "Guide": "Character Guide",
-                    "Items": "Items",
-                    "Appearance": "Appearance",
-                    "settings": "Settings"
-                },
-                "HopeFeatures": "Hope Features",
-                "Class Features": "Class Features",
-                "Domains": "Domains",
-                "DamageThresholds": {
-                    "Title": "Damage Thresholds",
-                    "Minor": "Minor",
-                    "Major": "Major",
-                    "Severe": "Severe"
-                },
-                "Evasion": "Evasion",
-                "HitPoints": "Hit Points",
-                "ClassFeatures": "Class Features",
-                "Subclasses": "Subclasses",
-                "Guide": {
-                    "Suggestions": {
-                        "Title": "Suggested Equipments",
-                        "Traits": {
-                            "Title": "Traits"
-                        }
-                    },
-                    "SuggestedPrimaryWeaponTitle": "Primary Weapon",
-                    "SuggestedSecondaryWeaponTitle": "Secondary Weapon",
-                    "SuggestedArmorTitle": "Armor",
-                    "Inventory": {
-                        "Title": "Inventory",
-                        "Take": "Take",
-                        "ThenChoose": "Then Choose Between",
-                        "AndEither": "And Either"
-                    },
-                    "Description": {
-                        "Title": "Character Description",
-                        "Explanation": "Choose one (or more) from each line, or make your own",
-                        "Clothes": "Clothes",
-                        "Eyes": "Eyes",
-                        "Body": "Body",
-                        "Color": "Color",
-                        "Attitude": "Attitude"
-                    },
-                    "Extra": {
-                        "Title": "Extra",
-                        "Subtitle": "Title"
-                    },
-                    "BackgroundQuestions": {
-                        "Title": "Background Questions",
-                        "Question": "Question"
-                    },
-                    "Connections": {
-                        "Title": "Connections",
-                        "Question": "Question"
-                    }
-                }
-            },
-            "Beastform": {
-                "FIELDS": {
-                    "tier": { "label": "Tier" },
-                    "examples": { "label": "Examples" },
-                    "advantageOn": { "label": "Gain Advantage On" },
-                    "tokenImg": { "label": "Token Image" },
-                    "tokenSize": {
-                        "placeholder": "Using character dimensions",
-                        "height": { "label": "Height" },
-                        "width": { "label": "Width" }
-                    }
-                },
-                "dialogTitle": "Beastform Selection",
-                "tokenTitle": "Beastform Token",
-                "transform": "Transform",
-                "beastformEffect": "Beastform Transformation"
-            },
-            "Global": {
-                "Actions": "Actions",
-                "Features": "Features",
-                "Effects": "Effects",
-                "activeEffects": "Active Effects",
-                "inactiveEffects": "Inactive Effects"
-            },
-            "DomainCard": {
-                "Type": "Type",
-                "Category": "Category",
-                "Foundation": "Foundation",
-                "Domain": "Domain",
-                "Costs": "Costs",
-                "Level": "Level",
-                "RecallCost": "Recall Cost",
-                "Description": "Description"
-            },
-            "Feature": {
-                "FeatureType": "Type",
-                "ActionType": "Action Type",
-                "RefreshType": "Refresh Type",
-                "ValueType": {
-                    "Title": "Feature Type",
-                    "Type": "Type",
-                    "Property": "Property",
-                    "Dice": "Dice",
-                    "Icon": "Icon"
-                },
-                "Max": "Max",
-                "Tabs": {
-                    "Features": "Features",
-                    "Effects": "Effects",
-                    "Settings": "Settings",
-                    "Actions": "Actions",
-                    "Description": "Description"
-                },
-                "Description": "Description",
-                "effects": {
-                    "addEffect": "Add Effect",
-                    "applyLocation": "Apply Location",
-                    "value": "Value",
-                    "initiallySelected": "Initially Selected",
-                    "hopeIncrease": "Hope Increase"
-                }
-            },
-            "Consumable": {
-                "Quantity": "Quantity",
-                "ConsumeOnUse": "Consume On Use"
-            },
-            "Miscellaneous": {
-                "Quantity": "Quantity"
-            },
-            "Subclass": {
-                "Tabs": {
-                    "General": "General",
-                    "Foundation": "Foundation",
-                    "Specialization": "Specialization",
-                    "Mastery": "Mastery"
-                },
-                "SpellcastingTrait": "Spellcasting Trait",
-                "Description": "Description",
-                "SubclassFeature": {
-                    "Description": "Description",
-                    "Abilities": "Abilities",
-                    "Actions": "Actions",
-                    "Effects": "Effects"
-                }
-            },
-            "Weapon": {
-                "PrimaryWeapon": "Primary Weapon",
-                "SecondaryWeapon": "Secondary Weapon",
-                "Trait": "Trait",
-                "Range": "Range",
-                "Damage": {
-                    "Title": "Damage",
-                    "Die": "Die",
-                    "Bonus": "Bonus",
-                    "Type": "Type"
-                },
-                "Burden": "Burden",
-                "Feature": "Feature",
-                "Description": "Description"
-            }
-        },
-        "Item": {
-            "Errors": {
-                "MissingClass": "The character is missing a class",
-                "SubclassNotInClass": "The subclass does not belong to the character's class",
-                "ClassAlreadySelected": "The character already has a class",
-                "SubclassAlreadySelected": "The character already has a subclass for that class.",
-                "NoClassSelected": "Your character has no class selected!",
-                "LacksDomain": "Your character doesn't have the domain of the card!",
-                "MaxLoadoutReached": "You can't have any more domain cards at this level!",
-                "DuplicateDomainCard": "You already have a domain card with that name!"
-            }
-        },
-        "Effects": {
-            "duration": {
+            "ActionType": {
                 "passive": "Passive",
-                "temporary": "Temporary"
+                "action": "Action",
+                "reaction": "Reaction"
             },
-            "Types": {
-                "health": {
-                    "Name": "Health"
+            "Condition": {
+                "vulnerable": {
+                    "name": "Vulnerable",
+                    "description": "While a creature is Vulnerable, all rolls targeting them have advantage.\nA creature who is already Vulnerable can’t be made to take the condition again."
+                },
+                "hidden": {
+                    "name": "Hidden",
+                    "description": "While Hidden, attacks cannot be made directly targeting them nd any rolls against them are at disadvantage.\nWhen a Hidden creature moves or attacks, they are no longer Hidden. However, if a creature is Hidden when they begin making an attack, the roll has advantage; the Hidden condition isn’t cleared until after the attack is resolved."
+                },
+                "restrained": {
+                    "name": "Restrained",
+                    "description": "When an effect makes a creature Restrained, it means they cannot move until this condition is cleared.\nThey can still take actions from their current position."
+                }
+            },
+            "Burden": {
+                "oneHanded": "One-Handed",
+                "twoHanded": "Two-Handed"
+            },
+            "Range": {
+                "self": {
+                    "name": "Self",
+                    "description": "means yourself."
+                },
+                "melee": {
+                    "name": "Melee",
+                    "description": "means a character is within touching distance of the target. PCs can generally touch targets up to a few feet away from them, but melee range may be greater for especially large NPCs."
+                },
+                "veryClose": {
+                    "name": "Very Close",
+                    "description": "means a distance where one can see fine details of a target- within moments of reaching, if need be. This is usually anywhere from about 5-10 feet away. While in danger, a PC can usually get to anything that’s very close as part of any other action they take. Anything on a battle map that is within the shortest length of a game card (~2-3 inches) can usually be considered very close."
+                },
+                "close": {
+                    "name": "Close",
+                    "description": "means a distance where one can see prominent details of a target-- across a room or to a neighboring market stall, generally about 10-30 feet away. While in danger, a PC can usually get to anything that’s close as part of any other action they take. Anything on a battle map that is within the length of a standard pen or pencil (~5-6 inches) can usually be considered close."
+                },
+                "far": {
+                    "name": "Far",
+                    "description": "means a distance where one can see the appearance of a person or object, but probably not in great detail-- across a small battlefield or down a large corridor. This is usually about 30-100 feet away. While under danger, a PC will likely have to make an Agility check to get here safely. Anything on a battle map that is within the length of a standard piece of paper (~10-11 inches) can usually be considered far."
+                },
+                "veryFar": {
+                    "name": "Very Far",
+                    "description": "means a distance where you can see the shape of a person or object, but probably not make outany details-- across a large battlefield or down a long street, generally about 100-300 feet away. While under danger, a PC likely has to make an Agility check to get here safely. Anything on a battle map that is beyond far distance, but still within sight of the characters can usually be considered very far."
+                }
+            },
+            "DamageType": {
+                "physical": {
+                    "name": "Physical",
+                    "abbreviation": "Phy"
+                },
+                "magical": {
+                    "name": "Magical",
+                    "abbreviation": "Mag"
+                }
+            },
+            "HealingType": {
+                "hitPoints": {
+                    "name": "Hit Points",
+                    "abbreviation": "HP"
                 },
                 "stress": {
-                    "Name": "Stress"
+                    "name": "Stress",
+                    "stress": "STR"
                 },
-                "reach": {
-                    "Name": "Reach"
+                "hope": {
+                    "name": "Hope",
+                    "abbreviation": "HO"
                 },
-                "damage": {
-                    "Name": "Damage"
+                "armorStack": {
+                    "name": "Armor Stack",
+                    "stress": "AS"
                 }
             },
-            "ApplyLocations": {
-                "AttackRoll": {
-                    "Name": "Attack Roll"
+            "ArmorFeature": {
+                "burning": {
+                    "name": "Burning",
+                    "description": "When an adversary attacks you within Melee range, they mark a Stress."
                 },
-                "DamageRoll": {
-                    "Name": "Damage Roll"
+                "channeling": {
+                    "name": "Channeling",
+                    "description": "+1 to Spellcast Rolls"
+                },
+                "difficult": {
+                    "name": "Difficult",
+                    "description": "-1 to all character traits and Evasion"
+                },
+                "flexible": {
+                    "name": "Flexible",
+                    "description": "+1 to Evasion"
+                },
+                "fortified": {
+                    "name": "Fortified",
+                    "description": "When you mark an Armor Slot, you reduce the severity of an attack by two thresholds instead of one."
+                },
+                "gilded": {
+                    "name": "Gilded",
+                    "description": "+1 to Presence"
+                },
+                "heavy": {
+                    "name": "Heavy",
+                    "description": "-1 to Evasion"
+                },
+                "hopeful": {
+                    "name": "Hopeful",
+                    "description": "When you would spend a Hope, you can mark an Armor Slot instead."
+                },
+                "impenetrable": {
+                    "name": "Impenetrable",
+                    "description": "Once per short rest, when you would mark your last Hit Point, you can instead mark a Stress."
+                },
+                "magic": {
+                    "name": "Magic",
+                    "description": "You can't mark an Armor Slot to reduce physical damage."
+                },
+                "painful": {
+                    "name": "Painful",
+                    "description": "Each time you mark an Armor Slot, you must mark a Stress."
+                },
+                "physical": {
+                    "name": "Physical",
+                    "description": "You can't mark an Armor Slot to reduce magic damage."
+                },
+                "quiet": {
+                    "name": "Quiet",
+                    "description": "You gain a +2 bonus to rolls you make to move silently."
+                },
+                "reinforced": {
+                    "name": "Reinforced",
+                    "description": "When you mark your last Armor Slot, increase your damage thresholds by +2 until you clear at least 1 Armor Slot."
+                },
+                "resilient": {
+                    "name": "Resilient",
+                    "description": "Before you mark your last Armor Slot, roll a d6. On a result of 6, reduce the severity by one threshold without marking an Armor Slot."
+                },
+                "sharp": {
+                    "name": "Sharp",
+                    "description": "On a successful attack against a target within Melee range, add a d4 to the damage roll."
+                },
+                "shifting": {
+                    "name": "Shifting",
+                    "description": "When you are targeted for an attack, you can mark an Armor Slot to give the attack roll against you disadvantage."
+                },
+                "timeslowing": {
+                    "name": "Timeslowing",
+                    "description": "Mark an Armor Slot to roll a d4 and add its result as a bonus to your Evasion against an incoming attack."
+                },
+                "truthseeking": {
+                    "name": "Truthseeking",
+                    "description": "This armor glows when another creature within Close range tells a lie."
+                },
+                "veryHeavy": {
+                    "name": "Very Heavy",
+                    "description": "-2 to Evasion; -1 to Agility"
+                },
+                "warded": {
+                    "name": "Warded",
+                    "description": "You reduce incoming magic damage by your Armor Score before applying it to your damage thresholds."
                 }
-            }
-        },
-        "Tooltip": {
-            "openItemWorld": "Open Item World",
-            "openActorWorld": "Open Actor World",
-            "sendToChat": "Send to Chat",
-            "moreOptions": "More Options",
-            "equip": "Equip",
-            "edit": "Edit",
-            "unequip": "Unequip",
-            "delete": "Delete",
-            "sendToVault": "Send to Vault",
-            "sendToLoadout": "Send to Loadout"
-        },
-        "Actions": {
-            "Types": {
-                "attack": {
-                    "name": "Attack"
+            },
+            "WeaponFeature": {
+                "barrier": {
+                    "name": "Barrier",
+                    "description": "+{armorScore} to Armor Score; -1 to Evasion"
                 },
-                "spellcast": {
-                    "name": "Spellcast"
+                "bonded": {
+                    "name": "Bonded",
+                    "description": "Gain a bonus to your damage rolls equal to your level."
                 },
-                "resource": {
-                    "name": "Resource"
+                "bouncing": {
+                    "name": "Bouncing",
+                    "description": "Mark 1 or more Stress to hit that many targets in range of the attack."
                 },
-                "damage": {
-                    "name": "Damage"
+                "brave": {
+                    "name": "Brave",
+                    "description": "-1 to Evasion; +3 to Severe damage threshold"
+                },
+                "brutal": {
+                    "name": "Brutal",
+                    "description": "When you roll the maximum value on a damage die, roll an additional damage die."
+                },
+                "charged": {
+                    "name": "Charged",
+                    "description": "Mark a Stress to gain a +1 bonus to your Proficiency on a primary weapon attack."
+                },
+                "concussive": {
+                    "name": "Concussive",
+                    "description": "On a successful attack, you can spend a Hope to knock the target back to Far range."
+                },
+                "cumbersome": {
+                    "name": "Cumbersome",
+                    "description": "-1 to Finesse"
+                },
+                "deadly": {
+                    "name": "Deadly",
+                    "description": "When you deal Severe damage, the target must mark an additional HP."
+                },
+                "deflecting": {
+                    "name": "Deflecting",
+                    "description": "When you are attacked, you can mark an Armor Slot to gain a bonus to your Evasion equal to your Armor Score against the attack."
+                },
+                "destructive": {
+                    "name": "Destructive",
+                    "description": "-1 to Agility; on a successful attack, all adversaries within Very Close range must mark a Stress."
+                },
+                "devastating": {
+                    "name": "Devastating",
+                    "description": "Before you make an attack roll, you can mark a Stress to use a d20 as your damage die."
+                },
+                "doubleDuty": {
+                    "name": "Double Duty",
+                    "description": "+1 to Armor Score; +1 to primary weapon damage within Melee range"
+                },
+                "doubledUp": {
+                    "name": "Doubled Up",
+                    "description": "When you make an attack with your primary weapon, you can deal damage to another target within Melee range."
+                },
+                "dueling": {
+                    "name": "Dueling",
+                    "description": "When there are no other creatures within Close range of the target, gain advantage on your attack roll against them."
+                },
+                "eruptive": {
+                    "name": "Eruptive",
+                    "description": "On a successful attack against a target within Melee range, all other adversaries within Very Close range must succeed on a reaction roll (14) or take half damage."
+                },
+                "grappling": {
+                    "name": "Grappling",
+                    "description": "On a successful attack, you can spend a Hope to Restrain the target or pull them into Melee range with you."
+                },
+                "greedy": {
+                    "name": "Greedy",
+                    "description": "Spend a handful of gold to gain a +1 bonus to your Proficiency on a damage roll."
                 },
                 "healing": {
-                    "name": "Healing"
+                    "name": "Healing",
+                    "description": "During downtime, automatically clear a Hit Point."
                 },
-                "summon": {
-                    "name": "Summon"
+                "heavy": {
+                    "name": "Heavy",
+                    "description": "-1 to Evasion"
                 },
-                "effect": {
-                    "name": "Effect"
+                "hooked": {
+                    "name": "Hooked",
+                    "description": "On a successful attack, you can pull the target into Melee range."
                 },
-                "macro": {
-                    "name": "Macro"
+                "hot": {
+                    "name": "Hot",
+                    "description": "This weapon cuts through solid material."
                 },
-                "beastform": {
-                    "name": "Beastform"
+                "invigorating": {
+                    "name": "Invigorating",
+                    "description": "On a successful attack, roll a d4. On a result of 4, clear a Stress."
+                },
+                "lifestealing": {
+                    "name": "Lifestealing",
+                    "description": "On a successful attack, roll a d6. On a result of 6, clear a Hit Point or clear a Stress."
+                },
+                "lockedOn": {
+                    "name": "Locked On",
+                    "description": "On a successful attack, your next attack against the same target with your primary weapon automatically succeeds."
+                },
+                "lucky": {
+                    "name": "Lucky",
+                    "description": "On a failed attack, you can mark a Stress to reroll your attack."
+                },
+                "long": {
+                    "name": "Long",
+                    "description": "This weapon's attack targets all adversaries in a line within range."
+                },
+                "massive": {
+                    "name": "Massive",
+                    "description": "-1 to Evasion; on a successful attack, roll an additional damage die and discard the lowest result."
+                },
+                "painful": {
+                    "name": "Painful",
+                    "description": "Each time you make a successful attack, you must mark a Stress."
+                },
+                "paired": {
+                    "name": "Paired",
+                    "description": "+{bonusDamage} to primary weapon damage to targets within Melee range"
+                },
+                "parry": {
+                    "name": "Parry",
+                    "description": "When you are attacked, roll this weapon's damage dice. If any of the attacker's damage dice rolled the same value as your dice, the matching results are discarded from the attacker's damage dice before the damage you take is totaled."
+                },
+                "persuasive": {
+                    "name": "Persuasive",
+                    "description": "Before you make a Presence Roll, you can mark a Stress to gain a +2 bonus to the result."
+                },
+                "pompous": {
+                    "name": "Pompous",
+                    "description": "You must have a Presence of 0 or lower to use this weapon."
+                },
+                "powerful": {
+                    "name": "Powerful",
+                    "description": "On a successful attack, roll an additional damage die and discard the lowest result."
+                },
+                "protective": {
+                    "name": "Protective",
+                    "description": "+{tier} to Armor Score"
+                },
+                "quick": {
+                    "name": "Quick",
+                    "description": "When you make an attack, you can mark a Stress to target another creature within range."
+                },
+                "reliable": {
+                    "name": "Reliable",
+                    "description": "+1 to attack rolls"
+                },
+                "reloading": {
+                    "name": "Reloading",
+                    "description": "After you make an attack, roll a d6. On a result of 1, you must mark a Stress to reload this weapon before you can fire it again."
+                },
+                "retractable": {
+                    "name": "Retractable",
+                    "description": "The blade can be hidden in the hilt to avoid detection."
+                },
+                "returning": {
+                    "name": "Returning",
+                    "description": "When this weapon is thrown within its range, it appears in your hand immediately after the attack."
+                },
+                "scary": {
+                    "name": "Scary",
+                    "description": "On a successful attack, the target must mark a Stress."
+                },
+                "serrated": {
+                    "name": "Serrated",
+                    "description": "When you roll a 1 on a damage die, it deals 8 damage instead."
+                },
+                "sharpwing": {
+                    "name": "Sharpwing",
+                    "description": "Gain a bonus to your damage rolls equal to your Agility."
+                },
+                "sheltering": {
+                    "name": "Sheltering",
+                    "description": "When you mark an Armor Slot, it reduces damage for you and all allies within Melee range of you who took the same damage."
+                },
+                "startling": {
+                    "name": "Startling",
+                    "description": "Mark a Stress to crack the whip and force all adversaries within Melee range back to Close range."
+                },
+                "timebending": {
+                    "name": "Timebending",
+                    "description": "You can choose the target of your attack after making your attack roll."
+                },
+                "versatile": {
+                    "name": "Versatile",
+                    "description": "This weapon can also be used with these statistics—{characterTrait}, {range}, {damage}."
                 }
             },
-            "Settings": {
-                "ResultBased": {
-                    "label": "Formula based on Hope/Fear result."
+            "DeathMoves": {
+                "avoidDeath": {
+                    "name": "Avoid Death",
+                    "description": "You drop unconscious temporarily and work with the GM to describe how the situation gets much worse because of it. Then roll your Fear die; if its value is equal to or under your Level, take a Scar."
+                },
+                "riskItAll": {
+                    "name": "Risk It All",
+                    "description": "Roll your Duality Dice. If Hope is higher, you stay on your feet and clear an amount of Hit Points and/or Stress equal to the value of the Hope die (divide the Hope die value up between these however you’d prefer). If your Fear die is higher, you cross through the veil of death. If the Duality Dice are tied, you stay on your feet and clear all Hit Points and Stress."
+                },
+                "blazeOfGlory": {
+                    "name": "Blaze Of Glory",
+                    "description": "With Blaze of Glory, the player is accepting death for the character. Take one action (at GM discretion), which becomes an automatic critical success, then cross through the veil of death."
                 }
             },
-            "Config": {
-                "Beastform": {
-                    "label": "Beastform",
-                    "exact": "Beastform Max Tier",
-                    "exactHint": "The Character's Tier is used if empty"
+            "RollTypes": {
+                "ability": {
+                    "name": "Ability"
+                },
+                "weapon": {
+                    "name": "Weapon"
+                },
+                "spellcast": {
+                    "name": "SpellCast"
+                },
+                "diceSet": {
+                    "name": "Dice Set"
                 }
             }
         },
-        "RollTypes": {
-            "ability": {
-                "name": "Ability"
+        "Settings": {
+            "Menu": {
+                "automation": {
+                    "name": "Automation Settings",
+                    "label": "Configure Automation",
+                    "hint": "Various settings automating resource management and more"
+                },
+                "homebrew": {
+                    "name": "Homebrew Settings",
+                    "label": "Configure Homebrew",
+                    "hint": "Various settings allowing extensions to types or altered game rules"
+                },
+                "range": {
+                    "name": "Range Settings",
+                    "label": "Configure Range Handling",
+                    "hint": "System ruler setup for displaying ranges in Daggerheart"
+                },
+                "appearance": {
+                    "title": "Appearance Settings",
+                    "label": "Appearance Settings",
+                    "hint": "Modify the look of various parts of the system",
+                    "name": "Appearance Settings",
+                    "duality": "Duality Rolls",
+                    "diceSoNice": {
+                        "title": "Dice So Nice",
+                        "hint": "Coloration of Hope and Fear dice if the Dice So Nice module is used.",
+                        "foreground": "Foreground",
+                        "background": "Background",
+                        "outline": "Outline",
+                        "edge": "Edge"
+                    }
+                },
+                "variantRules": {
+                    "title": "Variant Rules",
+                    "label": "Variant Rules",
+                    "hint": "Apply variant rules from the Daggerheart system",
+                    "name": "Variant Rules",
+                    "actionTokens": "Action Tokens"
+                }
             },
-            "weapon": {
-                "name": "Weapon"
+            "Appearance": {
+                "FIELDS": {
+                    "displayFear": { "label": "Fear Display" }
+                },
+                "fearDisplay": {
+                    "token": "Tokens",
+                    "bar": "Bar",
+                    "hide": "Hide"
+                }
             },
-            "spellcast": {
-                "name": "SpellCast"
+            "Automation": {
+                "fear": {
+                    "name": "Fear",
+                    "hint": "Automatically increase the GM's fear pool on a fear duality roll result."
+                },
+                "FIELDS": {
+                    "hope": {
+                        "label": "Hope",
+                        "hint": "Automatically increase a character's hope on a hope duality roll result."
+                    },
+                    "actionPoints": {
+                        "label": "Action Points",
+                        "hint": "Automatically give and take Action Points as combatants take their turns."
+                    },
+                    "countdowns": {
+                        "label": "Countdowns",
+                        "hint": "Automatically progress non-custom countdowns"
+                    }
+                }
             },
-            "diceSet": {
-                "name": "Dice Set"
+            "Homebrew": {
+                "newDowntimeMove": "Downtime Move",
+                "downtimeMoves": "Downtime Moves",
+                "nrChoices": "# Moves Per Rest",
+                "resetMovesTitle": "Reset {type} Downtime Moves",
+                "resetMovesText": "Are you sure you want to reset?",
+                "FIELDS": {
+                    "maxFear": { "label": "Max Fear" },
+                    "traitArray": { "label": "Initial Trait Modifiers" }
+                },
+                "currency": {
+                    "enabled": "Enable Overrides",
+                    "title": "Currency Overrides",
+                    "currencyName": "Currency Name",
+                    "coinName": "Coin Name",
+                    "handfullName": "Handfull Name",
+                    "bagName": "Bag Name",
+                    "chestName": "Chest Name"
+                }
+            },
+            "Resources": {
+                "fear": {
+                    "name": "Fear",
+                    "hint": "The Fear pool of the GM."
+                }
+            },
+            "VariantRules": {
+                "FIELDS": {
+                    "actionTokens": {
+                        "enabled": { "label": "Enabled" },
+                        "tokens": { "label": "Tokens" }
+                    },
+                    "useCoins": {
+                        "label": "Use Coins",
+                        "hint": "test"
+                    }
+                }
+            },
+            "DualityRollColor": {
+                "options": {
+                    "colorful": "Colorful",
+                    "normal": "Normal"
+                }
             }
         }
     }

--- a/lang/en.json
+++ b/lang/en.json
@@ -61,15 +61,28 @@
         "Actors": {
             "Adversary": {
                 "FIELDS": {
-                    "tier": { "label": "Tier" },
-                    "type": { "label": "Type" },
-                    "description": { "label": "Description" },
-                    "motivesAndTactics": { "label": "Motives & Tactics" },
-                    "difficulty": { "label": "Difficulty" },
+                    "attack": {
+                        "name": { "label": "Name" },
+                        "modifier": { "label": "Modifier" },
+                        "range": { "label": "Range" },
+                        "damage": {
+                            "value": { "label": "Damage" },
+                            "type": { "label": "Damage Type" }
+                        }
+                    },
                     "damageThresholds": {
                         "major": { "label": "Major" },
                         "severe": { "label": "Severe" }
                     },
+                    "description": { "label": "Description" },
+                    "difficulty": { "label": "Difficulty" },
+                    "experiences": {
+                        "element": {
+                            "name": { "label": "Name" },
+                            "value": { "label": "Modifier" }
+                        }
+                    },
+                    "motivesAndTactics": { "label": "Motives & Tactics" },
                     "resources": {
                         "hitPoints": {
                             "value": { "label": "Current" },
@@ -80,68 +93,52 @@
                             "max": { "label": "Max" }
                         }
                     },
-                    "experiences": {
-                        "element": {
-                            "name": { "label": "Name" },
-                            "value": { "label": "Modifier" }
-                        }
-                    },
-                    "attack": {
-                        "name": { "label": "Name" },
-                        "modifier": { "label": "Modifier" },
-                        "range": { "label": "Range" },
-                        "damage": {
-                            "value": { "label": "Damage" },
-                            "type": { "label": "Damage Type" }
-                        }
-                    }
+                    "tier": { "label": "Tier" },
+                    "type": { "label": "Type" }
                 },
                 "horderHp": "Horde/HP"
             },
             "Character": {
-                "pronouns": "Pronouns",
                 "age": "Age",
-                "faith": "Faith",
-                "levelUp": "You can level up",
                 "companionFeatures": "Companion Features",
                 "contextMenu": {
+                    "consume": "Consume Item",
                     "equip": "Equip",
-                    "unequip": "Unequip",
+                    "sendToChat": "Send To Chat",
                     "toLoadout": "Send to Loadout",
                     "toVault": "Send to Vault",
-                    "consume": "Consume Item",
-                    "sendToChat": "Send To Chat"
+                    "unequip": "Unequip"
                 },
+                "faith": "Faith",
+                "levelUp": "You can level up",
+                "pronouns": "Pronouns",
                 "story": {
                     "backgroundTitle": "Background",
-                    "connectionsTitle": "Connections",
-                    "characteristics": "Characteristics"
+                    "characteristics": "Characteristics",
+                    "connectionsTitle": "Connections"
                 }
             },
             "Companion": {
                 "FIELDS": {
-                    "partner": { "label": "Partner" },
+                    "attack": {
+                        "name": { "label": "Attack Name" }
+                    },
                     "evasion": {
                         "value": { "label": "Evasion" }
                     },
+                    "partner": { "label": "Partner" },
                     "resources": {
                         "stress": {
                             "value": { "label": "Stress" }
                         }
-                    },
-                    "attack": {
-                        "name": { "label": "Attack Name" }
                     }
                 },
                 "noPartner": "No Partner selected"
             },
             "Environment": {
                 "FIELDS": {
-                    "tier": {
-                        "label": "Tier"
-                    },
-                    "type": {
-                        "label": "Type"
+                    "description": {
+                        "label": "Description"
                     },
                     "difficulty": {
                         "label": "Difficulty"
@@ -149,8 +146,11 @@
                     "impulses": {
                         "label": "Impulses"
                     },
-                    "description": {
-                        "label": "Description"
+                    "tier": {
+                        "label": "Tier"
+                    },
+                    "type": {
+                        "label": "Type"
                     }
                 },
                 "newAdversary": "New Adversary"

--- a/lang/en.json
+++ b/lang/en.json
@@ -158,34 +158,35 @@
         },
         "Applications": {
             "CharacterCreation": {
-                "title": "{actor} - Character Setup",
-                "traitIncreases": "Trait Increases",
-                "suggestedTraits": "Suggested Traits",
-                "initialExperiences": "Initial Experiences",
+                "choice": "Choice",
+                "finishCreation": "Finish Character Setup",
                 "heritage": "Heritage",
+                "initialExperiences": "Initial Experiences",
+                "newExperience": "New Experience..",
                 "selectAncestry": "Select Ancestry",
-                "selectCommunity": "Select Community",
-                "selectClass": "Select Class",
-                "selectSubclass": "Select Subclass",
                 "selectArmor": "Select Armor",
+                "selectClass": "Select Class",
+                "selectCommunity": "Select Community",
                 "selectPrimaryWeapon": "Select Primary Weapon",
                 "selectSecondaryWeapon": "Select Secondary Weapon",
+                "selectSubclass": "Select Subclass",
+                "startingItems": "Starting Items",
                 "suggestedArmor": "Suggested Armor",
-                "suggestedWeapons": "Suggested Weapon",
                 "suggestedPrimaryWeapon": "Suggested Primary Weapon",
                 "suggestedSecondaryWeapon": "Suggested Secondary Weapon",
-                "startingItems": "Starting Items",
-                "choice": "Choice",
-                "newExperience": "New Experience..",
-                "finishCreation": "Finish Character Setup"
+                "suggestedTraits": "Suggested Traits",
+                "suggestedWeapons": "Suggested Weapon",
+                "title": "{actor} - Character Setup",
+                "traitIncreases": "Trait Increases"
             },
             "CombatTracker": {
+                "combatStarted": "Active",
                 "giveSpotlight": "Give The Spotlight",
-                "requestSpotlight": "Request The Spotlight",
                 "requestingSpotlight": "Requesting The Spotlight",
-                "combatStarted": "Active"
+                "requestSpotlight": "Request The Spotlight"
             },
             "Countdown": {
+                "addCountdown": "Add Countdown",
                 "FIELDS": {
                     "countdowns": {
                         "element": {
@@ -194,18 +195,17 @@
                                 "current": { "label": "Current" },
                                 "max": { "label": "Max" },
                                 "type": {
-                                    "value": { "label": "Value" },
-                                    "label": { "label": "Label", "hint": "Used for custom" }
+                                    "label": { "label": "Label", "hint": "Used for custom" },
+                                    "value": { "label": "Value" }
                                 }
                             }
                         }
                     }
                 },
                 "newCountdown": "New Countdown",
-                "addCountdown": "Add Countdown",
-                "removeCountdownTitle": "Remove Countdown",
-                "removeCountdownText": "Are you sure you want to remove the countdown: {name}?",
                 "openOwnership": "Edit Player Ownership",
+                "removeCountdownText": "Are you sure you want to remove the countdown: {name}?",
+                "removeCountdownTitle": "Remove Countdown",
                 "title": "{type} Countdowns",
                 "toggleSimple": "Toggle Simple View",
                 "types": {
@@ -214,20 +214,43 @@
                 }
             },
             "DamageReduction": {
-                "title": "Damage Reduction",
                 "armorMarks": "Armor Marks",
-                "usedMarks": "Used Marks",
-                "stress": "Stress",
                 "armorWithStress": "Spend 1 stress to use an extra mark",
+                "stress": "Stress",
+                "stressReduction": "Reduce By Stress",
+                "title": "Damage Reduction",
                 "unncessaryStress": "You don't need to expend stress",
-                "stressReduction": "Reduce By Stress"
+                "usedMarks": "Used Marks"
             },
             "DeathMove": {
-                "title": "{actor} - Death Move",
-                "takeMove": "Take Death Move"
+                "takeMove": "Take Death Move",
+                "title": "{actor} - Death Move"
             },
             "Downtime": {
                 "downtimeHeader": "Downtime Moves ({current}/{max})",
+                "longRest": {
+                    "clearStress": {
+                        "description": "Describe how you blow off steam or pull yourself together, and clear all marked Stress.",
+                        "name": "Clear Stress"
+                    },
+                    "prepare": {
+                        "description": "Describe how you are preparing for the next day's adventure, then gain a Hope. If you choose to Prepare with one or more members of your party, you may each take two Hope.",
+                        "name": "Prepare"
+                    },
+                    "repairArmor": {
+                        "description": "Describe how you spend time repairing your armor and clear all of its Armor Slots. You may also do this to an ally's armor instead.",
+                        "name": "Repair Armor"
+                    },
+                    "tendToWounds": {
+                        "description": "Describe how you patch yourself up and remove all marked Hit Points. You may also do this on an ally instead.",
+                        "name": "Tend to Wounds"
+                    },
+                    "title": "Long Rest",
+                    "workOnAProject": {
+                        "description": "Establish or continue work on a project.",
+                        "name": "Work on a Project"
+                    }
+                },
                 "shortRest": {
                     "title": "Short Rest",
                     "tendToWounds": {
@@ -246,40 +269,59 @@
                         "name": "Prepare",
                         "description": "Describe how you prepare yourself for the path ahead, then gain a Hope. If you choose to Prepare with one or more members of your party, you each gain 2 Hope."
                     }
-                },
-                "longRest": {
-                    "title": "Long Rest",
-                    "tendToWounds": {
-                        "name": "Tend to Wounds",
-                        "description": "Describe how you patch yourself up and remove all marked Hit Points. You may also do this on an ally instead."
-                    },
-                    "clearStress": {
-                        "name": "Clear Stress",
-                        "description": "Describe how you blow off steam or pull yourself together, and clear all marked Stress."
-                    },
-                    "repairArmor": {
-                        "name": "Repair Armor",
-                        "description": "Describe how you spend time repairing your armor and clear all of its Armor Slots. You may also do this to an ally's armor instead."
-                    },
-                    "prepare": {
-                        "name": "Prepare",
-                        "description": "Describe how you are preparing for the next day's adventure, then gain a Hope. If you choose to Prepare with one or more members of your party, you may each take two Hope."
-                    },
-                    "workOnAProject": {
-                        "name": "Work on a Project",
-                        "description": "Establish or continue work on a project."
-                    }
                 }
             },
             "Levelup": {
-                "title": "{actor} Level Up",
+                "actions": {
+                    "creatureComfort": {
+                        "name": "Creature Comfort",
+                        "description": "Once per rest, when you take time during a quiet moment to give your companion love and attention, you can gain a Hope or you can both clear a Stress."
+                    },
+                    "armored": {
+                        "name": "Armored",
+                        "description": "When your companion takes damage, you can mark one of your Armor Slots instead of marking one of their Stress."
+                    },
+                    "bonded": {
+                        "name": "Bonded",
+                        "description": "When you mark your last Hit Point, your companion rushes to your side to comfort you. Roll a number of d6s equal to the unmarked Stress slots they have and mark them. If any roll a 6, your companion helps you up. Clear your last Hit Point and return to the scene."
+                    }
+                },
+                "choiceDescriptions": {
+                    "attributes": "Gain a +1 bonus to two unmarked character traits and mark them.",
+                    "hitPointSlots": "Permanently gain one Hit Point slot.",
+                    "stressSlots": "Permanently gain one Stress slot.",
+                    "experiences": "Permanently gain a +1 bonus to two experiences.",
+                    "domainCard": "Choose an additional domain card of your level or lower from a domain you have access to (up to level {maxLevel})",
+                    "evasion": "Permanently gain a +1 bonus to your Evasion.",
+                    "proficiency": "Increase your Proficiency by +1.",
+                    "subclass": "Take an upgraded subclass card. Then cross out the multiclass option for this tier.",
+                    "multiclass": "Multiclass: Choose an additional class for your character, then cross out an unused “Take an upgraded subclass card” and the other multiclass option on this sheet."
+                },
+                "delevel": {
+                    "content": "Returning to the previous level selection will remove all selections made for this level. Do you want to proceed?",
+                    "title": "Go back to previous level"
+                },
                 "navigateLevel": "To Level {level}",
                 "navigateToLevelup": "Return To Levelup",
                 "navigateToSummary": "To Summary",
-                "takeLevelUp": "Finish Level Up",
-                "delevel": {
-                    "title": "Go back to previous level",
-                    "content": "Returning to the previous level selection will remove all selections made for this level. Do you want to proceed?"
+                "options": {
+                    "trait": "Gain a +1 bonus to two unmarked character traits and mark them.",
+                    "hitPoint": "Permanently gain one Hit Point slot.",
+                    "stress": "Permanently gain one Stress slot.",
+                    "experience": "Permanently gain a +1 bonus to two experiences.",
+                    "domainCard": "Choose an additional domain card of your level or lower from a domain you have access to (up to level {maxLevel})",
+                    "evasion": "Permanently gain a +1 bonus to your Evasion.",
+                    "subclass": "Take an upgraded subclass card. Then cross out the multiclass option for this tier.",
+                    "proficiency": "Increase your Proficiency by +1.",
+                    "multiclass": "Multiclass: Choose an additional class for your character, then cross out an unused “Take an upgraded subclass card” and the other multiclass option on this sheet.",
+                    "intelligent": "Your companion gains a permanent +1 bonus to a Companion Experience of your choice.",
+                    "lightInTheDark": "Gain an additional Hope slot for your character.",
+                    "creatureComfort": "Once per rest, when you take time during a quiet moment to give your companion love and attention, you can gain a Hope or you can both clear a Stress.",
+                    "armored": "When your companion takes damage, you can mark one of your Armor Slots instead of marking one of their Stress.",
+                    "vicious": "Increase your companion's damage dice or range by one step (d6 to d8, Close to Far, etc.)",
+                    "resilient": "Your companion gains an additional Stress slot.",
+                    "bonded": "When you mark your last Hit Point, your companion rushes to your side to comfort you. Roll a number of d6s equal to the unmarked Stress slots they have and mark them. If any roll a 6, your companion helps you up. Clear your last Hit Point and return to the scene.",
+                    "aware": "Your companion gains a permanent +2 bonus to their Evasion."
                 },
                 "selections": {
                     "emptyDomainCardHint": "{domain} level {level} or below",
@@ -308,39 +350,7 @@
                     "rangeIncreased": "Range Increased: {range}",
                     "simpleFeature": "Feature: {feature}"
                 },
-                "options": {
-                    "trait": "Gain a +1 bonus to two unmarked character traits and mark them.",
-                    "hitPoint": "Permanently gain one Hit Point slot.",
-                    "stress": "Permanently gain one Stress slot.",
-                    "experience": "Permanently gain a +1 bonus to two experiences.",
-                    "domainCard": "Choose an additional domain card of your level or lower from a domain you have access to (up to level {maxLevel})",
-                    "evasion": "Permanently gain a +1 bonus to your Evasion.",
-                    "subclass": "Take an upgraded subclass card. Then cross out the multiclass option for this tier.",
-                    "proficiency": "Increase your Proficiency by +1.",
-                    "multiclass": "Multiclass: Choose an additional class for your character, then cross out an unused “Take an upgraded subclass card” and the other multiclass option on this sheet.",
-                    "intelligent": "Your companion gains a permanent +1 bonus to a Companion Experience of your choice.",
-                    "lightInTheDark": "Gain an additional Hope slot for your character.",
-                    "creatureComfort": "Once per rest, when you take time during a quiet moment to give your companion love and attention, you can gain a Hope or you can both clear a Stress.",
-                    "armored": "When your companion takes damage, you can mark one of your Armor Slots instead of marking one of their Stress.",
-                    "vicious": "Increase your companion's damage dice or range by one step (d6 to d8, Close to Far, etc.)",
-                    "resilient": "Your companion gains an additional Stress slot.",
-                    "bonded": "When you mark your last Hit Point, your companion rushes to your side to comfort you. Roll a number of d6s equal to the unmarked Stress slots they have and mark them. If any roll a 6, your companion helps you up. Clear your last Hit Point and return to the scene.",
-                    "aware": "Your companion gains a permanent +2 bonus to their Evasion."
-                },
-                "actions": {
-                    "creatureComfort": {
-                        "name": "Creature Comfort",
-                        "description": "Once per rest, when you take time during a quiet moment to give your companion love and attention, you can gain a Hope or you can both clear a Stress."
-                    },
-                    "armored": {
-                        "name": "Armored",
-                        "description": "When your companion takes damage, you can mark one of your Armor Slots instead of marking one of their Stress."
-                    },
-                    "bonded": {
-                        "name": "Bonded",
-                        "description": "When you mark your last Hit Point, your companion rushes to your side to comfort you. Roll a number of d6s equal to the unmarked Stress slots they have and mark them. If any roll a 6, your companion helps you up. Clear your last Hit Point and return to the scene."
-                    }
-                },
+                "takeLevelUp": "Finish Level Up",
                 "tier2": {
                     "label": "Levels 2-4",
                     "infoLabel": "At Level 2, gain an additional Experience at +2 and gain a +1 bonus to your Proficiency.",
@@ -359,17 +369,7 @@
                     "pretext": "When you level up, record it on your character sheet, then choose two from the list below or any unmarked from the previous tier.",
                     "posttext": "Take an additional domain card of your level or lower from a domain you have access to."
                 },
-                "choiceDescriptions": {
-                    "attributes": "Gain a +1 bonus to two unmarked character traits and mark them.",
-                    "hitPointSlots": "Permanently gain one Hit Point slot.",
-                    "stressSlots": "Permanently gain one Stress slot.",
-                    "experiences": "Permanently gain a +1 bonus to two experiences.",
-                    "domainCard": "Choose an additional domain card of your level or lower from a domain you have access to (up to level {maxLevel})",
-                    "evasion": "Permanently gain a +1 bonus to your Evasion.",
-                    "proficiency": "Increase your Proficiency by +1.",
-                    "subclass": "Take an upgraded subclass card. Then cross out the multiclass option for this tier.",
-                    "multiclass": "Multiclass: Choose an additional class for your character, then cross out an unused “Take an upgraded subclass card” and the other multiclass option on this sheet."
-                }
+                "title": "{actor} Level Up"
             },
             "OwnershipSelection": {
                 "title": "Ownership Selection - {name}",

--- a/lang/en.json
+++ b/lang/en.json
@@ -21,6 +21,43 @@
         }
     },
     "DAGGERHEART": {
+        "Actions": {
+            "Config": {
+                "beastform": {
+                    "exact": "Beastform Max Tier",
+                    "exactHint": "The Character's Tier is used if empty",
+                    "label": "Beastform"
+                }
+            },
+            "Settings": {
+                "resultBased": {
+                    "label": "Formula based on Hope/Fear result."
+                }
+            },
+            "Types": {
+                "attack": {
+                    "name": "Attack"
+                },
+                "beastform": {
+                    "name": "Beastform"
+                },
+                "damage": {
+                    "name": "Damage"
+                },
+                "effect": {
+                    "name": "Effect"
+                },
+                "healing": {
+                    "name": "Healing"
+                },
+                "macro": {
+                    "name": "Macro"
+                },
+                "summon": {
+                    "name": "Summon"
+                }
+            }
+        },
         "Actors": {
             "Adversary": {
                 "FIELDS": {
@@ -81,6 +118,23 @@
                     "characteristics": "Characteristics"
                 }
             },
+            "Companion": {
+                "FIELDS": {
+                    "partner": { "label": "Partner" },
+                    "evasion": {
+                        "value": { "label": "Evasion" }
+                    },
+                    "resources": {
+                        "stress": {
+                            "value": { "label": "Stress" }
+                        }
+                    },
+                    "attack": {
+                        "name": { "label": "Attack Name" }
+                    }
+                },
+                "noPartner": "No Partner selected"
+            },
             "Environment": {
                 "FIELDS": {
                     "tier": {
@@ -100,412 +154,9 @@
                     }
                 },
                 "newAdversary": "New Adversary"
-            },
-            "Companion": {
-                "FIELDS": {
-                    "partner": { "label": "Partner" },
-                    "evasion": {
-                        "value": { "label": "Evasion" }
-                    },
-                    "resources": {
-                        "stress": {
-                            "value": { "label": "Stress" }
-                        }
-                    },
-                    "attack": {
-                        "name": { "label": "Attack Name" }
-                    }
-                },
-                "noPartner": "No Partner selected"
-            }
-        },
-        "Items": {
-            "Consumable": {
-                "consumeOnUse": "Consume On Use"
-            },
-            "Subclass": {
-                "spellcastingTrait": "Spellcasting Trait"
-            },
-            "Weapon": {
-                "primaryWeapon": "Primary Weapon",
-                "secondaryWeapon": "Secondary Weapon"
-            },
-            "Armor": {
-                "baseScore": "Base Score",
-                "baseThresholds": {
-                    "base": "Base Thresholds",
-                    "major": "Major Threshold",
-                    "severe": "Severe Threshold"
-                }
-            },
-            "Class": {
-                "hopeFeatures": "Hope Features",
-                "classFeatures": "Class Features",
-                "guide": {
-                    "suggestedEquipment": "Suggested Equipments",
-                    "suggestedPrimaryWeaponTitle": "Primary Weapon",
-                    "suggestedSecondaryWeaponTitle": "Secondary Weapon",
-                    "suggestedArmorTitle": "Armor",
-                    "inventory": {
-                        "thenChoose": "Then Choose Between",
-                        "andEither": "And Either"
-                    }
-                }
-            },
-            "Beastform": {
-                "FIELDS": {
-                    "tier": { "label": "Tier" },
-                    "examples": { "label": "Examples" },
-                    "advantageOn": { "label": "Gain Advantage On" },
-                    "tokenImg": { "label": "Token Image" },
-                    "tokenSize": {
-                        "placeholder": "Using character dimensions",
-                        "height": { "label": "Height" },
-                        "width": { "label": "Width" }
-                    }
-                },
-                "dialogTitle": "Beastform Selection",
-                "tokenTitle": "Beastform Token",
-                "transform": "Transform",
-                "beastformEffect": "Beastform Transformation"
-            },
-            "DomainCard": {
-                "type": "Type",
-                "foundation": "Foundation",
-                "recallCost": "Recall Cost",
-                "specializationTitle": "Specialization",
-                "masteryTitle": "Mastery"
-            }
-        },
-        "Effects": {
-            "Duration": {
-                "passive": "Passive",
-                "temporary": "Temporary"
-            },
-            "Types": {
-                "hitPoints": {
-                    "name": "Hit Points"
-                },
-                "stress": {
-                    "name": "Stress"
-                },
-                "reach": {
-                    "name": "Reach"
-                },
-                "damage": {
-                    "name": "Damage"
-                }
-            },
-            "ApplyLocations": {
-                "attackRoll": {
-                    "name": "Attack Roll"
-                },
-                "damageRoll": {
-                    "name": "Damage Roll"
-                }
-            }
-        },
-        "Actions": {
-            "Types": {
-                "attack": {
-                    "name": "Attack"
-                },
-                "damage": {
-                    "name": "Damage"
-                },
-                "healing": {
-                    "name": "Healing"
-                },
-                "summon": {
-                    "name": "Summon"
-                },
-                "effect": {
-                    "name": "Effect"
-                },
-                "macro": {
-                    "name": "Macro"
-                },
-                "beastform": {
-                    "name": "Beastform"
-                }
-            },
-            "Settings": {
-                "resultBased": {
-                    "label": "Formula based on Hope/Fear result."
-                }
-            },
-            "Config": {
-                "beastform": {
-                    "label": "Beastform",
-                    "exact": "Beastform Max Tier",
-                    "exactHint": "The Character's Tier is used if empty"
-                }
-            }
-        },
-        "General": {
-            "Tiers": {
-                "singular": "Tier",
-                "tier1": "Tier 1",
-                "tier2": "Tier 2",
-                "tier3": "Tier 3",
-                "tier4": "Tier 4"
-            },
-            "Domain": {
-                "single": "Domain",
-                "plural": "Domains",
-                "arcana": {
-                    "label": "Arcana",
-                    "Description": "This is the domain of the innate or instinctual use of magic. Those who walk this path tap into the raw, enigmatic forces of the realms to manipulate both the elements and their own energy. Arcana offers wielders a volatile power, but it is incredibly potent when correctly channeled."
-                },
-                "blade": {
-                    "label": "Blade",
-                    "Description": "This is the domain of those who dedicate their lives to the mastery of weapons. Whether by blade, bow, or perhaps a more specialized arm, those who follow this path have the skill to cut short the lives of others. Blade requires study and dedication from its followers, in exchange for inexorable power over death."
-                },
-                "bone": {
-                    "label": "Bone",
-                    "Description": "This is the domain of mastery of swiftness and tactical mastery. Practitioners of this domain have an uncanny control over their own physical abilities, and an eye for predicting the behaviors of others in combat. Bone grants its adherents unparalleled understanding of bodies and their movements in exchange for diligent training."
-                },
-                "codex": {
-                    "label": "Codex",
-                    "Description": "This is the domain of intensive magical study. Those who seek magical knowledge turn to the recipes of power recorded in books, on scrolls, etched into walls, or tattooed on bodies. Codex offers a commanding and versatile understanding of magic to those devotees who are willing to seek beyond the common knowledge."
-                },
-                "grace": {
-                    "label": "Grace",
-                    "Description": "This is the domain of charisma. Through rapturous storytelling, clever charm, or a shroud of lies, those who channel this power define the realities of their adversaries, bending perception to their will. Grace offers its wielders raw magnetism and mastery over language."
-                },
-                "midnight": {
-                    "label": "Midnight",
-                    "Description": "This is the domain of shadows and secrecy. Whether by clever tricks, or cloak of night those who channel these forces are practiced in that art of obscurity and there is nothing hidden they cannot reach. Midnight offers practitioners the incredible power to control and create enigmas."
-                },
-                "sage": {
-                    "label": "Sage",
-                    "Description": "This is the domain of the natural world. Those who walk this path tap into the unfettered power of the earth and its creatures to unleash raw magic. Sage grants its adherents the vitality of a blooming flower and ferocity of a hungry predator."
-                },
-                "splendor": {
-                    "label": "Splendor",
-                    "Description": "This is the domain of life. Through this magic, followers gain the ability to heal, though such power also grants the wielder some control over death. Splendor offers its disciples the magnificent ability to both give and end life."
-                },
-                "valor": {
-                    "label": "Valor",
-                    "Description": "This is the domain of protection. Whether through attack or defense, those who choose this discipline channel formidable strength to protect their allies in battle. Valor offers great power to those who raise their shield in defense of others."
-                }
-            },
-            "Tabs": {
-                "details": "Details",
-                "attack": "Attack",
-                "experiences": "Experiences",
-                "features": "Features",
-                "actions": "Actions",
-                "potentialAdversaries": "Potential Adversaries",
-                "adversaries": "Adversaries",
-                "advancement": "Level Advancement",
-                "selections": "Advancement Choices",
-                "summary": "Summary",
-                "effects": "Effects",
-                "settings": "Settings",
-                "description": "Description",
-                "main": "Data",
-                "information": "Information",
-                "notes": "Notes",
-                "inventory": "Inventory",
-                "loadout": "Loadout",
-                "vault": "Vault",
-                "heritage": "Heritage",
-                "story": "Story",
-                "biography": "Biography",
-                "general": "General",
-                "foundation": "Foundation",
-                "specialization": "Specialization",
-                "mastery": "Mastery",
-                "optional": "Optional",
-                "setup": "Setup",
-                "equipment": "Equipment"
-            },
-            "Action": {
-                "single": "Action",
-                "plural": "Actions"
-            },
-            "DamageThresholds": {
-                "title": "Damage Thresholds",
-                "minor": "Minor",
-                "major": "Major",
-                "severe": "Severe"
-            },
-            "Dice": {
-                "single": "Die",
-                "plural": "Dice"
-            },
-            "Effect": {
-                "single": "Effect",
-                "plural": "Effects"
-            },
-            "activeEffects": "Active Effects",
-            "inactiveEffects": "Inactive Effects",
-            "inventory": "Inventory",
-            "take": "Take",
-            "evasion": "Evasion",
-            "burden": "Burden",
-            "bonus": "Bonus",
-            "type": "Type",
-            "title": "Title",
-            "range": "Range",
-            "Trait": {
-                "single": "Trait",
-                "plural": "Traits"
-            },
-            "quantity": "Quantity",
-            "attack": "Attack",
-            "hitPoints": "Hit Points",
-            "stress": "Stress",
-            "level": "Level",
-            "features": "Features",
-            "multiclass": "Multiclass",
-            "use": "Use",
-            "hope": "Hope",
-            "fear": "Fear",
-            "duality": "Duality",
-            "check": "{check} Check",
-            "criticalSuccess": "Critical Success",
-            "Advantage": {
-                "full": "Advantage",
-                "short": "Adv"
-            },
-            "Disadvantage": {
-                "full": "Disadvantage",
-                "short": "Dis"
-            },
-            "Neutral": {
-                "full": "None",
-                "short": "no"
-            },
-            "enabled": "Enabled",
-            "description": "Description",
-            "modifier": "Modifier",
-            "unarmored": "Unarmored",
-            "Experience": {
-                "single": "Experience",
-                "plural": "Experiences"
-            },
-            "Adversary": {
-                "singular": "Adversary",
-                "plural": "Adversaries"
-            },
-            "Character": {
-                "singular": "Character",
-                "plural": "Characters"
-            },
-            "RefreshType": {
-                "session": "Session",
-                "shortrest": "Short Rest",
-                "longrest": "Long Rest"
-            },
-            "Damage": {
-                "severe": "Severe",
-                "major": "Major",
-                "minor": "Minor",
-                "none": "None"
-            },
-            "basics": "Basics",
-            "dualityRoll": "Duality Roll"
-        },
-        "UI": {
-            "Tooltip": {
-                "openItemWorld": "Open Item World",
-                "openActorWorld": "Open Actor World",
-                "sendToChat": "Send to Chat",
-                "moreOptions": "More Options",
-                "equip": "Equip",
-                "unequip": "Unequip",
-                "sendToVault": "Send to Vault",
-                "sendToLoadout": "Send to Loadout",
-                "makeDeathMove": "Make a Death Move"
-            },
-            "Notifications": {
-                "adversaryMissing": "The linked adversary doesn't exist in the world.",
-                "beastformInapplicable": "A beastform can only be applied to a Character.",
-                "beastformAlreadyApplied": "The character already has a beastform applied!",
-                "noTargetsSelected": "No targets are selected.",
-                "attackTargetDoesNotExist": "The target token no longer exists",
-                "insufficentAdvancements": "You don't have enough advancements left.",
-                "noAssignedPlayerCharacter": "You have no assigned character.",
-                "noSelectedToken": "You have no selected token",
-                "onlyUseableByPC": "This can only be used with a PC token",
-                "dualityParsing": "Duality roll not properly formated",
-                "attributeFaulty": "The supplied Attribute doesn't exist",
-                "domainCardWrongDomain": "You don't have access to that Domain",
-                "domainCardToHighLevel": "The Domain Card is too high level to be selected",
-                "domainCardDuplicate": "You already have that domain card!",
-                "noSelectionsLeft": "Nothing more to select!",
-                "alreadySelectedClass": "You already have that class!",
-                "classAlreadySelected": "The character already has a class",
-                "subclassAlreadySelected": "The character already has a subclass for that class.",
-                "noClassSelected": "Your character has no class selected!",
-                "lacksDomain": "Your character doesn't have the domain of the card!",
-                "duplicateDomainCard": "You already have a domain card with that name!",
-                "missingClassOrSubclass": "The character doesn't have a class and subclass",
-                "tooHighLevel": "You cannot raise the character level past the maximum",
-                "tooLowLevel": "You cannot lower the character level below starting level",
-                "subclassNotInClass": "This subclass does not belong to your selected class.",
-                "missingClass": "You don't have a class selected yet.",
-                "wrongDomain": "The card isn't from one of your class domains.",
-                "cardTooHighLevel": "The card is too high level!",
-                "duplicateCard": "You cannot select the same card more than once.",
-                "notPrimary": "The weapon is not a primary weapon!",
-                "notSecondary": "The weapon is not a secondary weapon!",
-                "itemTooHighTier": "The item must be from Tier1",
-                "primaryIsTwoHanded": "Cannot select a secondary weapon with a two-handed primary!",
-                "noMoreMoves": "You cannot select any more downtime moves",
-                "damageAlreadyNone": "The damage has already been reduced to none",
-                "noAvailableArmorMarks": "You have no more available armor marks",
-                "notEnoughStress": "You don't have enough stress",
-                "damageIgnore": "{character} did not take damage"
-            },
-            "Chat": {
-                "dualityRoll": {
-                    "abilityCheckTitle": "{ability} Check"
-                },
-                "attackRoll": {
-                    "title": "Attack - {attack}",
-                    "rollDamage": "Roll Damage",
-                    "rollHealing": "Roll Healing",
-                    "applyEffect": "Apply Effects"
-                },
-                "damageRoll": {
-                    "title": "Damage - {damage}",
-                    "dealDamageToTargets": "Damage Hit Targets",
-                    "dealDamage": "Deal Damage",
-                    "rollDamage": "Roll Damage",
-                    "hitTarget": "Hit Targets",
-                    "selectedTarget": "Selected"
-                },
-                "applyEffect": {
-                    "title": "Apply Effects - {name}"
-                },
-                "healingRoll": {
-                    "title": "Heal - {healing}",
-                    "heal": "Heal"
-                },
-                "deathMove": {
-                    "title": "Death Move"
-                },
-                "domainCard": {
-                    "title": "Domain Card"
-                },
-                "foundationCard": {
-                    "ancestryTitle": "Ancestry Card",
-                    "communityTitle": "Community Card",
-                    "subclassFeatureTitle": "Subclass Feature"
-                },
-                "featureTitle": "Class Feature"
             }
         },
         "Applications": {
-            "CombatTracker": {
-                "giveSpotlight": "Give The Spotlight",
-                "requestSpotlight": "Request The Spotlight",
-                "requestingSpotlight": "Requesting The Spotlight",
-                "combatStarted": "Active"
-            },
             "CharacterCreation": {
                 "title": "{actor} - Character Setup",
                 "traitIncreases": "Trait Increases",
@@ -527,6 +178,98 @@
                 "choice": "Choice",
                 "newExperience": "New Experience..",
                 "finishCreation": "Finish Character Setup"
+            },
+            "CombatTracker": {
+                "giveSpotlight": "Give The Spotlight",
+                "requestSpotlight": "Request The Spotlight",
+                "requestingSpotlight": "Requesting The Spotlight",
+                "combatStarted": "Active"
+            },
+            "Countdown": {
+                "FIELDS": {
+                    "countdowns": {
+                        "element": {
+                            "name": { "label": "Name" },
+                            "progress": {
+                                "current": { "label": "Current" },
+                                "max": { "label": "Max" },
+                                "type": {
+                                    "value": { "label": "Value" },
+                                    "label": { "label": "Label", "hint": "Used for custom" }
+                                }
+                            }
+                        }
+                    }
+                },
+                "newCountdown": "New Countdown",
+                "addCountdown": "Add Countdown",
+                "removeCountdownTitle": "Remove Countdown",
+                "removeCountdownText": "Are you sure you want to remove the countdown: {name}?",
+                "openOwnership": "Edit Player Ownership",
+                "title": "{type} Countdowns",
+                "toggleSimple": "Toggle Simple View",
+                "types": {
+                    "narrative": "Narrative",
+                    "encounter": "Encounter"
+                }
+            },
+            "DamageReduction": {
+                "title": "Damage Reduction",
+                "armorMarks": "Armor Marks",
+                "usedMarks": "Used Marks",
+                "stress": "Stress",
+                "armorWithStress": "Spend 1 stress to use an extra mark",
+                "unncessaryStress": "You don't need to expend stress",
+                "stressReduction": "Reduce By Stress"
+            },
+            "DeathMove": {
+                "title": "{actor} - Death Move",
+                "takeMove": "Take Death Move"
+            },
+            "Downtime": {
+                "downtimeHeader": "Downtime Moves ({current}/{max})",
+                "shortRest": {
+                    "title": "Short Rest",
+                    "tendToWounds": {
+                        "name": "Tend to Wounds",
+                        "description": "Describe how you hastily patch yourself up, then clear a number of Hit Points equal to 1d4 + your tier. You can do this to an ally instead."
+                    },
+                    "clearStress": {
+                        "name": "Clear Stress",
+                        "description": "Describe how you blow off steam or pull yourself together, then clear a number of Stress equal to 1d4 + your tier."
+                    },
+                    "repairArmor": {
+                        "name": "Repair Armor",
+                        "description": "Describe how you quickly repair your armor, then clear a number of Armor Slots equal to 1d4 + your tier. You can do this to an ally's armor instead."
+                    },
+                    "prepare": {
+                        "name": "Prepare",
+                        "description": "Describe how you prepare yourself for the path ahead, then gain a Hope. If you choose to Prepare with one or more members of your party, you each gain 2 Hope."
+                    }
+                },
+                "longRest": {
+                    "title": "Long Rest",
+                    "tendToWounds": {
+                        "name": "Tend to Wounds",
+                        "description": "Describe how you patch yourself up and remove all marked Hit Points. You may also do this on an ally instead."
+                    },
+                    "clearStress": {
+                        "name": "Clear Stress",
+                        "description": "Describe how you blow off steam or pull yourself together, and clear all marked Stress."
+                    },
+                    "repairArmor": {
+                        "name": "Repair Armor",
+                        "description": "Describe how you spend time repairing your armor and clear all of its Armor Slots. You may also do this to an ally's armor instead."
+                    },
+                    "prepare": {
+                        "name": "Prepare",
+                        "description": "Describe how you are preparing for the next day's adventure, then gain a Hope. If you choose to Prepare with one or more members of your party, you may each take two Hope."
+                    },
+                    "workOnAProject": {
+                        "name": "Work on a Project",
+                        "description": "Establish or continue work on a project."
+                    }
+                }
             },
             "Levelup": {
                 "title": "{actor} Level Up",
@@ -628,98 +371,34 @@
                     "multiclass": "Multiclass: Choose an additional class for your character, then cross out an unused “Take an upgraded subclass card” and the other multiclass option on this sheet."
                 }
             },
-            "Downtime": {
-                "downtimeHeader": "Downtime Moves ({current}/{max})",
-                "shortRest": {
-                    "title": "Short Rest",
-                    "tendToWounds": {
-                        "name": "Tend to Wounds",
-                        "description": "Describe how you hastily patch yourself up, then clear a number of Hit Points equal to 1d4 + your tier. You can do this to an ally instead."
-                    },
-                    "clearStress": {
-                        "name": "Clear Stress",
-                        "description": "Describe how you blow off steam or pull yourself together, then clear a number of Stress equal to 1d4 + your tier."
-                    },
-                    "repairArmor": {
-                        "name": "Repair Armor",
-                        "description": "Describe how you quickly repair your armor, then clear a number of Armor Slots equal to 1d4 + your tier. You can do this to an ally's armor instead."
-                    },
-                    "prepare": {
-                        "name": "Prepare",
-                        "description": "Describe how you prepare yourself for the path ahead, then gain a Hope. If you choose to Prepare with one or more members of your party, you each gain 2 Hope."
-                    }
-                },
-                "longRest": {
-                    "title": "Long Rest",
-                    "tendToWounds": {
-                        "name": "Tend to Wounds",
-                        "description": "Describe how you patch yourself up and remove all marked Hit Points. You may also do this on an ally instead."
-                    },
-                    "clearStress": {
-                        "name": "Clear Stress",
-                        "description": "Describe how you blow off steam or pull yourself together, and clear all marked Stress."
-                    },
-                    "repairArmor": {
-                        "name": "Repair Armor",
-                        "description": "Describe how you spend time repairing your armor and clear all of its Armor Slots. You may also do this to an ally's armor instead."
-                    },
-                    "prepare": {
-                        "name": "Prepare",
-                        "description": "Describe how you are preparing for the next day's adventure, then gain a Hope. If you choose to Prepare with one or more members of your party, you may each take two Hope."
-                    },
-                    "workOnAProject": {
-                        "name": "Work on a Project",
-                        "description": "Establish or continue work on a project."
-                    }
-                }
-            },
-            "DeathMove": {
-                "title": "{actor} - Death Move",
-                "takeMove": "Take Death Move"
-            },
-            "Countdown": {
-                "FIELDS": {
-                    "countdowns": {
-                        "element": {
-                            "name": { "label": "Name" },
-                            "progress": {
-                                "current": { "label": "Current" },
-                                "max": { "label": "Max" },
-                                "type": {
-                                    "value": { "label": "Value" },
-                                    "label": { "label": "Label", "hint": "Used for custom" }
-                                }
-                            }
-                        }
-                    }
-                },
-                "newCountdown": "New Countdown",
-                "addCountdown": "Add Countdown",
-                "removeCountdownTitle": "Remove Countdown",
-                "removeCountdownText": "Are you sure you want to remove the countdown: {name}?",
-                "openOwnership": "Edit Player Ownership",
-                "title": "{type} Countdowns",
-                "toggleSimple": "Toggle Simple View",
-                "types": {
-                    "narrative": "Narrative",
-                    "encounter": "Encounter"
-                }
-            },
             "OwnershipSelection": {
                 "title": "Ownership Selection - {name}",
                 "default": "Default Ownership"
-            },
-            "DamageReduction": {
-                "title": "Damage Reduction",
-                "armorMarks": "Armor Marks",
-                "usedMarks": "Used Marks",
-                "stress": "Stress",
-                "armorWithStress": "Spend 1 stress to use an extra mark",
-                "unncessaryStress": "You don't need to expend stress",
-                "stressReduction": "Reduce By Stress"
             }
         },
         "Config": {
+            "ActionType": {
+                "passive": "Passive",
+                "action": "Action",
+                "reaction": "Reaction"
+            },
+            "AdversaryTrait": {
+                "relentless": {
+                    "name": "Relentless",
+                    "description": "A foe with Relentless can activate up to X times during a GM move so long as there are enough action tokens.",
+                    "tip": "The Relentless move is useful if you want an adversary you can activate more than once during a single GM move. This is often best for exceedingly fast or dangerous foes, or for adversaries who are likely to be battling the party on their own."
+                },
+                "slow": {
+                    "name": "Slow",
+                    "description": "A foe with Slow costs X action tokens to activate.",
+                    "tip": "The Slow move is useful if you want an adversary who narratively takes longer to act than others, like a slug creature or a massive ogre. This is usually most effective when that creature is very powerful when it does act, but eats up lots of action tokens to do it."
+                },
+                "minion": {
+                    "name": "Minion",
+                    "description": "For every X damage a PC deals to this adversary, they also deal 1 HP to an additional minion within their attack’s range.",
+                    "tip": "The Minion move is useful when you want to drop lots of small enemies into the battlefield, knowing the party can swing through them very easily. This move means that if a PC hits one minion and they do enough damage, they also hit a number of others that are in range for them. Because of this, it’s often best to have minions crowd a PC–it will feel overwhelming and dangerous until they’re able to make an attack against them. If you want that cinematic feeling of the PCs taking out waves of enemies with a single attack roll, minions are a great tool to make that happen."
+                }
+            },
             "AdversaryType": {
                 "bruiser": {
                     "label": "Bruiser",
@@ -760,191 +439,6 @@
                 "support": {
                     "label": "Support",
                     "description": "Enemies that enhance their allies and/or disrupt their opponents."
-                }
-            },
-            "CountdownType": {
-                "spotlight": "Spotlight",
-                "custom": "Custom",
-                "characterAttack": "Character Attack"
-            },
-            "DomainCardTypes": {
-                "ability": "Ability",
-                "spell": "Spell",
-                "grimoire": "Grimoire"
-            },
-            "AdversaryTrait": {
-                "relentless": {
-                    "name": "Relentless",
-                    "description": "A foe with Relentless can activate up to X times during a GM move so long as there are enough action tokens.",
-                    "tip": "The Relentless move is useful if you want an adversary you can activate more than once during a single GM move. This is often best for exceedingly fast or dangerous foes, or for adversaries who are likely to be battling the party on their own."
-                },
-                "slow": {
-                    "name": "Slow",
-                    "description": "A foe with Slow costs X action tokens to activate.",
-                    "tip": "The Slow move is useful if you want an adversary who narratively takes longer to act than others, like a slug creature or a massive ogre. This is usually most effective when that creature is very powerful when it does act, but eats up lots of action tokens to do it."
-                },
-                "minion": {
-                    "name": "Minion",
-                    "description": "For every X damage a PC deals to this adversary, they also deal 1 HP to an additional minion within their attack’s range.",
-                    "tip": "The Minion move is useful when you want to drop lots of small enemies into the battlefield, knowing the party can swing through them very easily. This move means that if a PC hits one minion and they do enough damage, they also hit a number of others that are in range for them. Because of this, it’s often best to have minions crowd a PC–it will feel overwhelming and dangerous until they’re able to make an attack against them. If you want that cinematic feeling of the PCs taking out waves of enemies with a single attack roll, minions are a great tool to make that happen."
-                }
-            },
-            "EnvironmentType": {
-                "exploration": {
-                    "label": "Exploration",
-                    "description": ""
-                },
-                "social": {
-                    "label": "Social",
-                    "description": ""
-                },
-                "traversal": {
-                    "label": "Traversal",
-                    "description": ""
-                },
-                "event": {
-                    "label": "Event",
-                    "description": ""
-                }
-            },
-            "Gold": {
-                "title": "Gold",
-                "coins": "Coins",
-                "handfulls": "Handfulls",
-                "bags": "Bags",
-                "chests": "Chests"
-            },
-            "Traits": {
-                "agility": {
-                    "name": "Agility",
-                    "short": "AGI",
-                    "verb": {
-                        "sprint": "Sprint",
-                        "leap": "Leap",
-                        "maneuver": "Maneuver"
-                    }
-                },
-                "strength": {
-                    "name": "Strength",
-                    "short": "STR",
-                    "verb": {
-                        "lift": "Lift",
-                        "smash": "Smash",
-                        "grapple": "Grapple"
-                    }
-                },
-                "finesse": {
-                    "name": "Finesse",
-                    "short": "FIN",
-                    "verb": {
-                        "control": "Control",
-                        "hide": "Hide",
-                        "tinker": "Tinker"
-                    }
-                },
-                "instinct": {
-                    "name": "Instinct",
-                    "short": "INS",
-                    "verb": {
-                        "perceive": "Perceive",
-                        "sense": "Sense",
-                        "navigate": "Navigate"
-                    }
-                },
-                "presence": {
-                    "name": "Presence",
-                    "short": "PRE",
-                    "verb": {
-                        "charm": "Charm",
-                        "perform": "Perform",
-                        "deceive": "Deceive"
-                    }
-                },
-                "knowledge": {
-                    "name": "Knowledge",
-                    "short": "KNO",
-                    "verb": {
-                        "recall": "Recall",
-                        "analyze": "Analyze",
-                        "comprehend": "Comprehend"
-                    }
-                }
-            },
-            "ActionType": {
-                "passive": "Passive",
-                "action": "Action",
-                "reaction": "Reaction"
-            },
-            "Condition": {
-                "vulnerable": {
-                    "name": "Vulnerable",
-                    "description": "While a creature is Vulnerable, all rolls targeting them have advantage.\nA creature who is already Vulnerable can’t be made to take the condition again."
-                },
-                "hidden": {
-                    "name": "Hidden",
-                    "description": "While Hidden, attacks cannot be made directly targeting them nd any rolls against them are at disadvantage.\nWhen a Hidden creature moves or attacks, they are no longer Hidden. However, if a creature is Hidden when they begin making an attack, the roll has advantage; the Hidden condition isn’t cleared until after the attack is resolved."
-                },
-                "restrained": {
-                    "name": "Restrained",
-                    "description": "When an effect makes a creature Restrained, it means they cannot move until this condition is cleared.\nThey can still take actions from their current position."
-                }
-            },
-            "Burden": {
-                "oneHanded": "One-Handed",
-                "twoHanded": "Two-Handed"
-            },
-            "Range": {
-                "self": {
-                    "name": "Self",
-                    "description": "means yourself."
-                },
-                "melee": {
-                    "name": "Melee",
-                    "description": "means a character is within touching distance of the target. PCs can generally touch targets up to a few feet away from them, but melee range may be greater for especially large NPCs."
-                },
-                "veryClose": {
-                    "name": "Very Close",
-                    "description": "means a distance where one can see fine details of a target- within moments of reaching, if need be. This is usually anywhere from about 5-10 feet away. While in danger, a PC can usually get to anything that’s very close as part of any other action they take. Anything on a battle map that is within the shortest length of a game card (~2-3 inches) can usually be considered very close."
-                },
-                "close": {
-                    "name": "Close",
-                    "description": "means a distance where one can see prominent details of a target-- across a room or to a neighboring market stall, generally about 10-30 feet away. While in danger, a PC can usually get to anything that’s close as part of any other action they take. Anything on a battle map that is within the length of a standard pen or pencil (~5-6 inches) can usually be considered close."
-                },
-                "far": {
-                    "name": "Far",
-                    "description": "means a distance where one can see the appearance of a person or object, but probably not in great detail-- across a small battlefield or down a large corridor. This is usually about 30-100 feet away. While under danger, a PC will likely have to make an Agility check to get here safely. Anything on a battle map that is within the length of a standard piece of paper (~10-11 inches) can usually be considered far."
-                },
-                "veryFar": {
-                    "name": "Very Far",
-                    "description": "means a distance where you can see the shape of a person or object, but probably not make outany details-- across a large battlefield or down a long street, generally about 100-300 feet away. While under danger, a PC likely has to make an Agility check to get here safely. Anything on a battle map that is beyond far distance, but still within sight of the characters can usually be considered very far."
-                }
-            },
-            "DamageType": {
-                "physical": {
-                    "name": "Physical",
-                    "abbreviation": "Phy"
-                },
-                "magical": {
-                    "name": "Magical",
-                    "abbreviation": "Mag"
-                }
-            },
-            "HealingType": {
-                "hitPoints": {
-                    "name": "Hit Points",
-                    "abbreviation": "HP"
-                },
-                "stress": {
-                    "name": "Stress",
-                    "stress": "STR"
-                },
-                "hope": {
-                    "name": "Hope",
-                    "abbreviation": "HO"
-                },
-                "armorStack": {
-                    "name": "Armor Stack",
-                    "stress": "AS"
                 }
             },
             "ArmorFeature": {
@@ -1031,6 +525,197 @@
                 "warded": {
                     "name": "Warded",
                     "description": "You reduce incoming magic damage by your Armor Score before applying it to your damage thresholds."
+                }
+            },
+            "Burden": {
+                "oneHanded": "One-Handed",
+                "twoHanded": "Two-Handed"
+            },
+            "Condition": {
+                "vulnerable": {
+                    "name": "Vulnerable",
+                    "description": "While a creature is Vulnerable, all rolls targeting them have advantage.\nA creature who is already Vulnerable can’t be made to take the condition again."
+                },
+                "hidden": {
+                    "name": "Hidden",
+                    "description": "While Hidden, attacks cannot be made directly targeting them nd any rolls against them are at disadvantage.\nWhen a Hidden creature moves or attacks, they are no longer Hidden. However, if a creature is Hidden when they begin making an attack, the roll has advantage; the Hidden condition isn’t cleared until after the attack is resolved."
+                },
+                "restrained": {
+                    "name": "Restrained",
+                    "description": "When an effect makes a creature Restrained, it means they cannot move until this condition is cleared.\nThey can still take actions from their current position."
+                }
+            },
+            "CountdownType": {
+                "spotlight": "Spotlight",
+                "custom": "Custom",
+                "characterAttack": "Character Attack"
+            },
+            "DamageType": {
+                "physical": {
+                    "name": "Physical",
+                    "abbreviation": "Phy"
+                },
+                "magical": {
+                    "name": "Magical",
+                    "abbreviation": "Mag"
+                }
+            },
+            "DeathMoves": {
+                "avoidDeath": {
+                    "name": "Avoid Death",
+                    "description": "You drop unconscious temporarily and work with the GM to describe how the situation gets much worse because of it. Then roll your Fear die; if its value is equal to or under your Level, take a Scar."
+                },
+                "riskItAll": {
+                    "name": "Risk It All",
+                    "description": "Roll your Duality Dice. If Hope is higher, you stay on your feet and clear an amount of Hit Points and/or Stress equal to the value of the Hope die (divide the Hope die value up between these however you’d prefer). If your Fear die is higher, you cross through the veil of death. If the Duality Dice are tied, you stay on your feet and clear all Hit Points and Stress."
+                },
+                "blazeOfGlory": {
+                    "name": "Blaze Of Glory",
+                    "description": "With Blaze of Glory, the player is accepting death for the character. Take one action (at GM discretion), which becomes an automatic critical success, then cross through the veil of death."
+                }
+            },
+            "DomainCardTypes": {
+                "ability": "Ability",
+                "spell": "Spell",
+                "grimoire": "Grimoire"
+            },
+            "EnvironmentType": {
+                "exploration": {
+                    "label": "Exploration",
+                    "description": ""
+                },
+                "social": {
+                    "label": "Social",
+                    "description": ""
+                },
+                "traversal": {
+                    "label": "Traversal",
+                    "description": ""
+                },
+                "event": {
+                    "label": "Event",
+                    "description": ""
+                }
+            },
+            "Gold": {
+                "title": "Gold",
+                "coins": "Coins",
+                "handfulls": "Handfulls",
+                "bags": "Bags",
+                "chests": "Chests"
+            },
+            "HealingType": {
+                "hitPoints": {
+                    "name": "Hit Points",
+                    "abbreviation": "HP"
+                },
+                "stress": {
+                    "name": "Stress",
+                    "stress": "STR"
+                },
+                "hope": {
+                    "name": "Hope",
+                    "abbreviation": "HO"
+                },
+                "armorStack": {
+                    "name": "Armor Stack",
+                    "stress": "AS"
+                }
+            },
+            "Range": {
+                "self": {
+                    "name": "Self",
+                    "description": "means yourself."
+                },
+                "melee": {
+                    "name": "Melee",
+                    "description": "means a character is within touching distance of the target. PCs can generally touch targets up to a few feet away from them, but melee range may be greater for especially large NPCs."
+                },
+                "veryClose": {
+                    "name": "Very Close",
+                    "description": "means a distance where one can see fine details of a target- within moments of reaching, if need be. This is usually anywhere from about 5-10 feet away. While in danger, a PC can usually get to anything that’s very close as part of any other action they take. Anything on a battle map that is within the shortest length of a game card (~2-3 inches) can usually be considered very close."
+                },
+                "close": {
+                    "name": "Close",
+                    "description": "means a distance where one can see prominent details of a target-- across a room or to a neighboring market stall, generally about 10-30 feet away. While in danger, a PC can usually get to anything that’s close as part of any other action they take. Anything on a battle map that is within the length of a standard pen or pencil (~5-6 inches) can usually be considered close."
+                },
+                "far": {
+                    "name": "Far",
+                    "description": "means a distance where one can see the appearance of a person or object, but probably not in great detail-- across a small battlefield or down a large corridor. This is usually about 30-100 feet away. While under danger, a PC will likely have to make an Agility check to get here safely. Anything on a battle map that is within the length of a standard piece of paper (~10-11 inches) can usually be considered far."
+                },
+                "veryFar": {
+                    "name": "Very Far",
+                    "description": "means a distance where you can see the shape of a person or object, but probably not make outany details-- across a large battlefield or down a long street, generally about 100-300 feet away. While under danger, a PC likely has to make an Agility check to get here safely. Anything on a battle map that is beyond far distance, but still within sight of the characters can usually be considered very far."
+                }
+            },
+            "RollTypes": {
+                "ability": {
+                    "name": "Ability"
+                },
+                "weapon": {
+                    "name": "Weapon"
+                },
+                "spellcast": {
+                    "name": "SpellCast"
+                },
+                "diceSet": {
+                    "name": "Dice Set"
+                }
+            },
+            "Traits": {
+                "agility": {
+                    "name": "Agility",
+                    "short": "AGI",
+                    "verb": {
+                        "sprint": "Sprint",
+                        "leap": "Leap",
+                        "maneuver": "Maneuver"
+                    }
+                },
+                "strength": {
+                    "name": "Strength",
+                    "short": "STR",
+                    "verb": {
+                        "lift": "Lift",
+                        "smash": "Smash",
+                        "grapple": "Grapple"
+                    }
+                },
+                "finesse": {
+                    "name": "Finesse",
+                    "short": "FIN",
+                    "verb": {
+                        "control": "Control",
+                        "hide": "Hide",
+                        "tinker": "Tinker"
+                    }
+                },
+                "instinct": {
+                    "name": "Instinct",
+                    "short": "INS",
+                    "verb": {
+                        "perceive": "Perceive",
+                        "sense": "Sense",
+                        "navigate": "Navigate"
+                    }
+                },
+                "presence": {
+                    "name": "Presence",
+                    "short": "PRE",
+                    "verb": {
+                        "charm": "Charm",
+                        "perform": "Perform",
+                        "deceive": "Deceive"
+                    }
+                },
+                "knowledge": {
+                    "name": "Knowledge",
+                    "short": "KNO",
+                    "verb": {
+                        "recall": "Recall",
+                        "analyze": "Analyze",
+                        "comprehend": "Comprehend"
+                    }
                 }
             },
             "WeaponFeature": {
@@ -1222,37 +907,317 @@
                     "name": "Versatile",
                     "description": "This weapon can also be used with these statistics—{characterTrait}, {range}, {damage}."
                 }
-            },
-            "DeathMoves": {
-                "avoidDeath": {
-                    "name": "Avoid Death",
-                    "description": "You drop unconscious temporarily and work with the GM to describe how the situation gets much worse because of it. Then roll your Fear die; if its value is equal to or under your Level, take a Scar."
+            }
+        },
+        "Effects": {
+            "ApplyLocations": {
+                "attackRoll": {
+                    "name": "Attack Roll"
                 },
-                "riskItAll": {
-                    "name": "Risk It All",
-                    "description": "Roll your Duality Dice. If Hope is higher, you stay on your feet and clear an amount of Hit Points and/or Stress equal to the value of the Hope die (divide the Hope die value up between these however you’d prefer). If your Fear die is higher, you cross through the veil of death. If the Duality Dice are tied, you stay on your feet and clear all Hit Points and Stress."
-                },
-                "blazeOfGlory": {
-                    "name": "Blaze Of Glory",
-                    "description": "With Blaze of Glory, the player is accepting death for the character. Take one action (at GM discretion), which becomes an automatic critical success, then cross through the veil of death."
+                "damageRoll": {
+                    "name": "Damage Roll"
                 }
             },
-            "RollTypes": {
-                "ability": {
-                    "name": "Ability"
+            "Duration": {
+                "passive": "Passive",
+                "temporary": "Temporary"
+            },
+            "Types": {
+                "damage": {
+                    "name": "Damage"
                 },
-                "weapon": {
-                    "name": "Weapon"
+                "hitPoints": {
+                    "name": "Hit Points"
                 },
-                "spellcast": {
-                    "name": "SpellCast"
+                "reach": {
+                    "name": "Reach"
                 },
-                "diceSet": {
-                    "name": "Dice Set"
+                "stress": {
+                    "name": "Stress"
                 }
             }
         },
+        "General": {
+            "Action": {
+                "single": "Action",
+                "plural": "Actions"
+            },
+            "Advantage": {
+                "full": "Advantage",
+                "short": "Adv"
+            },
+            "Adversary": {
+                "singular": "Adversary",
+                "plural": "Adversaries"
+            },
+            "Character": {
+                "singular": "Character",
+                "plural": "Characters"
+            },
+            "Damage": {
+                "severe": "Severe",
+                "major": "Major",
+                "minor": "Minor",
+                "none": "None"
+            },
+            "DamageThresholds": {
+                "title": "Damage Thresholds",
+                "minor": "Minor",
+                "major": "Major",
+                "severe": "Severe"
+            },
+            "Dice": {
+                "single": "Die",
+                "plural": "Dice"
+            },
+            "Disadvantage": {
+                "full": "Disadvantage",
+                "short": "Dis"
+            },
+            "Domain": {
+                "single": "Domain",
+                "plural": "Domains",
+                "arcana": {
+                    "label": "Arcana",
+                    "Description": "This is the domain of the innate or instinctual use of magic. Those who walk this path tap into the raw, enigmatic forces of the realms to manipulate both the elements and their own energy. Arcana offers wielders a volatile power, but it is incredibly potent when correctly channeled."
+                },
+                "blade": {
+                    "label": "Blade",
+                    "Description": "This is the domain of those who dedicate their lives to the mastery of weapons. Whether by blade, bow, or perhaps a more specialized arm, those who follow this path have the skill to cut short the lives of others. Blade requires study and dedication from its followers, in exchange for inexorable power over death."
+                },
+                "bone": {
+                    "label": "Bone",
+                    "Description": "This is the domain of mastery of swiftness and tactical mastery. Practitioners of this domain have an uncanny control over their own physical abilities, and an eye for predicting the behaviors of others in combat. Bone grants its adherents unparalleled understanding of bodies and their movements in exchange for diligent training."
+                },
+                "codex": {
+                    "label": "Codex",
+                    "Description": "This is the domain of intensive magical study. Those who seek magical knowledge turn to the recipes of power recorded in books, on scrolls, etched into walls, or tattooed on bodies. Codex offers a commanding and versatile understanding of magic to those devotees who are willing to seek beyond the common knowledge."
+                },
+                "grace": {
+                    "label": "Grace",
+                    "Description": "This is the domain of charisma. Through rapturous storytelling, clever charm, or a shroud of lies, those who channel this power define the realities of their adversaries, bending perception to their will. Grace offers its wielders raw magnetism and mastery over language."
+                },
+                "midnight": {
+                    "label": "Midnight",
+                    "Description": "This is the domain of shadows and secrecy. Whether by clever tricks, or cloak of night those who channel these forces are practiced in that art of obscurity and there is nothing hidden they cannot reach. Midnight offers practitioners the incredible power to control and create enigmas."
+                },
+                "sage": {
+                    "label": "Sage",
+                    "Description": "This is the domain of the natural world. Those who walk this path tap into the unfettered power of the earth and its creatures to unleash raw magic. Sage grants its adherents the vitality of a blooming flower and ferocity of a hungry predator."
+                },
+                "splendor": {
+                    "label": "Splendor",
+                    "Description": "This is the domain of life. Through this magic, followers gain the ability to heal, though such power also grants the wielder some control over death. Splendor offers its disciples the magnificent ability to both give and end life."
+                },
+                "valor": {
+                    "label": "Valor",
+                    "Description": "This is the domain of protection. Whether through attack or defense, those who choose this discipline channel formidable strength to protect their allies in battle. Valor offers great power to those who raise their shield in defense of others."
+                }
+            },
+            "Effect": {
+                "single": "Effect",
+                "plural": "Effects"
+            },
+            "Experience": {
+                "single": "Experience",
+                "plural": "Experiences"
+            },
+            "Neutral": {
+                "full": "None",
+                "short": "no"
+            },
+            "RefreshType": {
+                "session": "Session",
+                "shortrest": "Short Rest",
+                "longrest": "Long Rest"
+            },
+            "Tabs": {
+                "details": "Details",
+                "attack": "Attack",
+                "experiences": "Experiences",
+                "features": "Features",
+                "actions": "Actions",
+                "potentialAdversaries": "Potential Adversaries",
+                "adversaries": "Adversaries",
+                "advancement": "Level Advancement",
+                "selections": "Advancement Choices",
+                "summary": "Summary",
+                "effects": "Effects",
+                "settings": "Settings",
+                "description": "Description",
+                "main": "Data",
+                "information": "Information",
+                "notes": "Notes",
+                "inventory": "Inventory",
+                "loadout": "Loadout",
+                "vault": "Vault",
+                "heritage": "Heritage",
+                "story": "Story",
+                "biography": "Biography",
+                "general": "General",
+                "foundation": "Foundation",
+                "specialization": "Specialization",
+                "mastery": "Mastery",
+                "optional": "Optional",
+                "setup": "Setup",
+                "equipment": "Equipment"
+            },
+            "Tiers": {
+                "singular": "Tier",
+                "tier1": "Tier 1",
+                "tier2": "Tier 2",
+                "tier3": "Tier 3",
+                "tier4": "Tier 4"
+            },
+            "Trait": {
+                "single": "Trait",
+                "plural": "Traits"
+            },
+            "activeEffects": "Active Effects",
+            "attack": "Attack",
+            "basics": "Basics",
+            "bonus": "Bonus",
+            "burden": "Burden",
+            "check": "{check} Check",
+            "criticalSuccess": "Critical Success",
+            "description": "Description",
+            "duality": "Duality",
+            "dualityRoll": "Duality Roll",
+            "enabled": "Enabled",
+            "evasion": "Evasion",
+            "fear": "Fear",
+            "features": "Features",
+            "hitPoints": "Hit Points",
+            "hope": "Hope",
+            "inactiveEffects": "Inactive Effects",
+            "inventory": "Inventory",
+            "level": "Level",
+            "modifier": "Modifier",
+            "multiclass": "Multiclass",
+            "quantity": "Quantity",
+            "range": "Range",
+            "stress": "Stress",
+            "take": "Take",
+            "title": "Title",
+            "type": "Type",
+            "unarmored": "Unarmored",
+            "use": "Use"
+        },
+        "Items": {
+            "Armor": {
+                "baseScore": "Base Score",
+                "baseThresholds": {
+                    "base": "Base Thresholds",
+                    "major": "Major Threshold",
+                    "severe": "Severe Threshold"
+                }
+            },
+            "Beastform": {
+                "FIELDS": {
+                    "tier": { "label": "Tier" },
+                    "examples": { "label": "Examples" },
+                    "advantageOn": { "label": "Gain Advantage On" },
+                    "tokenImg": { "label": "Token Image" },
+                    "tokenSize": {
+                        "placeholder": "Using character dimensions",
+                        "height": { "label": "Height" },
+                        "width": { "label": "Width" }
+                    }
+                },
+                "dialogTitle": "Beastform Selection",
+                "tokenTitle": "Beastform Token",
+                "transform": "Transform",
+                "beastformEffect": "Beastform Transformation"
+            },
+            "Class": {
+                "hopeFeatures": "Hope Features",
+                "classFeatures": "Class Features",
+                "guide": {
+                    "suggestedEquipment": "Suggested Equipments",
+                    "suggestedPrimaryWeaponTitle": "Primary Weapon",
+                    "suggestedSecondaryWeaponTitle": "Secondary Weapon",
+                    "suggestedArmorTitle": "Armor",
+                    "inventory": {
+                        "thenChoose": "Then Choose Between",
+                        "andEither": "And Either"
+                    }
+                }
+            },
+            "Consumable": {
+                "consumeOnUse": "Consume On Use"
+            },
+            "DomainCard": {
+                "type": "Type",
+                "foundation": "Foundation",
+                "recallCost": "Recall Cost",
+                "specializationTitle": "Specialization",
+                "masteryTitle": "Mastery"
+            },
+            "Subclass": {
+                "spellcastingTrait": "Spellcasting Trait"
+            },
+            "Weapon": {
+                "primaryWeapon": "Primary Weapon",
+                "secondaryWeapon": "Secondary Weapon"
+            }
+        },
         "Settings": {
+            "Appearance": {
+                "FIELDS": {
+                    "displayFear": { "label": "Fear Display" }
+                },
+                "fearDisplay": {
+                    "token": "Tokens",
+                    "bar": "Bar",
+                    "hide": "Hide"
+                }
+            },
+            "Automation": {
+                "fear": {
+                    "name": "Fear",
+                    "hint": "Automatically increase the GM's fear pool on a fear duality roll result."
+                },
+                "FIELDS": {
+                    "hope": {
+                        "label": "Hope",
+                        "hint": "Automatically increase a character's hope on a hope duality roll result."
+                    },
+                    "actionPoints": {
+                        "label": "Action Points",
+                        "hint": "Automatically give and take Action Points as combatants take their turns."
+                    },
+                    "countdowns": {
+                        "label": "Countdowns",
+                        "hint": "Automatically progress non-custom countdowns"
+                    }
+                }
+            },
+            "DualityRollColor": {
+                "options": {
+                    "colorful": "Colorful",
+                    "normal": "Normal"
+                }
+            },
+            "Homebrew": {
+                "newDowntimeMove": "Downtime Move",
+                "downtimeMoves": "Downtime Moves",
+                "nrChoices": "# Moves Per Rest",
+                "resetMovesTitle": "Reset {type} Downtime Moves",
+                "resetMovesText": "Are you sure you want to reset?",
+                "FIELDS": {
+                    "maxFear": { "label": "Max Fear" },
+                    "traitArray": { "label": "Initial Trait Modifiers" }
+                },
+                "currency": {
+                    "enabled": "Enable Overrides",
+                    "title": "Currency Overrides",
+                    "currencyName": "Currency Name",
+                    "coinName": "Coin Name",
+                    "handfullName": "Handfull Name",
+                    "bagName": "Bag Name",
+                    "chestName": "Chest Name"
+                }
+            },
             "Menu": {
                 "automation": {
                     "name": "Automation Settings",
@@ -1292,56 +1257,6 @@
                     "actionTokens": "Action Tokens"
                 }
             },
-            "Appearance": {
-                "FIELDS": {
-                    "displayFear": { "label": "Fear Display" }
-                },
-                "fearDisplay": {
-                    "token": "Tokens",
-                    "bar": "Bar",
-                    "hide": "Hide"
-                }
-            },
-            "Automation": {
-                "fear": {
-                    "name": "Fear",
-                    "hint": "Automatically increase the GM's fear pool on a fear duality roll result."
-                },
-                "FIELDS": {
-                    "hope": {
-                        "label": "Hope",
-                        "hint": "Automatically increase a character's hope on a hope duality roll result."
-                    },
-                    "actionPoints": {
-                        "label": "Action Points",
-                        "hint": "Automatically give and take Action Points as combatants take their turns."
-                    },
-                    "countdowns": {
-                        "label": "Countdowns",
-                        "hint": "Automatically progress non-custom countdowns"
-                    }
-                }
-            },
-            "Homebrew": {
-                "newDowntimeMove": "Downtime Move",
-                "downtimeMoves": "Downtime Moves",
-                "nrChoices": "# Moves Per Rest",
-                "resetMovesTitle": "Reset {type} Downtime Moves",
-                "resetMovesText": "Are you sure you want to reset?",
-                "FIELDS": {
-                    "maxFear": { "label": "Max Fear" },
-                    "traitArray": { "label": "Initial Trait Modifiers" }
-                },
-                "currency": {
-                    "enabled": "Enable Overrides",
-                    "title": "Currency Overrides",
-                    "currencyName": "Currency Name",
-                    "coinName": "Coin Name",
-                    "handfullName": "Handfull Name",
-                    "bagName": "Bag Name",
-                    "chestName": "Chest Name"
-                }
-            },
             "Resources": {
                 "fear": {
                     "name": "Fear",
@@ -1359,12 +1274,97 @@
                         "hint": "test"
                     }
                 }
+            }
+        },
+        "UI": {
+            "Chat": {
+                "dualityRoll": {
+                    "abilityCheckTitle": "{ability} Check"
+                },
+                "attackRoll": {
+                    "title": "Attack - {attack}",
+                    "rollDamage": "Roll Damage",
+                    "rollHealing": "Roll Healing",
+                    "applyEffect": "Apply Effects"
+                },
+                "damageRoll": {
+                    "title": "Damage - {damage}",
+                    "dealDamageToTargets": "Damage Hit Targets",
+                    "dealDamage": "Deal Damage",
+                    "rollDamage": "Roll Damage",
+                    "hitTarget": "Hit Targets",
+                    "selectedTarget": "Selected"
+                },
+                "applyEffect": {
+                    "title": "Apply Effects - {name}"
+                },
+                "healingRoll": {
+                    "title": "Heal - {healing}",
+                    "heal": "Heal"
+                },
+                "deathMove": {
+                    "title": "Death Move"
+                },
+                "domainCard": {
+                    "title": "Domain Card"
+                },
+                "foundationCard": {
+                    "ancestryTitle": "Ancestry Card",
+                    "communityTitle": "Community Card",
+                    "subclassFeatureTitle": "Subclass Feature"
+                },
+                "featureTitle": "Class Feature"
             },
-            "DualityRollColor": {
-                "options": {
-                    "colorful": "Colorful",
-                    "normal": "Normal"
-                }
+            "Notifications": {
+                "adversaryMissing": "The linked adversary doesn't exist in the world.",
+                "beastformInapplicable": "A beastform can only be applied to a Character.",
+                "beastformAlreadyApplied": "The character already has a beastform applied!",
+                "noTargetsSelected": "No targets are selected.",
+                "attackTargetDoesNotExist": "The target token no longer exists",
+                "insufficentAdvancements": "You don't have enough advancements left.",
+                "noAssignedPlayerCharacter": "You have no assigned character.",
+                "noSelectedToken": "You have no selected token",
+                "onlyUseableByPC": "This can only be used with a PC token",
+                "dualityParsing": "Duality roll not properly formated",
+                "attributeFaulty": "The supplied Attribute doesn't exist",
+                "domainCardWrongDomain": "You don't have access to that Domain",
+                "domainCardToHighLevel": "The Domain Card is too high level to be selected",
+                "domainCardDuplicate": "You already have that domain card!",
+                "noSelectionsLeft": "Nothing more to select!",
+                "alreadySelectedClass": "You already have that class!",
+                "classAlreadySelected": "The character already has a class",
+                "subclassAlreadySelected": "The character already has a subclass for that class.",
+                "noClassSelected": "Your character has no class selected!",
+                "lacksDomain": "Your character doesn't have the domain of the card!",
+                "duplicateDomainCard": "You already have a domain card with that name!",
+                "missingClassOrSubclass": "The character doesn't have a class and subclass",
+                "tooHighLevel": "You cannot raise the character level past the maximum",
+                "tooLowLevel": "You cannot lower the character level below starting level",
+                "subclassNotInClass": "This subclass does not belong to your selected class.",
+                "missingClass": "You don't have a class selected yet.",
+                "wrongDomain": "The card isn't from one of your class domains.",
+                "cardTooHighLevel": "The card is too high level!",
+                "duplicateCard": "You cannot select the same card more than once.",
+                "notPrimary": "The weapon is not a primary weapon!",
+                "notSecondary": "The weapon is not a secondary weapon!",
+                "itemTooHighTier": "The item must be from Tier1",
+                "primaryIsTwoHanded": "Cannot select a secondary weapon with a two-handed primary!",
+                "noMoreMoves": "You cannot select any more downtime moves",
+                "damageAlreadyNone": "The damage has already been reduced to none",
+                "noAvailableArmorMarks": "You have no more available armor marks",
+                "notEnoughStress": "You don't have enough stress",
+                "damageIgnore": "{character} did not take damage"
+            },
+            "Tooltip": {
+                "openItemWorld": "Open Item World",
+                "openActorWorld": "Open Actor World",
+                "sendToChat": "Send to Chat",
+                "moreOptions": "More Options",
+                "equip": "Equip",
+                "unequip": "Unequip",
+                "sendToVault": "Send to Vault",
+                "sendToLoadout": "Send to Loadout",
+                "makeDeathMove": "Make a Death Move"
             }
         }
     }

--- a/lang/en.json
+++ b/lang/en.json
@@ -21,7 +21,7 @@
         }
     },
     "DAGGERHEART": {
-        "Actions": {
+        "ACTIONS": {
             "Config": {
                 "beastform": {
                     "exact": "Beastform Max Tier",
@@ -34,7 +34,7 @@
                     "label": "Formula based on Hope/Fear result."
                 }
             },
-            "Types": {
+            "TYPES": {
                 "attack": {
                     "name": "Attack"
                 },
@@ -58,7 +58,7 @@
                 }
             }
         },
-        "Actors": {
+        "ACTORS": {
             "Adversary": {
                 "FIELDS": {
                     "attack": {
@@ -156,7 +156,7 @@
                 "newAdversary": "New Adversary"
             }
         },
-        "Applications": {
+        "APPLICATIONS": {
             "CharacterCreation": {
                 "choice": "Choice",
                 "finishCreation": "Finish Character Setup",
@@ -376,7 +376,7 @@
                 "default": "Default Ownership"
             }
         },
-        "Config": {
+        "CONFIG": {
             "ActionType": {
                 "passive": "Passive",
                 "action": "Action",
@@ -909,7 +909,7 @@
                 }
             }
         },
-        "Effects": {
+        "EFFECTS": {
             "ApplyLocations": {
                 "attackRoll": {
                     "name": "Attack Roll"
@@ -937,7 +937,7 @@
                 }
             }
         },
-        "General": {
+        "GENERAL": {
             "Action": {
                 "single": "Action",
                 "plural": "Actions"
@@ -1103,7 +1103,7 @@
             "unarmored": "Unarmored",
             "use": "Use"
         },
-        "Items": {
+        "ITEMS": {
             "Armor": {
                 "baseScore": "Base Score",
                 "baseThresholds": {
@@ -1161,7 +1161,7 @@
                 "secondaryWeapon": "Secondary Weapon"
             }
         },
-        "Settings": {
+        "SETTINGS": {
             "Appearance": {
                 "FIELDS": {
                     "displayFear": { "label": "Fear Display" }

--- a/module/applications/characterCreation/characterCreation.mjs
+++ b/module/applications/characterCreation/characterCreation.mjs
@@ -41,7 +41,7 @@ export default class DhCharacterCreation extends HandlebarsApplicationMixin(Appl
     }
 
     get title() {
-        return game.i18n.format('DAGGERHEART.Applications.CharacterCreation.title', { actor: this.character.name });
+        return game.i18n.format('DAGGERHEART.APPLICATIONS.CharacterCreation.title', { actor: this.character.name });
     }
 
     static DEFAULT_OPTIONS = {
@@ -87,14 +87,14 @@ export default class DhCharacterCreation extends HandlebarsApplicationMixin(Appl
             cssClass: '',
             group: 'primary',
             id: 'setup',
-            label: 'DAGGERHEART.General.Tabs.setup'
+            label: 'DAGGERHEART.GENERAL.Tabs.setup'
         },
         equipment: {
             active: false,
             cssClass: '',
             group: 'primary',
             id: 'equipment',
-            label: 'DAGGERHEART.General.Tabs.equipment',
+            label: 'DAGGERHEART.GENERAL.Tabs.equipment',
             optional: true
         }
         // story: {
@@ -102,7 +102,7 @@ export default class DhCharacterCreation extends HandlebarsApplicationMixin(Appl
         //     cssClass: '',
         //     group: 'primary',
         //     id: 'story',
-        //     label: 'DAGGERHEART.General.Tabs.story',
+        //     label: 'DAGGERHEART.GENERAL.Tabs.story',
         //     optional: true
         // }
     };
@@ -188,7 +188,7 @@ export default class DhCharacterCreation extends HandlebarsApplicationMixin(Appl
                 context.suggestedTraits = this.setup.class.system
                     ? Object.keys(this.setup.class.system.characterGuide.suggestedTraits).map(traitKey => {
                           const trait = this.setup.class.system.characterGuide.suggestedTraits[traitKey];
-                          return `${game.i18n.localize(`DAGGERHEART.Config.Traits.${traitKey}.short`)} ${trait > 0 ? `+${trait}` : trait}`;
+                          return `${game.i18n.localize(`DAGGERHEART.CONFIG.Traits.${traitKey}.short`)} ${trait > 0 ? `+${trait}` : trait}`;
                       })
                     : [];
                 context.traits = {

--- a/module/applications/characterCreation/characterCreation.mjs
+++ b/module/applications/characterCreation/characterCreation.mjs
@@ -41,7 +41,7 @@ export default class DhCharacterCreation extends HandlebarsApplicationMixin(Appl
     }
 
     get title() {
-        return game.i18n.format('DAGGERHEART.CharacterCreation.Title', { actor: this.character.name });
+        return game.i18n.format('DAGGERHEART.Applications.CharacterCreation.title', { actor: this.character.name });
     }
 
     static DEFAULT_OPTIONS = {
@@ -87,14 +87,14 @@ export default class DhCharacterCreation extends HandlebarsApplicationMixin(Appl
             cssClass: '',
             group: 'primary',
             id: 'setup',
-            label: 'DAGGERHEART.CharacterCreation.Tabs.Setup'
+            label: 'DAGGERHEART.General.Tabs.setup'
         },
         equipment: {
             active: false,
             cssClass: '',
             group: 'primary',
             id: 'equipment',
-            label: 'DAGGERHEART.CharacterCreation.Tabs.Equipment',
+            label: 'DAGGERHEART.General.Tabs.equipment',
             optional: true
         }
         // story: {
@@ -102,7 +102,7 @@ export default class DhCharacterCreation extends HandlebarsApplicationMixin(Appl
         //     cssClass: '',
         //     group: 'primary',
         //     id: 'story',
-        //     label: 'DAGGERHEART.CharacterCreation.Tabs.Story',
+        //     label: 'DAGGERHEART.General.Tabs.story',
         //     optional: true
         // }
     };
@@ -188,7 +188,7 @@ export default class DhCharacterCreation extends HandlebarsApplicationMixin(Appl
                 context.suggestedTraits = this.setup.class.system
                     ? Object.keys(this.setup.class.system.characterGuide.suggestedTraits).map(traitKey => {
                           const trait = this.setup.class.system.characterGuide.suggestedTraits[traitKey];
-                          return `${game.i18n.localize(`DAGGERHEART.Abilities.${traitKey}.short`)} ${trait > 0 ? `+${trait}` : trait}`;
+                          return `${game.i18n.localize(`DAGGERHEART.Config.Traits.${traitKey}.short`)} ${trait > 0 ? `+${trait}` : trait}`;
                       })
                     : [];
                 context.traits = {
@@ -417,9 +417,7 @@ export default class DhCharacterCreation extends HandlebarsApplicationMixin(Appl
             };
         } else if (item.type === 'subclass' && event.target.closest('.subclass-card')) {
             if (this.setup.class.system.subclasses.every(subclass => subclass.uuid !== item.uuid)) {
-                ui.notifications.error(
-                    game.i18n.localize('DAGGERHEART.CharacterCreation.Notifications.SubclassNotInClass')
-                );
+                ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.subclassNotInClass'));
                 return;
             }
 
@@ -430,68 +428,58 @@ export default class DhCharacterCreation extends HandlebarsApplicationMixin(Appl
             };
         } else if (item.type === 'domainCard' && event.target.closest('.domain-card')) {
             if (!this.setup.class.uuid) {
-                ui.notifications.error(game.i18n.localize('DAGGERHEART.CharacterCreation.Notifications.MissingClass'));
+                ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.missingClass'));
                 return;
             }
 
             if (!this.setup.class.system.domains.includes(item.system.domain)) {
-                ui.notifications.error(game.i18n.localize('DAGGERHEART.CharacterCreation.Notifications.WrongDomain'));
+                ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.wrongDomain'));
                 return;
             }
 
             if (item.system.level > 1) {
-                ui.notifications.error(
-                    game.i18n.localize('DAGGERHEART.CharacterCreation.Notifications.CardTooHighLevel')
-                );
+                ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.cardTooHighLevel'));
                 return;
             }
 
             if (Object.values(this.setup.domainCards).some(card => card.uuid === item.uuid)) {
-                ui.notifications.error(game.i18n.localize('DAGGERHEART.CharacterCreation.Notifications.DuplicateCard'));
+                ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.duplicateCard'));
                 return;
             }
 
             this.setup.domainCards[event.target.closest('.domain-card').dataset.card] = { ...item, uuid: item.uuid };
         } else if (item.type === 'armor' && event.target.closest('.armor-card')) {
             if (item.system.tier > 1) {
-                ui.notifications.error(
-                    game.i18n.localize('DAGGERHEART.CharacterCreation.Notifications.ItemTooHighTier')
-                );
+                ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.itemTooHighTier'));
                 return;
             }
 
             this.equipment.armor = { ...item, uuid: item.uuid };
         } else if (item.type === 'weapon' && event.target.closest('.primary-weapon-card')) {
             if (item.system.secondary) {
-                ui.notifications.error(game.i18n.localize('DAGGERHEART.CharacterCreation.Notifications.NotPrimary'));
+                ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.notPrimary'));
                 return;
             }
 
             if (item.system.tier > 1) {
-                ui.notifications.error(
-                    game.i18n.localize('DAGGERHEART.CharacterCreation.Notifications.ItemTooHighTier')
-                );
+                ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.itemTooHighTier'));
                 return;
             }
 
             this.equipment.primaryWeapon = { ...item, uuid: item.uuid };
         } else if (item.type === 'weapon' && event.target.closest('.secondary-weapon-card')) {
             if (this.equipment.primaryWeapon?.system?.burden === burden.twoHanded.value) {
-                ui.notifications.error(
-                    game.i18n.localize('DAGGERHEART.CharacterCreation.Notifications.PrimaryIsTwoHanded')
-                );
+                ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.primaryIsTwoHanded'));
                 return;
             }
 
             if (!item.system.secondary) {
-                ui.notifications.error(game.i18n.localize('DAGGERHEART.CharacterCreation.Notifications.NotSecondary'));
+                ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.notSecondary'));
                 return;
             }
 
             if (item.system.tier > 1) {
-                ui.notifications.error(
-                    game.i18n.localize('DAGGERHEART.CharacterCreation.Notifications.ItemTooHighTier')
-                );
+                ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.itemTooHighTier'));
                 return;
             }
 

--- a/module/applications/dialogs/beastformDialog.mjs
+++ b/module/applications/dialogs/beastformDialog.mjs
@@ -27,7 +27,7 @@ export default class BeastformDialog extends HandlebarsApplicationMixin(Applicat
     };
 
     get title() {
-        return game.i18n.localize('DAGGERHEART.Sheets.Beastform.dialogTitle');
+        return game.i18n.localize('DAGGERHEART.Items.Beastform.dialogTitle');
     }
 
     /** @override */

--- a/module/applications/dialogs/beastformDialog.mjs
+++ b/module/applications/dialogs/beastformDialog.mjs
@@ -27,7 +27,7 @@ export default class BeastformDialog extends HandlebarsApplicationMixin(Applicat
     };
 
     get title() {
-        return game.i18n.localize('DAGGERHEART.Items.Beastform.dialogTitle');
+        return game.i18n.localize('DAGGERHEART.ITEMS.Beastform.dialogTitle');
     }
 
     /** @override */

--- a/module/applications/dialogs/damageReductionDialog.mjs
+++ b/module/applications/dialogs/damageReductionDialog.mjs
@@ -45,7 +45,7 @@ export default class DamageReductionDialog extends HandlebarsApplicationMixin(Ap
     }
 
     get title() {
-        return game.i18n.localize('DAGGERHEART.DamageReduction.Title');
+        return game.i18n.localize('DAGGERHEART.Applications.DamageReduction.title');
     }
 
     static DEFAULT_OPTIONS = {
@@ -79,7 +79,7 @@ export default class DamageReductionDialog extends HandlebarsApplicationMixin(Ap
 
     /** @inheritDoc */
     get title() {
-        return game.i18n.localize('DAGGERHEART.DamageReduction.Title');
+        return game.i18n.localize('DAGGERHEART.Applications.DamageReduction.title');
     }
 
     async _prepareContext(_options) {
@@ -136,14 +136,12 @@ export default class DamageReductionDialog extends HandlebarsApplicationMixin(Ap
         const currentMark = this.marks[target.dataset.type][target.dataset.key];
         const { selectedStressMarks, stressReductions, currentMarks, currentDamage } = this.getDamageInfo();
         if (!currentMark.selected && currentDamage === 0) {
-            ui.notifications.info(game.i18n.localize('DAGGERHEART.DamageReduction.Notifications.DamageAlreadyNone'));
+            ui.notifications.info(game.i18n.localize('DAGGERHEART.UI.Notifications.damageAlreadyNone'));
             return;
         }
 
         if (!currentMark.selected && currentMarks === this.actor.system.armorScore) {
-            ui.notifications.info(
-                game.i18n.localize('DAGGERHEART.DamageReduction.Notifications.NoAvailableArmorMarks')
-            );
+            ui.notifications.info(game.i18n.localize('DAGGERHEART.UI.Notifications.noAvailableArmorMarks'));
             return;
         }
 
@@ -187,7 +185,7 @@ export default class DamageReductionDialog extends HandlebarsApplicationMixin(Ap
             const currentStress =
                 this.actor.system.resources.stress.value + selectedStressMarks.length + stressReductionStress;
             if (currentStress + stressReduction.cost > this.actor.system.resources.stress.maxTotal) {
-                ui.notifications.info(game.i18n.localize('DAGGERHEART.DamageReduction.Notifications.NotEnoughStress'));
+                ui.notifications.info(game.i18n.localize('DAGGERHEART.UI.Notifications.notEnoughStress'));
                 return;
             }
 

--- a/module/applications/dialogs/damageReductionDialog.mjs
+++ b/module/applications/dialogs/damageReductionDialog.mjs
@@ -45,7 +45,7 @@ export default class DamageReductionDialog extends HandlebarsApplicationMixin(Ap
     }
 
     get title() {
-        return game.i18n.localize('DAGGERHEART.Applications.DamageReduction.title');
+        return game.i18n.localize('DAGGERHEART.APPLICATIONS.DamageReduction.title');
     }
 
     static DEFAULT_OPTIONS = {
@@ -79,7 +79,7 @@ export default class DamageReductionDialog extends HandlebarsApplicationMixin(Ap
 
     /** @inheritDoc */
     get title() {
-        return game.i18n.localize('DAGGERHEART.Applications.DamageReduction.title');
+        return game.i18n.localize('DAGGERHEART.APPLICATIONS.DamageReduction.title');
     }
 
     async _prepareContext(_options) {

--- a/module/applications/dialogs/deathMove.mjs
+++ b/module/applications/dialogs/deathMove.mjs
@@ -9,7 +9,7 @@ export default class DhpDeathMove extends HandlebarsApplicationMixin(Application
     }
 
     get title() {
-        return game.i18n.format('DAGGERHEART.Applications.DeathMove.title', { actor: this.actor.name });
+        return game.i18n.format('DAGGERHEART.APPLICATIONS.DeathMove.title', { actor: this.actor.name });
     }
 
     static DEFAULT_OPTIONS = {

--- a/module/applications/dialogs/deathMove.mjs
+++ b/module/applications/dialogs/deathMove.mjs
@@ -9,7 +9,7 @@ export default class DhpDeathMove extends HandlebarsApplicationMixin(Application
     }
 
     get title() {
-        return game.i18n.format('DAGGERHEART.Application.DeathMove.Title', { actor: this.actor.name });
+        return game.i18n.format('DAGGERHEART.Applications.DeathMove.title', { actor: this.actor.name });
     }
 
     static DEFAULT_OPTIONS = {

--- a/module/applications/dialogs/downtime.mjs
+++ b/module/applications/dialogs/downtime.mjs
@@ -88,7 +88,7 @@ export default class DhpDowntime extends HandlebarsApplicationMixin(ApplicationV
             content: await foundry.applications.handlebars.renderTemplate(
                 'systems/daggerheart/templates/ui/chat/downtime.hbs',
                 {
-                    title: `${this.actor.name} - ${game.i18n.localize(`DAGGERHEART.Applications.Downtime.${this.shortRest ? 'shortRest' : 'longRest'}.title`)}`,
+                    title: `${this.actor.name} - ${game.i18n.localize(`DAGGERHEART.APPLICATIONS.Downtime.${this.shortRest ? 'shortRest' : 'longRest'}.title`)}`,
                     moves: moves
                 }
             )

--- a/module/applications/dialogs/downtime.mjs
+++ b/module/applications/dialogs/downtime.mjs
@@ -54,7 +54,7 @@ export default class DhpDowntime extends HandlebarsApplicationMixin(ApplicationV
     static selectMove(_, button) {
         const nrSelected = Object.values(this.moveData.moves).reduce((acc, x) => acc + (x.selected ?? 0), 0);
         if (nrSelected === this.moveData.nrChoices) {
-            ui.notifications.error(game.i18n.localize('DAGGERHEART.Downtime.Notifications.NoMoreMoves'));
+            ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.noMoreMoves'));
             return;
         }
 
@@ -88,7 +88,7 @@ export default class DhpDowntime extends HandlebarsApplicationMixin(ApplicationV
             content: await foundry.applications.handlebars.renderTemplate(
                 'systems/daggerheart/templates/ui/chat/downtime.hbs',
                 {
-                    title: `${this.actor.name} - ${game.i18n.localize(`DAGGERHEART.Downtime.${this.shortRest ? 'ShortRest' : 'LongRest'}.title`)}`,
+                    title: `${this.actor.name} - ${game.i18n.localize(`DAGGERHEART.Applications.Downtime.${this.shortRest ? 'shortRest' : 'longRest'}.title`)}`,
                     moves: moves
                 }
             )

--- a/module/applications/dialogs/ownershipSelection.mjs
+++ b/module/applications/dialogs/ownershipSelection.mjs
@@ -27,7 +27,7 @@ export default class OwnershipSelection extends HandlebarsApplicationMixin(Appli
     };
 
     get title() {
-        return game.i18n.format('DAGGERHEART.OwnershipSelection.Title', { name: this.name });
+        return game.i18n.format('DAGGERHEART.Applications.OwnershipSelection.title', { name: this.name });
     }
 
     async _prepareContext(_options) {

--- a/module/applications/dialogs/ownershipSelection.mjs
+++ b/module/applications/dialogs/ownershipSelection.mjs
@@ -27,7 +27,7 @@ export default class OwnershipSelection extends HandlebarsApplicationMixin(Appli
     };
 
     get title() {
-        return game.i18n.format('DAGGERHEART.Applications.OwnershipSelection.title', { name: this.name });
+        return game.i18n.format('DAGGERHEART.APPLICATIONS.OwnershipSelection.title', { name: this.name });
     }
 
     async _prepareContext(_options) {

--- a/module/applications/levelup/characterLevelup.mjs
+++ b/module/applications/levelup/characterLevelup.mjs
@@ -112,7 +112,7 @@ export default class DhCharacterLevelUp extends LevelUpBase {
                                 ? Math.min(domainCard.secondaryData.limit, levelBase)
                                 : levelBase;
 
-                            return game.i18n.format('DAGGERHEART.Applications.Levelup.selections.emptyDomainCardHint', {
+                            return game.i18n.format('DAGGERHEART.APPLICATIONS.Levelup.selections.emptyDomainCardHint', {
                                 domain: game.i18n.localize(domains[domain.domain].label),
                                 level: levelMax
                             });

--- a/module/applications/levelup/characterLevelup.mjs
+++ b/module/applications/levelup/characterLevelup.mjs
@@ -112,7 +112,7 @@ export default class DhCharacterLevelUp extends LevelUpBase {
                                 ? Math.min(domainCard.secondaryData.limit, levelBase)
                                 : levelBase;
 
-                            return game.i18n.format('DAGGERHEART.Application.LevelUp.Selections.emptyDomainCardHint', {
+                            return game.i18n.format('DAGGERHEART.Applications.Levelup.selections.emptyDomainCardHint', {
                                 domain: game.i18n.localize(domains[domain.domain].label),
                                 level: levelMax
                             });

--- a/module/applications/levelup/companionLevelup.mjs
+++ b/module/applications/levelup/companionLevelup.mjs
@@ -63,8 +63,8 @@ export default class DhCompanionLevelUp extends BaseLevelUp {
 
                 context.vicious = advancementChoices.vicious ? Object.values(advancementChoices.vicious) : null;
                 context.viciousChoices = {
-                    damage: game.i18n.localize('DAGGERHEART.Applications.Levelup.selections.viciousDamage'),
-                    range: game.i18n.localize('DAGGERHEART.Applications.Levelup.selections.viciousRange')
+                    damage: game.i18n.localize('DAGGERHEART.APPLICATIONS.Levelup.selections.viciousDamage'),
+                    range: game.i18n.localize('DAGGERHEART.APPLICATIONS.Levelup.selections.viciousRange')
                 };
 
                 break;
@@ -142,7 +142,7 @@ export default class DhCompanionLevelUp extends BaseLevelUp {
                             : null,
                         range: advancement.vicious?.range
                             ? {
-                                  old: game.i18n.localize(`DAGGERHEART.Config.Range.${actorRange}.name`),
+                                  old: game.i18n.localize(`DAGGERHEART.CONFIG.Range.${actorRange}.name`),
                                   new: game.i18n.localize(advancement.vicious.range.label)
                               }
                             : null

--- a/module/applications/levelup/companionLevelup.mjs
+++ b/module/applications/levelup/companionLevelup.mjs
@@ -63,8 +63,8 @@ export default class DhCompanionLevelUp extends BaseLevelUp {
 
                 context.vicious = advancementChoices.vicious ? Object.values(advancementChoices.vicious) : null;
                 context.viciousChoices = {
-                    damage: game.i18n.localize('DAGGERHEART.Application.LevelUp.Selections.viciousDamage'),
-                    range: game.i18n.localize('DAGGERHEART.Application.LevelUp.Selections.viciousRange')
+                    damage: game.i18n.localize('DAGGERHEART.Applications.Levelup.selections.viciousDamage'),
+                    range: game.i18n.localize('DAGGERHEART.Applications.Levelup.selections.viciousRange')
                 };
 
                 break;
@@ -142,7 +142,7 @@ export default class DhCompanionLevelUp extends BaseLevelUp {
                             : null,
                         range: advancement.vicious?.range
                             ? {
-                                  old: game.i18n.localize(`DAGGERHEART.Range.${actorRange}.name`),
+                                  old: game.i18n.localize(`DAGGERHEART.Config.Range.${actorRange}.name`),
                                   new: game.i18n.localize(advancement.vicious.range.label)
                               }
                             : null

--- a/module/applications/levelup/levelup.mjs
+++ b/module/applications/levelup/levelup.mjs
@@ -15,7 +15,7 @@ export default class DhlevelUp extends HandlebarsApplicationMixin(ApplicationV2)
     }
 
     get title() {
-        return game.i18n.format('DAGGERHEART.Application.LevelUp.Title', { actor: this.actor.name });
+        return game.i18n.format('DAGGERHEART.Applications.Levelup.title', { actor: this.actor.name });
     }
 
     static DEFAULT_OPTIONS = {
@@ -56,7 +56,7 @@ export default class DhlevelUp extends HandlebarsApplicationMixin(ApplicationV2)
             group: 'primary',
             id: 'advancements',
             icon: null,
-            label: 'DAGGERHEART.Application.LevelUp.Tabs.advancement'
+            label: 'DAGGERHEART.General.Tabs.advancement'
         },
         selections: {
             active: false,
@@ -64,7 +64,7 @@ export default class DhlevelUp extends HandlebarsApplicationMixin(ApplicationV2)
             group: 'primary',
             id: 'selections',
             icon: null,
-            label: 'DAGGERHEART.Application.LevelUp.Tabs.selections'
+            label: 'DAGGERHEART.General.Tabs.selections'
         },
         summary: {
             active: false,
@@ -72,7 +72,7 @@ export default class DhlevelUp extends HandlebarsApplicationMixin(ApplicationV2)
             group: 'primary',
             id: 'summary',
             icon: null,
-            label: 'DAGGERHEART.Application.LevelUp.Tabs.summary'
+            label: 'DAGGERHEART.General.Tabs.summary'
         }
     };
 
@@ -110,14 +110,14 @@ export default class DhlevelUp extends HandlebarsApplicationMixin(ApplicationV2)
                     previous: {
                         disabled: !previous,
                         label: previous
-                            ? game.i18n.format('DAGGERHEART.Application.LevelUp.navigateLevel', { level: previous })
+                            ? game.i18n.format('DAGGERHEART.Applications.Levelup.navigateLevel', { level: previous })
                             : '',
                         fromSummary: this.tabGroups.primary === 'summary'
                     },
                     next: {
                         disabled: !this.levelup.currentLevelFinished,
                         label: next
-                            ? game.i18n.format('DAGGERHEART.Application.LevelUp.navigateLevel', { level: next })
+                            ? game.i18n.format('DAGGERHEART.Applications.Levelup.navigateLevel', { level: next })
                             : '',
                         toSummary: !next,
                         show: this.tabGroups.primary !== 'summary'
@@ -384,9 +384,7 @@ export default class DhlevelUp extends HandlebarsApplicationMixin(ApplicationV2)
             );
 
             if (!updatePath) {
-                ui.notifications.error(
-                    game.i18n.localize('DAGGERHEART.Application.LevelUp.notifications.error.noSelectionsLeft')
-                );
+                ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.noSelectionsLeft'));
                 return;
             }
 
@@ -414,18 +412,14 @@ export default class DhlevelUp extends HandlebarsApplicationMixin(ApplicationV2)
                     !this.actor.system.domains.includes(item.system.domain) &&
                     this.levelup.classUpgradeChoices?.multiclass?.domain !== item.system.domain
                 ) {
-                    ui.notifications.error(
-                        game.i18n.localize('DAGGERHEART.Application.LevelUp.notifications.error.domainCardWrongDomain')
-                    );
+                    ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.domainCardWrongDomain'));
                     return;
                 }
 
                 const levelBase = isMulticlass ? Math.ceil(this.levelup.currentLevel / 2) : this.levelup.currentLevel;
                 const levelMax = target.dataset.limit ? Math.min(Number(target.dataset.limit), levelBase) : levelBase;
                 if (levelMax < item.system.level) {
-                    ui.notifications.error(
-                        game.i18n.localize('DAGGERHEART.Application.LevelUp.notifications.error.domainCardToHighLevel')
-                    );
+                    ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.domainCardToHighLevel'));
                     return;
                 }
 
@@ -443,9 +437,7 @@ export default class DhlevelUp extends HandlebarsApplicationMixin(ApplicationV2)
                     return achievementExists || advancementExists;
                 });
                 if (cardExistsInCharacter || cardExistsInLevelup) {
-                    ui.notifications.error(
-                        game.i18n.localize('DAGGERHEART.Application.LevelUp.notifications.error.domainCardDuplicate')
-                    );
+                    ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.domainCardDuplicate'));
                     return;
                 }
 
@@ -456,9 +448,7 @@ export default class DhlevelUp extends HandlebarsApplicationMixin(ApplicationV2)
             const target = event.target.closest('.multiclass-cards');
             if (item.type === 'class') {
                 if (item.name === this.actor.system.class.value.name) {
-                    ui.notifications.error(
-                        game.i18n.localize('DAGGERHEART.Application.LevelUp.notifications.error.alreadySelectedClass')
-                    );
+                    ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.alreadySelectedClass'));
                     return;
                 }
 
@@ -498,9 +488,7 @@ export default class DhlevelUp extends HandlebarsApplicationMixin(ApplicationV2)
             }
         } else {
             if (this.levelup.levels[this.levelup.currentLevel].nrSelections.available < Number(button.dataset.cost)) {
-                ui.notifications.info(
-                    game.i18n.localize('DAGGERHEART.Application.LevelUp.notifications.info.insufficentAdvancements')
-                );
+                ui.notifications.info(game.i18n.localize('DAGGERHEART.UI.Notifications.insufficentAdvancements'));
                 this.render();
                 return;
             }
@@ -571,9 +559,9 @@ export default class DhlevelUp extends HandlebarsApplicationMixin(ApplicationV2)
         if (!button.dataset.forward) {
             const confirmed = await foundry.applications.api.DialogV2.confirm({
                 window: {
-                    title: game.i18n.localize('DAGGERHEART.Application.LevelUp.Delevel.title')
+                    title: game.i18n.localize('DAGGERHEART.Applications.Levelup.delevel.title')
                 },
-                content: game.i18n.format('DAGGERHEART.Application.LevelUp.Delevel.content')
+                content: game.i18n.format('DAGGERHEART.Applications.Levelup.delevel.content')
             });
 
             if (!confirmed) return;

--- a/module/applications/levelup/levelup.mjs
+++ b/module/applications/levelup/levelup.mjs
@@ -15,7 +15,7 @@ export default class DhlevelUp extends HandlebarsApplicationMixin(ApplicationV2)
     }
 
     get title() {
-        return game.i18n.format('DAGGERHEART.Applications.Levelup.title', { actor: this.actor.name });
+        return game.i18n.format('DAGGERHEART.APPLICATIONS.Levelup.title', { actor: this.actor.name });
     }
 
     static DEFAULT_OPTIONS = {
@@ -56,7 +56,7 @@ export default class DhlevelUp extends HandlebarsApplicationMixin(ApplicationV2)
             group: 'primary',
             id: 'advancements',
             icon: null,
-            label: 'DAGGERHEART.General.Tabs.advancement'
+            label: 'DAGGERHEART.GENERAL.Tabs.advancement'
         },
         selections: {
             active: false,
@@ -64,7 +64,7 @@ export default class DhlevelUp extends HandlebarsApplicationMixin(ApplicationV2)
             group: 'primary',
             id: 'selections',
             icon: null,
-            label: 'DAGGERHEART.General.Tabs.selections'
+            label: 'DAGGERHEART.GENERAL.Tabs.selections'
         },
         summary: {
             active: false,
@@ -72,7 +72,7 @@ export default class DhlevelUp extends HandlebarsApplicationMixin(ApplicationV2)
             group: 'primary',
             id: 'summary',
             icon: null,
-            label: 'DAGGERHEART.General.Tabs.summary'
+            label: 'DAGGERHEART.GENERAL.Tabs.summary'
         }
     };
 
@@ -110,14 +110,14 @@ export default class DhlevelUp extends HandlebarsApplicationMixin(ApplicationV2)
                     previous: {
                         disabled: !previous,
                         label: previous
-                            ? game.i18n.format('DAGGERHEART.Applications.Levelup.navigateLevel', { level: previous })
+                            ? game.i18n.format('DAGGERHEART.APPLICATIONS.Levelup.navigateLevel', { level: previous })
                             : '',
                         fromSummary: this.tabGroups.primary === 'summary'
                     },
                     next: {
                         disabled: !this.levelup.currentLevelFinished,
                         label: next
-                            ? game.i18n.format('DAGGERHEART.Applications.Levelup.navigateLevel', { level: next })
+                            ? game.i18n.format('DAGGERHEART.APPLICATIONS.Levelup.navigateLevel', { level: next })
                             : '',
                         toSummary: !next,
                         show: this.tabGroups.primary !== 'summary'
@@ -559,9 +559,9 @@ export default class DhlevelUp extends HandlebarsApplicationMixin(ApplicationV2)
         if (!button.dataset.forward) {
             const confirmed = await foundry.applications.api.DialogV2.confirm({
                 window: {
-                    title: game.i18n.localize('DAGGERHEART.Applications.Levelup.delevel.title')
+                    title: game.i18n.localize('DAGGERHEART.APPLICATIONS.Levelup.delevel.title')
                 },
-                content: game.i18n.format('DAGGERHEART.Applications.Levelup.delevel.content')
+                content: game.i18n.format('DAGGERHEART.APPLICATIONS.Levelup.delevel.content')
             });
 
             if (!confirmed) return;

--- a/module/applications/settings/appearanceSettings.mjs
+++ b/module/applications/settings/appearanceSettings.mjs
@@ -12,7 +12,7 @@ export default class DHAppearanceSettings extends HandlebarsApplicationMixin(App
     }
 
     get title() {
-        return game.i18n.localize('DAGGERHEART.Settings.Menu.appearance.name');
+        return game.i18n.localize('DAGGERHEART.SETTINGS.Menu.appearance.name');
     }
 
     static DEFAULT_OPTIONS = {

--- a/module/applications/settings/appearanceSettings.mjs
+++ b/module/applications/settings/appearanceSettings.mjs
@@ -12,7 +12,7 @@ export default class DHAppearanceSettings extends HandlebarsApplicationMixin(App
     }
 
     get title() {
-        return game.i18n.localize('DAGGERHEART.Settings.Menu.Appearance.name');
+        return game.i18n.localize('DAGGERHEART.Settings.Menu.appearance.name');
     }
 
     static DEFAULT_OPTIONS = {

--- a/module/applications/settings/automationSettings.mjs
+++ b/module/applications/settings/automationSettings.mjs
@@ -12,7 +12,7 @@ export default class DhAutomationSettings extends HandlebarsApplicationMixin(App
     }
 
     get title() {
-        return game.i18n.localize('DAGGERHEART.Settings.Menu.automation.name');
+        return game.i18n.localize('DAGGERHEART.SETTINGS.Menu.automation.name');
     }
 
     static DEFAULT_OPTIONS = {

--- a/module/applications/settings/automationSettings.mjs
+++ b/module/applications/settings/automationSettings.mjs
@@ -12,7 +12,7 @@ export default class DhAutomationSettings extends HandlebarsApplicationMixin(App
     }
 
     get title() {
-        return game.i18n.localize('DAGGERHEART.Settings.Menu.Automation.Name');
+        return game.i18n.localize('DAGGERHEART.Settings.Menu.automation.name');
     }
 
     static DEFAULT_OPTIONS = {

--- a/module/applications/settings/homebrewSettings.mjs
+++ b/module/applications/settings/homebrewSettings.mjs
@@ -13,7 +13,7 @@ export default class DhHomebrewSettings extends HandlebarsApplicationMixin(Appli
     }
 
     get title() {
-        return game.i18n.localize('DAGGERHEART.Settings.Menu.homebrew.name');
+        return game.i18n.localize('DAGGERHEART.SETTINGS.Menu.homebrew.name');
     }
 
     static DEFAULT_OPTIONS = {
@@ -59,7 +59,7 @@ export default class DhHomebrewSettings extends HandlebarsApplicationMixin(Appli
     static async addItem(_, target) {
         await this.settings.updateSource({
             [`restMoves.${target.dataset.type}.moves.${foundry.utils.randomID()}`]: {
-                name: game.i18n.localize('DAGGERHEART.Settings.Homebrew.newDowntimeMove'),
+                name: game.i18n.localize('DAGGERHEART.SETTINGS.Homebrew.newDowntimeMove'),
                 img: 'icons/magic/life/cross-worn-green.webp',
                 description: '',
                 actions: []
@@ -74,7 +74,7 @@ export default class DhHomebrewSettings extends HandlebarsApplicationMixin(Appli
             new DhSettingsActionView(
                 resolve,
                 reject,
-                game.i18n.localize('DAGGERHEART.Settings.Homebrew.downtimeMoves'),
+                game.i18n.localize('DAGGERHEART.SETTINGS.Homebrew.downtimeMoves'),
                 move.name,
                 move.img,
                 move.description,
@@ -104,13 +104,13 @@ export default class DhHomebrewSettings extends HandlebarsApplicationMixin(Appli
     static async resetMoves(_, target) {
         const confirmed = await foundry.applications.api.DialogV2.confirm({
             window: {
-                title: game.i18n.format('DAGGERHEART.Settings.Homebrew.resetMovesTitle', {
+                title: game.i18n.format('DAGGERHEART.SETTINGS.Homebrew.resetMovesTitle', {
                     type: game.i18n.localize(
-                        `DAGGERHEART.Applications.Downtime.${target.dataset.type === 'shortRest' ? 'shortRest' : 'longRest'}.title`
+                        `DAGGERHEART.APPLICATIONS.Downtime.${target.dataset.type === 'shortRest' ? 'shortRest' : 'longRest'}.title`
                     )
                 })
             },
-            content: game.i18n.localize('DAGGERHEART.Settings.Homebrew.resetMovesText')
+            content: game.i18n.localize('DAGGERHEART.SETTINGS.Homebrew.resetMovesText')
         });
 
         if (!confirmed) return;

--- a/module/applications/settings/homebrewSettings.mjs
+++ b/module/applications/settings/homebrewSettings.mjs
@@ -13,7 +13,7 @@ export default class DhHomebrewSettings extends HandlebarsApplicationMixin(Appli
     }
 
     get title() {
-        return game.i18n.localize('DAGGERHEART.Settings.Menu.Homebrew.Name');
+        return game.i18n.localize('DAGGERHEART.Settings.Menu.homebrew.name');
     }
 
     static DEFAULT_OPTIONS = {
@@ -59,7 +59,7 @@ export default class DhHomebrewSettings extends HandlebarsApplicationMixin(Appli
     static async addItem(_, target) {
         await this.settings.updateSource({
             [`restMoves.${target.dataset.type}.moves.${foundry.utils.randomID()}`]: {
-                name: game.i18n.localize('DAGGERHEART.Settings.Homebrew.NewDowntimeMove'),
+                name: game.i18n.localize('DAGGERHEART.Settings.Homebrew.newDowntimeMove'),
                 img: 'icons/magic/life/cross-worn-green.webp',
                 description: '',
                 actions: []
@@ -74,7 +74,7 @@ export default class DhHomebrewSettings extends HandlebarsApplicationMixin(Appli
             new DhSettingsActionView(
                 resolve,
                 reject,
-                game.i18n.localize('DAGGERHEART.Settings.Homebrew.DowntimeMoves'),
+                game.i18n.localize('DAGGERHEART.Settings.Homebrew.downtimeMoves'),
                 move.name,
                 move.img,
                 move.description,
@@ -104,13 +104,13 @@ export default class DhHomebrewSettings extends HandlebarsApplicationMixin(Appli
     static async resetMoves(_, target) {
         const confirmed = await foundry.applications.api.DialogV2.confirm({
             window: {
-                title: game.i18n.format('DAGGERHEART.Settings.Homebrew.ResetMovesTitle', {
+                title: game.i18n.format('DAGGERHEART.Settings.Homebrew.resetMovesTitle', {
                     type: game.i18n.localize(
-                        `DAGGERHEART.Downtime.${target.dataset.type === 'shortRest' ? 'ShortRest' : 'LongRest'}.title`
+                        `DAGGERHEART.Applications.Downtime.${target.dataset.type === 'shortRest' ? 'shortRest' : 'longRest'}.title`
                     )
                 })
             },
-            content: game.i18n.localize('DAGGERHEART.Settings.Homebrew.ResetMovesText')
+            content: game.i18n.localize('DAGGERHEART.Settings.Homebrew.resetMovesText')
         });
 
         if (!confirmed) return;

--- a/module/applications/settings/rangeMeasurementSettings.mjs
+++ b/module/applications/settings/rangeMeasurementSettings.mjs
@@ -12,7 +12,7 @@ export default class DhRangeMeasurementSettings extends HandlebarsApplicationMix
     }
 
     get title() {
-        return game.i18n.localize('DAGGERHEART.Settings.Menu.automation.name');
+        return game.i18n.localize('DAGGERHEART.SETTINGS.Menu.automation.name');
     }
 
     static DEFAULT_OPTIONS = {

--- a/module/applications/settings/rangeMeasurementSettings.mjs
+++ b/module/applications/settings/rangeMeasurementSettings.mjs
@@ -12,7 +12,7 @@ export default class DhRangeMeasurementSettings extends HandlebarsApplicationMix
     }
 
     get title() {
-        return game.i18n.localize('DAGGERHEART.Settings.Menu.Automation.Name');
+        return game.i18n.localize('DAGGERHEART.Settings.Menu.automation.name');
     }
 
     static DEFAULT_OPTIONS = {

--- a/module/applications/settings/variantRuleSettings.mjs
+++ b/module/applications/settings/variantRuleSettings.mjs
@@ -12,7 +12,7 @@ export default class DHVariantRuleSettings extends HandlebarsApplicationMixin(Ap
     }
 
     get title() {
-        return game.i18n.localize('DAGGERHEART.Settings.Menu.variantRules.name');
+        return game.i18n.localize('DAGGERHEART.SETTINGS.Menu.variantRules.name');
     }
 
     static DEFAULT_OPTIONS = {

--- a/module/applications/settings/variantRuleSettings.mjs
+++ b/module/applications/settings/variantRuleSettings.mjs
@@ -12,7 +12,7 @@ export default class DHVariantRuleSettings extends HandlebarsApplicationMixin(Ap
     }
 
     get title() {
-        return game.i18n.localize('DAGGERHEART.Settings.Menu.VariantRules.name');
+        return game.i18n.localize('DAGGERHEART.Settings.Menu.variantRules.name');
     }
 
     static DEFAULT_OPTIONS = {

--- a/module/applications/sheets-configs/action-config.mjs
+++ b/module/applications/sheets-configs/action-config.mjs
@@ -10,7 +10,7 @@ export default class DHActionConfig extends DaggerheartSheet(ApplicationV2) {
     }
 
     get title() {
-        return `${game.i18n.localize('DAGGERHEART.General.Tabs.settings')}: ${this.action.name}`;
+        return `${game.i18n.localize('DAGGERHEART.GENERAL.Tabs.settings')}: ${this.action.name}`;
     }
 
     static DEFAULT_OPTIONS = {
@@ -117,7 +117,7 @@ export default class DHActionConfig extends DaggerheartSheet(ApplicationV2) {
 
         const settingsTiers = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.LevelTiers).tiers;
         context.tierOptions = [
-            { key: 1, label: game.i18n.localize('DAGGERHEART.General.Tiers.tier1') },
+            { key: 1, label: game.i18n.localize('DAGGERHEART.GENERAL.Tiers.tier1') },
             ...Object.values(settingsTiers).map(x => ({ key: x.tier, label: x.name }))
         ];
 

--- a/module/applications/sheets-configs/action-config.mjs
+++ b/module/applications/sheets-configs/action-config.mjs
@@ -10,7 +10,7 @@ export default class DHActionConfig extends DaggerheartSheet(ApplicationV2) {
     }
 
     get title() {
-        return `${game.i18n.localize('DAGGERHEART.Sheets.TABS.settings')}: ${this.action.name}`;
+        return `${game.i18n.localize('DAGGERHEART.General.Tabs.settings')}: ${this.action.name}`;
     }
 
     static DEFAULT_OPTIONS = {
@@ -117,7 +117,7 @@ export default class DHActionConfig extends DaggerheartSheet(ApplicationV2) {
 
         const settingsTiers = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.LevelTiers).tiers;
         context.tierOptions = [
-            { key: 1, label: game.i18n.localize('DAGGERHEART.Tiers.tier1') },
+            { key: 1, label: game.i18n.localize('DAGGERHEART.General.Tiers.tier1') },
             ...Object.values(settingsTiers).map(x => ({ key: x.tier, label: x.name }))
         ];
 

--- a/module/applications/sheets-configs/adversary-settings.mjs
+++ b/module/applications/sheets-configs/adversary-settings.mjs
@@ -9,7 +9,7 @@ export default class DHAdversarySettings extends HandlebarsApplicationMixin(Appl
     }
 
     get title() {
-        return `${game.i18n.localize('DAGGERHEART.General.Tabs.settings')}`;
+        return `${game.i18n.localize('DAGGERHEART.GENERAL.Tabs.settings')}`;
     }
 
     static DEFAULT_OPTIONS = {
@@ -69,7 +69,7 @@ export default class DHAdversarySettings extends HandlebarsApplicationMixin(Appl
             group: 'primary',
             id: 'details',
             icon: null,
-            label: 'DAGGERHEART.General.Tabs.details'
+            label: 'DAGGERHEART.GENERAL.Tabs.details'
         },
         attack: {
             active: false,
@@ -77,7 +77,7 @@ export default class DHAdversarySettings extends HandlebarsApplicationMixin(Appl
             group: 'primary',
             id: 'attack',
             icon: null,
-            label: 'DAGGERHEART.General.Tabs.attack'
+            label: 'DAGGERHEART.GENERAL.Tabs.attack'
         },
         experiences: {
             active: false,
@@ -85,7 +85,7 @@ export default class DHAdversarySettings extends HandlebarsApplicationMixin(Appl
             group: 'primary',
             id: 'experiences',
             icon: null,
-            label: 'DAGGERHEART.General.Tabs.experiences'
+            label: 'DAGGERHEART.GENERAL.Tabs.experiences'
         },
         features: {
             active: false,
@@ -93,7 +93,7 @@ export default class DHAdversarySettings extends HandlebarsApplicationMixin(Appl
             group: 'primary',
             id: 'features',
             icon: null,
-            label: 'DAGGERHEART.General.Tabs.features'
+            label: 'DAGGERHEART.GENERAL.Tabs.features'
         }
     };
 

--- a/module/applications/sheets-configs/adversary-settings.mjs
+++ b/module/applications/sheets-configs/adversary-settings.mjs
@@ -9,7 +9,7 @@ export default class DHAdversarySettings extends HandlebarsApplicationMixin(Appl
     }
 
     get title() {
-        return `${game.i18n.localize('DAGGERHEART.Sheets.TABS.settings')}`;
+        return `${game.i18n.localize('DAGGERHEART.General.Tabs.settings')}`;
     }
 
     static DEFAULT_OPTIONS = {
@@ -69,7 +69,7 @@ export default class DHAdversarySettings extends HandlebarsApplicationMixin(Appl
             group: 'primary',
             id: 'details',
             icon: null,
-            label: 'DAGGERHEART.General.tabs.details'
+            label: 'DAGGERHEART.General.Tabs.details'
         },
         attack: {
             active: false,
@@ -77,7 +77,7 @@ export default class DHAdversarySettings extends HandlebarsApplicationMixin(Appl
             group: 'primary',
             id: 'attack',
             icon: null,
-            label: 'DAGGERHEART.General.tabs.attack'
+            label: 'DAGGERHEART.General.Tabs.attack'
         },
         experiences: {
             active: false,
@@ -85,7 +85,7 @@ export default class DHAdversarySettings extends HandlebarsApplicationMixin(Appl
             group: 'primary',
             id: 'experiences',
             icon: null,
-            label: 'DAGGERHEART.General.tabs.experiences'
+            label: 'DAGGERHEART.General.Tabs.experiences'
         },
         features: {
             active: false,
@@ -93,7 +93,7 @@ export default class DHAdversarySettings extends HandlebarsApplicationMixin(Appl
             group: 'primary',
             id: 'features',
             icon: null,
-            label: 'DAGGERHEART.General.tabs.features'
+            label: 'DAGGERHEART.General.Tabs.features'
         }
     };
 

--- a/module/applications/sheets-configs/companion-settings.mjs
+++ b/module/applications/sheets-configs/companion-settings.mjs
@@ -11,7 +11,7 @@ export default class DHCompanionSettings extends HandlebarsApplicationMixin(Appl
     }
 
     get title() {
-        return `${game.i18n.localize('DAGGERHEART.General.Tabs.settings')}`;
+        return `${game.i18n.localize('DAGGERHEART.GENERAL.Tabs.settings')}`;
     }
 
     static DEFAULT_OPTIONS = {
@@ -59,7 +59,7 @@ export default class DHCompanionSettings extends HandlebarsApplicationMixin(Appl
             group: 'primary',
             id: 'details',
             icon: null,
-            label: 'DAGGERHEART.General.Tabs.details'
+            label: 'DAGGERHEART.GENERAL.Tabs.details'
         },
         experiences: {
             active: false,
@@ -67,7 +67,7 @@ export default class DHCompanionSettings extends HandlebarsApplicationMixin(Appl
             group: 'primary',
             id: 'experiences',
             icon: null,
-            label: 'DAGGERHEART.General.Tabs.experiences'
+            label: 'DAGGERHEART.GENERAL.Tabs.experiences'
         },
         attack: {
             active: false,
@@ -75,7 +75,7 @@ export default class DHCompanionSettings extends HandlebarsApplicationMixin(Appl
             group: 'primary',
             id: 'attack',
             icon: null,
-            label: 'DAGGERHEART.General.Tabs.attack'
+            label: 'DAGGERHEART.GENERAL.Tabs.attack'
         }
     };
 

--- a/module/applications/sheets-configs/companion-settings.mjs
+++ b/module/applications/sheets-configs/companion-settings.mjs
@@ -11,7 +11,7 @@ export default class DHCompanionSettings extends HandlebarsApplicationMixin(Appl
     }
 
     get title() {
-        return `${game.i18n.localize('DAGGERHEART.Sheets.TABS.settings')}`;
+        return `${game.i18n.localize('DAGGERHEART.General.Tabs.settings')}`;
     }
 
     static DEFAULT_OPTIONS = {
@@ -59,7 +59,7 @@ export default class DHCompanionSettings extends HandlebarsApplicationMixin(Appl
             group: 'primary',
             id: 'details',
             icon: null,
-            label: 'DAGGERHEART.General.tabs.details'
+            label: 'DAGGERHEART.General.Tabs.details'
         },
         experiences: {
             active: false,
@@ -67,7 +67,7 @@ export default class DHCompanionSettings extends HandlebarsApplicationMixin(Appl
             group: 'primary',
             id: 'experiences',
             icon: null,
-            label: 'DAGGERHEART.General.tabs.experiences'
+            label: 'DAGGERHEART.General.Tabs.experiences'
         },
         attack: {
             active: false,
@@ -75,7 +75,7 @@ export default class DHCompanionSettings extends HandlebarsApplicationMixin(Appl
             group: 'primary',
             id: 'attack',
             icon: null,
-            label: 'DAGGERHEART.General.tabs.attack'
+            label: 'DAGGERHEART.General.Tabs.attack'
         }
     };
 

--- a/module/applications/sheets-configs/environment-settings.mjs
+++ b/module/applications/sheets-configs/environment-settings.mjs
@@ -9,7 +9,7 @@ export default class DHEnvironmentSettings extends HandlebarsApplicationMixin(Ap
     }
 
     get title() {
-        return `${game.i18n.localize('DAGGERHEART.General.Tabs.settings')}`;
+        return `${game.i18n.localize('DAGGERHEART.GENERAL.Tabs.settings')}`;
     }
 
     static DEFAULT_OPTIONS = {
@@ -68,7 +68,7 @@ export default class DHEnvironmentSettings extends HandlebarsApplicationMixin(Ap
             group: 'primary',
             id: 'details',
             icon: null,
-            label: 'DAGGERHEART.General.Tabs.details'
+            label: 'DAGGERHEART.GENERAL.Tabs.details'
         },
         features: {
             active: false,
@@ -76,7 +76,7 @@ export default class DHEnvironmentSettings extends HandlebarsApplicationMixin(Ap
             group: 'primary',
             id: 'features',
             icon: null,
-            label: 'DAGGERHEART.General.Tabs.features'
+            label: 'DAGGERHEART.GENERAL.Tabs.features'
         },
         adversaries: {
             active: false,
@@ -84,7 +84,7 @@ export default class DHEnvironmentSettings extends HandlebarsApplicationMixin(Ap
             group: 'primary',
             id: 'adversaries',
             icon: null,
-            label: 'DAGGERHEART.General.Tabs.adversaries'
+            label: 'DAGGERHEART.GENERAL.Tabs.adversaries'
         }
     };
 
@@ -146,7 +146,7 @@ export default class DHEnvironmentSettings extends HandlebarsApplicationMixin(Ap
     static async #addCategory() {
         await this.actor.update({
             [`system.potentialAdversaries.${foundry.utils.randomID()}.label`]: game.i18n.localize(
-                'DAGGERHEART.Actors.Environment.newAdversary'
+                'DAGGERHEART.ACTORS.Environment.newAdversary'
             )
         });
         this.render();

--- a/module/applications/sheets-configs/environment-settings.mjs
+++ b/module/applications/sheets-configs/environment-settings.mjs
@@ -9,7 +9,7 @@ export default class DHEnvironmentSettings extends HandlebarsApplicationMixin(Ap
     }
 
     get title() {
-        return `${game.i18n.localize('DAGGERHEART.Sheets.TABS.settings')}`;
+        return `${game.i18n.localize('DAGGERHEART.General.Tabs.settings')}`;
     }
 
     static DEFAULT_OPTIONS = {
@@ -68,7 +68,7 @@ export default class DHEnvironmentSettings extends HandlebarsApplicationMixin(Ap
             group: 'primary',
             id: 'details',
             icon: null,
-            label: 'DAGGERHEART.General.tabs.details'
+            label: 'DAGGERHEART.General.Tabs.details'
         },
         features: {
             active: false,
@@ -76,7 +76,7 @@ export default class DHEnvironmentSettings extends HandlebarsApplicationMixin(Ap
             group: 'primary',
             id: 'features',
             icon: null,
-            label: 'DAGGERHEART.General.tabs.features'
+            label: 'DAGGERHEART.General.Tabs.features'
         },
         adversaries: {
             active: false,
@@ -84,7 +84,7 @@ export default class DHEnvironmentSettings extends HandlebarsApplicationMixin(Ap
             group: 'primary',
             id: 'adversaries',
             icon: null,
-            label: 'DAGGERHEART.General.tabs.adversaries'
+            label: 'DAGGERHEART.General.Tabs.adversaries'
         }
     };
 
@@ -146,7 +146,7 @@ export default class DHEnvironmentSettings extends HandlebarsApplicationMixin(Ap
     static async #addCategory() {
         await this.actor.update({
             [`system.potentialAdversaries.${foundry.utils.randomID()}.label`]: game.i18n.localize(
-                'DAGGERHEART.Sheets.Environment.newAdversary'
+                'DAGGERHEART.Actors.Environment.newAdversary'
             )
         });
         this.render();
@@ -160,7 +160,7 @@ export default class DHEnvironmentSettings extends HandlebarsApplicationMixin(Ap
     static async #viewAdversary(_, button) {
         const adversary = await foundry.utils.fromUuid(button.dataset.adversary);
         if (!adversary) {
-            ui.notifications.warn(game.i18n.localize('DAGGERHEART.UI.notifications.adversaryMissing'));
+            ui.notifications.warn(game.i18n.localize('DAGGERHEART.UI.Notifications.adversaryMissing'));
             return;
         }
 

--- a/module/applications/sheets/actors/adversary.mjs
+++ b/module/applications/sheets/actors/adversary.mjs
@@ -41,7 +41,7 @@ export default class AdversarySheet extends DaggerheartSheet(ActorSheetV2) {
             group: 'primary',
             id: 'features',
             icon: null,
-            label: 'DAGGERHEART.General.Tabs.features'
+            label: 'DAGGERHEART.GENERAL.Tabs.features'
         },
         notes: {
             active: false,
@@ -49,7 +49,7 @@ export default class AdversarySheet extends DaggerheartSheet(ActorSheetV2) {
             group: 'primary',
             id: 'notes',
             icon: null,
-            label: 'DAGGERHEART.General.Tabs.notes'
+            label: 'DAGGERHEART.GENERAL.Tabs.notes'
         },
         effects: {
             active: false,
@@ -57,7 +57,7 @@ export default class AdversarySheet extends DaggerheartSheet(ActorSheetV2) {
             group: 'primary',
             id: 'effects',
             icon: null,
-            label: 'DAGGERHEART.General.Tabs.effects'
+            label: 'DAGGERHEART.GENERAL.Tabs.effects'
         }
     };
 
@@ -118,7 +118,7 @@ export default class AdversarySheet extends DaggerheartSheet(ActorSheetV2) {
             const experience = this.document.system.experiences[button.dataset.uuid];
             const cls = getDocumentClass('ChatMessage');
             const systemData = {
-                name: game.i18n.localize('DAGGERHEART.General.Experience.single'),
+                name: game.i18n.localize('DAGGERHEART.GENERAL.Experience.single'),
                 description: `${experience.name} ${
                     experience.modifier < 0 ? experience.modifier : `+${experience.modifier}`
                 }`

--- a/module/applications/sheets/actors/adversary.mjs
+++ b/module/applications/sheets/actors/adversary.mjs
@@ -41,7 +41,7 @@ export default class AdversarySheet extends DaggerheartSheet(ActorSheetV2) {
             group: 'primary',
             id: 'features',
             icon: null,
-            label: 'DAGGERHEART.General.tabs.features'
+            label: 'DAGGERHEART.General.Tabs.features'
         },
         notes: {
             active: false,
@@ -49,7 +49,7 @@ export default class AdversarySheet extends DaggerheartSheet(ActorSheetV2) {
             group: 'primary',
             id: 'notes',
             icon: null,
-            label: 'DAGGERHEART.Sheets.Adversary.Tabs.notes'
+            label: 'DAGGERHEART.General.Tabs.notes'
         },
         effects: {
             active: false,
@@ -57,7 +57,7 @@ export default class AdversarySheet extends DaggerheartSheet(ActorSheetV2) {
             group: 'primary',
             id: 'effects',
             icon: null,
-            label: 'DAGGERHEART.Sheets.Adversary.Tabs.effects'
+            label: 'DAGGERHEART.General.Tabs.effects'
         }
     };
 
@@ -118,7 +118,7 @@ export default class AdversarySheet extends DaggerheartSheet(ActorSheetV2) {
             const experience = this.document.system.experiences[button.dataset.uuid];
             const cls = getDocumentClass('ChatMessage');
             const systemData = {
-                name: game.i18n.localize('DAGGERHEART.General.Experience.Single'),
+                name: game.i18n.localize('DAGGERHEART.General.Experience.single'),
                 description: `${experience.name} ${
                     experience.modifier < 0 ? experience.modifier : `+${experience.modifier}`
                 }`

--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -38,7 +38,6 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
             takeShortRest: this.takeShortRest,
             takeLongRest: this.takeLongRest,
             deleteItem: this.deleteItem,
-            addScar: this.addScar,
             deleteScar: this.deleteScar,
             makeDeathMove: this.makeDeathMove,
             itemQuantityDecrease: (_, button) => this.setItemQuantity(button, -1),
@@ -100,7 +99,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
             group: 'primary',
             id: 'features',
             icon: null,
-            label: 'DAGGERHEART.Sheets.PC.Tabs.Features'
+            label: 'DAGGERHEART.General.Tabs.features'
         },
         loadout: {
             active: false,
@@ -108,7 +107,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
             group: 'primary',
             id: 'loadout',
             icon: null,
-            label: 'DAGGERHEART.Sheets.PC.Tabs.Loadout'
+            label: 'DAGGERHEART.General.Tabs.loadout'
         },
         inventory: {
             active: false,
@@ -116,7 +115,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
             group: 'primary',
             id: 'inventory',
             icon: null,
-            label: 'DAGGERHEART.Sheets.PC.Tabs.Inventory'
+            label: 'DAGGERHEART.General.Tabs.inventory'
         },
         biography: {
             active: false,
@@ -124,7 +123,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
             group: 'primary',
             id: 'biography',
             icon: null,
-            label: 'DAGGERHEART.Sheets.PC.Tabs.biography'
+            label: 'DAGGERHEART.General.Tabs.biography'
         },
         effects: {
             active: false,
@@ -132,7 +131,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
             group: 'primary',
             id: 'effects',
             icon: null,
-            label: 'DAGGERHEART.Sheets.PC.Tabs.effects'
+            label: 'DAGGERHEART.General.Tabs.effects'
         }
     };
 
@@ -151,7 +150,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                 group: 'primary',
                 id: 'features',
                 icon: null,
-                label: game.i18n.localize('DAGGERHEART.Sheets.PC.Tabs.Features')
+                label: game.i18n.localize('DAGGERHEART.General.Tabs.features')
             },
             loadout: {
                 active: false,
@@ -159,7 +158,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                 group: 'primary',
                 id: 'loadout',
                 icon: null,
-                label: game.i18n.localize('DAGGERHEART.Sheets.PC.Tabs.Loadout')
+                label: game.i18n.localize('DAGGERHEART.General.Tabs.loadout')
             },
             inventory: {
                 active: false,
@@ -167,7 +166,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                 group: 'primary',
                 id: 'inventory',
                 icon: null,
-                label: game.i18n.localize('DAGGERHEART.Sheets.PC.Tabs.Inventory')
+                label: game.i18n.localize('DAGGERHEART.General.Tabs.inventory')
             },
             story: {
                 active: false,
@@ -175,7 +174,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                 group: 'primary',
                 id: 'story',
                 icon: null,
-                label: game.i18n.localize('DAGGERHEART.Sheets.PC.Tabs.Story')
+                label: game.i18n.localize('DAGGERHEART.General.Tabs.story')
             }
         };
         const secondaryTabs = {
@@ -185,7 +184,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                 group: 'secondary',
                 id: 'foundation',
                 icon: null,
-                label: game.i18n.localize('DAGGERHEART.Sheets.PC.Tabs.Foundation')
+                label: game.i18n.localize('DAGGERHEART.General.Tabs.foundation')
             },
             loadout: {
                 active: false,
@@ -193,7 +192,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                 group: 'secondary',
                 id: 'loadout',
                 icon: null,
-                label: game.i18n.localize('DAGGERHEART.Sheets.PC.Tabs.Loadout')
+                label: game.i18n.localize('DAGGERHEART.General.Tabs.loadout')
             },
             vault: {
                 active: false,
@@ -201,7 +200,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                 group: 'secondary',
                 id: 'vault',
                 icon: null,
-                label: game.i18n.localize('DAGGERHEART.Sheets.PC.Tabs.Vault')
+                label: game.i18n.localize('DAGGERHEART.General.Tabs.vault')
             }
         };
 
@@ -231,7 +230,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
     _createContextMenues() {
         const allOptions = {
             useItem: {
-                name: 'DAGGERHEART.Sheets.PC.ContextMenu.UseItem',
+                name: 'DAGGERHEART.General.use',
                 icon: '<i class="fa-solid fa-burst"></i>',
                 condition: el => {
                     const item = this.getItem(el);
@@ -240,7 +239,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                 callback: (button, event) => this.constructor.useItem.bind(this)(event, button)
             },
             equip: {
-                name: 'DAGGERHEART.Sheets.PC.ContextMenu.Equip',
+                name: 'DAGGERHEART.Actors.Character.contextMenu.equip',
                 icon: '<i class="fa-solid fa-hands"></i>',
                 condition: el => {
                     const item = this.getItem(el);
@@ -249,7 +248,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                 callback: this.constructor.toggleEquipItem.bind(this)
             },
             unequip: {
-                name: 'DAGGERHEART.Sheets.PC.ContextMenu.Unequip',
+                name: 'DAGGERHEART.Actors.Character.contextMenu.unequip',
                 icon: '<i class="fa-solid fa-hands"></i>',
                 condition: el => {
                     const item = this.getItem(el);
@@ -258,7 +257,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                 callback: this.constructor.toggleEquipItem.bind(this)
             },
             sendToLoadout: {
-                name: 'DAGGERHEART.Sheets.PC.ContextMenu.ToLoadout',
+                name: 'DAGGERHEART.Actors.Character.contextMenu.toLoadout',
                 icon: '<i class="fa-solid fa-arrow-up"></i>',
                 condition: el => {
                     const item = this.getItem(el);
@@ -267,7 +266,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                 callback: this.constructor.toggleVault.bind(this)
             },
             sendToVault: {
-                name: 'DAGGERHEART.Sheets.PC.ContextMenu.ToVault',
+                name: 'DAGGERHEART.Actors.Character.contextMenu.toVault',
                 icon: '<i class="fa-solid fa-arrow-down"></i>',
                 condition: el => {
                     const item = this.getItem(el);
@@ -276,17 +275,17 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                 callback: this.constructor.toggleVault.bind(this)
             },
             sendToChat: {
-                name: 'DAGGERHEART.Sheets.PC.ContextMenu.SendToChat',
+                name: 'DAGGERHEART.Actors.Character.contextMenu.sendToChat',
                 icon: '<i class="fa-regular fa-message"></i>',
                 callback: this.constructor.toChat.bind(this)
             },
             edit: {
-                name: 'DAGGERHEART.Sheets.PC.ContextMenu.Edit',
+                name: 'CONTROLS.CommonEdit',
                 icon: '<i class="fa-solid fa-pen-to-square"></i>',
                 callback: this.constructor.viewObject.bind(this)
             },
             delete: {
-                name: 'DAGGERHEART.Sheets.PC.ContextMenu.Delete',
+                name: 'CONTROLS.CommonDelete',
                 icon: '<i class="fa-solid fa-trash"></i>',
                 callback: this.constructor.deleteItem.bind(this)
             }
@@ -350,11 +349,11 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
 
         context.inventory = {
             currency: {
-                title: game.i18n.localize('DAGGERHEART.Sheets.PC.Gold.Title'),
-                coins: game.i18n.localize('DAGGERHEART.Sheets.PC.Gold.Coins'),
-                handfulls: game.i18n.localize('DAGGERHEART.Sheets.PC.Gold.Handfulls'),
-                bags: game.i18n.localize('DAGGERHEART.Sheets.PC.Gold.Bags'),
-                chests: game.i18n.localize('DAGGERHEART.Sheets.PC.Gold.Chests')
+                title: game.i18n.localize('DAGGERHEART.Config.Gold.title'),
+                coins: game.i18n.localize('DAGGERHEART.Config.Gold.coins'),
+                handfulls: game.i18n.localize('DAGGERHEART.Config.Gold.handfulls'),
+                bags: game.i18n.localize('DAGGERHEART.Config.Gold.bags'),
+                chests: game.i18n.localize('DAGGERHEART.Config.Gold.chests')
             }
         };
 
@@ -495,7 +494,9 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
         const config = {
             event: event,
             title: `${game.i18n.localize('DAGGERHEART.General.dualityRoll')}: ${this.actor.name}`,
-            headerTitle: game.i18n.format('DAGGERHEART.Chat.DualityRoll.AbilityCheckTitle', { ability: abilityLabel }),
+            headerTitle: game.i18n.format('DAGGERHEART.UI.Chat.dualityRoll.abilitychecktitle', {
+                ability: abilityLabel
+            }),
             roll: {
                 trait: button.dataset.attribute
             }
@@ -604,7 +605,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
         const abilityLabel = game.i18n.localize(abilities[button.dataset.attribute].label);
         const config = {
             event: event,
-            title: game.i18n.format('DAGGERHEART.Chat.DualityRoll.AbilityCheckTitle', { ability: abilityLabel }),
+            title: game.i18n.format('DAGGERHEART.UI.Chat.dualityRoll.abilitychecktitle', { ability: abilityLabel }),
             roll: {
                 trait: button.dataset.attribute
             }
@@ -681,7 +682,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
 
     openLevelUp() {
         if (!this.document.system.class.value || !this.document.system.class.subclass) {
-            ui.notifications.error(game.i18n.localize('DAGGERHEART.Sheets.PC.Errors.missingClassOrSubclass'));
+            ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.missingClassOrSubclass'));
             return;
         }
 
@@ -694,7 +695,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
 
         const cls = getDocumentClass('ChatMessage');
         const systemData = {
-            title: `${game.i18n.localize('DAGGERHEART.Chat.DomainCard.Title')} - ${capitalize(button.dataset.domain)}`,
+            title: `${game.i18n.localize('DAGGERHEART.UI.Chat.domainCard.title')} - ${capitalize(button.dataset.domain)}`,
             origin: this.document.id,
             img: card.img,
             name: card.name,
@@ -773,17 +774,6 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
         await this.minimize();
     }
 
-    static async addScar() {
-        if (this.document.system.story.scars.length === 5) return;
-
-        await this.document.update({
-            'system.story.scars': [
-                ...this.document.system.story.scars,
-                { name: game.i18n.localize('DAGGERHEART.Sheets.PC.NewScar'), description: '' }
-            ]
-        });
-    }
-
     static async deleteScar(event, button) {
         event.stopPropagation();
         await this.document.update({
@@ -823,7 +813,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
 
         const cls = getDocumentClass('ChatMessage');
         const systemData = {
-            title: game.i18n.localize('DAGGERHEART.Chat.FeatureTitle'),
+            title: game.i18n.localize('DAGGERHEART.UI.Chat.featureTitle'),
             origin: this.document.id,
             img: item.img,
             name: item.name,
@@ -848,7 +838,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
             const experience = this.document.system.experiences[button.dataset.uuid];
             const cls = getDocumentClass('ChatMessage');
             const systemData = {
-                name: game.i18n.localize('DAGGERHEART.General.Experience.Single'),
+                name: game.i18n.localize('DAGGERHEART.General.Experience.single'),
                 description: `${experience.name} ${experience.total < 0 ? experience.total : `+${experience.total}`}`
             };
             const msg = new cls({
@@ -876,12 +866,12 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                 : this.document.system.class.subclass;
         const ability = item.system[`${button.dataset.key}Feature`];
         const title = `${item.name} - ${game.i18n.localize(
-            `DAGGERHEART.Sheets.PC.DomainCard.${capitalize(button.dataset.key)}Title`
+            `DAGGERHEART.Items.DomainCard.${capitalize(button.dataset.key)}Title`
         )}`;
 
         const cls = getDocumentClass('ChatMessage');
         const systemData = {
-            title: game.i18n.localize('DAGGERHEART.Chat.FoundationCard.SubclassFeatureTitle'),
+            title: game.i18n.localize('DAGGERHEART.UI.Chat.foundationCard.subclassFeatureTitle'),
             origin: this.document.id,
             name: title,
             img: item.img,
@@ -905,7 +895,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
 
         const cls = getDocumentClass('ChatMessage');
         const systemData = {
-            title: game.i18n.localize('DAGGERHEART.Chat.FoundationCard.SubclassFeatureTitle'),
+            title: game.i18n.localize('DAGGERHEART.UI.Chat.foundationCard.subclassFeatureTitle'),
             origin: this.document.id,
             name: item.name,
             img: item.img,

--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -99,7 +99,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
             group: 'primary',
             id: 'features',
             icon: null,
-            label: 'DAGGERHEART.General.Tabs.features'
+            label: 'DAGGERHEART.GENERAL.Tabs.features'
         },
         loadout: {
             active: false,
@@ -107,7 +107,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
             group: 'primary',
             id: 'loadout',
             icon: null,
-            label: 'DAGGERHEART.General.Tabs.loadout'
+            label: 'DAGGERHEART.GENERAL.Tabs.loadout'
         },
         inventory: {
             active: false,
@@ -115,7 +115,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
             group: 'primary',
             id: 'inventory',
             icon: null,
-            label: 'DAGGERHEART.General.Tabs.inventory'
+            label: 'DAGGERHEART.GENERAL.Tabs.inventory'
         },
         biography: {
             active: false,
@@ -123,7 +123,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
             group: 'primary',
             id: 'biography',
             icon: null,
-            label: 'DAGGERHEART.General.Tabs.biography'
+            label: 'DAGGERHEART.GENERAL.Tabs.biography'
         },
         effects: {
             active: false,
@@ -131,7 +131,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
             group: 'primary',
             id: 'effects',
             icon: null,
-            label: 'DAGGERHEART.General.Tabs.effects'
+            label: 'DAGGERHEART.GENERAL.Tabs.effects'
         }
     };
 
@@ -150,7 +150,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                 group: 'primary',
                 id: 'features',
                 icon: null,
-                label: game.i18n.localize('DAGGERHEART.General.Tabs.features')
+                label: game.i18n.localize('DAGGERHEART.GENERAL.Tabs.features')
             },
             loadout: {
                 active: false,
@@ -158,7 +158,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                 group: 'primary',
                 id: 'loadout',
                 icon: null,
-                label: game.i18n.localize('DAGGERHEART.General.Tabs.loadout')
+                label: game.i18n.localize('DAGGERHEART.GENERAL.Tabs.loadout')
             },
             inventory: {
                 active: false,
@@ -166,7 +166,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                 group: 'primary',
                 id: 'inventory',
                 icon: null,
-                label: game.i18n.localize('DAGGERHEART.General.Tabs.inventory')
+                label: game.i18n.localize('DAGGERHEART.GENERAL.Tabs.inventory')
             },
             story: {
                 active: false,
@@ -174,7 +174,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                 group: 'primary',
                 id: 'story',
                 icon: null,
-                label: game.i18n.localize('DAGGERHEART.General.Tabs.story')
+                label: game.i18n.localize('DAGGERHEART.GENERAL.Tabs.story')
             }
         };
         const secondaryTabs = {
@@ -184,7 +184,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                 group: 'secondary',
                 id: 'foundation',
                 icon: null,
-                label: game.i18n.localize('DAGGERHEART.General.Tabs.foundation')
+                label: game.i18n.localize('DAGGERHEART.GENERAL.Tabs.foundation')
             },
             loadout: {
                 active: false,
@@ -192,7 +192,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                 group: 'secondary',
                 id: 'loadout',
                 icon: null,
-                label: game.i18n.localize('DAGGERHEART.General.Tabs.loadout')
+                label: game.i18n.localize('DAGGERHEART.GENERAL.Tabs.loadout')
             },
             vault: {
                 active: false,
@@ -200,7 +200,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                 group: 'secondary',
                 id: 'vault',
                 icon: null,
-                label: game.i18n.localize('DAGGERHEART.General.Tabs.vault')
+                label: game.i18n.localize('DAGGERHEART.GENERAL.Tabs.vault')
             }
         };
 
@@ -230,7 +230,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
     _createContextMenues() {
         const allOptions = {
             useItem: {
-                name: 'DAGGERHEART.General.use',
+                name: 'DAGGERHEART.GENERAL.use',
                 icon: '<i class="fa-solid fa-burst"></i>',
                 condition: el => {
                     const item = this.getItem(el);
@@ -239,7 +239,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                 callback: (button, event) => this.constructor.useItem.bind(this)(event, button)
             },
             equip: {
-                name: 'DAGGERHEART.Actors.Character.contextMenu.equip',
+                name: 'DAGGERHEART.ACTORS.Character.contextMenu.equip',
                 icon: '<i class="fa-solid fa-hands"></i>',
                 condition: el => {
                     const item = this.getItem(el);
@@ -248,7 +248,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                 callback: this.constructor.toggleEquipItem.bind(this)
             },
             unequip: {
-                name: 'DAGGERHEART.Actors.Character.contextMenu.unequip',
+                name: 'DAGGERHEART.ACTORS.Character.contextMenu.unequip',
                 icon: '<i class="fa-solid fa-hands"></i>',
                 condition: el => {
                     const item = this.getItem(el);
@@ -257,7 +257,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                 callback: this.constructor.toggleEquipItem.bind(this)
             },
             sendToLoadout: {
-                name: 'DAGGERHEART.Actors.Character.contextMenu.toLoadout',
+                name: 'DAGGERHEART.ACTORS.Character.contextMenu.toLoadout',
                 icon: '<i class="fa-solid fa-arrow-up"></i>',
                 condition: el => {
                     const item = this.getItem(el);
@@ -266,7 +266,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                 callback: this.constructor.toggleVault.bind(this)
             },
             sendToVault: {
-                name: 'DAGGERHEART.Actors.Character.contextMenu.toVault',
+                name: 'DAGGERHEART.ACTORS.Character.contextMenu.toVault',
                 icon: '<i class="fa-solid fa-arrow-down"></i>',
                 condition: el => {
                     const item = this.getItem(el);
@@ -275,7 +275,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                 callback: this.constructor.toggleVault.bind(this)
             },
             sendToChat: {
-                name: 'DAGGERHEART.Actors.Character.contextMenu.sendToChat',
+                name: 'DAGGERHEART.ACTORS.Character.contextMenu.sendToChat',
                 icon: '<i class="fa-regular fa-message"></i>',
                 callback: this.constructor.toChat.bind(this)
             },
@@ -349,11 +349,11 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
 
         context.inventory = {
             currency: {
-                title: game.i18n.localize('DAGGERHEART.Config.Gold.title'),
-                coins: game.i18n.localize('DAGGERHEART.Config.Gold.coins'),
-                handfulls: game.i18n.localize('DAGGERHEART.Config.Gold.handfulls'),
-                bags: game.i18n.localize('DAGGERHEART.Config.Gold.bags'),
-                chests: game.i18n.localize('DAGGERHEART.Config.Gold.chests')
+                title: game.i18n.localize('DAGGERHEART.CONFIG.Gold.title'),
+                coins: game.i18n.localize('DAGGERHEART.CONFIG.Gold.coins'),
+                handfulls: game.i18n.localize('DAGGERHEART.CONFIG.Gold.handfulls'),
+                bags: game.i18n.localize('DAGGERHEART.CONFIG.Gold.bags'),
+                chests: game.i18n.localize('DAGGERHEART.CONFIG.Gold.chests')
             }
         };
 
@@ -493,7 +493,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
         const abilityLabel = game.i18n.localize(abilities[button.dataset.attribute].label);
         const config = {
             event: event,
-            title: `${game.i18n.localize('DAGGERHEART.General.dualityRoll')}: ${this.actor.name}`,
+            title: `${game.i18n.localize('DAGGERHEART.GENERAL.dualityRoll')}: ${this.actor.name}`,
             headerTitle: game.i18n.format('DAGGERHEART.UI.Chat.dualityRoll.abilitychecktitle', {
                 ability: abilityLabel
             }),
@@ -838,7 +838,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
             const experience = this.document.system.experiences[button.dataset.uuid];
             const cls = getDocumentClass('ChatMessage');
             const systemData = {
-                name: game.i18n.localize('DAGGERHEART.General.Experience.single'),
+                name: game.i18n.localize('DAGGERHEART.GENERAL.Experience.single'),
                 description: `${experience.name} ${experience.total < 0 ? experience.total : `+${experience.total}`}`
             };
             const msg = new cls({
@@ -866,7 +866,7 @@ export default class CharacterSheet extends DaggerheartSheet(ActorSheetV2) {
                 : this.document.system.class.subclass;
         const ability = item.system[`${button.dataset.key}Feature`];
         const title = `${item.name} - ${game.i18n.localize(
-            `DAGGERHEART.Items.DomainCard.${capitalize(button.dataset.key)}Title`
+            `DAGGERHEART.ITEMS.DomainCard.${capitalize(button.dataset.key)}Title`
         )}`;
 
         const cls = getDocumentClass('ChatMessage');

--- a/module/applications/sheets/actors/companion.mjs
+++ b/module/applications/sheets/actors/companion.mjs
@@ -33,7 +33,7 @@ export default class DhCompanionSheet extends DaggerheartSheet(ActorSheetV2) {
             group: 'primary',
             id: 'details',
             icon: null,
-            label: 'DAGGERHEART.General.Tabs.details'
+            label: 'DAGGERHEART.GENERAL.Tabs.details'
         },
         effects: {
             active: false,
@@ -41,7 +41,7 @@ export default class DhCompanionSheet extends DaggerheartSheet(ActorSheetV2) {
             group: 'primary',
             id: 'effects',
             icon: null,
-            label: 'DAGGERHEART.General.Tabs.effects'
+            label: 'DAGGERHEART.GENERAL.Tabs.effects'
         }
     };
 
@@ -82,7 +82,7 @@ export default class DhCompanionSheet extends DaggerheartSheet(ActorSheetV2) {
             const experience = this.document.system.experiences[button.dataset.uuid];
             const cls = getDocumentClass('ChatMessage');
             const systemData = {
-                name: game.i18n.localize('DAGGERHEART.General.Experience.single'),
+                name: game.i18n.localize('DAGGERHEART.GENERAL.Experience.single'),
                 description: `${experience.name} ${experience.total < 0 ? experience.total : `+${experience.total}`}`
             };
             const msg = new cls({

--- a/module/applications/sheets/actors/companion.mjs
+++ b/module/applications/sheets/actors/companion.mjs
@@ -33,7 +33,7 @@ export default class DhCompanionSheet extends DaggerheartSheet(ActorSheetV2) {
             group: 'primary',
             id: 'details',
             icon: null,
-            label: 'DAGGERHEART.General.tabs.details'
+            label: 'DAGGERHEART.General.Tabs.details'
         },
         effects: {
             active: false,
@@ -41,7 +41,7 @@ export default class DhCompanionSheet extends DaggerheartSheet(ActorSheetV2) {
             group: 'primary',
             id: 'effects',
             icon: null,
-            label: 'DAGGERHEART.Sheets.PC.Tabs.effects'
+            label: 'DAGGERHEART.General.Tabs.effects'
         }
     };
 
@@ -82,7 +82,7 @@ export default class DhCompanionSheet extends DaggerheartSheet(ActorSheetV2) {
             const experience = this.document.system.experiences[button.dataset.uuid];
             const cls = getDocumentClass('ChatMessage');
             const systemData = {
-                name: game.i18n.localize('DAGGERHEART.General.Experience.Single'),
+                name: game.i18n.localize('DAGGERHEART.General.Experience.single'),
                 description: `${experience.name} ${experience.total < 0 ? experience.total : `+${experience.total}`}`
             };
             const msg = new cls({

--- a/module/applications/sheets/actors/environment.mjs
+++ b/module/applications/sheets/actors/environment.mjs
@@ -40,7 +40,7 @@ export default class DhpEnvironment extends DaggerheartSheet(ActorSheetV2) {
             group: 'primary',
             id: 'features',
             icon: null,
-            label: 'DAGGERHEART.General.tabs.features'
+            label: 'DAGGERHEART.General.Tabs.features'
         },
         potentialAdversaries: {
             active: false,
@@ -48,7 +48,7 @@ export default class DhpEnvironment extends DaggerheartSheet(ActorSheetV2) {
             group: 'primary',
             id: 'potentialAdversaries',
             icon: null,
-            label: 'DAGGERHEART.General.tabs.potentialAdversaries'
+            label: 'DAGGERHEART.General.Tabs.potentialAdversaries'
         },
         notes: {
             active: false,
@@ -56,7 +56,7 @@ export default class DhpEnvironment extends DaggerheartSheet(ActorSheetV2) {
             group: 'primary',
             id: 'notes',
             icon: null,
-            label: 'DAGGERHEART.Sheets.Adversary.Tabs.notes'
+            label: 'DAGGERHEART.General.Tabs.notes'
         }
     };
 
@@ -91,7 +91,7 @@ export default class DhpEnvironment extends DaggerheartSheet(ActorSheetV2) {
     static async addAdversary() {
         await this.document.update({
             [`system.potentialAdversaries.${foundry.utils.randomID()}.label`]: game.i18n.localize(
-                'DAGGERHEART.Sheets.Environment.newAdversary'
+                'DAGGERHEART.Actors.Environment.newAdversary'
             )
         });
         this.render();
@@ -106,7 +106,7 @@ export default class DhpEnvironment extends DaggerheartSheet(ActorSheetV2) {
         const target = button.closest('[data-item-uuid]');
         const adversary = await foundry.utils.fromUuid(target.dataset.itemUuid);
         if (!adversary) {
-            ui.notifications.warn(game.i18n.localize('DAGGERHEART.UI.notifications.adversaryMissing'));
+            ui.notifications.warn(game.i18n.localize('DAGGERHEART.UI.Notifications.adversaryMissing'));
             return;
         }
 

--- a/module/applications/sheets/actors/environment.mjs
+++ b/module/applications/sheets/actors/environment.mjs
@@ -40,7 +40,7 @@ export default class DhpEnvironment extends DaggerheartSheet(ActorSheetV2) {
             group: 'primary',
             id: 'features',
             icon: null,
-            label: 'DAGGERHEART.General.Tabs.features'
+            label: 'DAGGERHEART.GENERAL.Tabs.features'
         },
         potentialAdversaries: {
             active: false,
@@ -48,7 +48,7 @@ export default class DhpEnvironment extends DaggerheartSheet(ActorSheetV2) {
             group: 'primary',
             id: 'potentialAdversaries',
             icon: null,
-            label: 'DAGGERHEART.General.Tabs.potentialAdversaries'
+            label: 'DAGGERHEART.GENERAL.Tabs.potentialAdversaries'
         },
         notes: {
             active: false,
@@ -56,7 +56,7 @@ export default class DhpEnvironment extends DaggerheartSheet(ActorSheetV2) {
             group: 'primary',
             id: 'notes',
             icon: null,
-            label: 'DAGGERHEART.General.Tabs.notes'
+            label: 'DAGGERHEART.GENERAL.Tabs.notes'
         }
     };
 
@@ -91,7 +91,7 @@ export default class DhpEnvironment extends DaggerheartSheet(ActorSheetV2) {
     static async addAdversary() {
         await this.document.update({
             [`system.potentialAdversaries.${foundry.utils.randomID()}.label`]: game.i18n.localize(
-                'DAGGERHEART.Actors.Environment.newAdversary'
+                'DAGGERHEART.ACTORS.Environment.newAdversary'
             )
         });
         this.render();

--- a/module/applications/sheets/api/base-item.mjs
+++ b/module/applications/sheets/api/base-item.mjs
@@ -37,7 +37,7 @@ export default class DHBaseItemSheet extends DHApplicationMixin(ItemSheetV2) {
         primary: {
             tabs: [{ id: 'description' }, { id: 'actions' }, { id: 'settings' }],
             initial: 'description',
-            labelPrefix: 'DAGGERHEART.Sheets.TABS'
+            labelPrefix: 'DAGGERHEART.General.Tabs'
         }
     };
 

--- a/module/applications/sheets/api/base-item.mjs
+++ b/module/applications/sheets/api/base-item.mjs
@@ -37,7 +37,7 @@ export default class DHBaseItemSheet extends DHApplicationMixin(ItemSheetV2) {
         primary: {
             tabs: [{ id: 'description' }, { id: 'actions' }, { id: 'settings' }],
             initial: 'description',
-            labelPrefix: 'DAGGERHEART.General.Tabs'
+            labelPrefix: 'DAGGERHEART.GENERAL.Tabs'
         }
     };
 

--- a/module/applications/sheets/api/heritage-sheet.mjs
+++ b/module/applications/sheets/api/heritage-sheet.mjs
@@ -25,7 +25,7 @@ export default class DHHeritageSheet extends DHBaseItemSheet {
         primary: {
             tabs: [{ id: 'description' }, { id: 'features' }, { id: 'effects' }],
             initial: 'description',
-            labelPrefix: 'DAGGERHEART.Sheets.TABS'
+            labelPrefix: 'DAGGERHEART.General.Tabs'
         }
     };
 }

--- a/module/applications/sheets/api/heritage-sheet.mjs
+++ b/module/applications/sheets/api/heritage-sheet.mjs
@@ -25,7 +25,7 @@ export default class DHHeritageSheet extends DHBaseItemSheet {
         primary: {
             tabs: [{ id: 'description' }, { id: 'features' }, { id: 'effects' }],
             initial: 'description',
-            labelPrefix: 'DAGGERHEART.General.Tabs'
+            labelPrefix: 'DAGGERHEART.GENERAL.Tabs'
         }
     };
 }

--- a/module/applications/sheets/items/beastform.mjs
+++ b/module/applications/sheets/items/beastform.mjs
@@ -25,7 +25,7 @@ export default class BeastformSheet extends DHBaseItemSheet {
         primary: {
             tabs: [{ id: 'settings' }, { id: 'features' }, { id: 'effects' }],
             initial: 'settings',
-            labelPrefix: 'DAGGERHEART.Sheets.TABS'
+            labelPrefix: 'DAGGERHEART.General.Tabs'
         }
     };
 

--- a/module/applications/sheets/items/beastform.mjs
+++ b/module/applications/sheets/items/beastform.mjs
@@ -25,7 +25,7 @@ export default class BeastformSheet extends DHBaseItemSheet {
         primary: {
             tabs: [{ id: 'settings' }, { id: 'features' }, { id: 'effects' }],
             initial: 'settings',
-            labelPrefix: 'DAGGERHEART.General.Tabs'
+            labelPrefix: 'DAGGERHEART.GENERAL.Tabs'
         }
     };
 

--- a/module/applications/sheets/items/class.mjs
+++ b/module/applications/sheets/items/class.mjs
@@ -54,7 +54,7 @@ export default class ClassSheet extends DHBaseItemSheet {
         primary: {
             tabs: [{ id: 'description' }, { id: 'features' }, { id: 'settings' }],
             initial: 'description',
-            labelPrefix: 'DAGGERHEART.Sheets.TABS'
+            labelPrefix: 'DAGGERHEART.General.Tabs'
         }
     };
 

--- a/module/applications/sheets/items/class.mjs
+++ b/module/applications/sheets/items/class.mjs
@@ -54,7 +54,7 @@ export default class ClassSheet extends DHBaseItemSheet {
         primary: {
             tabs: [{ id: 'description' }, { id: 'features' }, { id: 'settings' }],
             initial: 'description',
-            labelPrefix: 'DAGGERHEART.General.Tabs'
+            labelPrefix: 'DAGGERHEART.GENERAL.Tabs'
         }
     };
 

--- a/module/applications/sheets/items/domainCard.mjs
+++ b/module/applications/sheets/items/domainCard.mjs
@@ -12,7 +12,7 @@ export default class DomainCardSheet extends DHBaseItemSheet {
         primary: {
             tabs: [{ id: 'description' }, { id: 'actions' }, { id: 'settings' }, { id: 'effects' }],
             initial: 'description',
-            labelPrefix: 'DAGGERHEART.Sheets.TABS'
+            labelPrefix: 'DAGGERHEART.General.Tabs'
         }
     };
 

--- a/module/applications/sheets/items/domainCard.mjs
+++ b/module/applications/sheets/items/domainCard.mjs
@@ -12,7 +12,7 @@ export default class DomainCardSheet extends DHBaseItemSheet {
         primary: {
             tabs: [{ id: 'description' }, { id: 'actions' }, { id: 'settings' }, { id: 'effects' }],
             initial: 'description',
-            labelPrefix: 'DAGGERHEART.General.Tabs'
+            labelPrefix: 'DAGGERHEART.GENERAL.Tabs'
         }
     };
 

--- a/module/applications/sheets/items/feature.mjs
+++ b/module/applications/sheets/items/feature.mjs
@@ -36,7 +36,7 @@ export default class FeatureSheet extends DHBaseItemSheet {
         primary: {
             tabs: [{ id: 'description' }, { id: 'actions' }, { id: 'effects' }],
             initial: 'description',
-            labelPrefix: 'DAGGERHEART.Sheets.TABS'
+            labelPrefix: 'DAGGERHEART.General.Tabs'
         }
     };
 

--- a/module/applications/sheets/items/feature.mjs
+++ b/module/applications/sheets/items/feature.mjs
@@ -36,7 +36,7 @@ export default class FeatureSheet extends DHBaseItemSheet {
         primary: {
             tabs: [{ id: 'description' }, { id: 'actions' }, { id: 'effects' }],
             initial: 'description',
-            labelPrefix: 'DAGGERHEART.General.Tabs'
+            labelPrefix: 'DAGGERHEART.GENERAL.Tabs'
         }
     };
 

--- a/module/applications/sheets/items/subclass.mjs
+++ b/module/applications/sheets/items/subclass.mjs
@@ -33,7 +33,7 @@ export default class SubclassSheet extends DHBaseItemSheet {
         primary: {
             tabs: [{ id: 'description' }, { id: 'features' }, { id: 'settings' }],
             initial: 'description',
-            labelPrefix: 'DAGGERHEART.General.Tabs'
+            labelPrefix: 'DAGGERHEART.GENERAL.Tabs'
         }
     };
 

--- a/module/applications/sheets/items/subclass.mjs
+++ b/module/applications/sheets/items/subclass.mjs
@@ -33,7 +33,7 @@ export default class SubclassSheet extends DHBaseItemSheet {
         primary: {
             tabs: [{ id: 'description' }, { id: 'features' }, { id: 'settings' }],
             initial: 'description',
-            labelPrefix: 'DAGGERHEART.Sheets.TABS'
+            labelPrefix: 'DAGGERHEART.General.Tabs'
         }
     };
 

--- a/module/applications/ui/chatLog.mjs
+++ b/module/applications/ui/chatLog.mjs
@@ -137,7 +137,7 @@ export default class DhpChatLog extends foundry.applications.sidebar.tabs.ChatLo
             if (!action || !action?.applyEffects) return;
             const { isHit, targets } = this.getTargetList(event, message);
             if (targets.length === 0)
-                ui.notifications.info(game.i18n.localize('DAGGERHEART.Notification.Info.NoTargetsSelected'));
+                ui.notifications.info(game.i18n.localize('DAGGERHEART.UI.Notifications.noTargetsSelected'));
             await action.applyEffects(event, message, targets);
         }
     };
@@ -148,7 +148,7 @@ export default class DhpChatLog extends foundry.applications.sidebar.tabs.ChatLo
             msg = ui.chat.collection.get(message._id);
         if (msg.system.targetSelection === targetSelection) return;
         if (targetSelection !== true && !Array.from(game.user.targets).length)
-            return ui.notifications.info(game.i18n.localize('DAGGERHEART.Notification.Info.NoTargetsSelected'));
+            return ui.notifications.info(game.i18n.localize('DAGGERHEART.UI.Notifications.noTargetsSelected'));
         msg.system.targetSelection = targetSelection;
         msg.system.prepareDerivedData();
         ui.chat.updateMessage(msg);
@@ -182,7 +182,7 @@ export default class DhpChatLog extends foundry.applications.sidebar.tabs.ChatLo
         event.stopPropagation();
         const token = canvas.tokens.get(event.currentTarget.dataset.token);
         if (!token) {
-            ui.notifications.info(game.i18n.localize('DAGGERHEART.Notification.Info.AttackTargetDoesNotExist'));
+            ui.notifications.info(game.i18n.localize('DAGGERHEART.UI.Notifications.attackTargetDoesNotExist'));
             return;
         }
 
@@ -207,7 +207,7 @@ export default class DhpChatLog extends foundry.applications.sidebar.tabs.ChatLo
         }
 
         if (targets.length === 0)
-            ui.notifications.info(game.i18n.localize('DAGGERHEART.Notification.Info.NoTargetsSelected'));
+            ui.notifications.info(game.i18n.localize('DAGGERHEART.UI.Notifications.noTargetsSelected'));
         for (let target of targets) {
             let damage = message.system.roll.total;
             if (message.system.onSave && message.system.targets.find(t => t.id === target.id)?.saved?.success === true)
@@ -222,7 +222,7 @@ export default class DhpChatLog extends foundry.applications.sidebar.tabs.ChatLo
         const targets = Array.from(game.user.targets);
 
         if (targets.length === 0)
-            ui.notifications.info(game.i18n.localize('DAGGERHEART.Notification.Info.NoTargetsSelected'));
+            ui.notifications.info(game.i18n.localize('DAGGERHEART.UI.Notifications.noTargetsSelected'));
 
         for (var target of targets) {
             await target.actor.takeHealing([{ value: message.system.roll.total, type: message.system.roll.type }]);

--- a/module/applications/ui/countdowns.mjs
+++ b/module/applications/ui/countdowns.mjs
@@ -13,8 +13,8 @@ class Countdowns extends HandlebarsApplicationMixin(ApplicationV2) {
     }
 
     get title() {
-        return game.i18n.format('DAGGERHEART.Countdown.Title', {
-            type: game.i18n.localize(`DAGGERHEART.Countdown.Types.${this.basePath}`)
+        return game.i18n.format('DAGGERHEART.Applications.Countdown.Title', {
+            type: game.i18n.localize(`DAGGERHEART.Applications.Countdown.types.${this.basePath}`)
         });
     }
 
@@ -78,7 +78,7 @@ class Countdowns extends HandlebarsApplicationMixin(ApplicationV2) {
             const button = constructHTMLButton({
                 label: '',
                 classes: ['header-control', 'icon', 'fa-solid', 'fa-wrench'],
-                dataset: { action: 'toggleSimpleView', tooltip: 'DAGGERHEART.Countdown.ToggleSimple' }
+                dataset: { action: 'toggleSimpleView', tooltip: 'DAGGERHEART.Applications.Countdown.toggleSimple' }
             });
             this.window.controls.after(button);
         }
@@ -265,7 +265,7 @@ class Countdowns extends HandlebarsApplicationMixin(ApplicationV2) {
         const countdownSetting = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Countdowns);
         await countdownSetting.updateSource({
             [`${this.basePath}.countdowns.${foundry.utils.randomID()}`]: {
-                name: game.i18n.localize('DAGGERHEART.Countdown.NewCountdown'),
+                name: game.i18n.localize('DAGGERHEART.Applications.Countdown.newCountdown'),
                 ownership: game.user.isGM
                     ? {}
                     : {
@@ -285,9 +285,9 @@ class Countdowns extends HandlebarsApplicationMixin(ApplicationV2) {
 
         const confirmed = await foundry.applications.api.DialogV2.confirm({
             window: {
-                title: game.i18n.localize('DAGGERHEART.Countdown.RemoveCountdownTitle')
+                title: game.i18n.localize('DAGGERHEART.Applications.Countdown.removeCountdownTitle')
             },
-            content: game.i18n.format('DAGGERHEART.Countdown.RemoveCountdownText', { name: countdownName })
+            content: game.i18n.format('DAGGERHEART.Applications.Countdown.removeCountdownText', { name: countdownName })
         });
         if (!confirmed) return;
 

--- a/module/applications/ui/countdowns.mjs
+++ b/module/applications/ui/countdowns.mjs
@@ -13,8 +13,8 @@ class Countdowns extends HandlebarsApplicationMixin(ApplicationV2) {
     }
 
     get title() {
-        return game.i18n.format('DAGGERHEART.Applications.Countdown.Title', {
-            type: game.i18n.localize(`DAGGERHEART.Applications.Countdown.types.${this.basePath}`)
+        return game.i18n.format('DAGGERHEART.APPLICATIONS.Countdown.Title', {
+            type: game.i18n.localize(`DAGGERHEART.APPLICATIONS.Countdown.types.${this.basePath}`)
         });
     }
 
@@ -78,7 +78,7 @@ class Countdowns extends HandlebarsApplicationMixin(ApplicationV2) {
             const button = constructHTMLButton({
                 label: '',
                 classes: ['header-control', 'icon', 'fa-solid', 'fa-wrench'],
-                dataset: { action: 'toggleSimpleView', tooltip: 'DAGGERHEART.Applications.Countdown.toggleSimple' }
+                dataset: { action: 'toggleSimpleView', tooltip: 'DAGGERHEART.APPLICATIONS.Countdown.toggleSimple' }
             });
             this.window.controls.after(button);
         }
@@ -265,7 +265,7 @@ class Countdowns extends HandlebarsApplicationMixin(ApplicationV2) {
         const countdownSetting = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Countdowns);
         await countdownSetting.updateSource({
             [`${this.basePath}.countdowns.${foundry.utils.randomID()}`]: {
-                name: game.i18n.localize('DAGGERHEART.Applications.Countdown.newCountdown'),
+                name: game.i18n.localize('DAGGERHEART.APPLICATIONS.Countdown.newCountdown'),
                 ownership: game.user.isGM
                     ? {}
                     : {
@@ -285,9 +285,9 @@ class Countdowns extends HandlebarsApplicationMixin(ApplicationV2) {
 
         const confirmed = await foundry.applications.api.DialogV2.confirm({
             window: {
-                title: game.i18n.localize('DAGGERHEART.Applications.Countdown.removeCountdownTitle')
+                title: game.i18n.localize('DAGGERHEART.APPLICATIONS.Countdown.removeCountdownTitle')
             },
-            content: game.i18n.format('DAGGERHEART.Applications.Countdown.removeCountdownText', { name: countdownName })
+            content: game.i18n.format('DAGGERHEART.APPLICATIONS.Countdown.removeCountdownText', { name: countdownName })
         });
         if (!confirmed) return;
 

--- a/module/applications/ux/filter-menu.mjs
+++ b/module/applications/ux/filter-menu.mjs
@@ -178,7 +178,7 @@ export default class FilterMenu extends foundry.applications.ux.ContextMenu {
             }));
 
         const burdenFilter = Object.values(CONFIG.DH.GENERAL.burden).map(({ value, label }) => ({
-            group: game.i18n.localize('DAGGERHEART.Sheets.Weapon.Burden'),
+            group: game.i18n.localize('DAGGERHEART.General.burden'),
             name: game.i18n.localize(label),
             filter: {
                 field: 'system.burden',
@@ -220,7 +220,7 @@ export default class FilterMenu extends foundry.applications.ux.ContextMenu {
         }));
 
         const domainFilter = Object.values(CONFIG.DH.DOMAIN.domains).map(({ id, label }) => ({
-            group: game.i18n.localize('DAGGERHEART.Sheets.DomainCard.Domain'),
+            group: game.i18n.localize('DAGGERHEART.General.Domain.single'),
             name: game.i18n.localize(label),
             filter: {
                 field: 'system.domain',

--- a/module/applications/ux/filter-menu.mjs
+++ b/module/applications/ux/filter-menu.mjs
@@ -178,7 +178,7 @@ export default class FilterMenu extends foundry.applications.ux.ContextMenu {
             }));
 
         const burdenFilter = Object.values(CONFIG.DH.GENERAL.burden).map(({ value, label }) => ({
-            group: game.i18n.localize('DAGGERHEART.General.burden'),
+            group: game.i18n.localize('DAGGERHEART.GENERAL.burden'),
             name: game.i18n.localize(label),
             filter: {
                 field: 'system.burden',
@@ -220,7 +220,7 @@ export default class FilterMenu extends foundry.applications.ux.ContextMenu {
         }));
 
         const domainFilter = Object.values(CONFIG.DH.DOMAIN.domains).map(({ id, label }) => ({
-            group: game.i18n.localize('DAGGERHEART.General.Domain.single'),
+            group: game.i18n.localize('DAGGERHEART.GENERAL.Domain.single'),
             name: game.i18n.localize(label),
             filter: {
                 field: 'system.domain',

--- a/module/canvas/placeables/measuredTemplate.mjs
+++ b/module/canvas/placeables/measuredTemplate.mjs
@@ -18,19 +18,19 @@ export default class DhMeasuredTemplate extends foundry.canvas.placeables.Measur
 
     static getDistanceLabel(distance, settings) {
         if (distance <= settings.melee) {
-            return game.i18n.localize('DAGGERHEART.Range.melee.name');
+            return game.i18n.localize('DAGGERHEART.Config.Range.melee.name');
         }
         if (distance <= settings.veryClose) {
-            return game.i18n.localize('DAGGERHEART.Range.veryClose.name');
+            return game.i18n.localize('DAGGERHEART.Config.Range.veryClose.name');
         }
         if (distance <= settings.close) {
-            return game.i18n.localize('DAGGERHEART.Range.close.name');
+            return game.i18n.localize('DAGGERHEART.Config.Range.close.name');
         }
         if (distance <= settings.far) {
-            return game.i18n.localize('DAGGERHEART.Range.far.name');
+            return game.i18n.localize('DAGGERHEART.Config.Range.far.name');
         }
         if (distance <= settings.veryFar) {
-            return game.i18n.localize('DAGGERHEART.Range.veryFar.name');
+            return game.i18n.localize('DAGGERHEART.Config.Range.veryFar.name');
         }
 
         return '';

--- a/module/canvas/placeables/measuredTemplate.mjs
+++ b/module/canvas/placeables/measuredTemplate.mjs
@@ -18,19 +18,19 @@ export default class DhMeasuredTemplate extends foundry.canvas.placeables.Measur
 
     static getDistanceLabel(distance, settings) {
         if (distance <= settings.melee) {
-            return game.i18n.localize('DAGGERHEART.Config.Range.melee.name');
+            return game.i18n.localize('DAGGERHEART.CONFIG.Range.melee.name');
         }
         if (distance <= settings.veryClose) {
-            return game.i18n.localize('DAGGERHEART.Config.Range.veryClose.name');
+            return game.i18n.localize('DAGGERHEART.CONFIG.Range.veryClose.name');
         }
         if (distance <= settings.close) {
-            return game.i18n.localize('DAGGERHEART.Config.Range.close.name');
+            return game.i18n.localize('DAGGERHEART.CONFIG.Range.close.name');
         }
         if (distance <= settings.far) {
-            return game.i18n.localize('DAGGERHEART.Config.Range.far.name');
+            return game.i18n.localize('DAGGERHEART.CONFIG.Range.far.name');
         }
         if (distance <= settings.veryFar) {
-            return game.i18n.localize('DAGGERHEART.Config.Range.veryFar.name');
+            return game.i18n.localize('DAGGERHEART.CONFIG.Range.veryFar.name');
         }
 
         return '';

--- a/module/config/actionConfig.mjs
+++ b/module/config/actionConfig.mjs
@@ -1,37 +1,37 @@
 export const actionTypes = {
     attack: {
         id: 'attack',
-        name: 'DAGGERHEART.Actions.Types.attack.name',
+        name: 'DAGGERHEART.ACTIONS.TYPES.attack.name',
         icon: 'fa-swords'
     },
     healing: {
         id: 'healing',
-        name: 'DAGGERHEART.Actions.Types.healing.name',
+        name: 'DAGGERHEART.ACTIONS.TYPES.healing.name',
         icon: 'fa-kit-medical'
     },
     damage: {
         id: 'damage',
-        name: 'DAGGERHEART.Actions.Types.damage.name',
+        name: 'DAGGERHEART.ACTIONS.TYPES.damage.name',
         icon: 'fa-bone-break'
     },
     summon: {
         id: 'summon',
-        name: 'DAGGERHEART.Actions.Types.summon.name',
+        name: 'DAGGERHEART.ACTIONS.TYPES.summon.name',
         icon: 'fa-ghost'
     },
     effect: {
         id: 'effect',
-        name: 'DAGGERHEART.Actions.Types.effect.name',
+        name: 'DAGGERHEART.ACTIONS.TYPES.effect.name',
         icon: 'fa-person-rays'
     },
     macro: {
         id: 'macro',
-        name: 'DAGGERHEART.Actions.Types.macro.name',
+        name: 'DAGGERHEART.ACTIONS.TYPES.macro.name',
         icon: 'fa-scroll'
     },
     beastform: {
         id: 'beastform',
-        name: 'DAGGERHEART.Actions.Types.beastform.name',
+        name: 'DAGGERHEART.ACTIONS.TYPES.beastform.name',
         icon: 'fa-paw'
     }
 };
@@ -103,15 +103,15 @@ export const diceCompare = {
 
 export const advandtageState = {
     disadvantage: {
-        label: 'DAGGERHEART.General.Disadvantage.full',
+        label: 'DAGGERHEART.GENERAL.Disadvantage.full',
         value: -1
     },
     neutral: {
-        label: 'DAGGERHEART.General.Neutral.full',
+        label: 'DAGGERHEART.GENERAL.Neutral.full',
         value: 0
     },
     advantage: {
-        label: 'DAGGERHEART.General.Advantage.full',
+        label: 'DAGGERHEART.GENERAL.Advantage.full',
         value: 1
     }
 };

--- a/module/config/actionConfig.mjs
+++ b/module/config/actionConfig.mjs
@@ -4,21 +4,11 @@ export const actionTypes = {
         name: 'DAGGERHEART.Actions.Types.attack.name',
         icon: 'fa-swords'
     },
-    // spellcast: {
-    //     id: 'spellcast',
-    //     name: 'DAGGERHEART.Actions.Types.spellcast.name',
-    //     icon: 'fa-book-sparkles'
-    // },
     healing: {
         id: 'healing',
         name: 'DAGGERHEART.Actions.Types.healing.name',
         icon: 'fa-kit-medical'
     },
-    // resource: {
-    //     id: 'resource',
-    //     name: 'DAGGERHEART.Actions.Types.resource.name',
-    //     icon: 'fa-honey-pot'
-    // },
     damage: {
         id: 'damage',
         name: 'DAGGERHEART.Actions.Types.damage.name',
@@ -113,15 +103,15 @@ export const diceCompare = {
 
 export const advandtageState = {
     disadvantage: {
-        label: 'DAGGERHEART.General.Disadvantage.Full',
+        label: 'DAGGERHEART.General.Disadvantage.full',
         value: -1
     },
     neutral: {
-        label: 'DAGGERHEART.General.Neutral.Full',
+        label: 'DAGGERHEART.General.Neutral.full',
         value: 0
     },
     advantage: {
-        label: 'DAGGERHEART.General.Advantage.Full',
+        label: 'DAGGERHEART.General.Advantage.full',
         value: 1
     }
 };

--- a/module/config/actorConfig.mjs
+++ b/module/config/actorConfig.mjs
@@ -1,77 +1,77 @@
 export const abilities = {
     agility: {
-        label: 'DAGGERHEART.Abilities.agility.name',
+        label: 'DAGGERHEART.Config.Traits.agility.name',
         verbs: [
-            'DAGGERHEART.Abilities.agility.verb.sprint',
-            'DAGGERHEART.Abilities.agility.verb.leap',
-            'DAGGERHEART.Abilities.agility.verb.maneuver'
+            'DAGGERHEART.Config.Traits.agility.verb.sprint',
+            'DAGGERHEART.Config.Traits.agility.verb.leap',
+            'DAGGERHEART.Config.Traits.agility.verb.maneuver'
         ]
     },
     strength: {
-        label: 'DAGGERHEART.Abilities.strength.name',
+        label: 'DAGGERHEART.Config.Traits.strength.name',
         verbs: [
-            'DAGGERHEART.Abilities.strength.verb.lift',
-            'DAGGERHEART.Abilities.strength.verb.smash',
-            'DAGGERHEART.Abilities.strength.verb.grapple'
+            'DAGGERHEART.Config.Traits.strength.verb.lift',
+            'DAGGERHEART.Config.Traits.strength.verb.smash',
+            'DAGGERHEART.Config.Traits.strength.verb.grapple'
         ]
     },
     finesse: {
-        label: 'DAGGERHEART.Abilities.finesse.name',
+        label: 'DAGGERHEART.Config.Traits.finesse.name',
         verbs: [
-            'DAGGERHEART.Abilities.finesse.verb.control',
-            'DAGGERHEART.Abilities.finesse.verb.hide',
-            'DAGGERHEART.Abilities.finesse.verb.tinker'
+            'DAGGERHEART.Config.Traits.finesse.verb.control',
+            'DAGGERHEART.Config.Traits.finesse.verb.hide',
+            'DAGGERHEART.Config.Traits.finesse.verb.tinker'
         ]
     },
     instinct: {
-        label: 'DAGGERHEART.Abilities.instinct.name',
+        label: 'DAGGERHEART.Config.Traits.instinct.name',
         verbs: [
-            'DAGGERHEART.Abilities.instinct.verb.perceive',
-            'DAGGERHEART.Abilities.instinct.verb.sense',
-            'DAGGERHEART.Abilities.instinct.verb.navigate'
+            'DAGGERHEART.Config.Traits.instinct.verb.perceive',
+            'DAGGERHEART.Config.Traits.instinct.verb.sense',
+            'DAGGERHEART.Config.Traits.instinct.verb.navigate'
         ]
     },
     presence: {
-        label: 'DAGGERHEART.Abilities.presence.name',
+        label: 'DAGGERHEART.Config.Traits.presence.name',
         verbs: [
-            'DAGGERHEART.Abilities.presence.verb.charm',
-            'DAGGERHEART.Abilities.presence.verb.perform',
-            'DAGGERHEART.Abilities.presence.verb.deceive'
+            'DAGGERHEART.Config.Traits.presence.verb.charm',
+            'DAGGERHEART.Config.Traits.presence.verb.perform',
+            'DAGGERHEART.Config.Traits.presence.verb.deceive'
         ]
     },
     knowledge: {
-        label: 'DAGGERHEART.Abilities.knowledge.name',
+        label: 'DAGGERHEART.Config.Traits.knowledge.name',
         verbs: [
-            'DAGGERHEART.Abilities.knowledge.verb.recall',
-            'DAGGERHEART.Abilities.knowledge.verb.analyze',
-            'DAGGERHEART.Abilities.knowledge.verb.comprehend'
+            'DAGGERHEART.Config.Traits.knowledge.verb.recall',
+            'DAGGERHEART.Config.Traits.knowledge.verb.analyze',
+            'DAGGERHEART.Config.Traits.knowledge.verb.comprehend'
         ]
     }
 };
 
 export const featureProperties = {
     agility: {
-        name: 'DAGGERHEART.Abilities.agility.name',
+        name: 'DAGGERHEART.Config.Traits.agility.name',
         path: actor => actor.system.traits.agility.data.value
     },
     strength: {
-        name: 'DAGGERHEART.Abilities.strength.name',
+        name: 'DAGGERHEART.Config.Traits.strength.name',
         path: actor => actor.system.traits.strength.data.value
     },
     finesse: {
-        name: 'DAGGERHEART.Abilities.finesse.name',
+        name: 'DAGGERHEART.Config.Traits.finesse.name',
         path: actor => actor.system.traits.finesse.data.value
     },
     instinct: {
-        name: 'DAGGERHEART.Abilities.instinct.name',
+        name: 'DAGGERHEART.Config.Traits.instinct.name',
         path: actor => actor.system.traits.instinct.data.value
     },
     presence: {
-        name: 'DAGGERHEART.Abilities.presence.name',
+        name: 'DAGGERHEART.Config.Traits.presence.name',
         path: actor => actor.system.traits.presence.data.value
     },
     knowledge: {
-        name: 'DAGGERHEART.Abilities.knowledge.name',
+        name: 'DAGGERHEART.Config.Traits.knowledge.name',
         path: actor => actor.system.traits.knowledge.data.value
     },
     spellcastingTrait: {
@@ -83,90 +83,90 @@ export const featureProperties = {
 export const adversaryTypes = {
     bruiser: {
         id: 'bruiser',
-        label: 'DAGGERHEART.Adversary.Type.bruiser.label',
-        description: 'DAGGERHEART.Adversary.bruiser.description'
+        label: 'DAGGERHEART.Config.AdversaryType.bruiser.label',
+        description: 'DAGGERHEART.Actors.Adversary.bruiser.description'
     },
     horde: {
         id: 'horde',
-        label: 'DAGGERHEART.Adversary.Type.horde.label',
-        description: 'DAGGERHEART.Adversary.horde.description'
+        label: 'DAGGERHEART.Config.AdversaryType.horde.label',
+        description: 'DAGGERHEART.Actors.Adversary.horde.description'
     },
     leader: {
         id: 'leader',
-        label: 'DAGGERHEART.Adversary.Type.leader.label',
-        description: 'DAGGERHEART.Adversary.leader.description'
+        label: 'DAGGERHEART.Config.AdversaryType.leader.label',
+        description: 'DAGGERHEART.Actors.Adversary.leader.description'
     },
     minion: {
         id: 'minion',
-        label: 'DAGGERHEART.Adversary.Type.minion.label',
-        description: 'DAGGERHEART.Adversary.minion.description'
+        label: 'DAGGERHEART.Config.AdversaryType.minion.label',
+        description: 'DAGGERHEART.Actors.Adversary.minion.description'
     },
     ranged: {
         id: 'ranged',
-        label: 'DAGGERHEART.Adversary.Type.ranged.label',
-        description: 'DAGGERHEART.Adversary.ranged.description'
+        label: 'DAGGERHEART.Config.AdversaryType.ranged.label',
+        description: 'DAGGERHEART.Actors.Adversary.ranged.description'
     },
     skulk: {
         id: 'skulk',
-        label: 'DAGGERHEART.Adversary.Type.skulk.label',
-        description: 'DAGGERHEART.Adversary.skulk.description'
+        label: 'DAGGERHEART.Config.AdversaryType.skulk.label',
+        description: 'DAGGERHEART.Actors.Adversary.skulk.description'
     },
     social: {
         id: 'social',
-        label: 'DAGGERHEART.Adversary.Type.social.label',
-        description: 'DAGGERHEART.Adversary.social.description'
+        label: 'DAGGERHEART.Config.AdversaryTypee.social.label',
+        description: 'DAGGERHEART.Actors.Adversary.social.description'
     },
     solo: {
         id: 'solo',
-        label: 'DAGGERHEART.Adversary.Type.solo.label',
-        description: 'DAGGERHEART.Adversary.solo.description'
+        label: 'DAGGERHEART.Config.AdversaryType.solo.label',
+        description: 'DAGGERHEART.Actors.Adversary.solo.description'
     },
     standard: {
         id: 'standard',
-        label: 'DAGGERHEART.Adversary.Type.standard.label',
-        description: 'DAGGERHEART.Adversary.standard.description'
+        label: 'DAGGERHEART.Config.AdversaryType.standard.label',
+        description: 'DAGGERHEART.Actors.Adversary.standard.description'
     },
     support: {
         id: 'support',
-        label: 'DAGGERHEART.Adversary.Type.support.label',
-        description: 'DAGGERHEART.Adversary.support.description'
+        label: 'DAGGERHEART.Config.AdversaryType.support.label',
+        description: 'DAGGERHEART.Actors.Adversary.support.description'
     }
 };
 
 export const environmentTypes = {
     exploration: {
-        label: 'DAGGERHEART.Environment.Type.exploration.label',
-        description: 'DAGGERHEART.Environment.Type.exploration.description'
+        label: 'Daggerheart.Config.EnvironmentType.exploration.label',
+        description: 'Daggerheart.Config.EnvironmentType.exploration.description'
     },
     social: {
-        label: 'DAGGERHEART.Environment.Type.social.label',
-        description: 'DAGGERHEART.Environment.Type.social.description'
+        label: 'Daggerheart.Config.EnvironmentType.social.label',
+        description: 'Daggerheart.Config.EnvironmentType.social.description'
     },
     traversal: {
-        label: 'DAGGERHEART.Environment.Type.traversal.label',
-        description: 'DAGGERHEART.Environment.Type.traversal.description'
+        label: 'Daggerheart.Config.EnvironmentType.traversal.label',
+        description: 'Daggerheart.Config.EnvironmentType.traversal.description'
     },
     event: {
-        label: 'DAGGERHEART.Environment.Type.event.label',
-        description: 'DAGGERHEART.Environment.Type.event.description'
+        label: 'Daggerheart.Config.EnvironmentType.event.label',
+        description: 'Daggerheart.Config.EnvironmentType.event.description'
     }
 };
 
 export const adversaryTraits = {
     relentless: {
-        name: 'DAGGERHEART.Adversary.Trait..Name',
-        description: 'DAGGERHEART.Adversary.Trait..Description',
-        tip: 'DAGGERHEART.Adversary.Trait..Tip'
+        name: 'DAGGERHEART.Config.AdversaryTrait.relentless.name',
+        description: 'DAGGERHEART.Config.AdversaryTrait.relentless.description',
+        tip: 'DAGGERHEART.Config.AdversaryTrait.relentless.tip'
     },
     slow: {
-        name: 'DAGGERHEART.Adversary.Trait..Name',
-        description: 'DAGGERHEART.Adversary.Trait..Description',
-        tip: 'DAGGERHEART.Adversary.Trait..Tip'
+        name: 'DAGGERHEART.Config.AdversaryTrait.slow.name',
+        description: 'DAGGERHEART.Config.AdversaryTrait.slow.description',
+        tip: 'DAGGERHEART.Config.AdversaryTrait.slow.tip'
     },
     minion: {
-        name: 'DAGGERHEART.Adversary.Trait..Name',
-        description: 'DAGGERHEART.Adversary.Trait..Description',
-        tip: 'DAGGERHEART.Adversary.Trait..Tip'
+        name: 'DAGGERHEART.Config.AdversaryTrait.slow.name',
+        description: 'DAGGERHEART.Config.AdversaryTrait.slow.description',
+        tip: 'DAGGERHEART.Config.AdversaryTrait.slow.tip'
     }
 };
 
@@ -265,41 +265,41 @@ export const levelupData = {
         id: '2_4',
         tier: 1,
         levels: [2, 3, 4],
-        label: 'DAGGERHEART.LevelUp.Tier1.Label',
-        info: 'DAGGERHEART.LevelUp.Tier1.InfoLabel',
-        pretext: 'DAGGERHEART.LevelUp.Tier1.Pretext',
-        posttext: 'DAGGERHEART.LevelUp.Tier1.Posttext',
+        label: 'DAGGERHEART.Applications.Levelup.tier1.Label',
+        info: 'DAGGERHEART.Applications.Levelup.tier1.InfoLabel',
+        pretext: 'DAGGERHEART.Applications.Levelup.tier1.Pretext',
+        posttext: 'DAGGERHEART.Applications.Levelup.tier1.Posttext',
         choices: {
             [levelChoices.attributes.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.Attributes',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.attributes',
                 maxChoices: 3
             },
             [levelChoices.hitPointSlots.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.HitPointSlots',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.hitPointSlots',
                 maxChoices: 1
             },
             [levelChoices.stressSlots.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.StressSlots',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.stressSlots',
                 maxChoices: 1
             },
             [levelChoices.experiences.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.Experiences',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.experiences',
                 maxChoices: 1
             },
             [levelChoices.proficiency.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.Proficiency',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.proficiency',
                 maxChoices: 1
             },
             [levelChoices.armorOrEvasionSlot.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.ArmorOrEvasionSlot',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.armorOrEvasionSlot',
                 maxChoices: 1
             },
             [levelChoices.majorDamageThreshold2.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.MajorDamageThreshold2',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.majorDamageThreshold2',
                 maxChoices: 1
             },
             [levelChoices.severeDamageThreshold2.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.SevereDamageThreshold2',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.severeDamageThreshold2',
                 maxChoices: 1
             }
         }
@@ -308,49 +308,49 @@ export const levelupData = {
         id: '5_7',
         tier: 2,
         levels: [5, 6, 7],
-        label: 'DAGGERHEART.LevelUp.Tier2.Label',
-        info: 'DAGGERHEART.LevelUp.Tier2.InfoLabel',
-        pretext: 'DAGGERHEART.LevelUp.Tier2.Pretext',
-        posttext: 'DAGGERHEART.LevelUp.Tier2.Posttext',
+        label: 'DAGGERHEART.Applications.Levelup.tier2.Label',
+        info: 'DAGGERHEART.Applications.Levelup.tier2.InfoLabel',
+        pretext: 'DAGGERHEART.Applications.Levelup.tier2.Pretext',
+        posttext: 'DAGGERHEART.Applications.Levelup.tier2.Posttext',
         choices: {
             [levelChoices.attributes.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.Attributes',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.attributes',
                 maxChoices: 3
             },
             [levelChoices.hitPointSlots.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.HitPointSlots',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.hitPointSlots',
                 maxChoices: 2
             },
             [levelChoices.stressSlots.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.StressSlots',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.stressSlots',
                 maxChoices: 2
             },
             [levelChoices.experiences.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.Experiences',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.experiences',
                 maxChoices: 1
             },
             [levelChoices.proficiency.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.Proficiency',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.proficiency',
                 maxChoices: 2
             },
             [levelChoices.armorOrEvasionSlot.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.ArmorOrEvasionSlot',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.armorOrEvasionSlot',
                 maxChoices: 2
             },
             [levelChoices.majorDamageThreshold2.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.MajorDamageThreshold2',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.majorDamageThreshold2',
                 maxChoices: 1
             },
             [levelChoices.severeDamageThreshold3.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.SevereDamageThreshold3',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.severeDamageThreshold3',
                 maxChoices: 1
             },
             [levelChoices.subclass.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.Subclass',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.subclass',
                 maxChoices: 1
             },
             [levelChoices.multiclass.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.Multiclass',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.multiclass',
                 maxChoices: 1,
                 cost: 2
             }
@@ -360,49 +360,49 @@ export const levelupData = {
         id: '8_10',
         tier: 3,
         levels: [8, 9, 10],
-        label: 'DAGGERHEART.LevelUp.Tier3.Label',
-        info: 'DAGGERHEART.LevelUp.Tier3.InfoLabel',
-        pretext: 'DAGGERHEART.LevelUp.Tier3.Pretext',
-        posttext: 'DAGGERHEART.LevelUp.Tier3.Posttext',
+        label: 'DAGGERHEART.Applications.Levelup.tier3.Label',
+        info: 'DAGGERHEART.Applications.Levelup.tier3.InfoLabel',
+        pretext: 'DAGGERHEART.Applications.Levelup.tier3.Pretext',
+        posttext: 'DAGGERHEART.Applications.Levelup.tier3.Posttext',
         choices: {
             [levelChoices.attributes.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.Attributes',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.attributes',
                 maxChoices: 3
             },
             [levelChoices.hitPointSlots.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.HitPointSlots',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.hitPointSlots',
                 maxChoices: 2
             },
             [levelChoices.stressSlots.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.StressSlots',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.stressSlots',
                 maxChoices: 2
             },
             [levelChoices.experiences.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.Experiences',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.experiences',
                 maxChoices: 1
             },
             [levelChoices.proficiency.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.Proficiency',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.proficiency',
                 maxChoices: 2
             },
             [levelChoices.armorOrEvasionSlot.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.ArmorOrEvasionSlot',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.armorOrEvasionSlot',
                 maxChoices: 2
             },
             [levelChoices.majorDamageThreshold2.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.MajorDamageThreshold2',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.majorDamageThreshold2',
                 maxChoices: 1
             },
             [levelChoices.severeDamageThreshold4.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.SevereDamageThreshold4',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.severeDamageThreshold4',
                 maxChoices: 1
             },
             [levelChoices.subclass.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.Subclass',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.subclass',
                 maxChoices: 1
             },
             [levelChoices.multiclass.name]: {
-                description: 'DAGGERHEART.LevelUp.ChoiceDescriptions.Multiclass',
+                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.multiclass',
                 maxChoices: 1,
                 cost: 2
             }
@@ -411,7 +411,7 @@ export const levelupData = {
 };
 
 export const subclassFeatureLabels = {
-    1: 'DAGGERHEART.Sheets.PC.DomainCard.FoundationTitle',
-    2: 'DAGGERHEART.Sheets.PC.DomainCard.SpecializationTitle',
-    3: 'DAGGERHEART.Sheets.PC.DomainCard.MasteryTitle'
+    1: 'DAGGERHEART.Items.DomainCard.foundation',
+    2: 'DAGGERHEART.Items.DomainCard.specializationTitle',
+    3: 'DAGGERHEART.Items.DomainCard.masteryTitle'
 };

--- a/module/config/actorConfig.mjs
+++ b/module/config/actorConfig.mjs
@@ -1,77 +1,77 @@
 export const abilities = {
     agility: {
-        label: 'DAGGERHEART.Config.Traits.agility.name',
+        label: 'DAGGERHEART.CONFIG.Traits.agility.name',
         verbs: [
-            'DAGGERHEART.Config.Traits.agility.verb.sprint',
-            'DAGGERHEART.Config.Traits.agility.verb.leap',
-            'DAGGERHEART.Config.Traits.agility.verb.maneuver'
+            'DAGGERHEART.CONFIG.Traits.agility.verb.sprint',
+            'DAGGERHEART.CONFIG.Traits.agility.verb.leap',
+            'DAGGERHEART.CONFIG.Traits.agility.verb.maneuver'
         ]
     },
     strength: {
-        label: 'DAGGERHEART.Config.Traits.strength.name',
+        label: 'DAGGERHEART.CONFIG.Traits.strength.name',
         verbs: [
-            'DAGGERHEART.Config.Traits.strength.verb.lift',
-            'DAGGERHEART.Config.Traits.strength.verb.smash',
-            'DAGGERHEART.Config.Traits.strength.verb.grapple'
+            'DAGGERHEART.CONFIG.Traits.strength.verb.lift',
+            'DAGGERHEART.CONFIG.Traits.strength.verb.smash',
+            'DAGGERHEART.CONFIG.Traits.strength.verb.grapple'
         ]
     },
     finesse: {
-        label: 'DAGGERHEART.Config.Traits.finesse.name',
+        label: 'DAGGERHEART.CONFIG.Traits.finesse.name',
         verbs: [
-            'DAGGERHEART.Config.Traits.finesse.verb.control',
-            'DAGGERHEART.Config.Traits.finesse.verb.hide',
-            'DAGGERHEART.Config.Traits.finesse.verb.tinker'
+            'DAGGERHEART.CONFIG.Traits.finesse.verb.control',
+            'DAGGERHEART.CONFIG.Traits.finesse.verb.hide',
+            'DAGGERHEART.CONFIG.Traits.finesse.verb.tinker'
         ]
     },
     instinct: {
-        label: 'DAGGERHEART.Config.Traits.instinct.name',
+        label: 'DAGGERHEART.CONFIG.Traits.instinct.name',
         verbs: [
-            'DAGGERHEART.Config.Traits.instinct.verb.perceive',
-            'DAGGERHEART.Config.Traits.instinct.verb.sense',
-            'DAGGERHEART.Config.Traits.instinct.verb.navigate'
+            'DAGGERHEART.CONFIG.Traits.instinct.verb.perceive',
+            'DAGGERHEART.CONFIG.Traits.instinct.verb.sense',
+            'DAGGERHEART.CONFIG.Traits.instinct.verb.navigate'
         ]
     },
     presence: {
-        label: 'DAGGERHEART.Config.Traits.presence.name',
+        label: 'DAGGERHEART.CONFIG.Traits.presence.name',
         verbs: [
-            'DAGGERHEART.Config.Traits.presence.verb.charm',
-            'DAGGERHEART.Config.Traits.presence.verb.perform',
-            'DAGGERHEART.Config.Traits.presence.verb.deceive'
+            'DAGGERHEART.CONFIG.Traits.presence.verb.charm',
+            'DAGGERHEART.CONFIG.Traits.presence.verb.perform',
+            'DAGGERHEART.CONFIG.Traits.presence.verb.deceive'
         ]
     },
     knowledge: {
-        label: 'DAGGERHEART.Config.Traits.knowledge.name',
+        label: 'DAGGERHEART.CONFIG.Traits.knowledge.name',
         verbs: [
-            'DAGGERHEART.Config.Traits.knowledge.verb.recall',
-            'DAGGERHEART.Config.Traits.knowledge.verb.analyze',
-            'DAGGERHEART.Config.Traits.knowledge.verb.comprehend'
+            'DAGGERHEART.CONFIG.Traits.knowledge.verb.recall',
+            'DAGGERHEART.CONFIG.Traits.knowledge.verb.analyze',
+            'DAGGERHEART.CONFIG.Traits.knowledge.verb.comprehend'
         ]
     }
 };
 
 export const featureProperties = {
     agility: {
-        name: 'DAGGERHEART.Config.Traits.agility.name',
+        name: 'DAGGERHEART.CONFIG.Traits.agility.name',
         path: actor => actor.system.traits.agility.data.value
     },
     strength: {
-        name: 'DAGGERHEART.Config.Traits.strength.name',
+        name: 'DAGGERHEART.CONFIG.Traits.strength.name',
         path: actor => actor.system.traits.strength.data.value
     },
     finesse: {
-        name: 'DAGGERHEART.Config.Traits.finesse.name',
+        name: 'DAGGERHEART.CONFIG.Traits.finesse.name',
         path: actor => actor.system.traits.finesse.data.value
     },
     instinct: {
-        name: 'DAGGERHEART.Config.Traits.instinct.name',
+        name: 'DAGGERHEART.CONFIG.Traits.instinct.name',
         path: actor => actor.system.traits.instinct.data.value
     },
     presence: {
-        name: 'DAGGERHEART.Config.Traits.presence.name',
+        name: 'DAGGERHEART.CONFIG.Traits.presence.name',
         path: actor => actor.system.traits.presence.data.value
     },
     knowledge: {
-        name: 'DAGGERHEART.Config.Traits.knowledge.name',
+        name: 'DAGGERHEART.CONFIG.Traits.knowledge.name',
         path: actor => actor.system.traits.knowledge.data.value
     },
     spellcastingTrait: {
@@ -83,90 +83,90 @@ export const featureProperties = {
 export const adversaryTypes = {
     bruiser: {
         id: 'bruiser',
-        label: 'DAGGERHEART.Config.AdversaryType.bruiser.label',
-        description: 'DAGGERHEART.Actors.Adversary.bruiser.description'
+        label: 'DAGGERHEART.CONFIG.AdversaryType.bruiser.label',
+        description: 'DAGGERHEART.ACTORS.Adversary.bruiser.description'
     },
     horde: {
         id: 'horde',
-        label: 'DAGGERHEART.Config.AdversaryType.horde.label',
-        description: 'DAGGERHEART.Actors.Adversary.horde.description'
+        label: 'DAGGERHEART.CONFIG.AdversaryType.horde.label',
+        description: 'DAGGERHEART.ACTORS.Adversary.horde.description'
     },
     leader: {
         id: 'leader',
-        label: 'DAGGERHEART.Config.AdversaryType.leader.label',
-        description: 'DAGGERHEART.Actors.Adversary.leader.description'
+        label: 'DAGGERHEART.CONFIG.AdversaryType.leader.label',
+        description: 'DAGGERHEART.ACTORS.Adversary.leader.description'
     },
     minion: {
         id: 'minion',
-        label: 'DAGGERHEART.Config.AdversaryType.minion.label',
-        description: 'DAGGERHEART.Actors.Adversary.minion.description'
+        label: 'DAGGERHEART.CONFIG.AdversaryType.minion.label',
+        description: 'DAGGERHEART.ACTORS.Adversary.minion.description'
     },
     ranged: {
         id: 'ranged',
-        label: 'DAGGERHEART.Config.AdversaryType.ranged.label',
-        description: 'DAGGERHEART.Actors.Adversary.ranged.description'
+        label: 'DAGGERHEART.CONFIG.AdversaryType.ranged.label',
+        description: 'DAGGERHEART.ACTORS.Adversary.ranged.description'
     },
     skulk: {
         id: 'skulk',
-        label: 'DAGGERHEART.Config.AdversaryType.skulk.label',
-        description: 'DAGGERHEART.Actors.Adversary.skulk.description'
+        label: 'DAGGERHEART.CONFIG.AdversaryType.skulk.label',
+        description: 'DAGGERHEART.ACTORS.Adversary.skulk.description'
     },
     social: {
         id: 'social',
-        label: 'DAGGERHEART.Config.AdversaryTypee.social.label',
-        description: 'DAGGERHEART.Actors.Adversary.social.description'
+        label: 'DAGGERHEART.CONFIG.AdversaryTypee.social.label',
+        description: 'DAGGERHEART.ACTORS.Adversary.social.description'
     },
     solo: {
         id: 'solo',
-        label: 'DAGGERHEART.Config.AdversaryType.solo.label',
-        description: 'DAGGERHEART.Actors.Adversary.solo.description'
+        label: 'DAGGERHEART.CONFIG.AdversaryType.solo.label',
+        description: 'DAGGERHEART.ACTORS.Adversary.solo.description'
     },
     standard: {
         id: 'standard',
-        label: 'DAGGERHEART.Config.AdversaryType.standard.label',
-        description: 'DAGGERHEART.Actors.Adversary.standard.description'
+        label: 'DAGGERHEART.CONFIG.AdversaryType.standard.label',
+        description: 'DAGGERHEART.ACTORS.Adversary.standard.description'
     },
     support: {
         id: 'support',
-        label: 'DAGGERHEART.Config.AdversaryType.support.label',
-        description: 'DAGGERHEART.Actors.Adversary.support.description'
+        label: 'DAGGERHEART.CONFIG.AdversaryType.support.label',
+        description: 'DAGGERHEART.ACTORS.Adversary.support.description'
     }
 };
 
 export const environmentTypes = {
     exploration: {
-        label: 'Daggerheart.Config.EnvironmentType.exploration.label',
-        description: 'Daggerheart.Config.EnvironmentType.exploration.description'
+        label: 'DAGGERHEART.CONFIG.EnvironmentType.exploration.label',
+        description: 'DAGGERHEART.CONFIG.EnvironmentType.exploration.description'
     },
     social: {
-        label: 'Daggerheart.Config.EnvironmentType.social.label',
-        description: 'Daggerheart.Config.EnvironmentType.social.description'
+        label: 'DAGGERHEART.CONFIG.EnvironmentType.social.label',
+        description: 'DAGGERHEART.CONFIG.EnvironmentType.social.description'
     },
     traversal: {
-        label: 'Daggerheart.Config.EnvironmentType.traversal.label',
-        description: 'Daggerheart.Config.EnvironmentType.traversal.description'
+        label: 'DAGGERHEART.CONFIG.EnvironmentType.traversal.label',
+        description: 'DAGGERHEART.CONFIG.EnvironmentType.traversal.description'
     },
     event: {
-        label: 'Daggerheart.Config.EnvironmentType.event.label',
-        description: 'Daggerheart.Config.EnvironmentType.event.description'
+        label: 'DAGGERHEART.CONFIG.EnvironmentType.event.label',
+        description: 'DAGGERHEART.CONFIG.EnvironmentType.event.description'
     }
 };
 
 export const adversaryTraits = {
     relentless: {
-        name: 'DAGGERHEART.Config.AdversaryTrait.relentless.name',
-        description: 'DAGGERHEART.Config.AdversaryTrait.relentless.description',
-        tip: 'DAGGERHEART.Config.AdversaryTrait.relentless.tip'
+        name: 'DAGGERHEART.CONFIG.AdversaryTrait.relentless.name',
+        description: 'DAGGERHEART.CONFIG.AdversaryTrait.relentless.description',
+        tip: 'DAGGERHEART.CONFIG.AdversaryTrait.relentless.tip'
     },
     slow: {
-        name: 'DAGGERHEART.Config.AdversaryTrait.slow.name',
-        description: 'DAGGERHEART.Config.AdversaryTrait.slow.description',
-        tip: 'DAGGERHEART.Config.AdversaryTrait.slow.tip'
+        name: 'DAGGERHEART.CONFIG.AdversaryTrait.slow.name',
+        description: 'DAGGERHEART.CONFIG.AdversaryTrait.slow.description',
+        tip: 'DAGGERHEART.CONFIG.AdversaryTrait.slow.tip'
     },
     minion: {
-        name: 'DAGGERHEART.Config.AdversaryTrait.slow.name',
-        description: 'DAGGERHEART.Config.AdversaryTrait.slow.description',
-        tip: 'DAGGERHEART.Config.AdversaryTrait.slow.tip'
+        name: 'DAGGERHEART.CONFIG.AdversaryTrait.slow.name',
+        description: 'DAGGERHEART.CONFIG.AdversaryTrait.slow.description',
+        tip: 'DAGGERHEART.CONFIG.AdversaryTrait.slow.tip'
     }
 };
 
@@ -265,41 +265,41 @@ export const levelupData = {
         id: '2_4',
         tier: 1,
         levels: [2, 3, 4],
-        label: 'DAGGERHEART.Applications.Levelup.tier1.Label',
-        info: 'DAGGERHEART.Applications.Levelup.tier1.InfoLabel',
-        pretext: 'DAGGERHEART.Applications.Levelup.tier1.Pretext',
-        posttext: 'DAGGERHEART.Applications.Levelup.tier1.Posttext',
+        label: 'DAGGERHEART.APPLICATIONS.Levelup.tier1.Label',
+        info: 'DAGGERHEART.APPLICATIONS.Levelup.tier1.InfoLabel',
+        pretext: 'DAGGERHEART.APPLICATIONS.Levelup.tier1.Pretext',
+        posttext: 'DAGGERHEART.APPLICATIONS.Levelup.tier1.Posttext',
         choices: {
             [levelChoices.attributes.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.attributes',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.attributes',
                 maxChoices: 3
             },
             [levelChoices.hitPointSlots.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.hitPointSlots',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.hitPointSlots',
                 maxChoices: 1
             },
             [levelChoices.stressSlots.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.stressSlots',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.stressSlots',
                 maxChoices: 1
             },
             [levelChoices.experiences.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.experiences',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.experiences',
                 maxChoices: 1
             },
             [levelChoices.proficiency.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.proficiency',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.proficiency',
                 maxChoices: 1
             },
             [levelChoices.armorOrEvasionSlot.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.armorOrEvasionSlot',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.armorOrEvasionSlot',
                 maxChoices: 1
             },
             [levelChoices.majorDamageThreshold2.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.majorDamageThreshold2',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.majorDamageThreshold2',
                 maxChoices: 1
             },
             [levelChoices.severeDamageThreshold2.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.severeDamageThreshold2',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.severeDamageThreshold2',
                 maxChoices: 1
             }
         }
@@ -308,49 +308,49 @@ export const levelupData = {
         id: '5_7',
         tier: 2,
         levels: [5, 6, 7],
-        label: 'DAGGERHEART.Applications.Levelup.tier2.Label',
-        info: 'DAGGERHEART.Applications.Levelup.tier2.InfoLabel',
-        pretext: 'DAGGERHEART.Applications.Levelup.tier2.Pretext',
-        posttext: 'DAGGERHEART.Applications.Levelup.tier2.Posttext',
+        label: 'DAGGERHEART.APPLICATIONS.Levelup.tier2.Label',
+        info: 'DAGGERHEART.APPLICATIONS.Levelup.tier2.InfoLabel',
+        pretext: 'DAGGERHEART.APPLICATIONS.Levelup.tier2.Pretext',
+        posttext: 'DAGGERHEART.APPLICATIONS.Levelup.tier2.Posttext',
         choices: {
             [levelChoices.attributes.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.attributes',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.attributes',
                 maxChoices: 3
             },
             [levelChoices.hitPointSlots.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.hitPointSlots',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.hitPointSlots',
                 maxChoices: 2
             },
             [levelChoices.stressSlots.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.stressSlots',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.stressSlots',
                 maxChoices: 2
             },
             [levelChoices.experiences.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.experiences',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.experiences',
                 maxChoices: 1
             },
             [levelChoices.proficiency.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.proficiency',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.proficiency',
                 maxChoices: 2
             },
             [levelChoices.armorOrEvasionSlot.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.armorOrEvasionSlot',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.armorOrEvasionSlot',
                 maxChoices: 2
             },
             [levelChoices.majorDamageThreshold2.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.majorDamageThreshold2',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.majorDamageThreshold2',
                 maxChoices: 1
             },
             [levelChoices.severeDamageThreshold3.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.severeDamageThreshold3',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.severeDamageThreshold3',
                 maxChoices: 1
             },
             [levelChoices.subclass.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.subclass',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.subclass',
                 maxChoices: 1
             },
             [levelChoices.multiclass.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.multiclass',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.multiclass',
                 maxChoices: 1,
                 cost: 2
             }
@@ -360,49 +360,49 @@ export const levelupData = {
         id: '8_10',
         tier: 3,
         levels: [8, 9, 10],
-        label: 'DAGGERHEART.Applications.Levelup.tier3.Label',
-        info: 'DAGGERHEART.Applications.Levelup.tier3.InfoLabel',
-        pretext: 'DAGGERHEART.Applications.Levelup.tier3.Pretext',
-        posttext: 'DAGGERHEART.Applications.Levelup.tier3.Posttext',
+        label: 'DAGGERHEART.APPLICATIONS.Levelup.tier3.Label',
+        info: 'DAGGERHEART.APPLICATIONS.Levelup.tier3.InfoLabel',
+        pretext: 'DAGGERHEART.APPLICATIONS.Levelup.tier3.Pretext',
+        posttext: 'DAGGERHEART.APPLICATIONS.Levelup.tier3.Posttext',
         choices: {
             [levelChoices.attributes.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.attributes',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.attributes',
                 maxChoices: 3
             },
             [levelChoices.hitPointSlots.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.hitPointSlots',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.hitPointSlots',
                 maxChoices: 2
             },
             [levelChoices.stressSlots.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.stressSlots',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.stressSlots',
                 maxChoices: 2
             },
             [levelChoices.experiences.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.experiences',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.experiences',
                 maxChoices: 1
             },
             [levelChoices.proficiency.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.proficiency',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.proficiency',
                 maxChoices: 2
             },
             [levelChoices.armorOrEvasionSlot.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.armorOrEvasionSlot',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.armorOrEvasionSlot',
                 maxChoices: 2
             },
             [levelChoices.majorDamageThreshold2.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.majorDamageThreshold2',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.majorDamageThreshold2',
                 maxChoices: 1
             },
             [levelChoices.severeDamageThreshold4.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.severeDamageThreshold4',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.severeDamageThreshold4',
                 maxChoices: 1
             },
             [levelChoices.subclass.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.subclass',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.subclass',
                 maxChoices: 1
             },
             [levelChoices.multiclass.name]: {
-                description: 'DAGGERHEART.Applications.Levelup.choiceDescriptions.multiclass',
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.choiceDescriptions.multiclass',
                 maxChoices: 1,
                 cost: 2
             }
@@ -411,7 +411,7 @@ export const levelupData = {
 };
 
 export const subclassFeatureLabels = {
-    1: 'DAGGERHEART.Items.DomainCard.foundation',
-    2: 'DAGGERHEART.Items.DomainCard.specializationTitle',
-    3: 'DAGGERHEART.Items.DomainCard.masteryTitle'
+    1: 'DAGGERHEART.ITEMS.DomainCard.foundation',
+    2: 'DAGGERHEART.ITEMS.DomainCard.specializationTitle',
+    3: 'DAGGERHEART.ITEMS.DomainCard.masteryTitle'
 };

--- a/module/config/domainConfig.mjs
+++ b/module/config/domainConfig.mjs
@@ -1,57 +1,57 @@
 export const domains = {
     arcana: {
         id: 'arcana',
-        label: 'DAGGERHEART.General.Domain.arcana.label',
+        label: 'DAGGERHEART.GENERAL.Domain.arcana.label',
         src: 'systems/daggerheart/assets/icons/domains/arcana.svg',
-        description: 'DAGGERHEART.General.Domain.Arcana'
+        description: 'DAGGERHEART.GENERAL.Domain.Arcana'
     },
     blade: {
         id: 'blade',
-        label: 'DAGGERHEART.General.Domain.blade.label',
+        label: 'DAGGERHEART.GENERAL.Domain.blade.label',
         src: 'systems/daggerheart/assets/icons/domains/blade.svg',
-        description: 'DAGGERHEART.General.Domain.Blade'
+        description: 'DAGGERHEART.GENERAL.Domain.Blade'
     },
     bone: {
         id: 'bone',
-        label: 'DAGGERHEART.General.Domain.bone.label',
+        label: 'DAGGERHEART.GENERAL.Domain.bone.label',
         src: 'systems/daggerheart/assets/icons/domains/bone.svg',
-        description: 'DAGGERHEART.General.Domain.Bone'
+        description: 'DAGGERHEART.GENERAL.Domain.Bone'
     },
     codex: {
         id: 'codex',
-        label: 'DAGGERHEART.General.Domain.codex.label',
+        label: 'DAGGERHEART.GENERAL.Domain.codex.label',
         src: 'systems/daggerheart/assets/icons/domains/codex.svg',
-        description: 'DAGGERHEART.General.Domain.Codex'
+        description: 'DAGGERHEART.GENERAL.Domain.Codex'
     },
     grace: {
         id: 'grace',
-        label: 'DAGGERHEART.General.Domain.grace.label',
+        label: 'DAGGERHEART.GENERAL.Domain.grace.label',
         src: 'systems/daggerheart/assets/icons/domains/grace.svg',
-        description: 'DAGGERHEART.General.Domain.Grace'
+        description: 'DAGGERHEART.GENERAL.Domain.Grace'
     },
     midnight: {
         id: 'midnight',
-        label: 'DAGGERHEART.General.Domain.midnight.label',
+        label: 'DAGGERHEART.GENERAL.Domain.midnight.label',
         src: 'systems/daggerheart/assets/icons/domains/midnight.svg',
-        description: 'DAGGERHEART.General.Domain.Midnight'
+        description: 'DAGGERHEART.GENERAL.Domain.Midnight'
     },
     sage: {
         id: 'sage',
-        label: 'DAGGERHEART.General.Domain.sage.label',
+        label: 'DAGGERHEART.GENERAL.Domain.sage.label',
         src: 'systems/daggerheart/assets/icons/domains/sage.svg',
-        description: 'DAGGERHEART.General.Domain.Sage'
+        description: 'DAGGERHEART.GENERAL.Domain.Sage'
     },
     splendor: {
         id: 'splendor',
-        label: 'DAGGERHEART.General.Domain.splendor.label',
+        label: 'DAGGERHEART.GENERAL.Domain.splendor.label',
         src: 'systems/daggerheart/assets/icons/domains/splendor.svg',
-        description: 'DAGGERHEART.General.Domain.Splendor'
+        description: 'DAGGERHEART.GENERAL.Domain.Splendor'
     },
     valor: {
         id: 'valor',
-        label: 'DAGGERHEART.General.Domain.valor.label',
+        label: 'DAGGERHEART.GENERAL.Domain.valor.label',
         src: 'systems/daggerheart/assets/icons/domains/valor.svg',
-        description: 'DAGGERHEART.General.Domain.Valor'
+        description: 'DAGGERHEART.GENERAL.Domain.Valor'
     }
 };
 
@@ -84,17 +84,17 @@ export const classMap = {
 export const cardTypes = {
     ability: {
         id: 'ability',
-        label: 'DAGGERHEART.Config.DomainCardTypes.ability',
+        label: 'DAGGERHEART.CONFIG.DomainCardTypes.ability',
         img: ''
     },
     spell: {
         id: 'spell',
-        label: 'DAGGERHEART.Config.DomainCardTypes.spell',
+        label: 'DAGGERHEART.CONFIG.DomainCardTypes.spell',
         img: ''
     },
     grimoire: {
         id: 'grimoire',
-        label: 'DAGGERHEART.Config.DomainCardTypes.grimoire',
+        label: 'DAGGERHEART.CONFIG.DomainCardTypes.grimoire',
         img: ''
     }
 };

--- a/module/config/domainConfig.mjs
+++ b/module/config/domainConfig.mjs
@@ -1,57 +1,57 @@
 export const domains = {
     arcana: {
         id: 'arcana',
-        label: 'DAGGERHEART.Domains.arcana.label',
+        label: 'DAGGERHEART.General.Domain.arcana.label',
         src: 'systems/daggerheart/assets/icons/domains/arcana.svg',
-        description: 'DAGGERHEART.Domains.Arcana'
+        description: 'DAGGERHEART.General.Domain.Arcana'
     },
     blade: {
         id: 'blade',
-        label: 'DAGGERHEART.Domains.blade.label',
+        label: 'DAGGERHEART.General.Domain.blade.label',
         src: 'systems/daggerheart/assets/icons/domains/blade.svg',
-        description: 'DAGGERHEART.Domains.Blade'
+        description: 'DAGGERHEART.General.Domain.Blade'
     },
     bone: {
         id: 'bone',
-        label: 'DAGGERHEART.Domains.bone.label',
+        label: 'DAGGERHEART.General.Domain.bone.label',
         src: 'systems/daggerheart/assets/icons/domains/bone.svg',
-        description: 'DAGGERHEART.Domains.Bone'
+        description: 'DAGGERHEART.General.Domain.Bone'
     },
     codex: {
         id: 'codex',
-        label: 'DAGGERHEART.Domains.codex.label',
+        label: 'DAGGERHEART.General.Domain.codex.label',
         src: 'systems/daggerheart/assets/icons/domains/codex.svg',
-        description: 'DAGGERHEART.Domains.Codex'
+        description: 'DAGGERHEART.General.Domain.Codex'
     },
     grace: {
         id: 'grace',
-        label: 'DAGGERHEART.Domains.grace.label',
+        label: 'DAGGERHEART.General.Domain.grace.label',
         src: 'systems/daggerheart/assets/icons/domains/grace.svg',
-        description: 'DAGGERHEART.Domains.Grace'
+        description: 'DAGGERHEART.General.Domain.Grace'
     },
     midnight: {
         id: 'midnight',
-        label: 'DAGGERHEART.Domains.midnight.label',
+        label: 'DAGGERHEART.General.Domain.midnight.label',
         src: 'systems/daggerheart/assets/icons/domains/midnight.svg',
-        description: 'DAGGERHEART.Domains.Midnight'
+        description: 'DAGGERHEART.General.Domain.Midnight'
     },
     sage: {
         id: 'sage',
-        label: 'DAGGERHEART.Domains.sage.label',
+        label: 'DAGGERHEART.General.Domain.sage.label',
         src: 'systems/daggerheart/assets/icons/domains/sage.svg',
-        description: 'DAGGERHEART.Domains.Sage'
+        description: 'DAGGERHEART.General.Domain.Sage'
     },
     splendor: {
         id: 'splendor',
-        label: 'DAGGERHEART.Domains.splendor.label',
+        label: 'DAGGERHEART.General.Domain.splendor.label',
         src: 'systems/daggerheart/assets/icons/domains/splendor.svg',
-        description: 'DAGGERHEART.Domains.Splendor'
+        description: 'DAGGERHEART.General.Domain.Splendor'
     },
     valor: {
         id: 'valor',
-        label: 'DAGGERHEART.Domains.valor.label',
+        label: 'DAGGERHEART.General.Domain.valor.label',
         src: 'systems/daggerheart/assets/icons/domains/valor.svg',
-        description: 'DAGGERHEART.Domains.Valor'
+        description: 'DAGGERHEART.General.Domain.Valor'
     }
 };
 
@@ -84,17 +84,17 @@ export const classMap = {
 export const cardTypes = {
     ability: {
         id: 'ability',
-        label: 'DAGGERHEART.Domain.CardTypes.ability',
+        label: 'DAGGERHEART.Config.DomainCardTypes.ability',
         img: ''
     },
     spell: {
         id: 'spell',
-        label: 'DAGGERHEART.Domain.CardTypes.spell',
+        label: 'DAGGERHEART.Config.DomainCardTypes.spell',
         img: ''
     },
     grimoire: {
         id: 'grimoire',
-        label: 'DAGGERHEART.Domain.CardTypes.grimoire',
+        label: 'DAGGERHEART.Config.DomainCardTypes.grimoire',
         img: ''
     }
 };

--- a/module/config/effectConfig.mjs
+++ b/module/config/effectConfig.mjs
@@ -21,38 +21,38 @@ export const parseTypes = {
 export const applyLocations = {
     attackRoll: {
         id: 'attackRoll',
-        name: 'DAGGERHEART.Effects.ApplyLocations.AttackRoll.Name'
+        name: 'DAGGERHEART.Effects.ApplyLocations.attackRoll.name'
     },
     damageRoll: {
         id: 'damageRoll',
-        name: 'DAGGERHEART.Effects.ApplyLocations.DamageRoll.Name'
+        name: 'DAGGERHEART.Effects.ApplyLocations.damageRoll.name'
     }
 };
 
 export const effectTypes = {
     health: {
         id: 'health',
-        name: 'DAGGERHEART.Effects.Types.Health.Name',
+        name: 'DAGGERHEART.Effects.Types.HitPoints.name',
         values: [],
         valueType: valueTypes.numberString.id,
         parseType: parseTypes.number.id
     },
     stress: {
         id: 'stress',
-        name: 'DAGGERHEART.Effects.Types.Stress.Name',
+        name: 'DAGGERHEART.Effects.Types.Stress.name',
         valueType: valueTypes.numberString.id,
         parseType: parseTypes.number.id
     },
     reach: {
         id: 'reach',
-        name: 'DAGGERHEART.Effects.Types.Reach.Name',
+        name: 'DAGGERHEART.Effects.Types.Reach.name',
         valueType: valueTypes.select.id,
         parseType: parseTypes.string.id,
         options: Object.keys(range).map(x => ({ name: range[x].name, value: x }))
     },
     damage: {
         id: 'damage',
-        name: 'DAGGERHEART.Effects.Types.Damage.Name',
+        name: 'DAGGERHEART.Effects.Types.Damage.name',
         valueType: valueTypes.numberString.id,
         parseType: parseTypes.string.id,
         appliesOn: applyLocations.damageRoll.id,

--- a/module/config/effectConfig.mjs
+++ b/module/config/effectConfig.mjs
@@ -21,38 +21,38 @@ export const parseTypes = {
 export const applyLocations = {
     attackRoll: {
         id: 'attackRoll',
-        name: 'DAGGERHEART.Effects.ApplyLocations.attackRoll.name'
+        name: 'DAGGERHEART.EFFECTS.ApplyLocations.attackRoll.name'
     },
     damageRoll: {
         id: 'damageRoll',
-        name: 'DAGGERHEART.Effects.ApplyLocations.damageRoll.name'
+        name: 'DAGGERHEART.EFFECTS.ApplyLocations.damageRoll.name'
     }
 };
 
 export const effectTypes = {
     health: {
         id: 'health',
-        name: 'DAGGERHEART.Effects.Types.HitPoints.name',
+        name: 'DAGGERHEART.EFFECTS.Types.HitPoints.name',
         values: [],
         valueType: valueTypes.numberString.id,
         parseType: parseTypes.number.id
     },
     stress: {
         id: 'stress',
-        name: 'DAGGERHEART.Effects.Types.Stress.name',
+        name: 'DAGGERHEART.EFFECTS.Types.Stress.name',
         valueType: valueTypes.numberString.id,
         parseType: parseTypes.number.id
     },
     reach: {
         id: 'reach',
-        name: 'DAGGERHEART.Effects.Types.Reach.name',
+        name: 'DAGGERHEART.EFFECTS.Types.Reach.name',
         valueType: valueTypes.select.id,
         parseType: parseTypes.string.id,
         options: Object.keys(range).map(x => ({ name: range[x].name, value: x }))
     },
     damage: {
         id: 'damage',
-        name: 'DAGGERHEART.Effects.Types.Damage.name',
+        name: 'DAGGERHEART.EFFECTS.Types.Damage.name',
         valueType: valueTypes.numberString.id,
         parseType: parseTypes.string.id,
         appliesOn: applyLocations.damageRoll.id,

--- a/module/config/generalConfig.mjs
+++ b/module/config/generalConfig.mjs
@@ -2,43 +2,43 @@ export const range = {
     self: {
         id: 'self',
         short: 's',
-        label: 'DAGGERHEART.Range.self.name',
-        description: 'DAGGERHEART.Range.self.description',
+        label: 'DAGGERHEART.Config.Range.self.name',
+        description: 'DAGGERHEART.Config.Range.self.description',
         distance: 0
     },
     melee: {
         id: 'melee',
         short: 'm',
-        label: 'DAGGERHEART.Range.melee.name',
-        description: 'DAGGERHEART.Range.melee.description',
+        label: 'DAGGERHEART.Config.Range.melee.name',
+        description: 'DAGGERHEART.Config.Range.melee.description',
         distance: 1
     },
     veryClose: {
         id: 'veryClose',
         short: 'vc',
-        label: 'DAGGERHEART.Range.veryClose.name',
-        description: 'DAGGERHEART.Range.veryClose.description',
+        label: 'DAGGERHEART.Config.Range.veryClose.name',
+        description: 'DAGGERHEART.Config.Range.veryClose.description',
         distance: 3
     },
     close: {
         id: 'close',
         short: 'c',
-        label: 'DAGGERHEART.Range.close.name',
-        description: 'DAGGERHEART.Range.close.description',
+        label: 'DAGGERHEART.Config.Range.close.name',
+        description: 'DAGGERHEART.Config.Range.close.description',
         distance: 10
     },
     far: {
         id: 'far',
         short: 'f',
-        label: 'DAGGERHEART.Range.far.name',
-        description: 'DAGGERHEART.Range.far.description',
+        label: 'DAGGERHEART.Config.Range.far.name',
+        description: 'DAGGERHEART.Config.Range.far.description',
         distance: 20
     },
     veryFar: {
         id: 'veryFar',
         short: 'vf',
-        label: 'DAGGERHEART.Range.veryFar.name',
-        description: 'DAGGERHEART.Range.veryFar.description',
+        label: 'DAGGERHEART.Config.Range.veryFar.name',
+        description: 'DAGGERHEART.Config.Range.veryFar.description',
         distance: 30
     }
 };
@@ -46,68 +46,68 @@ export const range = {
 export const burden = {
     oneHanded: {
         value: 'oneHanded',
-        label: 'DAGGERHEART.Burden.oneHanded'
+        label: 'DAGGERHEART.Config.Burden.oneHanded'
     },
     twoHanded: {
         value: 'twoHanded',
-        label: 'DAGGERHEART.Burden.twoHanded'
+        label: 'DAGGERHEART.Config.Burden.twoHanded'
     }
 };
 
 export const damageTypes = {
     physical: {
         id: 'physical',
-        label: 'DAGGERHEART.DamageType.physical.name',
-        abbreviation: 'DAGGERHEART.DamageType.physical.abbreviation'
+        label: 'DAGGERHEART.Config.DamageType.physical.name',
+        abbreviation: 'DAGGERHEART.Config.DamageType.physical.abbreviation'
     },
     magical: {
         id: 'magical',
-        label: 'DAGGERHEART.DamageType.magical.name',
-        abbreviation: 'DAGGERHEART.DamageType.magical.abbreviation'
+        label: 'DAGGERHEART.Config.DamageType.magical.name',
+        abbreviation: 'DAGGERHEART.Config.DamageType.magical.abbreviation'
     }
 };
 
 export const healingTypes = {
     hitPoints: {
         id: 'hitPoints',
-        label: 'DAGGERHEART.HealingType.HitPoints.Name',
-        abbreviation: 'DAGGERHEART.HealingType.HitPoints.Abbreviation'
+        label: 'DAGGERHEART.Config.HealingType.hitPoints.name',
+        abbreviation: 'DAGGERHEART.Config.HealingType.hitPoints.abbreviation'
     },
     stress: {
         id: 'stress',
-        label: 'DAGGERHEART.HealingType.Stress.Name',
-        abbreviation: 'DAGGERHEART.HealingType.Stress.Abbreviation'
+        label: 'DAGGERHEART.Config.HealingType.stress.name',
+        abbreviation: 'DAGGERHEART.Config.HealingType.stress.abbreviation'
     },
     hope: {
         id: 'hope',
-        label: 'DAGGERHEART.HealingType.Hope.Name',
-        abbreviation: 'DAGGERHEART.HealingType.Hope.Abbreviation'
+        label: 'DAGGERHEART.Config.HealingType.hope.name',
+        abbreviation: 'DAGGERHEART.Config.HealingType.hope.abbreviation'
     },
     armorStack: {
         id: 'armorStack',
-        label: 'DAGGERHEART.HealingType.ArmorStack.Name',
-        abbreviation: 'DAGGERHEART.HealingType.ArmorStack.Abbreviation'
+        label: 'DAGGERHEART.Config.HealingType.armorStack.name',
+        abbreviation: 'DAGGERHEART.Config.HealingType.armorStack.abbreviation'
     }
 };
 
 export const conditions = {
     vulnerable: {
         id: 'vulnerable',
-        name: 'DAGGERHEART.Condition.vulnerable.name',
+        name: 'DAGGERHEART.Config.Condition.vulnerable.name',
         icon: 'icons/magic/control/silhouette-fall-slip-prone.webp',
-        description: 'DAGGERHEART.Condition.vulnerable.description'
+        description: 'DAGGERHEART.Config.Condition.vulnerable.description'
     },
     hidden: {
         id: 'hidden',
-        name: 'DAGGERHEART.Condition.hidden.name',
+        name: 'DAGGERHEART.Config.Condition.hidden.name',
         icon: 'icons/magic/perception/silhouette-stealth-shadow.webp',
-        description: 'DAGGERHEART.Condition.hidden.description'
+        description: 'DAGGERHEART.Config.Condition.hidden.description'
     },
     restrained: {
         id: 'restrained',
-        name: 'DAGGERHEART.Condition.restrained.name',
+        name: 'DAGGERHEART.Config.Condition.restrained.name',
         icon: 'icons/magic/control/debuff-chains-shackle-movement-red.webp',
-        description: 'DAGGERHEART.Condition.restrained.description'
+        description: 'DAGGERHEART.Config.Condition.restrained.description'
     }
 };
 
@@ -115,13 +115,13 @@ export const defaultRestOptions = {
     shortRest: () => ({
         tendToWounds: {
             id: 'tendToWounds',
-            name: game.i18n.localize('DAGGERHEART.Downtime.ShortRest.TendToWounds.Name'),
+            name: game.i18n.localize('DAGGERHEART.Applications.Downtime.shortRest.tendToWounds.name'),
             img: 'icons/magic/life/cross-worn-green.webp',
-            description: game.i18n.localize('DAGGERHEART.Downtime.ShortRest.TendToWounds.Description'),
+            description: game.i18n.localize('DAGGERHEART.Applications.Downtime.shortRest.tendToWounds.description'),
             actions: [
                 {
                     type: 'healing',
-                    name: game.i18n.localize('DAGGERHEART.Downtime.ShortRest.TendToWounds.Name'),
+                    name: game.i18n.localize('DAGGERHEART.Applications.Downtime.shortRest.tendToWounds.name'),
                     img: 'icons/magic/life/cross-worn-green.webp',
                     actionType: 'action',
                     healing: {
@@ -138,13 +138,13 @@ export const defaultRestOptions = {
         },
         clearStress: {
             id: 'clearStress',
-            name: game.i18n.localize('DAGGERHEART.Downtime.ShortRest.ClearStress.Name'),
+            name: game.i18n.localize('DAGGERHEART.Applications.Downtime.shortRest.clearStress.name'),
             img: 'icons/magic/perception/eye-ringed-green.webp',
-            description: game.i18n.localize('DAGGERHEART.Downtime.ShortRest.ClearStress.Description'),
+            description: game.i18n.localize('DAGGERHEART.Applications.Downtime.shortRest.clearStress.description'),
             actions: [
                 {
                     type: 'healing',
-                    name: game.i18n.localize('DAGGERHEART.Downtime.ShortRest.ClearStress.Name'),
+                    name: game.i18n.localize('DAGGERHEART.Applications.Downtime.shortRest.clearStress.name'),
                     img: 'icons/magic/perception/eye-ringed-green.webp',
                     actionType: 'action',
                     healing: {
@@ -161,53 +161,53 @@ export const defaultRestOptions = {
         },
         repairArmor: {
             id: 'repairArmor',
-            name: game.i18n.localize('DAGGERHEART.Downtime.ShortRest.RepairArmor.Name'),
+            name: game.i18n.localize('DAGGERHEART.Applications.Downtime.shortRest.repairArmor.name'),
             img: 'icons/skills/trades/smithing-anvil-silver-red.webp',
-            description: game.i18n.localize('DAGGERHEART.Downtime.ShortRest.RepairArmor.Description'),
+            description: game.i18n.localize('DAGGERHEART.Applications.Downtime.shortRest.repairArmor.description'),
             actions: []
         },
         prepare: {
             id: 'prepare',
-            name: game.i18n.localize('DAGGERHEART.Downtime.ShortRest.Prepare.Name'),
+            name: game.i18n.localize('DAGGERHEART.Applications.Downtime.shortRest.prepare.name'),
             img: 'icons/skills/trades/academics-merchant-scribe.webp',
-            description: game.i18n.localize('DAGGERHEART.Downtime.ShortRest.Prepare.Description'),
+            description: game.i18n.localize('DAGGERHEART.Applications.Downtime.shortRest.prepare.description'),
             actions: []
         }
     }),
     longRest: () => ({
         tendToWounds: {
             id: 'tendToWounds',
-            name: game.i18n.localize('DAGGERHEART.Downtime.LongRest.TendToWounds.Name'),
+            name: game.i18n.localize('DAGGERHEART.Applications.Downtime.longRest.tendToWounds.name'),
             img: 'icons/magic/life/cross-worn-green.webp',
-            description: game.i18n.localize('DAGGERHEART.Downtime.LongRest.TendToWounds.Description'),
+            description: game.i18n.localize('DAGGERHEART.Applications.Downtime.longRest.tendToWounds.description'),
             actions: []
         },
         clearStress: {
             id: 'clearStress',
-            name: game.i18n.localize('DAGGERHEART.Downtime.LongRest.ClearStress.Name'),
+            name: game.i18n.localize('DAGGERHEART.Applications.Downtime.longRest.clearStress.name'),
             img: 'icons/magic/perception/eye-ringed-green.webp',
-            description: game.i18n.localize('DAGGERHEART.Downtime.LongRest.ClearStress.Description'),
+            description: game.i18n.localize('DAGGERHEART.Applications.Downtime.longRest.clearStress.description'),
             actions: []
         },
         repairArmor: {
             id: 'repairArmor',
-            name: game.i18n.localize('DAGGERHEART.Downtime.LongRest.RepairArmor.Name'),
+            name: game.i18n.localize('DAGGERHEART.Applications.Downtime.longRest.repairArmor.name'),
             img: 'icons/skills/trades/smithing-anvil-silver-red.webp',
-            description: game.i18n.localize('DAGGERHEART.Downtime.LongRest.RepairArmor.Description'),
+            description: game.i18n.localize('DAGGERHEART.Applications.Downtime.longRest.repairArmor.description'),
             actions: []
         },
         prepare: {
             id: 'prepare',
-            name: game.i18n.localize('DAGGERHEART.Downtime.LongRest.Prepare.Name'),
+            name: game.i18n.localize('DAGGERHEART.Applications.Downtime.longRest.prepare.name'),
             img: 'icons/skills/trades/academics-merchant-scribe.webp',
-            description: game.i18n.localize('DAGGERHEART.Downtime.LongRest.Prepare.Description'),
+            description: game.i18n.localize('DAGGERHEART.Applications.Downtime.longRest.prepare.description'),
             actions: []
         },
         workOnAProject: {
             id: 'workOnAProject',
-            name: game.i18n.localize('DAGGERHEART.Downtime.LongRest.WorkOnAProject.Name'),
+            name: game.i18n.localize('DAGGERHEART.Applications.Downtime.longRest.workOnAProject.name'),
             img: 'icons/skills/social/thumbsup-approval-like.webp',
-            description: game.i18n.localize('DAGGERHEART.Downtime.LongRest.WorkOnAProject.Description'),
+            description: game.i18n.localize('DAGGERHEART.Applications.Downtime.longRest.workOnAProject.description'),
             actions: []
         }
     }),
@@ -216,51 +216,51 @@ export const defaultRestOptions = {
         name: '',
         img: 'icons/skills/trades/academics-investigation-puzzles.webp',
         description: '',
-        namePlaceholder: 'DAGGERHEART.Downtime.Custom.NamePlaceholder',
-        placeholder: 'DAGGERHEART.Downtime.Custom.Placeholder'
+        namePlaceholder: 'DAGGERHEART.Applications.Downtime.custom.namePlaceholder',
+        placeholder: 'DAGGERHEART.Applications.Downtime.custom.placeholder'
     }
 };
 
 export const deathMoves = {
     avoidDeath: {
         id: 'avoidDeath',
-        name: 'DAGGERHEART.DeathMoves.AvoidDeath.Name',
+        name: 'DAGGERHEART.Config.DeathMoves.avoidDeath.name',
         img: 'icons/magic/time/hourglass-yellow-green.webp',
-        description: 'DAGGERHEART.DeathMoves.AvoidDeath.Description'
+        description: 'DAGGERHEART.Config.DeathMoves.avoidDeath.description'
     },
     riskItAll: {
         id: 'riskItAll',
-        name: 'DAGGERHEART.DeathMoves.RiskItAll.Name',
+        name: 'DAGGERHEART.Config.DeathMoves.riskItAll.name',
         img: 'icons/sundries/gaming/dice-pair-white-green.webp',
-        description: 'DAGGERHEART.DeathMoves.RiskItAll.Description'
+        description: 'DAGGERHEART.Config.DeathMoves.riskItAll.description'
     },
     blazeOfGlory: {
         id: 'blazeOfGlory',
-        name: 'DAGGERHEART.DeathMoves.BlazeOfGlory.Name',
+        name: 'DAGGERHEART.Config.DeathMoves.blazeOfGlory.name',
         img: 'icons/magic/life/heart-cross-strong-flame-purple-orange.webp',
-        description: 'DAGGERHEART.DeathMoves.BlazeOfGlory.Description'
+        description: 'DAGGERHEART.Config.DeathMoves.blazeOfGlory.description'
     }
 };
 
 export const tiers = {
     tier1: {
         id: 'tier1',
-        label: 'DAGGERHEART.Tiers.tier1',
+        label: 'DAGGERHEART.General.Tiers.tier1',
         value: 1
     },
     tier2: {
         id: 'tier2',
-        label: 'DAGGERHEART.Tiers.tier2',
+        label: 'DAGGERHEART.General.Tiers.tier2',
         value: 2
     },
     tier3: {
         id: 'tier3',
-        label: 'DAGGERHEART.Tiers.tier3',
+        label: 'DAGGERHEART.General.Tiers.tier3',
         value: 3
     },
     tier4: {
         id: 'tier4',
-        label: 'DAGGERHEART.Tiers.tier4',
+        label: 'DAGGERHEART.General.Tiers.tier4',
         value: 4
     }
 };
@@ -331,15 +331,15 @@ export const getDiceSoNicePresets = () => {
 export const refreshTypes = {
     session: {
         id: 'session',
-        label: 'DAGGERHEART.General.RefreshType.Session'
+        label: 'DAGGERHEART.General.RefreshType.session'
     },
     shortRest: {
         id: 'shortRest',
-        label: 'DAGGERHEART.General.RefreshType.Shortrest'
+        label: 'DAGGERHEART.General.RefreshType.shortrest'
     },
     longRest: {
         id: 'longRest',
-        label: 'DAGGERHEART.General.RefreshType.Longrest'
+        label: 'DAGGERHEART.General.RefreshType.longrest'
     }
 };
 
@@ -351,7 +351,7 @@ export const abilityCosts = {
     },
     stress: {
         id: 'stress',
-        label: 'DAGGERHEART.HealingType.Stress.Name',
+        label: 'DAGGERHEART.Config.HealingType.Stress.Name',
         group: 'TYPES.Actor.character'
     },
     armor: {
@@ -361,7 +361,7 @@ export const abilityCosts = {
     },
     hp: {
         id: 'hp',
-        label: 'DAGGERHEART.HealingType.HitPoints.Name',
+        label: 'DAGGERHEART.Config.HealingType.HitPoints.Name',
         group: 'TYPES.Actor.character'
     },
     prayer: {
@@ -399,38 +399,38 @@ export const abilityCosts = {
 export const countdownTypes = {
     spotlight: {
         id: 'spotlight',
-        label: 'DAGGERHEART.Countdown.Type.Spotlight'
+        label: 'DAGGERHEART.Config.CountdownTypes.Spotlight'
     },
     characterAttack: {
         id: 'characterAttack',
-        label: 'DAGGERHEART.Countdown.Type.CharacterAttack'
+        label: 'DAGGERHEART.Config.CountdownTypes.CharacterAttack'
     },
     custom: {
         id: 'custom',
-        label: 'DAGGERHEART.Countdown.Type.Custom'
+        label: 'DAGGERHEART.Config.CountdownTypes.Custom'
     }
 };
 export const rollTypes = {
     weapon: {
         id: 'weapon',
-        label: 'DAGGERHEART.RollTypes.weapon.name'
+        label: 'DAGGERHEART.Config.RollTypes.weapon.name'
     },
     spellcast: {
         id: 'spellcast',
-        label: 'DAGGERHEART.RollTypes.spellcast.name'
+        label: 'DAGGERHEART.Config.RollTypes.spellcast.name'
     },
     ability: {
         id: 'ability',
-        label: 'DAGGERHEART.RollTypes.ability.name'
+        label: 'DAGGERHEART.Config.RollTypes.ability.name'
     },
     diceSet: {
         id: 'diceSet',
-        label: 'DAGGERHEART.RollTypes.diceSet.name'
+        label: 'DAGGERHEART.Config.RollTypes.diceSet.name'
     }
 };
 
 export const fearDisplay = {
-    token: { value: 'token', label: 'DAGGERHEART.Settings.Appearance.FearDisplay.Token' },
-    bar: { value: 'bar', label: 'DAGGERHEART.Settings.Appearance.FearDisplay.Bar' },
-    hide: { value: 'hide', label: 'DAGGERHEART.Settings.Appearance.FearDisplay.Hide' }
+    token: { value: 'token', label: 'DAGGERHEART.Settings.Appearance.fearDisplay.token' },
+    bar: { value: 'bar', label: 'DAGGERHEART.Settings.Appearance.fearDisplay.bar' },
+    hide: { value: 'hide', label: 'DAGGERHEART.Settings.Appearance.fearDisplay.hide' }
 };

--- a/module/config/generalConfig.mjs
+++ b/module/config/generalConfig.mjs
@@ -2,43 +2,43 @@ export const range = {
     self: {
         id: 'self',
         short: 's',
-        label: 'DAGGERHEART.Config.Range.self.name',
-        description: 'DAGGERHEART.Config.Range.self.description',
+        label: 'DAGGERHEART.CONFIG.Range.self.name',
+        description: 'DAGGERHEART.CONFIG.Range.self.description',
         distance: 0
     },
     melee: {
         id: 'melee',
         short: 'm',
-        label: 'DAGGERHEART.Config.Range.melee.name',
-        description: 'DAGGERHEART.Config.Range.melee.description',
+        label: 'DAGGERHEART.CONFIG.Range.melee.name',
+        description: 'DAGGERHEART.CONFIG.Range.melee.description',
         distance: 1
     },
     veryClose: {
         id: 'veryClose',
         short: 'vc',
-        label: 'DAGGERHEART.Config.Range.veryClose.name',
-        description: 'DAGGERHEART.Config.Range.veryClose.description',
+        label: 'DAGGERHEART.CONFIG.Range.veryClose.name',
+        description: 'DAGGERHEART.CONFIG.Range.veryClose.description',
         distance: 3
     },
     close: {
         id: 'close',
         short: 'c',
-        label: 'DAGGERHEART.Config.Range.close.name',
-        description: 'DAGGERHEART.Config.Range.close.description',
+        label: 'DAGGERHEART.CONFIG.Range.close.name',
+        description: 'DAGGERHEART.CONFIG.Range.close.description',
         distance: 10
     },
     far: {
         id: 'far',
         short: 'f',
-        label: 'DAGGERHEART.Config.Range.far.name',
-        description: 'DAGGERHEART.Config.Range.far.description',
+        label: 'DAGGERHEART.CONFIG.Range.far.name',
+        description: 'DAGGERHEART.CONFIG.Range.far.description',
         distance: 20
     },
     veryFar: {
         id: 'veryFar',
         short: 'vf',
-        label: 'DAGGERHEART.Config.Range.veryFar.name',
-        description: 'DAGGERHEART.Config.Range.veryFar.description',
+        label: 'DAGGERHEART.CONFIG.Range.veryFar.name',
+        description: 'DAGGERHEART.CONFIG.Range.veryFar.description',
         distance: 30
     }
 };
@@ -46,68 +46,68 @@ export const range = {
 export const burden = {
     oneHanded: {
         value: 'oneHanded',
-        label: 'DAGGERHEART.Config.Burden.oneHanded'
+        label: 'DAGGERHEART.CONFIG.Burden.oneHanded'
     },
     twoHanded: {
         value: 'twoHanded',
-        label: 'DAGGERHEART.Config.Burden.twoHanded'
+        label: 'DAGGERHEART.CONFIG.Burden.twoHanded'
     }
 };
 
 export const damageTypes = {
     physical: {
         id: 'physical',
-        label: 'DAGGERHEART.Config.DamageType.physical.name',
-        abbreviation: 'DAGGERHEART.Config.DamageType.physical.abbreviation'
+        label: 'DAGGERHEART.CONFIG.DamageType.physical.name',
+        abbreviation: 'DAGGERHEART.CONFIG.DamageType.physical.abbreviation'
     },
     magical: {
         id: 'magical',
-        label: 'DAGGERHEART.Config.DamageType.magical.name',
-        abbreviation: 'DAGGERHEART.Config.DamageType.magical.abbreviation'
+        label: 'DAGGERHEART.CONFIG.DamageType.magical.name',
+        abbreviation: 'DAGGERHEART.CONFIG.DamageType.magical.abbreviation'
     }
 };
 
 export const healingTypes = {
     hitPoints: {
         id: 'hitPoints',
-        label: 'DAGGERHEART.Config.HealingType.hitPoints.name',
-        abbreviation: 'DAGGERHEART.Config.HealingType.hitPoints.abbreviation'
+        label: 'DAGGERHEART.CONFIG.HealingType.hitPoints.name',
+        abbreviation: 'DAGGERHEART.CONFIG.HealingType.hitPoints.abbreviation'
     },
     stress: {
         id: 'stress',
-        label: 'DAGGERHEART.Config.HealingType.stress.name',
-        abbreviation: 'DAGGERHEART.Config.HealingType.stress.abbreviation'
+        label: 'DAGGERHEART.CONFIG.HealingType.stress.name',
+        abbreviation: 'DAGGERHEART.CONFIG.HealingType.stress.abbreviation'
     },
     hope: {
         id: 'hope',
-        label: 'DAGGERHEART.Config.HealingType.hope.name',
-        abbreviation: 'DAGGERHEART.Config.HealingType.hope.abbreviation'
+        label: 'DAGGERHEART.CONFIG.HealingType.hope.name',
+        abbreviation: 'DAGGERHEART.CONFIG.HealingType.hope.abbreviation'
     },
     armorStack: {
         id: 'armorStack',
-        label: 'DAGGERHEART.Config.HealingType.armorStack.name',
-        abbreviation: 'DAGGERHEART.Config.HealingType.armorStack.abbreviation'
+        label: 'DAGGERHEART.CONFIG.HealingType.armorStack.name',
+        abbreviation: 'DAGGERHEART.CONFIG.HealingType.armorStack.abbreviation'
     }
 };
 
 export const conditions = {
     vulnerable: {
         id: 'vulnerable',
-        name: 'DAGGERHEART.Config.Condition.vulnerable.name',
+        name: 'DAGGERHEART.CONFIG.Condition.vulnerable.name',
         icon: 'icons/magic/control/silhouette-fall-slip-prone.webp',
-        description: 'DAGGERHEART.Config.Condition.vulnerable.description'
+        description: 'DAGGERHEART.CONFIG.Condition.vulnerable.description'
     },
     hidden: {
         id: 'hidden',
-        name: 'DAGGERHEART.Config.Condition.hidden.name',
+        name: 'DAGGERHEART.CONFIG.Condition.hidden.name',
         icon: 'icons/magic/perception/silhouette-stealth-shadow.webp',
-        description: 'DAGGERHEART.Config.Condition.hidden.description'
+        description: 'DAGGERHEART.CONFIG.Condition.hidden.description'
     },
     restrained: {
         id: 'restrained',
-        name: 'DAGGERHEART.Config.Condition.restrained.name',
+        name: 'DAGGERHEART.CONFIG.Condition.restrained.name',
         icon: 'icons/magic/control/debuff-chains-shackle-movement-red.webp',
-        description: 'DAGGERHEART.Config.Condition.restrained.description'
+        description: 'DAGGERHEART.CONFIG.Condition.restrained.description'
     }
 };
 
@@ -115,13 +115,13 @@ export const defaultRestOptions = {
     shortRest: () => ({
         tendToWounds: {
             id: 'tendToWounds',
-            name: game.i18n.localize('DAGGERHEART.Applications.Downtime.shortRest.tendToWounds.name'),
+            name: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.shortRest.tendToWounds.name'),
             img: 'icons/magic/life/cross-worn-green.webp',
-            description: game.i18n.localize('DAGGERHEART.Applications.Downtime.shortRest.tendToWounds.description'),
+            description: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.shortRest.tendToWounds.description'),
             actions: [
                 {
                     type: 'healing',
-                    name: game.i18n.localize('DAGGERHEART.Applications.Downtime.shortRest.tendToWounds.name'),
+                    name: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.shortRest.tendToWounds.name'),
                     img: 'icons/magic/life/cross-worn-green.webp',
                     actionType: 'action',
                     healing: {
@@ -138,13 +138,13 @@ export const defaultRestOptions = {
         },
         clearStress: {
             id: 'clearStress',
-            name: game.i18n.localize('DAGGERHEART.Applications.Downtime.shortRest.clearStress.name'),
+            name: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.shortRest.clearStress.name'),
             img: 'icons/magic/perception/eye-ringed-green.webp',
-            description: game.i18n.localize('DAGGERHEART.Applications.Downtime.shortRest.clearStress.description'),
+            description: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.shortRest.clearStress.description'),
             actions: [
                 {
                     type: 'healing',
-                    name: game.i18n.localize('DAGGERHEART.Applications.Downtime.shortRest.clearStress.name'),
+                    name: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.shortRest.clearStress.name'),
                     img: 'icons/magic/perception/eye-ringed-green.webp',
                     actionType: 'action',
                     healing: {
@@ -161,53 +161,53 @@ export const defaultRestOptions = {
         },
         repairArmor: {
             id: 'repairArmor',
-            name: game.i18n.localize('DAGGERHEART.Applications.Downtime.shortRest.repairArmor.name'),
+            name: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.shortRest.repairArmor.name'),
             img: 'icons/skills/trades/smithing-anvil-silver-red.webp',
-            description: game.i18n.localize('DAGGERHEART.Applications.Downtime.shortRest.repairArmor.description'),
+            description: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.shortRest.repairArmor.description'),
             actions: []
         },
         prepare: {
             id: 'prepare',
-            name: game.i18n.localize('DAGGERHEART.Applications.Downtime.shortRest.prepare.name'),
+            name: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.shortRest.prepare.name'),
             img: 'icons/skills/trades/academics-merchant-scribe.webp',
-            description: game.i18n.localize('DAGGERHEART.Applications.Downtime.shortRest.prepare.description'),
+            description: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.shortRest.prepare.description'),
             actions: []
         }
     }),
     longRest: () => ({
         tendToWounds: {
             id: 'tendToWounds',
-            name: game.i18n.localize('DAGGERHEART.Applications.Downtime.longRest.tendToWounds.name'),
+            name: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.longRest.tendToWounds.name'),
             img: 'icons/magic/life/cross-worn-green.webp',
-            description: game.i18n.localize('DAGGERHEART.Applications.Downtime.longRest.tendToWounds.description'),
+            description: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.longRest.tendToWounds.description'),
             actions: []
         },
         clearStress: {
             id: 'clearStress',
-            name: game.i18n.localize('DAGGERHEART.Applications.Downtime.longRest.clearStress.name'),
+            name: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.longRest.clearStress.name'),
             img: 'icons/magic/perception/eye-ringed-green.webp',
-            description: game.i18n.localize('DAGGERHEART.Applications.Downtime.longRest.clearStress.description'),
+            description: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.longRest.clearStress.description'),
             actions: []
         },
         repairArmor: {
             id: 'repairArmor',
-            name: game.i18n.localize('DAGGERHEART.Applications.Downtime.longRest.repairArmor.name'),
+            name: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.longRest.repairArmor.name'),
             img: 'icons/skills/trades/smithing-anvil-silver-red.webp',
-            description: game.i18n.localize('DAGGERHEART.Applications.Downtime.longRest.repairArmor.description'),
+            description: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.longRest.repairArmor.description'),
             actions: []
         },
         prepare: {
             id: 'prepare',
-            name: game.i18n.localize('DAGGERHEART.Applications.Downtime.longRest.prepare.name'),
+            name: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.longRest.prepare.name'),
             img: 'icons/skills/trades/academics-merchant-scribe.webp',
-            description: game.i18n.localize('DAGGERHEART.Applications.Downtime.longRest.prepare.description'),
+            description: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.longRest.prepare.description'),
             actions: []
         },
         workOnAProject: {
             id: 'workOnAProject',
-            name: game.i18n.localize('DAGGERHEART.Applications.Downtime.longRest.workOnAProject.name'),
+            name: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.longRest.workOnAProject.name'),
             img: 'icons/skills/social/thumbsup-approval-like.webp',
-            description: game.i18n.localize('DAGGERHEART.Applications.Downtime.longRest.workOnAProject.description'),
+            description: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.longRest.workOnAProject.description'),
             actions: []
         }
     }),
@@ -216,51 +216,51 @@ export const defaultRestOptions = {
         name: '',
         img: 'icons/skills/trades/academics-investigation-puzzles.webp',
         description: '',
-        namePlaceholder: 'DAGGERHEART.Applications.Downtime.custom.namePlaceholder',
-        placeholder: 'DAGGERHEART.Applications.Downtime.custom.placeholder'
+        namePlaceholder: 'DAGGERHEART.APPLICATIONS.Downtime.custom.namePlaceholder',
+        placeholder: 'DAGGERHEART.APPLICATIONS.Downtime.custom.placeholder'
     }
 };
 
 export const deathMoves = {
     avoidDeath: {
         id: 'avoidDeath',
-        name: 'DAGGERHEART.Config.DeathMoves.avoidDeath.name',
+        name: 'DAGGERHEART.CONFIG.DeathMoves.avoidDeath.name',
         img: 'icons/magic/time/hourglass-yellow-green.webp',
-        description: 'DAGGERHEART.Config.DeathMoves.avoidDeath.description'
+        description: 'DAGGERHEART.CONFIG.DeathMoves.avoidDeath.description'
     },
     riskItAll: {
         id: 'riskItAll',
-        name: 'DAGGERHEART.Config.DeathMoves.riskItAll.name',
+        name: 'DAGGERHEART.CONFIG.DeathMoves.riskItAll.name',
         img: 'icons/sundries/gaming/dice-pair-white-green.webp',
-        description: 'DAGGERHEART.Config.DeathMoves.riskItAll.description'
+        description: 'DAGGERHEART.CONFIG.DeathMoves.riskItAll.description'
     },
     blazeOfGlory: {
         id: 'blazeOfGlory',
-        name: 'DAGGERHEART.Config.DeathMoves.blazeOfGlory.name',
+        name: 'DAGGERHEART.CONFIG.DeathMoves.blazeOfGlory.name',
         img: 'icons/magic/life/heart-cross-strong-flame-purple-orange.webp',
-        description: 'DAGGERHEART.Config.DeathMoves.blazeOfGlory.description'
+        description: 'DAGGERHEART.CONFIG.DeathMoves.blazeOfGlory.description'
     }
 };
 
 export const tiers = {
     tier1: {
         id: 'tier1',
-        label: 'DAGGERHEART.General.Tiers.tier1',
+        label: 'DAGGERHEART.GENERAL.Tiers.tier1',
         value: 1
     },
     tier2: {
         id: 'tier2',
-        label: 'DAGGERHEART.General.Tiers.tier2',
+        label: 'DAGGERHEART.GENERAL.Tiers.tier2',
         value: 2
     },
     tier3: {
         id: 'tier3',
-        label: 'DAGGERHEART.General.Tiers.tier3',
+        label: 'DAGGERHEART.GENERAL.Tiers.tier3',
         value: 3
     },
     tier4: {
         id: 'tier4',
-        label: 'DAGGERHEART.General.Tiers.tier4',
+        label: 'DAGGERHEART.GENERAL.Tiers.tier4',
         value: 4
     }
 };
@@ -331,15 +331,15 @@ export const getDiceSoNicePresets = () => {
 export const refreshTypes = {
     session: {
         id: 'session',
-        label: 'DAGGERHEART.General.RefreshType.session'
+        label: 'DAGGERHEART.GENERAL.RefreshType.session'
     },
     shortRest: {
         id: 'shortRest',
-        label: 'DAGGERHEART.General.RefreshType.shortrest'
+        label: 'DAGGERHEART.GENERAL.RefreshType.shortrest'
     },
     longRest: {
         id: 'longRest',
-        label: 'DAGGERHEART.General.RefreshType.longrest'
+        label: 'DAGGERHEART.GENERAL.RefreshType.longrest'
     }
 };
 
@@ -351,7 +351,7 @@ export const abilityCosts = {
     },
     stress: {
         id: 'stress',
-        label: 'DAGGERHEART.Config.HealingType.Stress.Name',
+        label: 'DAGGERHEART.CONFIG.HealingType.Stress.Name',
         group: 'TYPES.Actor.character'
     },
     armor: {
@@ -361,7 +361,7 @@ export const abilityCosts = {
     },
     hp: {
         id: 'hp',
-        label: 'DAGGERHEART.Config.HealingType.HitPoints.Name',
+        label: 'DAGGERHEART.CONFIG.HealingType.HitPoints.Name',
         group: 'TYPES.Actor.character'
     },
     prayer: {
@@ -399,38 +399,38 @@ export const abilityCosts = {
 export const countdownTypes = {
     spotlight: {
         id: 'spotlight',
-        label: 'DAGGERHEART.Config.CountdownTypes.Spotlight'
+        label: 'DAGGERHEART.CONFIG.CountdownTypes.Spotlight'
     },
     characterAttack: {
         id: 'characterAttack',
-        label: 'DAGGERHEART.Config.CountdownTypes.CharacterAttack'
+        label: 'DAGGERHEART.CONFIG.CountdownTypes.CharacterAttack'
     },
     custom: {
         id: 'custom',
-        label: 'DAGGERHEART.Config.CountdownTypes.Custom'
+        label: 'DAGGERHEART.CONFIG.CountdownTypes.Custom'
     }
 };
 export const rollTypes = {
     weapon: {
         id: 'weapon',
-        label: 'DAGGERHEART.Config.RollTypes.weapon.name'
+        label: 'DAGGERHEART.CONFIG.RollTypes.weapon.name'
     },
     spellcast: {
         id: 'spellcast',
-        label: 'DAGGERHEART.Config.RollTypes.spellcast.name'
+        label: 'DAGGERHEART.CONFIG.RollTypes.spellcast.name'
     },
     ability: {
         id: 'ability',
-        label: 'DAGGERHEART.Config.RollTypes.ability.name'
+        label: 'DAGGERHEART.CONFIG.RollTypes.ability.name'
     },
     diceSet: {
         id: 'diceSet',
-        label: 'DAGGERHEART.Config.RollTypes.diceSet.name'
+        label: 'DAGGERHEART.CONFIG.RollTypes.diceSet.name'
     }
 };
 
 export const fearDisplay = {
-    token: { value: 'token', label: 'DAGGERHEART.Settings.Appearance.fearDisplay.token' },
-    bar: { value: 'bar', label: 'DAGGERHEART.Settings.Appearance.fearDisplay.bar' },
-    hide: { value: 'hide', label: 'DAGGERHEART.Settings.Appearance.fearDisplay.hide' }
+    token: { value: 'token', label: 'DAGGERHEART.SETTINGS.Appearance.fearDisplay.token' },
+    bar: { value: 'bar', label: 'DAGGERHEART.SETTINGS.Appearance.fearDisplay.bar' },
+    hide: { value: 'hide', label: 'DAGGERHEART.SETTINGS.Appearance.fearDisplay.hide' }
 };

--- a/module/config/itemConfig.mjs
+++ b/module/config/itemConfig.mjs
@@ -1,11 +1,11 @@
 export const armorFeatures = {
     burning: {
-        label: 'DAGGERHEART.ArmorFeature.Burning.Name',
-        description: 'DAGGERHEART.ArmorFeature.Burning.Description'
+        label: 'DAGGERHEART.Config.ArmorFeature.burning.name',
+        description: 'DAGGERHEART.Config.ArmorFeature.burning.description'
     },
     channeling: {
-        label: 'DAGGERHEART.ArmorFeature.Channeling.Name',
-        description: 'DAGGERHEART.ArmorFeature.Channeling.Description',
+        label: 'DAGGERHEART.Config.ArmorFeature.channeling.name',
+        description: 'DAGGERHEART.Config.ArmorFeature.channeling.description',
         effects: [
             {
                 changes: [
@@ -19,8 +19,8 @@ export const armorFeatures = {
         ]
     },
     difficult: {
-        label: 'DAGGERHEART.ArmorFeature.Difficult.Name',
-        description: 'DAGGERHEART.ArmorFeature.Difficult.Description',
+        label: 'DAGGERHEART.Config.ArmorFeature.difficult.name',
+        description: 'DAGGERHEART.Config.ArmorFeature.difficult.description',
         effects: [
             {
                 changes: [
@@ -64,8 +64,8 @@ export const armorFeatures = {
         ]
     },
     flexible: {
-        label: 'DAGGERHEART.ArmorFeature.Flexible.Name',
-        description: 'DAGGERHEART.ArmorFeature.Flexible.Description',
+        label: 'DAGGERHEART.Config.ArmorFeature.flexible.name',
+        description: 'DAGGERHEART.Config.ArmorFeature.flexible.description',
         effects: [
             {
                 changes: [
@@ -79,12 +79,12 @@ export const armorFeatures = {
         ]
     },
     fortified: {
-        label: 'DAGGERHEART.ArmorFeature.Fortified.Name',
-        description: 'DAGGERHEART.ArmorFeature.Fortified.Description'
+        label: 'DAGGERHEART.Config.ArmorFeature.fortified.name',
+        description: 'DAGGERHEART.Config.ArmorFeature.fortified.description'
     },
     gilded: {
-        label: 'DAGGERHEART.ArmorFeature.Gilded.Name',
-        description: 'DAGGERHEART.ArmorFeature.Gilded.Description',
+        label: 'DAGGERHEART.Config.ArmorFeature.gilded.name',
+        description: 'DAGGERHEART.Config.ArmorFeature.gilded.description',
         effects: [
             {
                 changes: [
@@ -98,8 +98,8 @@ export const armorFeatures = {
         ]
     },
     heavy: {
-        label: 'DAGGERHEART.ArmorFeature.Heavy.Name',
-        description: 'DAGGERHEART.ArmorFeature.Heavy.Description',
+        label: 'DAGGERHEART.Config.ArmorFeature.heavy.name',
+        description: 'DAGGERHEART.Config.ArmorFeature.heavy.description',
         effects: [
             {
                 changes: [
@@ -113,56 +113,56 @@ export const armorFeatures = {
         ]
     },
     hopeful: {
-        label: 'DAGGERHEART.ArmorFeature.Hopeful.Name',
-        description: 'DAGGERHEART.ArmorFeature.Hopeful.Description'
+        label: 'DAGGERHEART.Config.ArmorFeature.hopeful.name',
+        description: 'DAGGERHEART.Config.ArmorFeature.hopeful.description'
     },
     impenetrable: {
-        label: 'DAGGERHEART.ArmorFeature.Impenetrable.Name',
-        description: 'DAGGERHEART.ArmorFeature.Impenetrable.Description'
+        label: 'DAGGERHEART.Config.ArmorFeature.impenetrable.name',
+        description: 'DAGGERHEART.Config.ArmorFeature.impenetrable.description'
     },
     magic: {
-        label: 'DAGGERHEART.ArmorFeature.Magic.Name',
-        description: 'DAGGERHEART.ArmorFeature.Magic.Description'
+        label: 'DAGGERHEART.Config.ArmorFeature.magic.name',
+        description: 'DAGGERHEART.Config.ArmorFeature.magic.description'
     },
     painful: {
-        label: 'DAGGERHEART.ArmorFeature.Painful.Name',
-        description: 'DAGGERHEART.ArmorFeature.Painful.Description'
+        label: 'DAGGERHEART.Config.ArmorFeature.painful.name',
+        description: 'DAGGERHEART.Config.ArmorFeature.painful.description'
     },
     physical: {
-        label: 'DAGGERHEART.ArmorFeature.Physical.Name',
-        description: 'DAGGERHEART.ArmorFeature.Physical.Description'
+        label: 'DAGGERHEART.Config.ArmorFeature.physical.name',
+        description: 'DAGGERHEART.Config.ArmorFeature.physical.description'
     },
     quiet: {
-        label: 'DAGGERHEART.ArmorFeature.Quiet.Name',
-        description: 'DAGGERHEART.ArmorFeature.Quiet.Description'
+        label: 'DAGGERHEART.Config.ArmorFeature.quiet.name',
+        description: 'DAGGERHEART.Config.ArmorFeature.quiet.description'
     },
     reinforced: {
-        label: 'DAGGERHEART.ArmorFeature.Reinforced.Name',
-        description: 'DAGGERHEART.ArmorFeature.Reinforced.Description'
+        label: 'DAGGERHEART.Config.ArmorFeature.reinforced.name',
+        description: 'DAGGERHEART.Config.ArmorFeature.reinforced.description'
     },
     resilient: {
-        label: 'DAGGERHEART.ArmorFeature.Resilient.Name',
-        description: 'DAGGERHEART.ArmorFeature.Resilient.Description'
+        label: 'DAGGERHEART.Config.ArmorFeature.resilient.name',
+        description: 'DAGGERHEART.Config.ArmorFeature.resilient.description'
     },
     sharp: {
-        label: 'DAGGERHEART.ArmorFeature.Sharp.Name',
-        description: 'DAGGERHEART.ArmorFeature.Sharp.Description'
+        label: 'DAGGERHEART.Config.ArmorFeature.sharp.name',
+        description: 'DAGGERHEART.Config.ArmorFeature.sharp.description'
     },
     shifting: {
-        label: 'DAGGERHEART.ArmorFeature.Shifting.Name',
-        description: 'DAGGERHEART.ArmorFeature.Shifting.Description'
+        label: 'DAGGERHEART.Config.ArmorFeature.shifting.name',
+        description: 'DAGGERHEART.Config.ArmorFeature.shifting.description'
     },
     timeslowing: {
-        label: 'DAGGERHEART.ArmorFeature.Timeslowing.Name',
-        description: 'DAGGERHEART.ArmorFeature.Timeslowing.Description'
+        label: 'DAGGERHEART.Config.ArmorFeature.timeslowing.name',
+        description: 'DAGGERHEART.Config.ArmorFeature.timeslowing.description'
     },
     truthseeking: {
-        label: 'DAGGERHEART.ArmorFeature.Truthseeking.Name',
-        description: 'DAGGERHEART.ArmorFeature.Truthseeking.Description'
+        label: 'DAGGERHEART.Config.ArmorFeature.truthseeking.name',
+        description: 'DAGGERHEART.Config.ArmorFeature.truthseeking.description'
     },
     veryheavy: {
-        label: 'DAGGERHEART.ArmorFeature.VeryHeavy.Name',
-        description: 'DAGGERHEART.ArmorFeature.VeryHeavy.Description',
+        label: 'DAGGERHEART.Config.ArmorFeature.veryHeavy.name',
+        description: 'DAGGERHEART.Config.ArmorFeature.veryHeavy.description',
         effects: [
             {
                 changes: [
@@ -181,15 +181,15 @@ export const armorFeatures = {
         ]
     },
     warded: {
-        label: 'DAGGERHEART.ArmorFeature.Warded.Name',
-        description: 'DAGGERHEART.ArmorFeature.Warded.Description'
+        label: 'DAGGERHEART.Config.ArmorFeature.warded.name',
+        description: 'DAGGERHEART.Config.ArmorFeature.warded.description'
     }
 };
 
 export const weaponFeatures = {
     barrier: {
-        label: 'DAGGERHEART.WeaponFeature.Barrier.Name',
-        description: 'DAGGERHEART.WeaponFeature.Barrier.Description',
+        label: 'DAGGERHEART.Config.WeaponFeature.barrier.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.barrier.description',
         effects: [
             {
                 changes: [
@@ -212,8 +212,8 @@ export const weaponFeatures = {
         ]
     },
     bonded: {
-        label: 'DAGGERHEART.WeaponFeature.Bonded.Name',
-        description: 'DAGGERHEART.WeaponFeature.Bonded.Description',
+        label: 'DAGGERHEART.Config.WeaponFeature.bonded.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.bonded.description',
         effects: [
             {
                 changes: [
@@ -227,12 +227,12 @@ export const weaponFeatures = {
         ]
     },
     bouncing: {
-        label: 'DAGGERHEART.WeaponFeature.Bouncing.Name',
-        description: 'DAGGERHEART.WeaponFeature.Bouncing.Description'
+        label: 'DAGGERHEART.Config.WeaponFeature.bouncing.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.bouncing.description'
     },
     brave: {
-        label: 'DAGGERHEART.WeaponFeature.Brave.Name',
-        description: 'DAGGERHEART.WeaponFeature.Brave.Description',
+        label: 'DAGGERHEART.Config.WeaponFeature.brave.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.brave.description',
         effects: [
             {
                 changes: [
@@ -255,16 +255,16 @@ export const weaponFeatures = {
         ]
     },
     brutal: {
-        label: 'DAGGERHEART.WeaponFeature.Brutal.Name',
-        description: 'DAGGERHEART.WeaponFeature.Brutal.Description'
+        label: 'DAGGERHEART.Config.WeaponFeature.brutal.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.brutal.description'
     },
     charged: {
-        label: 'DAGGERHEART.WeaponFeature.Charged.Name',
-        description: 'DAGGERHEART.WeaponFeature.Charged.Description',
+        label: 'DAGGERHEART.Config.WeaponFeature.charged.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.charged.description',
         actions: [
             {
                 type: 'effect',
-                name: 'DAGGERHEART.WeaponFeature.Concussive.Name',
+                name: 'DAGGERHEART.Config.WeaponFeature.concussive.name',
                 img: 'icons/skills/melee/shield-damaged-broken-brown.webp',
                 actionType: 'action',
                 cost: [
@@ -278,12 +278,12 @@ export const weaponFeatures = {
         ]
     },
     concussive: {
-        label: 'DAGGERHEART.WeaponFeature.Concussive.Name',
-        description: 'DAGGERHEART.WeaponFeature.Concussive.Description',
+        label: 'DAGGERHEART.Config.WeaponFeature.concussive.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.concussive.description',
         actions: [
             {
                 type: 'resource',
-                name: 'DAGGERHEART.WeaponFeature.Concussive.Name',
+                name: 'DAGGERHEART.Config.WeaponFeature.concussive.name',
                 img: 'icons/skills/melee/shield-damaged-broken-brown.webp',
                 actionType: 'action',
                 cost: [
@@ -296,8 +296,8 @@ export const weaponFeatures = {
         ]
     },
     cumbersome: {
-        label: 'DAGGERHEART.WeaponFeature.Cumbersome.Name',
-        description: 'DAGGERHEART.WeaponFeature.Cumbersome.Description',
+        label: 'DAGGERHEART.Config.WeaponFeature.cumbersome.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.cumbersome.description',
         effects: [
             {
                 changes: [
@@ -311,15 +311,15 @@ export const weaponFeatures = {
         ]
     },
     deadly: {
-        label: 'DAGGERHEART.WeaponFeature.Deadly.Name',
-        description: 'DAGGERHEART.WeaponFeature.Deadly.Description'
+        label: 'DAGGERHEART.Config.WeaponFeature.deadly.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.deadly.description'
     },
     deflecting: {
-        label: 'DAGGERHEART.WeaponFeature.Deflecting.Name',
-        description: 'DAGGERHEART.WeaponFeature.Deflecting.Description'
+        label: 'DAGGERHEART.Config.WeaponFeature.deflecting.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.deflecting.description'
         // actions: [{
         //     type: 'effect',
-        //     name: 'DAGGERHEART.WeaponFeature.Deflecting.Name',
+        //     name: 'DAGGERHEART.Config.WeaponFeature.Deflecting.Name',
         //     img: 'icons/skills/melee/strike-flail-destructive-yellow.webp',
         //     actionType: 'reaction',
         //     cost: [{
@@ -329,8 +329,8 @@ export const weaponFeatures = {
         // }],
     },
     destructive: {
-        label: 'DAGGERHEART.WeaponFeature.Destructive.Name',
-        description: 'DAGGERHEART.WeaponFeature.Destructive.Description',
+        label: 'DAGGERHEART.Config.WeaponFeature.destructive.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.destructive.description',
         effects: [
             {
                 changes: [
@@ -344,12 +344,12 @@ export const weaponFeatures = {
         ]
     },
     devastating: {
-        label: 'DAGGERHEART.WeaponFeature.Devastating.Name',
-        description: 'DAGGERHEART.WeaponFeature.Devastating.Description',
+        label: 'DAGGERHEART.Config.WeaponFeature.devastating.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.devastating.description',
         actions: [
             {
                 type: 'resource',
-                name: 'DAGGERHEART.WeaponFeature.Devastating.Name',
+                name: 'DAGGERHEART.Config.WeaponFeature.devastating.name',
                 img: 'icons/skills/melee/strike-flail-destructive-yellow.webp',
                 actionType: 'action',
                 cost: [
@@ -362,8 +362,8 @@ export const weaponFeatures = {
         ]
     },
     doubleduty: {
-        label: 'DAGGERHEART.WeaponFeature.DoubleDuty.Name',
-        description: 'DAGGERHEART.WeaponFeature.DoubleDuty.Description',
+        label: 'DAGGERHEART.Config.WeaponFeature.doubleDuty.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.doubleDuty.description',
         effects: [
             {
                 changes: [
@@ -377,24 +377,24 @@ export const weaponFeatures = {
         ]
     },
     doubledup: {
-        label: 'DAGGERHEART.WeaponFeature.DoubledUp.Name',
-        description: 'DAGGERHEART.WeaponFeature.DoubledUp.Description'
+        label: 'DAGGERHEART.Config.WeaponFeature.doubledUp.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.doubledUp.description'
     },
     dueling: {
-        label: 'DAGGERHEART.WeaponFeature.Dueling.Name',
-        description: 'DAGGERHEART.WeaponFeature.Dueling.Description'
+        label: 'DAGGERHEART.Config.WeaponFeature.dueling.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.dueling.description'
     },
     eruptive: {
-        label: 'DAGGERHEART.WeaponFeature.Eruptive.Name',
-        description: 'DAGGERHEART.WeaponFeature.Eruptive.Description'
+        label: 'DAGGERHEART.Config.WeaponFeature.eruptive.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.eruptive.description'
     },
     grappling: {
-        label: 'DAGGERHEART.WeaponFeature.Grappling.Name',
-        description: 'DAGGERHEART.WeaponFeature.Grappling.Description',
+        label: 'DAGGERHEART.Config.WeaponFeature.grappling.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.grappling.description',
         actions: [
             {
                 type: 'resource',
-                name: 'DAGGERHEART.WeaponFeature.Grappling.Name',
+                name: 'DAGGERHEART.Config.WeaponFeature.grappling.name',
                 img: 'icons/magic/control/debuff-chains-ropes-net-white.webp',
                 actionType: 'action',
                 cost: [
@@ -407,16 +407,16 @@ export const weaponFeatures = {
         ]
     },
     greedy: {
-        label: 'DAGGERHEART.WeaponFeature.Greedy.Name',
-        description: 'DAGGERHEART.WeaponFeature.Greedy.Description'
+        label: 'DAGGERHEART.Config.WeaponFeature.greedy.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.greedy.description'
     },
     healing: {
-        label: 'DAGGERHEART.WeaponFeature.Healing.Name',
-        description: 'DAGGERHEART.WeaponFeature.Healing.Description',
+        label: 'DAGGERHEART.Config.WeaponFeature.healing.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.healing.description',
         actions: [
             {
                 type: 'healing',
-                name: 'DAGGERHEART.WeaponFeature.Healing.Name',
+                name: 'DAGGERHEART.Config.WeaponFeature.healing.name',
                 img: 'icons/magic/life/cross-beam-green.webp',
                 actionType: 'action',
                 healing: {
@@ -432,8 +432,8 @@ export const weaponFeatures = {
         ]
     },
     heavy: {
-        label: 'DAGGERHEART.WeaponFeature.Heavy.Name',
-        description: 'DAGGERHEART.WeaponFeature.Heavy.Description',
+        label: 'DAGGERHEART.Config.WeaponFeature.heavy.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.heavy.description',
         effects: [
             {
                 changes: [
@@ -447,36 +447,36 @@ export const weaponFeatures = {
         ]
     },
     hooked: {
-        label: 'DAGGERHEART.WeaponFeature.Hooked.Name',
-        description: 'DAGGERHEART.WeaponFeature.Hooked.Description'
+        label: 'DAGGERHEART.Config.WeaponFeature.hooked.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.hooked.description'
     },
     hot: {
-        label: 'DAGGERHEART.WeaponFeature.Hot.Name',
-        description: 'DAGGERHEART.WeaponFeature.Hot.Description'
+        label: 'DAGGERHEART.Config.WeaponFeature.hot.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.hot.description'
     },
     invigorating: {
-        label: 'DAGGERHEART.WeaponFeature.Invigorating.Name',
-        description: 'DAGGERHEART.WeaponFeature.Invigorating.Description'
+        label: 'DAGGERHEART.Config.WeaponFeature.invigorating.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.invigorating.description'
     },
     lifestealing: {
-        label: 'DAGGERHEART.WeaponFeature.Lifestealing.Name',
-        description: 'DAGGERHEART.WeaponFeature.Lifestealing.Description'
+        label: 'DAGGERHEART.Config.WeaponFeature.lifestealing.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.lifestealing.description'
     },
     lockedon: {
-        label: 'DAGGERHEART.WeaponFeature.LockedOn.Name',
-        description: 'DAGGERHEART.WeaponFeature.LockedOn.Description'
+        label: 'DAGGERHEART.Config.WeaponFeature.lockedOn.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.lockedOn.description'
     },
     long: {
-        label: 'DAGGERHEART.WeaponFeature.Long.Name',
-        description: 'DAGGERHEART.WeaponFeature.Long.Description'
+        label: 'DAGGERHEART.Config.WeaponFeature.long.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.long.description'
     },
     lucky: {
-        label: 'DAGGERHEART.WeaponFeature.Lucky.Name',
-        description: 'DAGGERHEART.WeaponFeature.Lucky.Description',
+        label: 'DAGGERHEART.Config.WeaponFeature.lucky.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.lucky.description',
         actions: [
             {
                 type: 'resource',
-                name: 'DAGGERHEART.WeaponFeature.Lucky.Name',
+                name: 'DAGGERHEART.Config.WeaponFeature.lucky.name',
                 img: 'icons/magic/control/buff-luck-fortune-green.webp',
                 actionType: 'action',
                 cost: [
@@ -489,8 +489,8 @@ export const weaponFeatures = {
         ]
     },
     massive: {
-        label: 'DAGGERHEART.WeaponFeature.Massive.Name',
-        description: 'DAGGERHEART.WeaponFeature.Massive.Description',
+        label: 'DAGGERHEART.Config.WeaponFeature.massive.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.massive.description',
         effects: [
             {
                 changes: [
@@ -504,12 +504,12 @@ export const weaponFeatures = {
         ]
     },
     painful: {
-        label: 'DAGGERHEART.WeaponFeature.Painful.Name',
-        description: 'DAGGERHEART.WeaponFeature.Painful.Description',
+        label: 'DAGGERHEART.Config.WeaponFeature.painful.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.painful.description',
         actions: [
             {
                 type: 'resource',
-                name: 'DAGGERHEART.WeaponFeature.Painful.Name',
+                name: 'DAGGERHEART.Config.WeaponFeature.painful.name',
                 img: 'icons/skills/wounds/injury-face-impact-orange.webp',
                 actionType: 'action',
                 cost: [
@@ -522,31 +522,31 @@ export const weaponFeatures = {
         ]
     },
     paired: {
-        label: 'DAGGERHEART.WeaponFeature.Paired.Name',
-        description: 'DAGGERHEART.WeaponFeature.Paired.Description',
+        label: 'DAGGERHEART.Config.WeaponFeature.paired.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.paired.description',
         override: {
             bonusDamage: 1
         }
     },
     parry: {
-        label: 'DAGGERHEART.WeaponFeature.Parry.Name',
-        description: 'DAGGERHEART.WeaponFeature.Parry.Description'
+        label: 'DAGGERHEART.Config.WeaponFeature.parry.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.parry.description'
     },
     persuasive: {
-        label: 'DAGGERHEART.WeaponFeature.Persuasive.Name',
-        description: 'DAGGERHEART.WeaponFeature.Persuasive.Description'
+        label: 'DAGGERHEART.Config.WeaponFeature.persuasive.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.persuasive.description'
     },
     pompous: {
-        label: 'DAGGERHEART.WeaponFeature.Pompous.Name',
-        description: 'DAGGERHEART.WeaponFeature.Pompous.Description'
+        label: 'DAGGERHEART.Config.WeaponFeature.pompous.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.pompous.description'
     },
     powerful: {
-        label: 'DAGGERHEART.WeaponFeature.Powerful.Name',
-        description: 'DAGGERHEART.WeaponFeature.Powerful.Description'
+        label: 'DAGGERHEART.Config.WeaponFeature.powerful.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.powerful.description'
     },
     protective: {
-        label: 'DAGGERHEART.WeaponFeature.Protective.Name',
-        description: 'DAGGERHEART.WeaponFeature.Protective.Description',
+        label: 'DAGGERHEART.Config.WeaponFeature.protective.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.protective.description',
         effects: [
             {
                 changes: [
@@ -560,12 +560,12 @@ export const weaponFeatures = {
         ]
     },
     quick: {
-        label: 'DAGGERHEART.WeaponFeature.Quick.Name',
-        description: 'DAGGERHEART.WeaponFeature.Quick.Description',
+        label: 'DAGGERHEART.Config.WeaponFeature.quick.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.quick.description',
         actions: [
             {
                 type: 'resource',
-                name: 'DAGGERHEART.WeaponFeature.Quick.Name',
+                name: 'DAGGERHEART.Config.WeaponFeature.quick.name',
                 img: 'icons/skills/movement/arrow-upward-yellow.webp',
                 actionType: 'action',
                 cost: [
@@ -578,8 +578,8 @@ export const weaponFeatures = {
         ]
     },
     reliable: {
-        label: 'DAGGERHEART.WeaponFeature.Reliable.Name',
-        description: 'DAGGERHEART.WeaponFeature.Reliable.Description',
+        label: 'DAGGERHEART.Config.WeaponFeature.reliable.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.reliable.description',
         effects: [
             {
                 changes: [
@@ -593,40 +593,40 @@ export const weaponFeatures = {
         ]
     },
     reloading: {
-        label: 'DAGGERHEART.WeaponFeature.Reloading.Name',
-        description: 'DAGGERHEART.WeaponFeature.Reloading.Description'
+        label: 'DAGGERHEART.Config.WeaponFeature.reloading.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.reloading.description'
     },
     retractable: {
-        label: 'DAGGERHEART.WeaponFeature.Retractable.Name',
-        description: 'DAGGERHEART.WeaponFeature.Retractable.Description'
+        label: 'DAGGERHEART.Config.WeaponFeature.retractable.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.retractable.description'
     },
     returning: {
-        label: 'DAGGERHEART.WeaponFeature.Returning.Name',
-        description: 'DAGGERHEART.WeaponFeature.Returning.Description'
+        label: 'DAGGERHEART.Config.WeaponFeature.returning.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.returning.description'
     },
     scary: {
-        label: 'DAGGERHEART.WeaponFeature.Scary.Name',
-        description: 'DAGGERHEART.WeaponFeature.Scary.Description'
+        label: 'DAGGERHEART.Config.WeaponFeature.scary.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.scary.description'
     },
     serrated: {
-        label: 'DAGGERHEART.WeaponFeature.Serrated.Name',
-        description: 'DAGGERHEART.WeaponFeature.Serrated.Description'
+        label: 'DAGGERHEART.Config.WeaponFeature.serrated.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.serrated.description'
     },
     sharpwing: {
-        label: 'DAGGERHEART.WeaponFeature.Sharpwing.Name',
-        description: 'DAGGERHEART.WeaponFeature.Sharpwing.Description'
+        label: 'DAGGERHEART.Config.WeaponFeature.sharpwing.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.sharpwing.description'
     },
     sheltering: {
-        label: 'DAGGERHEART.WeaponFeature.Sheltering.Name',
-        description: 'DAGGERHEART.WeaponFeature.Sheltering.Description'
+        label: 'DAGGERHEART.Config.WeaponFeature.sheltering.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.sheltering.description'
     },
     startling: {
-        label: 'DAGGERHEART.WeaponFeature.Startling.Name',
-        description: 'DAGGERHEART.WeaponFeature.Startling.Description',
+        label: 'DAGGERHEART.Config.WeaponFeature.startling.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.startling.description',
         actions: [
             {
                 type: 'resource',
-                name: 'DAGGERHEART.WeaponFeature.Startling.Name',
+                name: 'DAGGERHEART.Config.WeaponFeature.startling.name',
                 img: 'icons/magic/control/fear-fright-mask-orange.webp',
                 actionType: 'action',
                 cost: [
@@ -639,12 +639,12 @@ export const weaponFeatures = {
         ]
     },
     timebending: {
-        label: 'DAGGERHEART.WeaponFeature.Timebending.Name',
-        description: 'DAGGERHEART.WeaponFeature.Timebending.Description'
+        label: 'DAGGERHEART.Config.WeaponFeature.timebending.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.timebending.description'
     },
     versatile: {
-        label: 'DAGGERHEART.WeaponFeature.Versatile.Name',
-        description: 'DAGGERHEART.WeaponFeature.Versatile.Description',
+        label: 'DAGGERHEART.Config.WeaponFeature.versatile.name',
+        description: 'DAGGERHEART.Config.WeaponFeature.versatile.description',
         versatile: {
             characterTrait: '',
             range: '',
@@ -700,42 +700,17 @@ export const featureTypes = {
     }
 };
 
-export const valueTypes = {
-    normal: {
-        id: 'normal',
-        name: 'DAGGERHEART.Feature.ValueType.Normal',
-        data: {
-            value: 0,
-            max: 0
-        }
-    },
-    input: {
-        id: 'input',
-        name: 'DAGGERHEART.Feature.ValueType.Input',
-        data: {
-            value: null
-        }
-    },
-    dice: {
-        id: 'dice',
-        name: 'DAGGERHEART.Feature.ValueType.Dice',
-        data: {
-            value: null
-        }
-    }
-};
-
 export const actionTypes = {
     passive: {
         id: 'passive',
-        label: 'DAGGERHEART.ActionType.passive'
+        label: 'DAGGERHEART.Config.ActionType.passive'
     },
     action: {
         id: 'action',
-        label: 'DAGGERHEART.ActionType.action'
+        label: 'DAGGERHEART.Config.ActionType.action'
     },
     reaction: {
         id: 'reaction',
-        label: 'DAGGERHEART.ActionType.reaction'
+        label: 'DAGGERHEART.Config.ActionType.reaction'
     }
 };

--- a/module/config/itemConfig.mjs
+++ b/module/config/itemConfig.mjs
@@ -1,11 +1,11 @@
 export const armorFeatures = {
     burning: {
-        label: 'DAGGERHEART.Config.ArmorFeature.burning.name',
-        description: 'DAGGERHEART.Config.ArmorFeature.burning.description'
+        label: 'DAGGERHEART.CONFIG.ArmorFeature.burning.name',
+        description: 'DAGGERHEART.CONFIG.ArmorFeature.burning.description'
     },
     channeling: {
-        label: 'DAGGERHEART.Config.ArmorFeature.channeling.name',
-        description: 'DAGGERHEART.Config.ArmorFeature.channeling.description',
+        label: 'DAGGERHEART.CONFIG.ArmorFeature.channeling.name',
+        description: 'DAGGERHEART.CONFIG.ArmorFeature.channeling.description',
         effects: [
             {
                 changes: [
@@ -19,8 +19,8 @@ export const armorFeatures = {
         ]
     },
     difficult: {
-        label: 'DAGGERHEART.Config.ArmorFeature.difficult.name',
-        description: 'DAGGERHEART.Config.ArmorFeature.difficult.description',
+        label: 'DAGGERHEART.CONFIG.ArmorFeature.difficult.name',
+        description: 'DAGGERHEART.CONFIG.ArmorFeature.difficult.description',
         effects: [
             {
                 changes: [
@@ -64,8 +64,8 @@ export const armorFeatures = {
         ]
     },
     flexible: {
-        label: 'DAGGERHEART.Config.ArmorFeature.flexible.name',
-        description: 'DAGGERHEART.Config.ArmorFeature.flexible.description',
+        label: 'DAGGERHEART.CONFIG.ArmorFeature.flexible.name',
+        description: 'DAGGERHEART.CONFIG.ArmorFeature.flexible.description',
         effects: [
             {
                 changes: [
@@ -79,12 +79,12 @@ export const armorFeatures = {
         ]
     },
     fortified: {
-        label: 'DAGGERHEART.Config.ArmorFeature.fortified.name',
-        description: 'DAGGERHEART.Config.ArmorFeature.fortified.description'
+        label: 'DAGGERHEART.CONFIG.ArmorFeature.fortified.name',
+        description: 'DAGGERHEART.CONFIG.ArmorFeature.fortified.description'
     },
     gilded: {
-        label: 'DAGGERHEART.Config.ArmorFeature.gilded.name',
-        description: 'DAGGERHEART.Config.ArmorFeature.gilded.description',
+        label: 'DAGGERHEART.CONFIG.ArmorFeature.gilded.name',
+        description: 'DAGGERHEART.CONFIG.ArmorFeature.gilded.description',
         effects: [
             {
                 changes: [
@@ -98,8 +98,8 @@ export const armorFeatures = {
         ]
     },
     heavy: {
-        label: 'DAGGERHEART.Config.ArmorFeature.heavy.name',
-        description: 'DAGGERHEART.Config.ArmorFeature.heavy.description',
+        label: 'DAGGERHEART.CONFIG.ArmorFeature.heavy.name',
+        description: 'DAGGERHEART.CONFIG.ArmorFeature.heavy.description',
         effects: [
             {
                 changes: [
@@ -113,56 +113,56 @@ export const armorFeatures = {
         ]
     },
     hopeful: {
-        label: 'DAGGERHEART.Config.ArmorFeature.hopeful.name',
-        description: 'DAGGERHEART.Config.ArmorFeature.hopeful.description'
+        label: 'DAGGERHEART.CONFIG.ArmorFeature.hopeful.name',
+        description: 'DAGGERHEART.CONFIG.ArmorFeature.hopeful.description'
     },
     impenetrable: {
-        label: 'DAGGERHEART.Config.ArmorFeature.impenetrable.name',
-        description: 'DAGGERHEART.Config.ArmorFeature.impenetrable.description'
+        label: 'DAGGERHEART.CONFIG.ArmorFeature.impenetrable.name',
+        description: 'DAGGERHEART.CONFIG.ArmorFeature.impenetrable.description'
     },
     magic: {
-        label: 'DAGGERHEART.Config.ArmorFeature.magic.name',
-        description: 'DAGGERHEART.Config.ArmorFeature.magic.description'
+        label: 'DAGGERHEART.CONFIG.ArmorFeature.magic.name',
+        description: 'DAGGERHEART.CONFIG.ArmorFeature.magic.description'
     },
     painful: {
-        label: 'DAGGERHEART.Config.ArmorFeature.painful.name',
-        description: 'DAGGERHEART.Config.ArmorFeature.painful.description'
+        label: 'DAGGERHEART.CONFIG.ArmorFeature.painful.name',
+        description: 'DAGGERHEART.CONFIG.ArmorFeature.painful.description'
     },
     physical: {
-        label: 'DAGGERHEART.Config.ArmorFeature.physical.name',
-        description: 'DAGGERHEART.Config.ArmorFeature.physical.description'
+        label: 'DAGGERHEART.CONFIG.ArmorFeature.physical.name',
+        description: 'DAGGERHEART.CONFIG.ArmorFeature.physical.description'
     },
     quiet: {
-        label: 'DAGGERHEART.Config.ArmorFeature.quiet.name',
-        description: 'DAGGERHEART.Config.ArmorFeature.quiet.description'
+        label: 'DAGGERHEART.CONFIG.ArmorFeature.quiet.name',
+        description: 'DAGGERHEART.CONFIG.ArmorFeature.quiet.description'
     },
     reinforced: {
-        label: 'DAGGERHEART.Config.ArmorFeature.reinforced.name',
-        description: 'DAGGERHEART.Config.ArmorFeature.reinforced.description'
+        label: 'DAGGERHEART.CONFIG.ArmorFeature.reinforced.name',
+        description: 'DAGGERHEART.CONFIG.ArmorFeature.reinforced.description'
     },
     resilient: {
-        label: 'DAGGERHEART.Config.ArmorFeature.resilient.name',
-        description: 'DAGGERHEART.Config.ArmorFeature.resilient.description'
+        label: 'DAGGERHEART.CONFIG.ArmorFeature.resilient.name',
+        description: 'DAGGERHEART.CONFIG.ArmorFeature.resilient.description'
     },
     sharp: {
-        label: 'DAGGERHEART.Config.ArmorFeature.sharp.name',
-        description: 'DAGGERHEART.Config.ArmorFeature.sharp.description'
+        label: 'DAGGERHEART.CONFIG.ArmorFeature.sharp.name',
+        description: 'DAGGERHEART.CONFIG.ArmorFeature.sharp.description'
     },
     shifting: {
-        label: 'DAGGERHEART.Config.ArmorFeature.shifting.name',
-        description: 'DAGGERHEART.Config.ArmorFeature.shifting.description'
+        label: 'DAGGERHEART.CONFIG.ArmorFeature.shifting.name',
+        description: 'DAGGERHEART.CONFIG.ArmorFeature.shifting.description'
     },
     timeslowing: {
-        label: 'DAGGERHEART.Config.ArmorFeature.timeslowing.name',
-        description: 'DAGGERHEART.Config.ArmorFeature.timeslowing.description'
+        label: 'DAGGERHEART.CONFIG.ArmorFeature.timeslowing.name',
+        description: 'DAGGERHEART.CONFIG.ArmorFeature.timeslowing.description'
     },
     truthseeking: {
-        label: 'DAGGERHEART.Config.ArmorFeature.truthseeking.name',
-        description: 'DAGGERHEART.Config.ArmorFeature.truthseeking.description'
+        label: 'DAGGERHEART.CONFIG.ArmorFeature.truthseeking.name',
+        description: 'DAGGERHEART.CONFIG.ArmorFeature.truthseeking.description'
     },
     veryheavy: {
-        label: 'DAGGERHEART.Config.ArmorFeature.veryHeavy.name',
-        description: 'DAGGERHEART.Config.ArmorFeature.veryHeavy.description',
+        label: 'DAGGERHEART.CONFIG.ArmorFeature.veryHeavy.name',
+        description: 'DAGGERHEART.CONFIG.ArmorFeature.veryHeavy.description',
         effects: [
             {
                 changes: [
@@ -181,15 +181,15 @@ export const armorFeatures = {
         ]
     },
     warded: {
-        label: 'DAGGERHEART.Config.ArmorFeature.warded.name',
-        description: 'DAGGERHEART.Config.ArmorFeature.warded.description'
+        label: 'DAGGERHEART.CONFIG.ArmorFeature.warded.name',
+        description: 'DAGGERHEART.CONFIG.ArmorFeature.warded.description'
     }
 };
 
 export const weaponFeatures = {
     barrier: {
-        label: 'DAGGERHEART.Config.WeaponFeature.barrier.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.barrier.description',
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.barrier.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.barrier.description',
         effects: [
             {
                 changes: [
@@ -212,8 +212,8 @@ export const weaponFeatures = {
         ]
     },
     bonded: {
-        label: 'DAGGERHEART.Config.WeaponFeature.bonded.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.bonded.description',
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.bonded.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.bonded.description',
         effects: [
             {
                 changes: [
@@ -227,12 +227,12 @@ export const weaponFeatures = {
         ]
     },
     bouncing: {
-        label: 'DAGGERHEART.Config.WeaponFeature.bouncing.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.bouncing.description'
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.bouncing.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.bouncing.description'
     },
     brave: {
-        label: 'DAGGERHEART.Config.WeaponFeature.brave.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.brave.description',
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.brave.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.brave.description',
         effects: [
             {
                 changes: [
@@ -255,16 +255,16 @@ export const weaponFeatures = {
         ]
     },
     brutal: {
-        label: 'DAGGERHEART.Config.WeaponFeature.brutal.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.brutal.description'
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.brutal.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.brutal.description'
     },
     charged: {
-        label: 'DAGGERHEART.Config.WeaponFeature.charged.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.charged.description',
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.charged.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.charged.description',
         actions: [
             {
                 type: 'effect',
-                name: 'DAGGERHEART.Config.WeaponFeature.concussive.name',
+                name: 'DAGGERHEART.CONFIG.WeaponFeature.concussive.name',
                 img: 'icons/skills/melee/shield-damaged-broken-brown.webp',
                 actionType: 'action',
                 cost: [
@@ -278,12 +278,12 @@ export const weaponFeatures = {
         ]
     },
     concussive: {
-        label: 'DAGGERHEART.Config.WeaponFeature.concussive.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.concussive.description',
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.concussive.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.concussive.description',
         actions: [
             {
                 type: 'resource',
-                name: 'DAGGERHEART.Config.WeaponFeature.concussive.name',
+                name: 'DAGGERHEART.CONFIG.WeaponFeature.concussive.name',
                 img: 'icons/skills/melee/shield-damaged-broken-brown.webp',
                 actionType: 'action',
                 cost: [
@@ -296,8 +296,8 @@ export const weaponFeatures = {
         ]
     },
     cumbersome: {
-        label: 'DAGGERHEART.Config.WeaponFeature.cumbersome.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.cumbersome.description',
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.cumbersome.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.cumbersome.description',
         effects: [
             {
                 changes: [
@@ -311,15 +311,15 @@ export const weaponFeatures = {
         ]
     },
     deadly: {
-        label: 'DAGGERHEART.Config.WeaponFeature.deadly.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.deadly.description'
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.deadly.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.deadly.description'
     },
     deflecting: {
-        label: 'DAGGERHEART.Config.WeaponFeature.deflecting.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.deflecting.description'
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.deflecting.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.deflecting.description'
         // actions: [{
         //     type: 'effect',
-        //     name: 'DAGGERHEART.Config.WeaponFeature.Deflecting.Name',
+        //     name: 'DAGGERHEART.CONFIG.WeaponFeature.Deflecting.Name',
         //     img: 'icons/skills/melee/strike-flail-destructive-yellow.webp',
         //     actionType: 'reaction',
         //     cost: [{
@@ -329,8 +329,8 @@ export const weaponFeatures = {
         // }],
     },
     destructive: {
-        label: 'DAGGERHEART.Config.WeaponFeature.destructive.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.destructive.description',
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.destructive.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.destructive.description',
         effects: [
             {
                 changes: [
@@ -344,12 +344,12 @@ export const weaponFeatures = {
         ]
     },
     devastating: {
-        label: 'DAGGERHEART.Config.WeaponFeature.devastating.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.devastating.description',
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.devastating.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.devastating.description',
         actions: [
             {
                 type: 'resource',
-                name: 'DAGGERHEART.Config.WeaponFeature.devastating.name',
+                name: 'DAGGERHEART.CONFIG.WeaponFeature.devastating.name',
                 img: 'icons/skills/melee/strike-flail-destructive-yellow.webp',
                 actionType: 'action',
                 cost: [
@@ -362,8 +362,8 @@ export const weaponFeatures = {
         ]
     },
     doubleduty: {
-        label: 'DAGGERHEART.Config.WeaponFeature.doubleDuty.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.doubleDuty.description',
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.doubleDuty.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.doubleDuty.description',
         effects: [
             {
                 changes: [
@@ -377,24 +377,24 @@ export const weaponFeatures = {
         ]
     },
     doubledup: {
-        label: 'DAGGERHEART.Config.WeaponFeature.doubledUp.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.doubledUp.description'
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.doubledUp.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.doubledUp.description'
     },
     dueling: {
-        label: 'DAGGERHEART.Config.WeaponFeature.dueling.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.dueling.description'
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.dueling.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.dueling.description'
     },
     eruptive: {
-        label: 'DAGGERHEART.Config.WeaponFeature.eruptive.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.eruptive.description'
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.eruptive.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.eruptive.description'
     },
     grappling: {
-        label: 'DAGGERHEART.Config.WeaponFeature.grappling.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.grappling.description',
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.grappling.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.grappling.description',
         actions: [
             {
                 type: 'resource',
-                name: 'DAGGERHEART.Config.WeaponFeature.grappling.name',
+                name: 'DAGGERHEART.CONFIG.WeaponFeature.grappling.name',
                 img: 'icons/magic/control/debuff-chains-ropes-net-white.webp',
                 actionType: 'action',
                 cost: [
@@ -407,16 +407,16 @@ export const weaponFeatures = {
         ]
     },
     greedy: {
-        label: 'DAGGERHEART.Config.WeaponFeature.greedy.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.greedy.description'
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.greedy.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.greedy.description'
     },
     healing: {
-        label: 'DAGGERHEART.Config.WeaponFeature.healing.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.healing.description',
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.healing.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.healing.description',
         actions: [
             {
                 type: 'healing',
-                name: 'DAGGERHEART.Config.WeaponFeature.healing.name',
+                name: 'DAGGERHEART.CONFIG.WeaponFeature.healing.name',
                 img: 'icons/magic/life/cross-beam-green.webp',
                 actionType: 'action',
                 healing: {
@@ -432,8 +432,8 @@ export const weaponFeatures = {
         ]
     },
     heavy: {
-        label: 'DAGGERHEART.Config.WeaponFeature.heavy.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.heavy.description',
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.heavy.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.heavy.description',
         effects: [
             {
                 changes: [
@@ -447,36 +447,36 @@ export const weaponFeatures = {
         ]
     },
     hooked: {
-        label: 'DAGGERHEART.Config.WeaponFeature.hooked.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.hooked.description'
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.hooked.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.hooked.description'
     },
     hot: {
-        label: 'DAGGERHEART.Config.WeaponFeature.hot.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.hot.description'
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.hot.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.hot.description'
     },
     invigorating: {
-        label: 'DAGGERHEART.Config.WeaponFeature.invigorating.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.invigorating.description'
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.invigorating.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.invigorating.description'
     },
     lifestealing: {
-        label: 'DAGGERHEART.Config.WeaponFeature.lifestealing.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.lifestealing.description'
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.lifestealing.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.lifestealing.description'
     },
     lockedon: {
-        label: 'DAGGERHEART.Config.WeaponFeature.lockedOn.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.lockedOn.description'
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.lockedOn.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.lockedOn.description'
     },
     long: {
-        label: 'DAGGERHEART.Config.WeaponFeature.long.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.long.description'
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.long.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.long.description'
     },
     lucky: {
-        label: 'DAGGERHEART.Config.WeaponFeature.lucky.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.lucky.description',
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.lucky.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.lucky.description',
         actions: [
             {
                 type: 'resource',
-                name: 'DAGGERHEART.Config.WeaponFeature.lucky.name',
+                name: 'DAGGERHEART.CONFIG.WeaponFeature.lucky.name',
                 img: 'icons/magic/control/buff-luck-fortune-green.webp',
                 actionType: 'action',
                 cost: [
@@ -489,8 +489,8 @@ export const weaponFeatures = {
         ]
     },
     massive: {
-        label: 'DAGGERHEART.Config.WeaponFeature.massive.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.massive.description',
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.massive.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.massive.description',
         effects: [
             {
                 changes: [
@@ -504,12 +504,12 @@ export const weaponFeatures = {
         ]
     },
     painful: {
-        label: 'DAGGERHEART.Config.WeaponFeature.painful.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.painful.description',
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.painful.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.painful.description',
         actions: [
             {
                 type: 'resource',
-                name: 'DAGGERHEART.Config.WeaponFeature.painful.name',
+                name: 'DAGGERHEART.CONFIG.WeaponFeature.painful.name',
                 img: 'icons/skills/wounds/injury-face-impact-orange.webp',
                 actionType: 'action',
                 cost: [
@@ -522,31 +522,31 @@ export const weaponFeatures = {
         ]
     },
     paired: {
-        label: 'DAGGERHEART.Config.WeaponFeature.paired.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.paired.description',
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.paired.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.paired.description',
         override: {
             bonusDamage: 1
         }
     },
     parry: {
-        label: 'DAGGERHEART.Config.WeaponFeature.parry.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.parry.description'
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.parry.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.parry.description'
     },
     persuasive: {
-        label: 'DAGGERHEART.Config.WeaponFeature.persuasive.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.persuasive.description'
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.persuasive.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.persuasive.description'
     },
     pompous: {
-        label: 'DAGGERHEART.Config.WeaponFeature.pompous.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.pompous.description'
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.pompous.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.pompous.description'
     },
     powerful: {
-        label: 'DAGGERHEART.Config.WeaponFeature.powerful.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.powerful.description'
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.powerful.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.powerful.description'
     },
     protective: {
-        label: 'DAGGERHEART.Config.WeaponFeature.protective.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.protective.description',
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.protective.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.protective.description',
         effects: [
             {
                 changes: [
@@ -560,12 +560,12 @@ export const weaponFeatures = {
         ]
     },
     quick: {
-        label: 'DAGGERHEART.Config.WeaponFeature.quick.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.quick.description',
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.quick.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.quick.description',
         actions: [
             {
                 type: 'resource',
-                name: 'DAGGERHEART.Config.WeaponFeature.quick.name',
+                name: 'DAGGERHEART.CONFIG.WeaponFeature.quick.name',
                 img: 'icons/skills/movement/arrow-upward-yellow.webp',
                 actionType: 'action',
                 cost: [
@@ -578,8 +578,8 @@ export const weaponFeatures = {
         ]
     },
     reliable: {
-        label: 'DAGGERHEART.Config.WeaponFeature.reliable.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.reliable.description',
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.reliable.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.reliable.description',
         effects: [
             {
                 changes: [
@@ -593,40 +593,40 @@ export const weaponFeatures = {
         ]
     },
     reloading: {
-        label: 'DAGGERHEART.Config.WeaponFeature.reloading.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.reloading.description'
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.reloading.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.reloading.description'
     },
     retractable: {
-        label: 'DAGGERHEART.Config.WeaponFeature.retractable.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.retractable.description'
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.retractable.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.retractable.description'
     },
     returning: {
-        label: 'DAGGERHEART.Config.WeaponFeature.returning.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.returning.description'
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.returning.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.returning.description'
     },
     scary: {
-        label: 'DAGGERHEART.Config.WeaponFeature.scary.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.scary.description'
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.scary.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.scary.description'
     },
     serrated: {
-        label: 'DAGGERHEART.Config.WeaponFeature.serrated.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.serrated.description'
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.serrated.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.serrated.description'
     },
     sharpwing: {
-        label: 'DAGGERHEART.Config.WeaponFeature.sharpwing.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.sharpwing.description'
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.sharpwing.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.sharpwing.description'
     },
     sheltering: {
-        label: 'DAGGERHEART.Config.WeaponFeature.sheltering.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.sheltering.description'
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.sheltering.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.sheltering.description'
     },
     startling: {
-        label: 'DAGGERHEART.Config.WeaponFeature.startling.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.startling.description',
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.startling.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.startling.description',
         actions: [
             {
                 type: 'resource',
-                name: 'DAGGERHEART.Config.WeaponFeature.startling.name',
+                name: 'DAGGERHEART.CONFIG.WeaponFeature.startling.name',
                 img: 'icons/magic/control/fear-fright-mask-orange.webp',
                 actionType: 'action',
                 cost: [
@@ -639,12 +639,12 @@ export const weaponFeatures = {
         ]
     },
     timebending: {
-        label: 'DAGGERHEART.Config.WeaponFeature.timebending.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.timebending.description'
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.timebending.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.timebending.description'
     },
     versatile: {
-        label: 'DAGGERHEART.Config.WeaponFeature.versatile.name',
-        description: 'DAGGERHEART.Config.WeaponFeature.versatile.description',
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.versatile.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.versatile.description',
         versatile: {
             characterTrait: '',
             range: '',
@@ -703,14 +703,14 @@ export const featureTypes = {
 export const actionTypes = {
     passive: {
         id: 'passive',
-        label: 'DAGGERHEART.Config.ActionType.passive'
+        label: 'DAGGERHEART.CONFIG.ActionType.passive'
     },
     action: {
         id: 'action',
-        label: 'DAGGERHEART.Config.ActionType.action'
+        label: 'DAGGERHEART.CONFIG.ActionType.action'
     },
     reaction: {
         id: 'reaction',
-        label: 'DAGGERHEART.Config.ActionType.reaction'
+        label: 'DAGGERHEART.CONFIG.ActionType.reaction'
     }
 };

--- a/module/config/settingsConfig.mjs
+++ b/module/config/settingsConfig.mjs
@@ -33,10 +33,10 @@ export const gameSettings = {
 export const DualityRollColor = {
     colorful: {
         value: 0,
-        label: 'DAGGERHEART.Settings.DualityRollColor.options.colorful'
+        label: 'DAGGERHEART.SETTINGS.DualityRollColor.options.colorful'
     },
     normal: {
         value: 1,
-        label: 'DAGGERHEART.Settings.DualityRollColor.options.normal'
+        label: 'DAGGERHEART.SETTINGS.DualityRollColor.options.normal'
     }
 };

--- a/module/config/settingsConfig.mjs
+++ b/module/config/settingsConfig.mjs
@@ -33,10 +33,10 @@ export const gameSettings = {
 export const DualityRollColor = {
     colorful: {
         value: 0,
-        label: 'DAGGERHEART.Settings.DualityRollColor.Options.Colorful'
+        label: 'DAGGERHEART.Settings.DualityRollColor.options.colorful'
     },
     normal: {
         value: 1,
-        label: 'DAGGERHEART.Settings.DualityRollColor.Options.Normal'
+        label: 'DAGGERHEART.Settings.DualityRollColor.options.normal'
     }
 };

--- a/module/data/action/actionDice.mjs
+++ b/module/data/action/actionDice.mjs
@@ -113,7 +113,7 @@ export class DHDamageData extends foundry.abstract.DataModel {
             }),
             resultBased: new fields.BooleanField({
                 initial: false,
-                label: 'DAGGERHEART.Actions.Settings.ResultBased.label'
+                label: 'DAGGERHEART.Actions.Settings.resultBased.label'
             }),
             value: new fields.EmbeddedDataField(DHActionDiceData),
             valueAlt: new fields.EmbeddedDataField(DHActionDiceData)

--- a/module/data/action/actionDice.mjs
+++ b/module/data/action/actionDice.mjs
@@ -113,7 +113,7 @@ export class DHDamageData extends foundry.abstract.DataModel {
             }),
             resultBased: new fields.BooleanField({
                 initial: false,
-                label: 'DAGGERHEART.Actions.Settings.resultBased.label'
+                label: 'DAGGERHEART.ACTIONS.Settings.resultBased.label'
             }),
             value: new fields.EmbeddedDataField(DHActionDiceData),
             valueAlt: new fields.EmbeddedDataField(DHActionDiceData)

--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -110,7 +110,7 @@ export default class DHBaseAction extends foundry.abstract.DataModel {
                     }),
                     resultBased: new fields.BooleanField({
                         initial: false,
-                        label: 'DAGGERHEART.Actions.Settings.resultBased.label'
+                        label: 'DAGGERHEART.ACTIONS.Settings.resultBased.label'
                     }),
                     value: new fields.EmbeddedDataField(DHActionDiceData),
                     valueAlt: new fields.EmbeddedDataField(DHActionDiceData)
@@ -563,7 +563,7 @@ export default class DHBaseAction extends foundry.abstract.DataModel {
     async toChat(origin) {
         const cls = getDocumentClass('ChatMessage');
         const systemData = {
-            title: game.i18n.localize('DAGGERHEART.Config.ActionType.action'),
+            title: game.i18n.localize('DAGGERHEART.CONFIG.ActionType.action'),
             origin: origin,
             img: this.img,
             name: this.name,

--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -110,7 +110,7 @@ export default class DHBaseAction extends foundry.abstract.DataModel {
                     }),
                     resultBased: new fields.BooleanField({
                         initial: false,
-                        label: 'DAGGERHEART.Actions.Settings.ResultBased.label'
+                        label: 'DAGGERHEART.Actions.Settings.resultBased.label'
                     }),
                     value: new fields.EmbeddedDataField(DHActionDiceData),
                     valueAlt: new fields.EmbeddedDataField(DHActionDiceData)
@@ -563,7 +563,7 @@ export default class DHBaseAction extends foundry.abstract.DataModel {
     async toChat(origin) {
         const cls = getDocumentClass('ChatMessage');
         const systemData = {
-            title: game.i18n.localize('DAGGERHEART.ActionType.action'),
+            title: game.i18n.localize('DAGGERHEART.Config.ActionType.action'),
             origin: origin,
             img: this.img,
             name: this.name,

--- a/module/data/action/damageAction.mjs
+++ b/module/data/action/damageAction.mjs
@@ -19,7 +19,7 @@ export default class DHDamageAction extends DHBaseAction {
         if (isNaN(formula)) formula = Roll.replaceFormulaData(formula, this.getRollData(data.system ?? data));
 
         const config = {
-            title: game.i18n.format('DAGGERHEART.Chat.DamageRoll.Title', { damage: this.name }),
+            title: game.i18n.format('DAGGERHEART.UI.Chat.damageRoll.title', { damage: this.name }),
             roll: { formula },
             targets: data.system?.targets.filter(t => t.hit) ?? data.targets,
             hasSave: this.hasSave,

--- a/module/data/action/effectAction.mjs
+++ b/module/data/action/effectAction.mjs
@@ -12,7 +12,7 @@ export default class DHEffectAction extends DHBaseAction {
     async chatApplyEffects(event, data) {
         const cls = getDocumentClass('ChatMessage'),
             systemData = {
-                title: game.i18n.format('DAGGERHEART.Chat.ApplyEffect.Title', { name: this.name }),
+                title: game.i18n.format('DAGGERHEART.UI.Chat.applyEffect.title', { name: this.name }),
                 origin: this.actor._id,
                 description: '',
                 targets: data.targets.map(x => ({ id: x.id, name: x.name, img: x.img, hit: true })),

--- a/module/data/action/healingAction.mjs
+++ b/module/data/action/healingAction.mjs
@@ -23,7 +23,7 @@ export default class DHHealingAction extends DHBaseAction {
             bonusDamage = [];
 
         const config = {
-            title: game.i18n.format('DAGGERHEART.Chat.HealingRoll.Title', {
+            title: game.i18n.format('DAGGERHEART.UI.Chat.healingRoll.title', {
                 healing: game.i18n.localize(CONFIG.DH.GENERAL.healingTypes[this.healing.type].label)
             }),
             roll: { formula },

--- a/module/data/actor/adversary.mjs
+++ b/module/data/actor/adversary.mjs
@@ -8,7 +8,7 @@ const resourceField = () =>
     });
 
 export default class DhpAdversary extends BaseDataActor {
-    static LOCALIZATION_PREFIXES = ['DAGGERHEART.Actors.Adversary'];
+    static LOCALIZATION_PREFIXES = ['DAGGERHEART.ACTORS.Adversary'];
 
     static get metadata() {
         return foundry.utils.mergeObject(super.metadata, {

--- a/module/data/actor/adversary.mjs
+++ b/module/data/actor/adversary.mjs
@@ -8,7 +8,7 @@ const resourceField = () =>
     });
 
 export default class DhpAdversary extends BaseDataActor {
-    static LOCALIZATION_PREFIXES = ['DAGGERHEART.Sheets.Adversary'];
+    static LOCALIZATION_PREFIXES = ['DAGGERHEART.Actors.Adversary'];
 
     static get metadata() {
         return foundry.utils.mergeObject(super.metadata, {

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -251,11 +251,11 @@ export default class DhCharacter extends BaseDataActor {
                 values: subclassFeatures
             },
             companionFeatures: {
-                title: game.i18n.localize('DAGGERHEART.Sheets.PC.CompanionFeatures'),
+                title: game.i18n.localize('DAGGERHEART.Actors.Character.companionFeatures'),
                 type: 'companion',
                 values: companionFeatures
             },
-            features: { title: game.i18n.localize('DAGGERHEART.Sheets.PC.Features'), type: 'feature', values: features }
+            features: { title: game.i18n.localize('DAGGERHEART.General.features'), type: 'feature', values: features }
         };
     }
 

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -251,11 +251,11 @@ export default class DhCharacter extends BaseDataActor {
                 values: subclassFeatures
             },
             companionFeatures: {
-                title: game.i18n.localize('DAGGERHEART.Actors.Character.companionFeatures'),
+                title: game.i18n.localize('DAGGERHEART.ACTORS.Character.companionFeatures'),
                 type: 'companion',
                 values: companionFeatures
             },
-            features: { title: game.i18n.localize('DAGGERHEART.General.features'), type: 'feature', values: features }
+            features: { title: game.i18n.localize('DAGGERHEART.GENERAL.features'), type: 'feature', values: features }
         };
     }
 

--- a/module/data/actor/companion.mjs
+++ b/module/data/actor/companion.mjs
@@ -5,7 +5,7 @@ import ActionField from '../fields/actionField.mjs';
 import { adjustDice, adjustRange } from '../../helpers/utils.mjs';
 
 export default class DhCompanion extends BaseDataActor {
-    static LOCALIZATION_PREFIXES = ['DAGGERHEART.Sheets.Companion'];
+    static LOCALIZATION_PREFIXES = ['DAGGERHEART.Actors.Companion'];
 
     static get metadata() {
         return foundry.utils.mergeObject(super.metadata, {

--- a/module/data/actor/companion.mjs
+++ b/module/data/actor/companion.mjs
@@ -5,7 +5,7 @@ import ActionField from '../fields/actionField.mjs';
 import { adjustDice, adjustRange } from '../../helpers/utils.mjs';
 
 export default class DhCompanion extends BaseDataActor {
-    static LOCALIZATION_PREFIXES = ['DAGGERHEART.Actors.Companion'];
+    static LOCALIZATION_PREFIXES = ['DAGGERHEART.ACTORS.Companion'];
 
     static get metadata() {
         return foundry.utils.mergeObject(super.metadata, {

--- a/module/data/actor/environment.mjs
+++ b/module/data/actor/environment.mjs
@@ -2,7 +2,7 @@ import BaseDataActor from './base.mjs';
 import ForeignDocumentUUIDArrayField from '../fields/foreignDocumentUUIDArrayField.mjs';
 
 export default class DhEnvironment extends BaseDataActor {
-    static LOCALIZATION_PREFIXES = ['DAGGERHEART.Actors.Environment'];
+    static LOCALIZATION_PREFIXES = ['DAGGERHEART.ACTORS.Environment'];
 
     static get metadata() {
         return foundry.utils.mergeObject(super.metadata, {

--- a/module/data/actor/environment.mjs
+++ b/module/data/actor/environment.mjs
@@ -1,9 +1,8 @@
 import BaseDataActor from './base.mjs';
-import ActionField from '../fields/actionField.mjs';
 import ForeignDocumentUUIDArrayField from '../fields/foreignDocumentUUIDArrayField.mjs';
 
 export default class DhEnvironment extends BaseDataActor {
-    static LOCALIZATION_PREFIXES = ['DAGGERHEART.Sheets.Environment'];
+    static LOCALIZATION_PREFIXES = ['DAGGERHEART.Actors.Environment'];
 
     static get metadata() {
         return foundry.utils.mergeObject(super.metadata, {

--- a/module/data/countdowns.mjs
+++ b/module/data/countdowns.mjs
@@ -14,7 +14,7 @@ export default class DhCountdowns extends foundry.abstract.DataModel {
 }
 
 class DhCountdownData extends foundry.abstract.DataModel {
-    static LOCALIZATION_PREFIXES = ['DAGGERHEART.Applications.Countdown']; // Nots ure why this won't work. Setting labels manually for now
+    static LOCALIZATION_PREFIXES = ['DAGGERHEART.APPLICATIONS.Countdown']; // Nots ure why this won't work. Setting labels manually for now
 
     static defineSchema() {
         const fields = foundry.data.fields;
@@ -62,7 +62,7 @@ class DhCountdown extends foundry.abstract.DataModel {
         return {
             name: new fields.StringField({
                 required: true,
-                label: 'DAGGERHEART.Applications.Countdown.FIELDS.countdowns.element.name.label'
+                label: 'DAGGERHEART.APPLICATIONS.Countdown.FIELDS.countdowns.element.name.label'
             }),
             img: new fields.FilePathField({
                 categories: ['IMAGE'],
@@ -90,23 +90,23 @@ class DhCountdown extends foundry.abstract.DataModel {
                     required: true,
                     integer: true,
                     initial: 1,
-                    label: 'DAGGERHEART.Applications.Countdown.FIELDS.countdowns.element.progress.current.label'
+                    label: 'DAGGERHEART.APPLICATIONS.Countdown.FIELDS.countdowns.element.progress.current.label'
                 }),
                 max: new fields.NumberField({
                     required: true,
                     integer: true,
                     initial: 1,
-                    label: 'DAGGERHEART.Applications.Countdown.FIELDS.countdowns.element.progress.max.label'
+                    label: 'DAGGERHEART.APPLICATIONS.Countdown.FIELDS.countdowns.element.progress.max.label'
                 }),
                 type: new fields.SchemaField({
                     value: new fields.StringField({
                         required: true,
                         choices: CONFIG.DH.GENERAL.countdownTypes,
                         initial: CONFIG.DH.GENERAL.countdownTypes.spotlight.id,
-                        label: 'DAGGERHEART.Applications.Countdown.FIELDS.countdowns.element.progress.type.value.label'
+                        label: 'DAGGERHEART.APPLICATIONS.Countdown.FIELDS.countdowns.element.progress.type.value.label'
                     }),
                     label: new fields.StringField({
-                        label: 'DAGGERHEART.Applications.Countdown.FIELDS.countdowns.element.progress.type.label.label'
+                        label: 'DAGGERHEART.APPLICATIONS.Countdown.FIELDS.countdowns.element.progress.type.label.label'
                     })
                 })
             })

--- a/module/data/countdowns.mjs
+++ b/module/data/countdowns.mjs
@@ -14,7 +14,7 @@ export default class DhCountdowns extends foundry.abstract.DataModel {
 }
 
 class DhCountdownData extends foundry.abstract.DataModel {
-    static LOCALIZATION_PREFIXES = ['DAGGERHEART.Countdown']; // Nots ure why this won't work. Setting labels manually for now
+    static LOCALIZATION_PREFIXES = ['DAGGERHEART.Applications.Countdown']; // Nots ure why this won't work. Setting labels manually for now
 
     static defineSchema() {
         const fields = foundry.data.fields;
@@ -62,7 +62,7 @@ class DhCountdown extends foundry.abstract.DataModel {
         return {
             name: new fields.StringField({
                 required: true,
-                label: 'DAGGERHEART.Countdown.FIELDS.countdowns.element.name.label'
+                label: 'DAGGERHEART.Applications.Countdown.FIELDS.countdowns.element.name.label'
             }),
             img: new fields.FilePathField({
                 categories: ['IMAGE'],
@@ -90,23 +90,23 @@ class DhCountdown extends foundry.abstract.DataModel {
                     required: true,
                     integer: true,
                     initial: 1,
-                    label: 'DAGGERHEART.Countdown.FIELDS.countdowns.element.progress.current.label'
+                    label: 'DAGGERHEART.Applications.Countdown.FIELDS.countdowns.element.progress.current.label'
                 }),
                 max: new fields.NumberField({
                     required: true,
                     integer: true,
                     initial: 1,
-                    label: 'DAGGERHEART.Countdown.FIELDS.countdowns.element.progress.max.label'
+                    label: 'DAGGERHEART.Applications.Countdown.FIELDS.countdowns.element.progress.max.label'
                 }),
                 type: new fields.SchemaField({
                     value: new fields.StringField({
                         required: true,
                         choices: CONFIG.DH.GENERAL.countdownTypes,
                         initial: CONFIG.DH.GENERAL.countdownTypes.spotlight.id,
-                        label: 'DAGGERHEART.Countdown.FIELDS.countdowns.element.progress.type.value.label'
+                        label: 'DAGGERHEART.Applications.Countdown.FIELDS.countdowns.element.progress.type.value.label'
                     }),
                     label: new fields.StringField({
-                        label: 'DAGGERHEART.Countdown.FIELDS.countdowns.element.progress.type.label.label'
+                        label: 'DAGGERHEART.Applications.Countdown.FIELDS.countdowns.element.progress.type.label.label'
                     })
                 })
             })

--- a/module/data/item/beastform.mjs
+++ b/module/data/item/beastform.mjs
@@ -64,7 +64,7 @@ export default class DHBeastform extends BaseDataItem {
         await this.parent.parent.createEmbeddedDocuments('ActiveEffect', [
             {
                 type: 'beastform',
-                name: game.i18n.localize('DAGGERHEART.Items.Beastform.beastformEffect'),
+                name: game.i18n.localize('DAGGERHEART.ITEMS.Beastform.beastformEffect'),
                 img: 'icons/creatures/abilities/paw-print-pair-purple.webp',
                 system: {
                     isBeastform: true,

--- a/module/data/item/beastform.mjs
+++ b/module/data/item/beastform.mjs
@@ -43,12 +43,12 @@ export default class DHBeastform extends BaseDataItem {
         if (!this.actor) return;
 
         if (this.actor.type !== 'character') {
-            ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.notifications.beastformInapplicable'));
+            ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.beastformInapplicable'));
             return false;
         }
 
         if (this.actor.items.find(x => x.type === 'beastform')) {
-            ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.notifications.beastformAlreadyApplied'));
+            ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.beastformAlreadyApplied'));
             return false;
         }
 
@@ -64,7 +64,7 @@ export default class DHBeastform extends BaseDataItem {
         await this.parent.parent.createEmbeddedDocuments('ActiveEffect', [
             {
                 type: 'beastform',
-                name: game.i18n.localize('DAGGERHEART.Sheets.Beastform.beastformEffect'),
+                name: game.i18n.localize('DAGGERHEART.Items.Beastform.beastformEffect'),
                 img: 'icons/creatures/abilities/paw-print-pair-purple.webp',
                 system: {
                     isBeastform: true,

--- a/module/data/item/class.mjs
+++ b/module/data/item/class.mjs
@@ -24,9 +24,9 @@ export default class DHClass extends BaseDataItem {
                 integer: true,
                 min: 1,
                 initial: 5,
-                label: 'DAGGERHEART.General.hitPoints'
+                label: 'DAGGERHEART.GENERAL.hitPoints'
             }),
-            evasion: new fields.NumberField({ initial: 0, integer: true, label: 'DAGGERHEART.General.evasion' }),
+            evasion: new fields.NumberField({ initial: 0, integer: true, label: 'DAGGERHEART.GENERAL.evasion' }),
             hopeFeatures: new ForeignDocumentUUIDArrayField({ type: 'Item' }),
             classFeatures: new ForeignDocumentUUIDArrayField({ type: 'Item' }),
             subclasses: new ForeignDocumentUUIDArrayField({ type: 'Item', required: false }),

--- a/module/data/item/class.mjs
+++ b/module/data/item/class.mjs
@@ -24,9 +24,9 @@ export default class DHClass extends BaseDataItem {
                 integer: true,
                 min: 1,
                 initial: 5,
-                label: 'DAGGERHEART.Sheets.Class.HitPoints'
+                label: 'DAGGERHEART.General.hitPoints'
             }),
-            evasion: new fields.NumberField({ initial: 0, integer: true, label: 'DAGGERHEART.Sheets.Class.Evasion' }),
+            evasion: new fields.NumberField({ initial: 0, integer: true, label: 'DAGGERHEART.General.evasion' }),
             hopeFeatures: new ForeignDocumentUUIDArrayField({ type: 'Item' }),
             classFeatures: new ForeignDocumentUUIDArrayField({ type: 'Item' }),
             subclasses: new ForeignDocumentUUIDArrayField({ type: 'Item', required: false }),
@@ -67,7 +67,7 @@ export default class DHClass extends BaseDataItem {
         if (this.actor?.type === 'character') {
             const path = data.system.isMulticlass ? 'system.multiclass.value' : 'system.class.value';
             if (foundry.utils.getProperty(this.actor, path)) {
-                ui.notifications.error(game.i18n.localize('DAGGERHEART.Item.Errors.ClassAlreadySelected'));
+                ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.classAlreadySelected'));
                 return false;
             }
         }

--- a/module/data/item/domainCard.mjs
+++ b/module/data/item/domainCard.mjs
@@ -40,17 +40,17 @@ export default class DHDomainCard extends BaseDataItem {
 
         if (this.actor?.type === 'character') {
             if (!this.actor.system.class.value) {
-                ui.notifications.error(game.i18n.localize('DAGGERHEART.Item.Errors.NoClassSelected'));
+                ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.noClassSelected'));
                 return false;
             }
 
             if (!this.actor.system.domains.find(x => x === this.domain)) {
-                ui.notifications.error(game.i18n.localize('DAGGERHEART.Item.Errors.LacksDomain'));
+                ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.lacksDomain'));
                 return false;
             }
 
             if (this.actor.system.domainCards.total.find(x => x.name === this.parent.name)) {
-                ui.notifications.error(game.i18n.localize('DAGGERHEART.Item.Errors.DuplicateDomainCard'));
+                ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.duplicateDomainCard'));
                 return false;
             }
         }

--- a/module/data/item/subclass.mjs
+++ b/module/data/item/subclass.mjs
@@ -50,13 +50,13 @@ export default class DHSubclass extends BaseDataItem {
                 x => x.type === 'subclass' && x.system.isMulticlass === data.system.isMulticlass
             );
             if (!classData) {
-                ui.notifications.error(game.i18n.localize('DAGGERHEART.Item.Errors.MissingClass'));
+                ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.missingClass'));
                 return false;
             } else if (subclassData) {
-                ui.notifications.error(game.i18n.localize('DAGGERHEART.Item.Errors.SubclassAlreadySelected'));
+                ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.subclassAlreadySelected'));
                 return false;
             } else if (classData.system.subclasses.every(x => x.uuid !== (data.uuid ?? `Item.${data._id}`))) {
-                ui.notifications.error(game.i18n.localize('DAGGERHEART.Item.Errors.SubclassNotInClass'));
+                ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.subclassNotInClass'));
                 return false;
             }
         }

--- a/module/data/levelTier.mjs
+++ b/module/data/levelTier.mjs
@@ -68,9 +68,9 @@ export const CompanionLevelOptionType = {
         label: 'Creature Comfort',
         features: [
             {
-                name: 'DAGGERHEART.Applications.Levelup.actions.creatureComfort.name',
+                name: 'DAGGERHEART.APPLICATIONS.Levelup.actions.creatureComfort.name',
                 img: 'icons/magic/life/heart-cross-purple-orange.webp',
-                description: 'DAGGERHEART.Applications.Levelup.actions.creatureComfort.description'
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.actions.creatureComfort.description'
             }
         ]
     },
@@ -79,9 +79,9 @@ export const CompanionLevelOptionType = {
         label: 'Armored',
         features: [
             {
-                name: 'DAGGERHEART.Applications.Levelup.actions.armored.name',
+                name: 'DAGGERHEART.APPLICATIONS.Levelup.actions.armored.name',
                 img: 'icons/equipment/shield/kite-wooden-oak-glow.webp',
-                description: 'DAGGERHEART.Applications.Levelup.actions.armored.description'
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.actions.armored.description'
             }
         ]
     },
@@ -98,9 +98,9 @@ export const CompanionLevelOptionType = {
         label: 'Bonded',
         features: [
             {
-                name: 'DAGGERHEART.Applications.Levelup.actions.bonded.name',
+                name: 'DAGGERHEART.APPLICATIONS.Levelup.actions.bonded.name',
                 img: 'icons/magic/life/heart-red-blue.webp',
-                description: 'DAGGERHEART.Applications.Levelup.actions.bonded.description'
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.actions.bonded.description'
             }
         ]
     },
@@ -182,14 +182,14 @@ export const defaultLevelTiers = {
             domainCardByLevel: 1,
             options: {
                 trait: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.trait',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.trait',
                     checkboxSelections: 3,
                     minCost: 1,
                     type: LevelOptionType.trait.id,
                     amount: 2
                 },
                 hitPoint: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.hitPoint',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.hitPoint',
                     checkboxSelections: 2,
                     minCost: 1,
                     type: LevelOptionType.hitPoint.id,
@@ -197,14 +197,14 @@ export const defaultLevelTiers = {
                     value: 1
                 },
                 stress: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.stress',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.stress',
                     checkboxSelections: 2,
                     minCost: 1,
                     type: LevelOptionType.stress.id,
                     value: 1
                 },
                 experience: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.experience',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.experience',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: LevelOptionType.experience.id,
@@ -212,14 +212,14 @@ export const defaultLevelTiers = {
                     amount: 2
                 },
                 domainCard: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.domainCard',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.domainCard',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: LevelOptionType.domainCard.id,
                     amount: 1
                 },
                 evasion: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.evasion',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.evasion',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: LevelOptionType.evasion.id,
@@ -245,28 +245,28 @@ export const defaultLevelTiers = {
             domainCardByLevel: 1,
             options: {
                 trait: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.trait',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.trait',
                     checkboxSelections: 3,
                     minCost: 1,
                     type: LevelOptionType.trait.id,
                     amount: 2
                 },
                 hitPoint: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.hitPoint',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.hitPoint',
                     checkboxSelections: 2,
                     minCost: 1,
                     type: LevelOptionType.hitPoint.id,
                     value: 1
                 },
                 stress: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.stress',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.stress',
                     checkboxSelections: 2,
                     minCost: 1,
                     type: LevelOptionType.stress.id,
                     value: 1
                 },
                 experience: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.experience',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.experience',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: LevelOptionType.experience.id,
@@ -274,34 +274,34 @@ export const defaultLevelTiers = {
                     amount: 2
                 },
                 domainCard: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.domainCard',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.domainCard',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: LevelOptionType.domainCard.id,
                     amount: 1
                 },
                 evasion: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.evasion',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.evasion',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: LevelOptionType.evasion.id,
                     value: 1
                 },
                 subclass: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.subclass',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.subclass',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: LevelOptionType.subclass.id
                 },
                 proficiency: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.proficiency',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.proficiency',
                     checkboxSelections: 2,
                     minCost: 2,
                     type: LevelOptionType.proficiency.id,
                     value: 1
                 },
                 multiclass: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.multiclass',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.multiclass',
                     checkboxSelections: 2,
                     minCost: 2,
                     type: LevelOptionType.multiclass.id
@@ -326,28 +326,28 @@ export const defaultLevelTiers = {
             domainCardByLevel: 1,
             options: {
                 trait: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.trait',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.trait',
                     checkboxSelections: 3,
                     minCost: 1,
                     type: LevelOptionType.trait.id,
                     amount: 2
                 },
                 hitPoint: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.hitPoint',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.hitPoint',
                     checkboxSelections: 2,
                     minCost: 1,
                     type: LevelOptionType.hitPoint.id,
                     value: 1
                 },
                 stress: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.stress',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.stress',
                     checkboxSelections: 2,
                     minCost: 1,
                     type: LevelOptionType.stress.id,
                     value: 1
                 },
                 experience: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.experience',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.experience',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: LevelOptionType.experience.id,
@@ -355,34 +355,34 @@ export const defaultLevelTiers = {
                     amount: 2
                 },
                 domainCard: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.domainCard',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.domainCard',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: LevelOptionType.domainCard.id,
                     amount: 1
                 },
                 evasion: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.evasion',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.evasion',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: LevelOptionType.evasion.id,
                     value: 1
                 },
                 subclass: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.subclass',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.subclass',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: LevelOptionType.subclass.id
                 },
                 proficiency: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.proficiency',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.proficiency',
                     checkboxSelections: 2,
                     minCost: 2,
                     type: LevelOptionType.proficiency.id,
                     value: 1
                 },
                 multiclass: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.multiclass',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.multiclass',
                     checkboxSelections: 2,
                     minCost: 2,
                     type: LevelOptionType.multiclass.id
@@ -406,7 +406,7 @@ export const defaultCompanionTier = {
             domainCardByLevel: 0,
             options: {
                 experience: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.intelligent',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.intelligent',
                     checkboxSelections: 3,
                     minCost: 1,
                     type: LevelOptionType.experience.id,
@@ -414,28 +414,28 @@ export const defaultCompanionTier = {
                     amount: 1
                 },
                 hope: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.lightInTheDark',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.lightInTheDark',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: CompanionLevelOptionType.hope.id,
                     value: 1
                 },
                 creatureComfort: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.creatureComfort',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.creatureComfort',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: CompanionLevelOptionType.creatureComfort.id,
                     value: 1
                 },
                 armored: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.armored',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.armored',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: CompanionLevelOptionType.armored.id,
                     value: 1
                 },
                 vicious: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.vicious',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.vicious',
                     checkboxSelections: 3,
                     minCost: 1,
                     type: CompanionLevelOptionType.vicious.id,
@@ -443,21 +443,21 @@ export const defaultCompanionTier = {
                     amount: 1
                 },
                 stress: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.resilient',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.resilient',
                     checkboxSelections: 3,
                     minCost: 1,
                     type: LevelOptionType.stress.id,
                     value: 1
                 },
                 bonded: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.bonded',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.bonded',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: CompanionLevelOptionType.bonded.id,
                     value: 1
                 },
                 evasion: {
-                    label: 'DAGGERHEART.Applications.Levelup.options.aware',
+                    label: 'DAGGERHEART.APPLICATIONS.Levelup.options.aware',
                     checkboxSelections: 3,
                     minCost: 1,
                     type: LevelOptionType.evasion.id,

--- a/module/data/levelTier.mjs
+++ b/module/data/levelTier.mjs
@@ -68,9 +68,9 @@ export const CompanionLevelOptionType = {
         label: 'Creature Comfort',
         features: [
             {
-                name: 'DAGGERHEART.LevelUp.Actions.CreatureComfort.Name',
+                name: 'DAGGERHEART.Applications.Levelup.actions.creatureComfort.name',
                 img: 'icons/magic/life/heart-cross-purple-orange.webp',
-                description: 'DAGGERHEART.LevelUp.Actions.CreatureComfort.Description'
+                description: 'DAGGERHEART.Applications.Levelup.actions.creatureComfort.description'
             }
         ]
     },
@@ -79,9 +79,9 @@ export const CompanionLevelOptionType = {
         label: 'Armored',
         features: [
             {
-                name: 'DAGGERHEART.LevelUp.Actions.Armored.Name',
+                name: 'DAGGERHEART.Applications.Levelup.actions.armored.name',
                 img: 'icons/equipment/shield/kite-wooden-oak-glow.webp',
-                description: 'DAGGERHEART.LevelUp.Actions.Armored.Description'
+                description: 'DAGGERHEART.Applications.Levelup.actions.armored.description'
             }
         ]
     },
@@ -98,9 +98,9 @@ export const CompanionLevelOptionType = {
         label: 'Bonded',
         features: [
             {
-                name: 'DAGGERHEART.LevelUp.Actions.Bonded.Name',
+                name: 'DAGGERHEART.Applications.Levelup.actions.bonded.name',
                 img: 'icons/magic/life/heart-red-blue.webp',
-                description: 'DAGGERHEART.LevelUp.Actions.Bonded.Description'
+                description: 'DAGGERHEART.Applications.Levelup.actions.bonded.description'
             }
         ]
     },
@@ -182,14 +182,14 @@ export const defaultLevelTiers = {
             domainCardByLevel: 1,
             options: {
                 trait: {
-                    label: 'DAGGERHEART.LevelUp.Options.trait',
+                    label: 'DAGGERHEART.Applications.Levelup.options.trait',
                     checkboxSelections: 3,
                     minCost: 1,
                     type: LevelOptionType.trait.id,
                     amount: 2
                 },
                 hitPoint: {
-                    label: 'DAGGERHEART.LevelUp.Options.hitPoint',
+                    label: 'DAGGERHEART.Applications.Levelup.options.hitPoint',
                     checkboxSelections: 2,
                     minCost: 1,
                     type: LevelOptionType.hitPoint.id,
@@ -197,14 +197,14 @@ export const defaultLevelTiers = {
                     value: 1
                 },
                 stress: {
-                    label: 'DAGGERHEART.LevelUp.Options.stress',
+                    label: 'DAGGERHEART.Applications.Levelup.options.stress',
                     checkboxSelections: 2,
                     minCost: 1,
                     type: LevelOptionType.stress.id,
                     value: 1
                 },
                 experience: {
-                    label: 'DAGGERHEART.LevelUp.Options.experience',
+                    label: 'DAGGERHEART.Applications.Levelup.options.experience',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: LevelOptionType.experience.id,
@@ -212,14 +212,14 @@ export const defaultLevelTiers = {
                     amount: 2
                 },
                 domainCard: {
-                    label: 'DAGGERHEART.LevelUp.Options.domainCard',
+                    label: 'DAGGERHEART.Applications.Levelup.options.domainCard',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: LevelOptionType.domainCard.id,
                     amount: 1
                 },
                 evasion: {
-                    label: 'DAGGERHEART.LevelUp.Options.evasion',
+                    label: 'DAGGERHEART.Applications.Levelup.options.evasion',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: LevelOptionType.evasion.id,
@@ -245,28 +245,28 @@ export const defaultLevelTiers = {
             domainCardByLevel: 1,
             options: {
                 trait: {
-                    label: 'DAGGERHEART.LevelUp.Options.trait',
+                    label: 'DAGGERHEART.Applications.Levelup.options.trait',
                     checkboxSelections: 3,
                     minCost: 1,
                     type: LevelOptionType.trait.id,
                     amount: 2
                 },
                 hitPoint: {
-                    label: 'DAGGERHEART.LevelUp.Options.hitPoint',
+                    label: 'DAGGERHEART.Applications.Levelup.options.hitPoint',
                     checkboxSelections: 2,
                     minCost: 1,
                     type: LevelOptionType.hitPoint.id,
                     value: 1
                 },
                 stress: {
-                    label: 'DAGGERHEART.LevelUp.Options.stress',
+                    label: 'DAGGERHEART.Applications.Levelup.options.stress',
                     checkboxSelections: 2,
                     minCost: 1,
                     type: LevelOptionType.stress.id,
                     value: 1
                 },
                 experience: {
-                    label: 'DAGGERHEART.LevelUp.Options.experience',
+                    label: 'DAGGERHEART.Applications.Levelup.options.experience',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: LevelOptionType.experience.id,
@@ -274,34 +274,34 @@ export const defaultLevelTiers = {
                     amount: 2
                 },
                 domainCard: {
-                    label: 'DAGGERHEART.LevelUp.Options.domainCard',
+                    label: 'DAGGERHEART.Applications.Levelup.options.domainCard',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: LevelOptionType.domainCard.id,
                     amount: 1
                 },
                 evasion: {
-                    label: 'DAGGERHEART.LevelUp.Options.evasion',
+                    label: 'DAGGERHEART.Applications.Levelup.options.evasion',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: LevelOptionType.evasion.id,
                     value: 1
                 },
                 subclass: {
-                    label: 'DAGGERHEART.LevelUp.Options.subclass',
+                    label: 'DAGGERHEART.Applications.Levelup.options.subclass',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: LevelOptionType.subclass.id
                 },
                 proficiency: {
-                    label: 'DAGGERHEART.LevelUp.Options.proficiency',
+                    label: 'DAGGERHEART.Applications.Levelup.options.proficiency',
                     checkboxSelections: 2,
                     minCost: 2,
                     type: LevelOptionType.proficiency.id,
                     value: 1
                 },
                 multiclass: {
-                    label: 'DAGGERHEART.LevelUp.Options.multiclass',
+                    label: 'DAGGERHEART.Applications.Levelup.options.multiclass',
                     checkboxSelections: 2,
                     minCost: 2,
                     type: LevelOptionType.multiclass.id
@@ -326,28 +326,28 @@ export const defaultLevelTiers = {
             domainCardByLevel: 1,
             options: {
                 trait: {
-                    label: 'DAGGERHEART.LevelUp.Options.trait',
+                    label: 'DAGGERHEART.Applications.Levelup.options.trait',
                     checkboxSelections: 3,
                     minCost: 1,
                     type: LevelOptionType.trait.id,
                     amount: 2
                 },
                 hitPoint: {
-                    label: 'DAGGERHEART.LevelUp.Options.hitPoint',
+                    label: 'DAGGERHEART.Applications.Levelup.options.hitPoint',
                     checkboxSelections: 2,
                     minCost: 1,
                     type: LevelOptionType.hitPoint.id,
                     value: 1
                 },
                 stress: {
-                    label: 'DAGGERHEART.LevelUp.Options.stress',
+                    label: 'DAGGERHEART.Applications.Levelup.options.stress',
                     checkboxSelections: 2,
                     minCost: 1,
                     type: LevelOptionType.stress.id,
                     value: 1
                 },
                 experience: {
-                    label: 'DAGGERHEART.LevelUp.Options.experience',
+                    label: 'DAGGERHEART.Applications.Levelup.options.experience',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: LevelOptionType.experience.id,
@@ -355,34 +355,34 @@ export const defaultLevelTiers = {
                     amount: 2
                 },
                 domainCard: {
-                    label: 'DAGGERHEART.LevelUp.Options.domainCard',
+                    label: 'DAGGERHEART.Applications.Levelup.options.domainCard',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: LevelOptionType.domainCard.id,
                     amount: 1
                 },
                 evasion: {
-                    label: 'DAGGERHEART.LevelUp.Options.evasion',
+                    label: 'DAGGERHEART.Applications.Levelup.options.evasion',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: LevelOptionType.evasion.id,
                     value: 1
                 },
                 subclass: {
-                    label: 'DAGGERHEART.LevelUp.Options.subclass',
+                    label: 'DAGGERHEART.Applications.Levelup.options.subclass',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: LevelOptionType.subclass.id
                 },
                 proficiency: {
-                    label: 'DAGGERHEART.LevelUp.Options.proficiency',
+                    label: 'DAGGERHEART.Applications.Levelup.options.proficiency',
                     checkboxSelections: 2,
                     minCost: 2,
                     type: LevelOptionType.proficiency.id,
                     value: 1
                 },
                 multiclass: {
-                    label: 'DAGGERHEART.LevelUp.Options.multiclass',
+                    label: 'DAGGERHEART.Applications.Levelup.options.multiclass',
                     checkboxSelections: 2,
                     minCost: 2,
                     type: LevelOptionType.multiclass.id
@@ -406,7 +406,7 @@ export const defaultCompanionTier = {
             domainCardByLevel: 0,
             options: {
                 experience: {
-                    label: 'DAGGERHEART.LevelUp.Options.intelligent',
+                    label: 'DAGGERHEART.Applications.Levelup.options.intelligent',
                     checkboxSelections: 3,
                     minCost: 1,
                     type: LevelOptionType.experience.id,
@@ -414,28 +414,28 @@ export const defaultCompanionTier = {
                     amount: 1
                 },
                 hope: {
-                    label: 'DAGGERHEART.LevelUp.Options.lightInTheDark',
+                    label: 'DAGGERHEART.Applications.Levelup.options.lightInTheDark',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: CompanionLevelOptionType.hope.id,
                     value: 1
                 },
                 creatureComfort: {
-                    label: 'DAGGERHEART.LevelUp.Options.creatureComfort',
+                    label: 'DAGGERHEART.Applications.Levelup.options.creatureComfort',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: CompanionLevelOptionType.creatureComfort.id,
                     value: 1
                 },
                 armored: {
-                    label: 'DAGGERHEART.LevelUp.Options.armored',
+                    label: 'DAGGERHEART.Applications.Levelup.options.armored',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: CompanionLevelOptionType.armored.id,
                     value: 1
                 },
                 vicious: {
-                    label: 'DAGGERHEART.LevelUp.Options.vicious',
+                    label: 'DAGGERHEART.Applications.Levelup.options.vicious',
                     checkboxSelections: 3,
                     minCost: 1,
                     type: CompanionLevelOptionType.vicious.id,
@@ -443,21 +443,21 @@ export const defaultCompanionTier = {
                     amount: 1
                 },
                 stress: {
-                    label: 'DAGGERHEART.LevelUp.Options.resilient',
+                    label: 'DAGGERHEART.Applications.Levelup.options.resilient',
                     checkboxSelections: 3,
                     minCost: 1,
                     type: LevelOptionType.stress.id,
                     value: 1
                 },
                 bonded: {
-                    label: 'DAGGERHEART.LevelUp.Options.bonded',
+                    label: 'DAGGERHEART.Applications.Levelup.options.bonded',
                     checkboxSelections: 1,
                     minCost: 1,
                     type: CompanionLevelOptionType.bonded.id,
                     value: 1
                 },
                 evasion: {
-                    label: 'DAGGERHEART.LevelUp.Options.aware',
+                    label: 'DAGGERHEART.Applications.Levelup.options.aware',
                     checkboxSelections: 3,
                     minCost: 1,
                     type: LevelOptionType.evasion.id,

--- a/module/data/settings/Appearance.mjs
+++ b/module/data/settings/Appearance.mjs
@@ -48,10 +48,10 @@ export default class DhAppearance extends foundry.abstract.DataModel {
 export const DualityRollColor = {
     colorful: {
         value: 'colorful',
-        label: 'DAGGERHEART.Settings.DualityRollColor.Options.Colorful'
+        label: 'DAGGERHEART.Settings.DualityRollColor.options.colorful'
     },
     normal: {
         value: 'normal',
-        label: 'DAGGERHEART.Settings.DualityRollColor.Options.Normal'
+        label: 'DAGGERHEART.Settings.DualityRollColor.options.normal'
     }
 };

--- a/module/data/settings/Appearance.mjs
+++ b/module/data/settings/Appearance.mjs
@@ -8,7 +8,7 @@ export default class DhAppearance extends foundry.abstract.DataModel {
                 required: true,
                 choices: fearDisplay,
                 initial: fearDisplay.token.value,
-                label: 'DAGGERHEART.Settings.Appearance.FIELDS.displayFear.label'
+                label: 'DAGGERHEART.SETTINGS.Appearance.FIELDS.displayFear.label'
             }),
             dualityColorScheme: new fields.StringField({
                 required: true,
@@ -48,10 +48,10 @@ export default class DhAppearance extends foundry.abstract.DataModel {
 export const DualityRollColor = {
     colorful: {
         value: 'colorful',
-        label: 'DAGGERHEART.Settings.DualityRollColor.options.colorful'
+        label: 'DAGGERHEART.SETTINGS.DualityRollColor.options.colorful'
     },
     normal: {
         value: 'normal',
-        label: 'DAGGERHEART.Settings.DualityRollColor.options.normal'
+        label: 'DAGGERHEART.SETTINGS.DualityRollColor.options.normal'
     }
 };

--- a/module/data/settings/Automation.mjs
+++ b/module/data/settings/Automation.mjs
@@ -1,5 +1,5 @@
 export default class DhAutomation extends foundry.abstract.DataModel {
-    static LOCALIZATION_PREFIXES = ['DAGGERHEART.Settings.Automation']; // Doesn't work for some reason
+    static LOCALIZATION_PREFIXES = ['DAGGERHEART.SETTINGS.Automation']; // Doesn't work for some reason
 
     static defineSchema() {
         const fields = foundry.data.fields;

--- a/module/data/settings/Homebrew.mjs
+++ b/module/data/settings/Homebrew.mjs
@@ -1,7 +1,7 @@
 import { defaultRestOptions } from '../../config/generalConfig.mjs';
 
 export default class DhHomebrew extends foundry.abstract.DataModel {
-    static LOCALIZATION_PREFIXES = ['DAGGERHEART.Settings.Homebrew']; // Doesn't work for some reason
+    static LOCALIZATION_PREFIXES = ['DAGGERHEART.SETTINGS.Homebrew']; // Doesn't work for some reason
 
     static defineSchema() {
         const fields = foundry.data.fields;
@@ -11,7 +11,7 @@ export default class DhHomebrew extends foundry.abstract.DataModel {
                 integer: true,
                 min: 0,
                 initial: 12,
-                label: 'DAGGERHEART.Settings.Homebrew.FIELDS.maxFear.label'
+                label: 'DAGGERHEART.SETTINGS.Homebrew.FIELDS.maxFear.label'
             }),
             traitArray: new fields.ArrayField(new fields.NumberField({ required: true, integer: true }), {
                 initial: () => [2, 1, 1, 0, 0, -1]
@@ -20,32 +20,32 @@ export default class DhHomebrew extends foundry.abstract.DataModel {
                 enabled: new fields.BooleanField({
                     required: true,
                     initial: false,
-                    label: 'DAGGERHEART.Settings.Homebrew.currency.enabled'
+                    label: 'DAGGERHEART.SETTINGS.Homebrew.currency.enabled'
                 }),
                 title: new fields.StringField({
                     required: true,
                     initial: 'Gold',
-                    label: 'DAGGERHEART.Settings.Homebrew.currency.currencyName'
+                    label: 'DAGGERHEART.SETTINGS.Homebrew.currency.currencyName'
                 }),
                 coins: new fields.StringField({
                     required: true,
                     initial: 'Coins',
-                    label: 'DAGGERHEART.Settings.Homebrew.currency.coinName'
+                    label: 'DAGGERHEART.SETTINGS.Homebrew.currency.coinName'
                 }),
                 handfulls: new fields.StringField({
                     required: true,
                     initial: 'Handfulls',
-                    label: 'DAGGERHEART.Settings.Homebrew.currency.handfullName'
+                    label: 'DAGGERHEART.SETTINGS.Homebrew.currency.handfullName'
                 }),
                 bags: new fields.StringField({
                     required: true,
                     initial: 'Bags',
-                    label: 'DAGGERHEART.Settings.Homebrew.currency.bagName'
+                    label: 'DAGGERHEART.SETTINGS.Homebrew.currency.bagName'
                 }),
                 chests: new fields.StringField({
                     required: true,
                     initial: 'Chests',
-                    label: 'DAGGERHEART.Settings.Homebrew.currency.chestName'
+                    label: 'DAGGERHEART.SETTINGS.Homebrew.currency.chestName'
                 })
             }),
             restMoves: new fields.SchemaField({

--- a/module/data/settings/Homebrew.mjs
+++ b/module/data/settings/Homebrew.mjs
@@ -20,32 +20,32 @@ export default class DhHomebrew extends foundry.abstract.DataModel {
                 enabled: new fields.BooleanField({
                     required: true,
                     initial: false,
-                    label: 'DAGGERHEART.Settings.Homebrew.Currency.enabled'
+                    label: 'DAGGERHEART.Settings.Homebrew.currency.enabled'
                 }),
                 title: new fields.StringField({
                     required: true,
                     initial: 'Gold',
-                    label: 'DAGGERHEART.Settings.Homebrew.Currency.currencyName'
+                    label: 'DAGGERHEART.Settings.Homebrew.currency.currencyName'
                 }),
                 coins: new fields.StringField({
                     required: true,
                     initial: 'Coins',
-                    label: 'DAGGERHEART.Settings.Homebrew.Currency.coinName'
+                    label: 'DAGGERHEART.Settings.Homebrew.currency.coinName'
                 }),
                 handfulls: new fields.StringField({
                     required: true,
                     initial: 'Handfulls',
-                    label: 'DAGGERHEART.Settings.Homebrew.Currency.handfullName'
+                    label: 'DAGGERHEART.Settings.Homebrew.currency.handfullName'
                 }),
                 bags: new fields.StringField({
                     required: true,
                     initial: 'Bags',
-                    label: 'DAGGERHEART.Settings.Homebrew.Currency.bagName'
+                    label: 'DAGGERHEART.Settings.Homebrew.currency.bagName'
                 }),
                 chests: new fields.StringField({
                     required: true,
                     initial: 'Chests',
-                    label: 'DAGGERHEART.Settings.Homebrew.Currency.chestName'
+                    label: 'DAGGERHEART.Settings.Homebrew.currency.chestName'
                 })
             }),
             restMoves: new fields.SchemaField({

--- a/module/data/settings/RangeMeasurement.mjs
+++ b/module/data/settings/RangeMeasurement.mjs
@@ -2,16 +2,24 @@ export default class DhRangeMeasurement extends foundry.abstract.DataModel {
     static defineSchema() {
         const fields = foundry.data.fields;
         return {
-            enabled: new fields.BooleanField({ required: true, initial: false, label: 'DAGGERHEART.General.Enabled' }),
-            melee: new fields.NumberField({ required: true, initial: 5, label: 'DAGGERHEART.Range.melee.name' }),
+            enabled: new fields.BooleanField({ required: true, initial: false, label: 'DAGGERHEART.General.enabled' }),
+            melee: new fields.NumberField({ required: true, initial: 5, label: 'DAGGERHEART.Config.Range.melee.name' }),
             veryClose: new fields.NumberField({
                 required: true,
                 initial: 15,
-                label: 'DAGGERHEART.Range.veryClose.name'
+                label: 'DAGGERHEART.Config.Range.veryClose.name'
             }),
-            close: new fields.NumberField({ required: true, initial: 30, label: 'DAGGERHEART.Range.close.name' }),
-            far: new fields.NumberField({ required: true, initial: 60, label: 'DAGGERHEART.Range.far.name' }),
-            veryFar: new fields.NumberField({ required: true, initial: 120, label: 'DAGGERHEART.Range.veryFar.name' })
+            close: new fields.NumberField({
+                required: true,
+                initial: 30,
+                label: 'DAGGERHEART.Config.Range.close.name'
+            }),
+            far: new fields.NumberField({ required: true, initial: 60, label: 'DAGGERHEART.Config.Range.far.name' }),
+            veryFar: new fields.NumberField({
+                required: true,
+                initial: 120,
+                label: 'DAGGERHEART.Config.Range.veryFar.name'
+            })
         };
     }
 }

--- a/module/data/settings/RangeMeasurement.mjs
+++ b/module/data/settings/RangeMeasurement.mjs
@@ -2,23 +2,23 @@ export default class DhRangeMeasurement extends foundry.abstract.DataModel {
     static defineSchema() {
         const fields = foundry.data.fields;
         return {
-            enabled: new fields.BooleanField({ required: true, initial: false, label: 'DAGGERHEART.General.enabled' }),
-            melee: new fields.NumberField({ required: true, initial: 5, label: 'DAGGERHEART.Config.Range.melee.name' }),
+            enabled: new fields.BooleanField({ required: true, initial: false, label: 'DAGGERHEART.GENERAL.enabled' }),
+            melee: new fields.NumberField({ required: true, initial: 5, label: 'DAGGERHEART.CONFIG.Range.melee.name' }),
             veryClose: new fields.NumberField({
                 required: true,
                 initial: 15,
-                label: 'DAGGERHEART.Config.Range.veryClose.name'
+                label: 'DAGGERHEART.CONFIG.Range.veryClose.name'
             }),
             close: new fields.NumberField({
                 required: true,
                 initial: 30,
-                label: 'DAGGERHEART.Config.Range.close.name'
+                label: 'DAGGERHEART.CONFIG.Range.close.name'
             }),
-            far: new fields.NumberField({ required: true, initial: 60, label: 'DAGGERHEART.Config.Range.far.name' }),
+            far: new fields.NumberField({ required: true, initial: 60, label: 'DAGGERHEART.CONFIG.Range.far.name' }),
             veryFar: new fields.NumberField({
                 required: true,
                 initial: 120,
-                label: 'DAGGERHEART.Config.Range.veryFar.name'
+                label: 'DAGGERHEART.CONFIG.Range.veryFar.name'
             })
         };
     }

--- a/module/data/settings/VariantRules.mjs
+++ b/module/data/settings/VariantRules.mjs
@@ -1,5 +1,5 @@
 export default class DhVariantRules extends foundry.abstract.DataModel {
-    static LOCALIZATION_PREFIXES = ['DAGGERHEART.Settings.VariantRules'];
+    static LOCALIZATION_PREFIXES = ['DAGGERHEART.SETTINGS.VariantRules'];
 
     static defineSchema() {
         const fields = foundry.data.fields;
@@ -8,18 +8,18 @@ export default class DhVariantRules extends foundry.abstract.DataModel {
                 enabled: new fields.BooleanField({
                     required: true,
                     initial: false,
-                    label: 'DAGGERHEART.Settings.VariantRules.FIELDS.actionTokens.enabled.label'
+                    label: 'DAGGERHEART.SETTINGS.VariantRules.FIELDS.actionTokens.enabled.label'
                 }),
                 tokens: new fields.NumberField({
                     required: true,
                     integer: true,
                     initial: 3,
-                    label: 'DAGGERHEART.Settings.VariantRules.FIELDS.actionTokens.tokens.label'
+                    label: 'DAGGERHEART.SETTINGS.VariantRules.FIELDS.actionTokens.tokens.label'
                 })
             }),
             useCoins: new fields.BooleanField({
                 initial: false,
-                label: 'DAGGERHEART.Settings.VariantRules.FIELDS.useCoins.label'
+                label: 'DAGGERHEART.SETTINGS.VariantRules.FIELDS.useCoins.label'
             })
         };
     }

--- a/module/dice/dualityRoll.mjs
+++ b/module/dice/dualityRoll.mjs
@@ -71,10 +71,10 @@ export default class DualityRoll extends D20Roll {
 
     get totalLabel() {
         const label = this.withHope
-            ? 'DAGGERHEART.General.hope'
+            ? 'DAGGERHEART.GENERAL.hope'
             : this.withFear
-              ? 'DAGGERHEART.General.fear'
-              : 'DAGGERHEART.General.criticalSuccess';
+              ? 'DAGGERHEART.GENERAL.fear'
+              : 'DAGGERHEART.GENERAL.criticalSuccess';
 
         return game.i18n.localize(label);
     }
@@ -119,7 +119,7 @@ export default class DualityRoll extends D20Roll {
         this.options.roll.modifiers = [];
         if (!this.options.roll.trait) return;
         this.options.roll.modifiers.push({
-            label: `DAGGERHEART.Config.Traits.${this.options.roll.trait}.name`,
+            label: `DAGGERHEART.CONFIG.Traits.${this.options.roll.trait}.name`,
             value: Roll.replaceFormulaData(`@traits.${this.options.roll.trait}.total`, this.data)
         });
     }

--- a/module/dice/dualityRoll.mjs
+++ b/module/dice/dualityRoll.mjs
@@ -71,10 +71,10 @@ export default class DualityRoll extends D20Roll {
 
     get totalLabel() {
         const label = this.withHope
-            ? 'DAGGERHEART.General.Hope'
+            ? 'DAGGERHEART.General.hope'
             : this.withFear
-              ? 'DAGGERHEART.General.Fear'
-              : 'DAGGERHEART.General.CriticalSuccess';
+              ? 'DAGGERHEART.General.fear'
+              : 'DAGGERHEART.General.criticalSuccess';
 
         return game.i18n.localize(label);
     }
@@ -119,7 +119,7 @@ export default class DualityRoll extends D20Roll {
         this.options.roll.modifiers = [];
         if (!this.options.roll.trait) return;
         this.options.roll.modifiers.push({
-            label: `DAGGERHEART.Abilities.${this.options.roll.trait}.name`,
+            label: `DAGGERHEART.Config.Traits.${this.options.roll.trait}.name`,
             value: Roll.replaceFormulaData(`@traits.${this.options.roll.trait}.total`, this.data)
         });
     }

--- a/module/documents/activeEffect.mjs
+++ b/module/documents/activeEffect.mjs
@@ -32,7 +32,7 @@ export default class DhActiveEffect extends ActiveEffect {
     async toChat(origin) {
         const cls = getDocumentClass('ChatMessage');
         const systemData = {
-            title: game.i18n.localize('DAGGERHEART.Config.ActionType.action'),
+            title: game.i18n.localize('DAGGERHEART.CONFIG.ActionType.action'),
             origin: origin,
             img: this.img,
             name: this.name,

--- a/module/documents/activeEffect.mjs
+++ b/module/documents/activeEffect.mjs
@@ -32,7 +32,7 @@ export default class DhActiveEffect extends ActiveEffect {
     async toChat(origin) {
         const cls = getDocumentClass('ChatMessage');
         const systemData = {
-            title: game.i18n.localize('DAGGERHEART.ActionType.action'),
+            title: game.i18n.localize('DAGGERHEART.Config.ActionType.action'),
             origin: origin,
             img: this.img,
             name: this.name,

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -27,14 +27,14 @@ export default class DhpActor extends Actor {
                 game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.LevelTiers).tiers
             ).reduce((acc, tier) => Math.max(acc, tier.levels.end), 0);
             if (newLevel > maxLevel) {
-                ui.notifications.warn(game.i18n.localize('DAGGERHEART.Sheets.PC.Errors.tooHighLevel'));
+                ui.notifications.warn(game.i18n.localize('DAGGERHEART.UI.Notifications.tooHighLevel'));
             }
 
             await this.update({ 'system.levelData.level.changed': Math.min(newLevel, maxLevel) });
         } else {
             const usedLevel = Math.max(newLevel, 1);
             if (newLevel < 1) {
-                ui.notifications.warn(game.i18n.localize('DAGGERHEART.Sheets.PC.Errors.tooLowLevel'));
+                ui.notifications.warn(game.i18n.localize('DAGGERHEART.UI.Notifications.tooLowLevel'));
             }
 
             const updatedLevelups = Object.keys(this.system.levelData.levelups).reduce((acc, level) => {
@@ -405,7 +405,7 @@ export default class DhpActor extends Actor {
 
         const cls = getDocumentClass('ChatMessage');
         const systemData = {
-            title: game.i18n.format('DAGGERHEART.Chat.DamageRoll.Title', { damage: title }),
+            title: game.i18n.format('DAGGERHEART.UI.Chat.damageRoll.title', { damage: title }),
             roll: rollString,
             damage: {
                 total: rollResult.total,
@@ -465,7 +465,7 @@ export default class DhpActor extends Actor {
                     const cls = getDocumentClass('ChatMessage');
                     const msg = new cls({
                         user: game.user.id,
-                        content: game.i18n.format('DAGGERHEART.DamageReduction.Notifications.DamageIgnore', {
+                        content: game.i18n.format('DAGGERHEART.UI.Notifications.damageIgnore', {
                             character: this.name
                         })
                     });

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -114,12 +114,12 @@ export default class DHItem extends foundry.documents.Item {
         const systemData = {
             title:
                 this.type === 'ancestry'
-                    ? game.i18n.localize('DAGGERHEART.Chat.FoundationCard.AncestryTitle')
+                    ? game.i18n.localize('DAGGERHEART.UI.Chat.foundationCard.ancestryTitle')
                     : this.type === 'community'
-                      ? game.i18n.localize('DAGGERHEART.Chat.FoundationCard.CommunityTitle')
+                      ? game.i18n.localize('DAGGERHEART.UI.Chat.foundationCard.communityTitle')
                       : this.type === 'feature'
                         ? game.i18n.localize('TYPES.Item.feature')
-                        : game.i18n.localize('DAGGERHEART.Chat.FoundationCard.SubclassFeatureTitle'),
+                        : game.i18n.localize('DAGGERHEART.UI.Chat.foundationCard.subclassFeatureTitle'),
             origin: origin,
             img: this.img,
             name: this.name,

--- a/module/enrichers/DualityRollEnricher.mjs
+++ b/module/enrichers/DualityRollEnricher.mjs
@@ -11,15 +11,15 @@ export default function DhDualityRollEnricher(match, _options) {
 export function getDualityMessage(roll) {
     const traitLabel =
         roll.trait && abilities[roll.trait]
-            ? game.i18n.format('DAGGERHEART.General.Check', {
+            ? game.i18n.format('DAGGERHEART.General.check', {
                   check: game.i18n.localize(abilities[roll.trait].label)
               })
             : null;
 
-    const label = traitLabel ?? game.i18n.localize('DAGGERHEART.General.Duality');
+    const label = traitLabel ?? game.i18n.localize('DAGGERHEART.General.duality');
     const dataLabel = traitLabel
         ? game.i18n.localize(abilities[roll.trait].label)
-        : game.i18n.localize('DAGGERHEART.General.Duality');
+        : game.i18n.localize('DAGGERHEART.General.duality');
 
     const dualityElement = document.createElement('span');
     dualityElement.innerHTML = `

--- a/module/enrichers/DualityRollEnricher.mjs
+++ b/module/enrichers/DualityRollEnricher.mjs
@@ -11,15 +11,15 @@ export default function DhDualityRollEnricher(match, _options) {
 export function getDualityMessage(roll) {
     const traitLabel =
         roll.trait && abilities[roll.trait]
-            ? game.i18n.format('DAGGERHEART.General.check', {
+            ? game.i18n.format('DAGGERHEART.GENERAL.check', {
                   check: game.i18n.localize(abilities[roll.trait].label)
               })
             : null;
 
-    const label = traitLabel ?? game.i18n.localize('DAGGERHEART.General.duality');
+    const label = traitLabel ?? game.i18n.localize('DAGGERHEART.GENERAL.duality');
     const dataLabel = traitLabel
         ? game.i18n.localize(abilities[roll.trait].label)
-        : game.i18n.localize('DAGGERHEART.General.duality');
+        : game.i18n.localize('DAGGERHEART.GENERAL.duality');
 
     const dualityElement = document.createElement('span');
     dualityElement.innerHTML = `

--- a/module/enrichers/TemplateEnricher.mjs
+++ b/module/enrichers/TemplateEnricher.mjs
@@ -31,7 +31,7 @@ export default function DhTemplateEnricher(match, _options) {
     const templateElement = document.createElement('span');
     templateElement.innerHTML = `
         <button class="measured-template-button" data-type="${type}" data-range="${range}">
-            ${game.i18n.localize(`TEMPLATE.TYPES.${type}`)} - ${game.i18n.localize(`DAGGERHEART.Range.${range}.name`)}
+            ${game.i18n.localize(`TEMPLATE.TYPES.${type}`)} - ${game.i18n.localize(`DAGGERHEART.Config.Range.${range}.name`)}
         </button>
     `;
 

--- a/module/enrichers/TemplateEnricher.mjs
+++ b/module/enrichers/TemplateEnricher.mjs
@@ -31,7 +31,7 @@ export default function DhTemplateEnricher(match, _options) {
     const templateElement = document.createElement('span');
     templateElement.innerHTML = `
         <button class="measured-template-button" data-type="${type}" data-range="${range}">
-            ${game.i18n.localize(`TEMPLATE.TYPES.${type}`)} - ${game.i18n.localize(`DAGGERHEART.Config.Range.${range}.name`)}
+            ${game.i18n.localize(`TEMPLATE.TYPES.${type}`)} - ${game.i18n.localize(`DAGGERHEART.CONFIG.Range.${range}.name`)}
         </button>
     `;
 

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -106,16 +106,16 @@ export const getCommandTarget = () => {
     if (!game.user.isGM) {
         target = game.user.character;
         if (!target) {
-            ui.notifications.error(game.i18n.localize('DAGGERHEART.Notification.Error.NoAssignedPlayerCharacter'));
+            ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.noAssignedPlayerCharacter'));
             return null;
         }
     }
     if (!target) {
-        ui.notifications.error(game.i18n.localize('DAGGERHEART.Notification.Error.NoSelectedToken'));
+        ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.noSelectedToken'));
         return null;
     }
     if (target.type !== 'character') {
-        ui.notifications.error(game.i18n.localize('DAGGERHEART.Notification.Error.OnlyUseableByPC'));
+        ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.onlyUseableByPC'));
         return null;
     }
 
@@ -236,13 +236,13 @@ Roll.replaceFormulaData = function (formula, data = {}, { missing, warn = false 
 export const getDamageLabel = damage => {
     switch (damage) {
         case 3:
-            return game.i18n.localize('DAGGERHEART.General.Damage.Severe');
+            return game.i18n.localize('DAGGERHEART.General.Damage.severe');
         case 2:
-            return game.i18n.localize('DAGGERHEART.General.Damage.Major');
+            return game.i18n.localize('DAGGERHEART.General.Damage.major');
         case 1:
-            return game.i18n.localize('DAGGERHEART.General.Damage.Minor');
+            return game.i18n.localize('DAGGERHEART.General.Damage.minor');
         case 0:
-            return game.i18n.localize('DAGGERHEART.General.Damage.None');
+            return game.i18n.localize('DAGGERHEART.General.Damage.none');
     }
 };
 

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -236,13 +236,13 @@ Roll.replaceFormulaData = function (formula, data = {}, { missing, warn = false 
 export const getDamageLabel = damage => {
     switch (damage) {
         case 3:
-            return game.i18n.localize('DAGGERHEART.General.Damage.severe');
+            return game.i18n.localize('DAGGERHEART.GENERAL.Damage.severe');
         case 2:
-            return game.i18n.localize('DAGGERHEART.General.Damage.major');
+            return game.i18n.localize('DAGGERHEART.GENERAL.Damage.major');
         case 1:
-            return game.i18n.localize('DAGGERHEART.General.Damage.minor');
+            return game.i18n.localize('DAGGERHEART.GENERAL.Damage.minor');
         case 0:
-            return game.i18n.localize('DAGGERHEART.General.Damage.none');
+            return game.i18n.localize('DAGGERHEART.GENERAL.Damage.none');
     }
 };
 

--- a/module/systemRegistration/settings.mjs
+++ b/module/systemRegistration/settings.mjs
@@ -68,43 +68,43 @@ const registerMenuSettings = () => {
 
 const registerMenus = () => {
     game.settings.registerMenu(CONFIG.DH.id, CONFIG.DH.SETTINGS.menu.Automation.Name, {
-        name: game.i18n.localize('DAGGERHEART.Settings.Menu.automation.name'),
-        label: game.i18n.localize('DAGGERHEART.Settings.Menu.automation.label'),
-        hint: game.i18n.localize('DAGGERHEART.Settings.Menu.automation.hint'),
+        name: game.i18n.localize('DAGGERHEART.SETTINGS.Menu.automation.name'),
+        label: game.i18n.localize('DAGGERHEART.SETTINGS.Menu.automation.label'),
+        hint: game.i18n.localize('DAGGERHEART.SETTINGS.Menu.automation.hint'),
         icon: CONFIG.DH.SETTINGS.menu.Automation.Icon,
         type: DhAutomationSettings,
         restricted: true
     });
     game.settings.registerMenu(CONFIG.DH.id, CONFIG.DH.SETTINGS.menu.Homebrew.Name, {
-        name: game.i18n.localize('DAGGERHEART.Settings.Menu.homebrew.name'),
-        label: game.i18n.localize('DAGGERHEART.Settings.Menu.homebrew.label'),
-        hint: game.i18n.localize('DAGGERHEART.Settings.Menu.homebrew.hint'),
+        name: game.i18n.localize('DAGGERHEART.SETTINGS.Menu.homebrew.name'),
+        label: game.i18n.localize('DAGGERHEART.SETTINGS.Menu.homebrew.label'),
+        hint: game.i18n.localize('DAGGERHEART.SETTINGS.Menu.homebrew.hint'),
         icon: CONFIG.DH.SETTINGS.menu.Homebrew.Icon,
         type: DhHomebrewSettings,
         restricted: true
     });
     game.settings.registerMenu(CONFIG.DH.id, CONFIG.DH.SETTINGS.menu.Range.Name, {
-        name: game.i18n.localize('DAGGERHEART.Settings.Menu.range.name'),
-        label: game.i18n.localize('DAGGERHEART.Settings.Menu.range.label'),
-        hint: game.i18n.localize('DAGGERHEART.Settings.Menu.range.hint'),
+        name: game.i18n.localize('DAGGERHEART.SETTINGS.Menu.range.name'),
+        label: game.i18n.localize('DAGGERHEART.SETTINGS.Menu.range.label'),
+        hint: game.i18n.localize('DAGGERHEART.SETTINGS.Menu.range.hint'),
         icon: CONFIG.DH.SETTINGS.menu.Range.Icon,
         type: DhRangeMeasurementSettings,
         restricted: true
     });
 
     game.settings.registerMenu(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.appearance, {
-        name: game.i18n.localize('DAGGERHEART.Settings.Menu.appearance.title'),
-        label: game.i18n.localize('DAGGERHEART.Settings.Menu.appearance.label'),
-        hint: game.i18n.localize('DAGGERHEART.Settings.Menu.appearance.hint'),
+        name: game.i18n.localize('DAGGERHEART.SETTINGS.Menu.appearance.title'),
+        label: game.i18n.localize('DAGGERHEART.SETTINGS.Menu.appearance.label'),
+        hint: game.i18n.localize('DAGGERHEART.SETTINGS.Menu.appearance.hint'),
         icon: 'fa-solid fa-palette',
         type: DhAppearanceSettings,
         restricted: false
     });
 
     game.settings.registerMenu(CONFIG.DH.id, CONFIG.DH.SETTINGS.menu.VariantRules.Name, {
-        name: game.i18n.localize('DAGGERHEART.Settings.Menu.variantRules.title'),
-        label: game.i18n.localize('DAGGERHEART.Settings.Menu.variantRules.label'),
-        hint: game.i18n.localize('DAGGERHEART.Settings.Menu.variantRules.hint'),
+        name: game.i18n.localize('DAGGERHEART.SETTINGS.Menu.variantRules.title'),
+        label: game.i18n.localize('DAGGERHEART.SETTINGS.Menu.variantRules.label'),
+        hint: game.i18n.localize('DAGGERHEART.SETTINGS.Menu.variantRules.hint'),
         icon: CONFIG.DH.SETTINGS.menu.VariantRules.Icon,
         type: DhVariantRuleSettings,
         restricted: false
@@ -120,8 +120,8 @@ const registerNonConfigSettings = () => {
     });
 
     game.settings.register(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Resources.Fear, {
-        name: game.i18n.localize('DAGGERHEART.Settings.Resources.fear.name'),
-        hint: game.i18n.localize('DAGGERHEART.Settings.Resources.fear.hint'),
+        name: game.i18n.localize('DAGGERHEART.SETTINGS.Resources.fear.name'),
+        hint: game.i18n.localize('DAGGERHEART.SETTINGS.Resources.fear.hint'),
         scope: 'world',
         config: false,
         type: Number,

--- a/module/systemRegistration/settings.mjs
+++ b/module/systemRegistration/settings.mjs
@@ -68,43 +68,43 @@ const registerMenuSettings = () => {
 
 const registerMenus = () => {
     game.settings.registerMenu(CONFIG.DH.id, CONFIG.DH.SETTINGS.menu.Automation.Name, {
-        name: game.i18n.localize('DAGGERHEART.Settings.Menu.Automation.Name'),
-        label: game.i18n.localize('DAGGERHEART.Settings.Menu.Automation.Label'),
-        hint: game.i18n.localize('DAGGERHEART.Settings.Menu.Automation.Hint'),
+        name: game.i18n.localize('DAGGERHEART.Settings.Menu.automation.name'),
+        label: game.i18n.localize('DAGGERHEART.Settings.Menu.automation.label'),
+        hint: game.i18n.localize('DAGGERHEART.Settings.Menu.automation.hint'),
         icon: CONFIG.DH.SETTINGS.menu.Automation.Icon,
         type: DhAutomationSettings,
         restricted: true
     });
     game.settings.registerMenu(CONFIG.DH.id, CONFIG.DH.SETTINGS.menu.Homebrew.Name, {
-        name: game.i18n.localize('DAGGERHEART.Settings.Menu.Homebrew.Name'),
-        label: game.i18n.localize('DAGGERHEART.Settings.Menu.Homebrew.Label'),
-        hint: game.i18n.localize('DAGGERHEART.Settings.Menu.Homebrew.Hint'),
+        name: game.i18n.localize('DAGGERHEART.Settings.Menu.homebrew.name'),
+        label: game.i18n.localize('DAGGERHEART.Settings.Menu.homebrew.label'),
+        hint: game.i18n.localize('DAGGERHEART.Settings.Menu.homebrew.hint'),
         icon: CONFIG.DH.SETTINGS.menu.Homebrew.Icon,
         type: DhHomebrewSettings,
         restricted: true
     });
     game.settings.registerMenu(CONFIG.DH.id, CONFIG.DH.SETTINGS.menu.Range.Name, {
-        name: game.i18n.localize('DAGGERHEART.Settings.Menu.Range.Name'),
-        label: game.i18n.localize('DAGGERHEART.Settings.Menu.Range.Label'),
-        hint: game.i18n.localize('DAGGERHEART.Settings.Menu.Range.Hint'),
+        name: game.i18n.localize('DAGGERHEART.Settings.Menu.range.name'),
+        label: game.i18n.localize('DAGGERHEART.Settings.Menu.range.label'),
+        hint: game.i18n.localize('DAGGERHEART.Settings.Menu.range.hint'),
         icon: CONFIG.DH.SETTINGS.menu.Range.Icon,
         type: DhRangeMeasurementSettings,
         restricted: true
     });
 
     game.settings.registerMenu(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.appearance, {
-        name: game.i18n.localize('DAGGERHEART.Settings.Menu.Appearance.title'),
-        label: game.i18n.localize('DAGGERHEART.Settings.Menu.Appearance.label'),
-        hint: game.i18n.localize('DAGGERHEART.Settings.Menu.Appearance.hint'),
+        name: game.i18n.localize('DAGGERHEART.Settings.Menu.appearance.title'),
+        label: game.i18n.localize('DAGGERHEART.Settings.Menu.appearance.label'),
+        hint: game.i18n.localize('DAGGERHEART.Settings.Menu.appearance.hint'),
         icon: 'fa-solid fa-palette',
         type: DhAppearanceSettings,
         restricted: false
     });
 
     game.settings.registerMenu(CONFIG.DH.id, CONFIG.DH.SETTINGS.menu.VariantRules.Name, {
-        name: game.i18n.localize('DAGGERHEART.Settings.Menu.VariantRules.title'),
-        label: game.i18n.localize('DAGGERHEART.Settings.Menu.VariantRules.label'),
-        hint: game.i18n.localize('DAGGERHEART.Settings.Menu.VariantRules.hint'),
+        name: game.i18n.localize('DAGGERHEART.Settings.Menu.variantRules.title'),
+        label: game.i18n.localize('DAGGERHEART.Settings.Menu.variantRules.label'),
+        hint: game.i18n.localize('DAGGERHEART.Settings.Menu.variantRules.hint'),
         icon: CONFIG.DH.SETTINGS.menu.VariantRules.Icon,
         type: DhVariantRuleSettings,
         restricted: false
@@ -120,8 +120,8 @@ const registerNonConfigSettings = () => {
     });
 
     game.settings.register(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Resources.Fear, {
-        name: game.i18n.localize('DAGGERHEART.Settings.Resources.Fear.Name'),
-        hint: game.i18n.localize('DAGGERHEART.Settings.Resources.Fear.Hint'),
+        name: game.i18n.localize('DAGGERHEART.Settings.Resources.fear.name'),
+        hint: game.i18n.localize('DAGGERHEART.Settings.Resources.fear.hint'),
         scope: 'world',
         config: false,
         type: Number,

--- a/styles/daggerheart.css
+++ b/styles/daggerheart.css
@@ -5667,10 +5667,16 @@ body.theme-light.application.daggerheart.dialog {
   outline: 2px solid light-dark(#222, #efe6d8);
   box-shadow: none;
 }
-.application.dh-style select option {
+.application.dh-style select option,
+.application.dh-style select optgroup {
   color: #efe6d8;
   background-color: #18162e;
   border-radius: 6px;
+}
+.application.dh-style select:disabled {
+  opacity: 0.6;
+  outline: 2px solid transparent;
+  cursor: not-allowed;
 }
 .application.dh-style p {
   margin: 0;
@@ -5728,15 +5734,6 @@ body.theme-light.application.daggerheart.dialog {
   width: 2rem;
   height: 2rem;
 }
-.application.dh-style fieldset .checkbox {
-  display: flex;
-  align-items: center;
-  gap: 20px;
-  align-self: end;
-}
-.application.dh-style fieldset .fas.fa-trash {
-  align-self: end;
-}
 .application.dh-style fieldset.one-column {
   display: flex;
   flex-direction: column;
@@ -5746,10 +5743,6 @@ body.theme-light.application.daggerheart.dialog {
   flex: 1;
 }
 .application.dh-style fieldset.one-column > .one-column {
-  width: 100%;
-}
-.application.dh-style fieldset.one-column .nest-inputs fieldset {
-  flex: 1;
   width: 100%;
 }
 .application.dh-style fieldset.two-columns {
@@ -5792,6 +5785,16 @@ body.theme-light.application.daggerheart.dialog {
   width: 100%;
   gap: 5px;
 }
+.application.dh-style fieldset .nest-inputs .btn {
+  padding-top: 15px;
+}
+.application.dh-style fieldset .nest-inputs .image {
+  height: 40px;
+  width: 40px;
+  object-fit: cover;
+  border-radius: 6px;
+  border: none;
+}
 .application.dh-style fieldset .form-group {
   width: 100%;
 }
@@ -5800,21 +5803,15 @@ body.theme-light.application.daggerheart.dialog {
   font-weight: bold;
   font-size: smaller;
 }
+.application.dh-style fieldset .form-group.checkbox {
+  width: fit-content;
+}
+.application.dh-style fieldset .form-group.checkbox .form-fields {
+  height: 32px;
+  align-content: center;
+}
 .application.dh-style fieldset:has(.list-w-img) {
   gap: 0;
-}
-.application.dh-style fieldset:has(+ .fas.fa-trash) {
-  border-bottom-right-radius: 0;
-}
-.application.dh-style fieldset .fas.fa-trash {
-  color: darkred;
-  border-radius: 0 6px 6px 0;
-  border-color: light-dark(#18162e, #f3c267);
-  border-width: 2px;
-  border-style: groove;
-  border-left-width: 0;
-  padding: 5px;
-  margin-left: -7px;
 }
 .application.dh-style .two-columns {
   display: grid;
@@ -6048,8 +6045,6 @@ body.theme-light.application.daggerheart.dialog {
 .sheet.daggerheart.dh-style .tab-form-footer {
   display: flex;
   padding: 0 10px;
-  position: relative;
-  bottom: -32px;
 }
 .sheet.daggerheart.dh-style .tab-form-footer button {
   flex: 1;
@@ -6455,6 +6450,7 @@ body.theme-light.application.daggerheart.dialog {
   flex-direction: column;
   gap: 10px;
   align-items: center;
+  width: 100%;
 }
 .application.daggerheart.dh-style .card-list {
   display: flex;

--- a/templates/actionTypes/beastform.hbs
+++ b/templates/actionTypes/beastform.hbs
@@ -1,17 +1,17 @@
 <fieldset class="action-category">
     <legend class="action-category-label">
-        <div>{{localize "DAGGERHEART.Actions.Config.Beastform.label"}}</div>
+        <div>{{localize "DAGGERHEART.Actions.Config.beastform.label"}}</div>
     </legend>
 
     <div class="action-category-data open">
         <div class="hint-group">
             <div class="form-fields">
-                <label>{{localize "DAGGERHEART.Actions.Config.Beastform.exact"}}</label>
+                <label>{{localize "DAGGERHEART.Actions.Config.beastform.exact"}}</label>
                 <select name="beastform.tierAccess.exact" data-dtype="Number">
                     {{selectOptions tierOptions selected=@root.source.beastform.tierAccess.exact  labelAttr="label" valueAttr="key" blank="" }}
                 </select>
             </div>
-            <p class="hint">{{localize "DAGGERHEART.Actions.Config.Beastform.exactHint"}}</p>
+            <p class="hint">{{localize "DAGGERHEART.Actions.Config.beastform.exactHint"}}</p>
         </div>
     </div>
 </fieldset>

--- a/templates/actionTypes/beastform.hbs
+++ b/templates/actionTypes/beastform.hbs
@@ -1,17 +1,17 @@
 <fieldset class="action-category">
     <legend class="action-category-label">
-        <div>{{localize "DAGGERHEART.Actions.Config.beastform.label"}}</div>
+        <div>{{localize "DAGGERHEART.ACTIONS.Config.beastform.label"}}</div>
     </legend>
 
     <div class="action-category-data open">
         <div class="hint-group">
             <div class="form-fields">
-                <label>{{localize "DAGGERHEART.Actions.Config.beastform.exact"}}</label>
+                <label>{{localize "DAGGERHEART.ACTIONS.Config.beastform.exact"}}</label>
                 <select name="beastform.tierAccess.exact" data-dtype="Number">
                     {{selectOptions tierOptions selected=@root.source.beastform.tierAccess.exact  labelAttr="label" valueAttr="key" blank="" }}
                 </select>
             </div>
-            <p class="hint">{{localize "DAGGERHEART.Actions.Config.beastform.exactHint"}}</p>
+            <p class="hint">{{localize "DAGGERHEART.ACTIONS.Config.beastform.exactHint"}}</p>
         </div>
     </div>
 </fieldset>

--- a/templates/actionTypes/cost.hbs
+++ b/templates/actionTypes/cost.hbs
@@ -9,7 +9,7 @@
             {{formField ../fields.type choices=(@root.disableOption index ../fields.type.choices ../source) label="Resource" value=cost.type name=(concat "cost." index ".type") localize=true}}
             {{formField ../fields.value label="Amount" value=cost.value name=(concat "cost." index ".value")}}
             {{formField ../fields.step label="Step" value=cost.step name=(concat "cost." index ".step") disabled=(not cost.scalable)}}
-            <a class="btn" data-tooltip="{{localize "DAGGERHEART.Tooltip.delete"}}" data-action="removeElement" data-index="{{index}}"><i class="fas fa-trash"></i></a>
+            <a class="btn" data-tooltip="{{localize "CONTROLS.CommonDelete"}}" data-action="removeElement" data-index="{{index}}"><i class="fas fa-trash"></i></a>
         </div>
     {{/each}}
 </fieldset>

--- a/templates/actionTypes/effect.hbs
+++ b/templates/actionTypes/effect.hbs
@@ -15,7 +15,7 @@
                 <input type="hidden" name="effects.{{index}}._id" value="{{effect._id}}">
                 {{#if @root.source.save.trait}}{{formInput ../fields.onSave value=effect.onSave name=(concat "effects." index ".onSave") dataset=(object tooltip="Applied even if save succeeded" tooltipDirection="UP")}}{{/if}}
                 <div class="controls">
-                    <a data-tooltip="{{localize "DAGGERHEART.Tooltip.delete"}}" data-action="removeEffect" data-index="{{index}}"><i class="fas fa-trash"></i></a>
+                    <a data-tooltip="{{localize "CONTROLS.CommonDelete"}}" data-action="removeEffect" data-index="{{index}}"><i class="fas fa-trash"></i></a>
                 </div>
             </div>
         {{/each}}

--- a/templates/characterCreation/footer.hbs
+++ b/templates/characterCreation/footer.hbs
@@ -1,4 +1,4 @@
 <section class="creation-action-footer">
     <button data-action="close">{{localize "Cancel"}}</button>
-    <button {{#if tabs.setup.finished}}data-action="finish"{{else}}disabled{{/if}}>{{localize "DAGGERHEART.Applications.CharacterCreation.finishCreation"}}</button>
+    <button {{#if tabs.setup.finished}}data-action="finish"{{else}}disabled{{/if}}>{{localize "DAGGERHEART.APPLICATIONS.CharacterCreation.finishCreation"}}</button>
 </section>

--- a/templates/characterCreation/footer.hbs
+++ b/templates/characterCreation/footer.hbs
@@ -1,4 +1,4 @@
 <section class="creation-action-footer">
     <button data-action="close">{{localize "Cancel"}}</button>
-    <button {{#if tabs.setup.finished}}data-action="finish"{{else}}disabled{{/if}}>{{localize "DAGGERHEART.CharacterCreation.FinishCreation"}}</button>
+    <button {{#if tabs.setup.finished}}data-action="finish"{{else}}disabled{{/if}}>{{localize "DAGGERHEART.Applications.CharacterCreation.finishCreation"}}</button>
 </section>

--- a/templates/characterCreation/tabs.hbs
+++ b/templates/characterCreation/tabs.hbs
@@ -5,7 +5,7 @@
             <a class='{{tab.id}} {{tab.cssClass}}' data-action='tab' data-group='{{tab.group}}' data-tab='{{tab.id}}'>
                 {{localize tab.label}}
                 <div class="finish-marker {{#if (eq tab.cssClass 'active')}}active{{/if}}">{{#if tab.finished}}<i class="fa-solid fa-check"></i>{{/if}}</div>
-                {{#if tab.optional}}<div class="descriptor">{{localize "DAGGERHEART.CharacterCreation.Tabs.Optional"}}</div>{{/if}}
+                {{#if tab.optional}}<div class="descriptor">{{localize "DAGGERHEART.General.Tabs.optional"}}</div>{{/if}}
             </a>
         {{/each}}
     </nav>

--- a/templates/characterCreation/tabs.hbs
+++ b/templates/characterCreation/tabs.hbs
@@ -5,7 +5,7 @@
             <a class='{{tab.id}} {{tab.cssClass}}' data-action='tab' data-group='{{tab.group}}' data-tab='{{tab.id}}'>
                 {{localize tab.label}}
                 <div class="finish-marker {{#if (eq tab.cssClass 'active')}}active{{/if}}">{{#if tab.finished}}<i class="fa-solid fa-check"></i>{{/if}}</div>
-                {{#if tab.optional}}<div class="descriptor">{{localize "DAGGERHEART.General.Tabs.optional"}}</div>{{/if}}
+                {{#if tab.optional}}<div class="descriptor">{{localize "DAGGERHEART.GENERAL.Tabs.optional"}}</div>{{/if}}
             </a>
         {{/each}}
     </nav>

--- a/templates/characterCreation/tabs/equipment.hbs
+++ b/templates/characterCreation/tabs/equipment.hbs
@@ -6,11 +6,11 @@
     <div class="main-selections-container">
         <div class="main-equipment-selection">
             <fieldset class="equipment-selection">
-                <legend>{{localize "DAGGERHEART.CharacterCreation.SuggestedArmor"}}</legend>
+                <legend>{{localize "DAGGERHEART.Applications.CharacterCreation.suggestedArmor"}}</legend>
 
                 <div class="selections-container armor-card">
                     {{#> "systems/daggerheart/templates/components/card-preview.hbs" armor }}
-                        {{localize "DAGGERHEART.CharacterCreation.SelectArmor"}}
+                        {{localize "DAGGERHEART.Applications.CharacterCreation.selectArmor"}}
                     {{/"systems/daggerheart/templates/components/card-preview.hbs"}}
                 </div>
                 {{#if armor.suggestion}}
@@ -24,13 +24,13 @@
             </fieldset>
 
             <fieldset class="equipment-selection">
-                <legend>{{localize "DAGGERHEART.CharacterCreation.SuggestedWeapons"}}</legend>
+                <legend>{{localize "DAGGERHEART.Applications.CharacterCreation.suggestedWeapons"}}</legend>
 
                 <div class="equipment-subsection">
                     <div class="equipment-wrapper">
                         <div class="selections-container primary-weapon-card">
                             {{#> "systems/daggerheart/templates/components/card-preview.hbs" primaryWeapon }}
-                                {{localize "DAGGERHEART.CharacterCreation.SelectPrimaryWeapon"}}
+                                {{localize "DAGGERHEART.Applications.CharacterCreation.selectPrimaryWeapon"}}
                             {{/"systems/daggerheart/templates/components/card-preview.hbs"}}
                         </div>
                         {{#if primaryWeapon.suggestion}}
@@ -45,7 +45,7 @@
                     <div class="equipment-wrapper">
                         <div class="selections-container secondary-weapon-card">
                             {{#> "systems/daggerheart/templates/components/card-preview.hbs" secondaryWeapon }}
-                                {{localize "DAGGERHEART.CharacterCreation.SelectSecondaryWeapon"}}
+                                {{localize "DAGGERHEART.Applications.CharacterCreation.selectSecondaryWeapon"}}
                             {{/"systems/daggerheart/templates/components/card-preview.hbs"}}
                         </div>
                         {{#if secondaryWeapon.suggestion}}
@@ -65,7 +65,7 @@
         </div>
         <div class="main-equipment-selection triple">
             <fieldset class="equipment-selection">
-                <legend>{{localize "DAGGERHEART.CharacterCreation.StartingItems"}}</legend>
+                <legend>{{localize "DAGGERHEART.Applications.CharacterCreation.startingItems"}}</legend>
 
                 <div class="simple-equipment-container">
                     {{#each inventory.take}}
@@ -78,7 +78,7 @@
             </fieldset>
 
             <fieldset class="equipment-selection">
-                <legend>{{localize "DAGGERHEART.CharacterCreation.Choice"}}</legend>
+                <legend>{{localize "DAGGERHEART.Applications.CharacterCreation.choice"}}</legend>
 
                 <div class="simple-equipment-container">
                     {{#each inventory.choiceA.suggestions}}
@@ -91,7 +91,7 @@
             </fieldset>
 
             <fieldset class="equipment-selection">
-                <legend>{{localize "DAGGERHEART.CharacterCreation.Choice"}}</legend>
+                <legend>{{localize "DAGGERHEART.Applications.CharacterCreation.choice"}}</legend>
 
                 <div class="simple-equipment-container">
                     {{#each inventory.choiceB.suggestions}}

--- a/templates/characterCreation/tabs/equipment.hbs
+++ b/templates/characterCreation/tabs/equipment.hbs
@@ -6,11 +6,11 @@
     <div class="main-selections-container">
         <div class="main-equipment-selection">
             <fieldset class="equipment-selection">
-                <legend>{{localize "DAGGERHEART.Applications.CharacterCreation.suggestedArmor"}}</legend>
+                <legend>{{localize "DAGGERHEART.APPLICATIONS.CharacterCreation.suggestedArmor"}}</legend>
 
                 <div class="selections-container armor-card">
                     {{#> "systems/daggerheart/templates/components/card-preview.hbs" armor }}
-                        {{localize "DAGGERHEART.Applications.CharacterCreation.selectArmor"}}
+                        {{localize "DAGGERHEART.APPLICATIONS.CharacterCreation.selectArmor"}}
                     {{/"systems/daggerheart/templates/components/card-preview.hbs"}}
                 </div>
                 {{#if armor.suggestion}}
@@ -24,13 +24,13 @@
             </fieldset>
 
             <fieldset class="equipment-selection">
-                <legend>{{localize "DAGGERHEART.Applications.CharacterCreation.suggestedWeapons"}}</legend>
+                <legend>{{localize "DAGGERHEART.APPLICATIONS.CharacterCreation.suggestedWeapons"}}</legend>
 
                 <div class="equipment-subsection">
                     <div class="equipment-wrapper">
                         <div class="selections-container primary-weapon-card">
                             {{#> "systems/daggerheart/templates/components/card-preview.hbs" primaryWeapon }}
-                                {{localize "DAGGERHEART.Applications.CharacterCreation.selectPrimaryWeapon"}}
+                                {{localize "DAGGERHEART.APPLICATIONS.CharacterCreation.selectPrimaryWeapon"}}
                             {{/"systems/daggerheart/templates/components/card-preview.hbs"}}
                         </div>
                         {{#if primaryWeapon.suggestion}}
@@ -45,7 +45,7 @@
                     <div class="equipment-wrapper">
                         <div class="selections-container secondary-weapon-card">
                             {{#> "systems/daggerheart/templates/components/card-preview.hbs" secondaryWeapon }}
-                                {{localize "DAGGERHEART.Applications.CharacterCreation.selectSecondaryWeapon"}}
+                                {{localize "DAGGERHEART.APPLICATIONS.CharacterCreation.selectSecondaryWeapon"}}
                             {{/"systems/daggerheart/templates/components/card-preview.hbs"}}
                         </div>
                         {{#if secondaryWeapon.suggestion}}
@@ -65,7 +65,7 @@
         </div>
         <div class="main-equipment-selection triple">
             <fieldset class="equipment-selection">
-                <legend>{{localize "DAGGERHEART.Applications.CharacterCreation.startingItems"}}</legend>
+                <legend>{{localize "DAGGERHEART.APPLICATIONS.CharacterCreation.startingItems"}}</legend>
 
                 <div class="simple-equipment-container">
                     {{#each inventory.take}}
@@ -78,7 +78,7 @@
             </fieldset>
 
             <fieldset class="equipment-selection">
-                <legend>{{localize "DAGGERHEART.Applications.CharacterCreation.choice"}}</legend>
+                <legend>{{localize "DAGGERHEART.APPLICATIONS.CharacterCreation.choice"}}</legend>
 
                 <div class="simple-equipment-container">
                     {{#each inventory.choiceA.suggestions}}
@@ -91,7 +91,7 @@
             </fieldset>
 
             <fieldset class="equipment-selection">
-                <legend>{{localize "DAGGERHEART.Applications.CharacterCreation.choice"}}</legend>
+                <legend>{{localize "DAGGERHEART.APPLICATIONS.CharacterCreation.choice"}}</legend>
 
                 <div class="simple-equipment-container">
                     {{#each inventory.choiceB.suggestions}}

--- a/templates/characterCreation/tabs/setup.hbs
+++ b/templates/characterCreation/tabs/setup.hbs
@@ -9,13 +9,13 @@
             <div class="selections-outer-container">
                 <div class="selections-container class-card">
                     {{#> "systems/daggerheart/templates/components/card-preview.hbs" class }}
-                        {{localize "DAGGERHEART.Applications.CharacterCreation.selectClass"}}
+                        {{localize "DAGGERHEART.APPLICATIONS.CharacterCreation.selectClass"}}
                     {{/"systems/daggerheart/templates/components/card-preview.hbs"}}
                 </div>
 
                 <div class="selections-container subclass-card">
                     {{#> "systems/daggerheart/templates/components/card-preview.hbs" subclass disabled=(not class.img) }}
-                        {{localize "DAGGERHEART.Applications.CharacterCreation.selectSubclass"}}
+                        {{localize "DAGGERHEART.APPLICATIONS.CharacterCreation.selectSubclass"}}
                     {{/"systems/daggerheart/templates/components/card-preview.hbs"}}
                 </div>
             </div>
@@ -23,17 +23,17 @@
 
         {{#if (gte visibility 2)}} 
             <fieldset class="section-container">
-                <legend>{{localize "DAGGERHEART.Applications.CharacterCreation.heritage"}}</legend>
+                <legend>{{localize "DAGGERHEART.APPLICATIONS.CharacterCreation.heritage"}}</legend>
                 <div class="selections-outer-container">
                     <div class="selections-container ancestry-card">
                         {{#> "systems/daggerheart/templates/components/card-preview.hbs" ancestry }}
-                            {{localize "DAGGERHEART.Applications.CharacterCreation.selectAncestry"}}
+                            {{localize "DAGGERHEART.APPLICATIONS.CharacterCreation.selectAncestry"}}
                         {{/"systems/daggerheart/templates/components/card-preview.hbs"}}
                     </div>
 
                     <div class="selections-container community-card">
                         {{#> "systems/daggerheart/templates/components/card-preview.hbs" community }}
-                            {{localize "DAGGERHEART.Applications.CharacterCreation.selectCommunity"}}
+                            {{localize "DAGGERHEART.APPLICATIONS.CharacterCreation.selectCommunity"}}
                         {{/"systems/daggerheart/templates/components/card-preview.hbs"}}
                     </div>
                 </div>
@@ -42,10 +42,10 @@
 
         {{#if (gte visibility 3)}}
             <fieldset class="section-container">
-                <legend>{{localize "DAGGERHEART.Applications.CharacterCreation.traitIncreases"}} {{traits.nrSelected}}/{{traits.nrTotal}}</legend>
+                <legend>{{localize "DAGGERHEART.APPLICATIONS.CharacterCreation.traitIncreases"}} {{traits.nrSelected}}/{{traits.nrTotal}}</legend>
                 <div class="traits-container">
                     <fieldset class="section-inner-container">
-                        <legend>{{localize "DAGGERHEART.Applications.CharacterCreation.suggestedTraits"}}</legend>
+                        <legend>{{localize "DAGGERHEART.APPLICATIONS.CharacterCreation.suggestedTraits"}}</legend>
                         <div class="suggested-traits-container">
                             {{#each suggestedTraits}}
                                 <div class="suggested-trait-container">{{this}}</div>
@@ -69,11 +69,11 @@
 
         {{#if (gte visibility 4)}}
             <fieldset class="section-container">
-                <legend>{{localize "DAGGERHEART.Applications.CharacterCreation.initialExperiences"}} {{experience.nrSelected}}/{{experience.nrTotal}}</legend>
+                <legend>{{localize "DAGGERHEART.APPLICATIONS.CharacterCreation.initialExperiences"}} {{experience.nrSelected}}/{{experience.nrTotal}}</legend>
                 <div class="experiences-inner-container">
                     {{#each experience.values as |experience id|}}
                         <div class="experience-container">
-                            <input class="experience-description" type="text" name="{{concat "experiences." id ".description" }}" value="{{experience.description}}" placeholder="{{localize "DAGGERHEART.Applications.CharacterCreation.newExperience"}}" />
+                            <input class="experience-description" type="text" name="{{concat "experiences." id ".description" }}" value="{{experience.description}}" placeholder="{{localize "DAGGERHEART.APPLICATIONS.CharacterCreation.newExperience"}}" />
                             <div class="experience-value">{{numberFormat this.value sign=true}}</div>
                         </div>
                     {{/each}}
@@ -89,7 +89,7 @@
                         <div class="selections-container domain-card" data-card="{{id}}"> 
                             {{#> "systems/daggerheart/templates/components/card-preview.hbs" domainCard }}
                                 {{#each @root.class.system.domains }}
-                                    <div>{{localize (concat "DAGGERHEART.General.Domain." this ".label")}}</div>
+                                    <div>{{localize (concat "DAGGERHEART.GENERAL.Domain." this ".label")}}</div>
                                 {{/each}}
                             {{/"systems/daggerheart/templates/components/card-preview.hbs"}}
                         </div>

--- a/templates/characterCreation/tabs/setup.hbs
+++ b/templates/characterCreation/tabs/setup.hbs
@@ -9,13 +9,13 @@
             <div class="selections-outer-container">
                 <div class="selections-container class-card">
                     {{#> "systems/daggerheart/templates/components/card-preview.hbs" class }}
-                        {{localize "DAGGERHEART.CharacterCreation.SelectClass"}}
+                        {{localize "DAGGERHEART.Applications.CharacterCreation.selectClass"}}
                     {{/"systems/daggerheart/templates/components/card-preview.hbs"}}
                 </div>
 
                 <div class="selections-container subclass-card">
                     {{#> "systems/daggerheart/templates/components/card-preview.hbs" subclass disabled=(not class.img) }}
-                        {{localize "DAGGERHEART.CharacterCreation.SelectSubclass"}}
+                        {{localize "DAGGERHEART.Applications.CharacterCreation.selectSubclass"}}
                     {{/"systems/daggerheart/templates/components/card-preview.hbs"}}
                 </div>
             </div>
@@ -23,17 +23,17 @@
 
         {{#if (gte visibility 2)}} 
             <fieldset class="section-container">
-                <legend>{{localize "DAGGERHEART.CharacterCreation.Heritage"}}</legend>
+                <legend>{{localize "DAGGERHEART.Applications.CharacterCreation.heritage"}}</legend>
                 <div class="selections-outer-container">
                     <div class="selections-container ancestry-card">
                         {{#> "systems/daggerheart/templates/components/card-preview.hbs" ancestry }}
-                            {{localize "DAGGERHEART.CharacterCreation.SelectAncestry"}}
+                            {{localize "DAGGERHEART.Applications.CharacterCreation.selectAncestry"}}
                         {{/"systems/daggerheart/templates/components/card-preview.hbs"}}
                     </div>
 
                     <div class="selections-container community-card">
                         {{#> "systems/daggerheart/templates/components/card-preview.hbs" community }}
-                            {{localize "DAGGERHEART.CharacterCreation.SelectCommunity"}}
+                            {{localize "DAGGERHEART.Applications.CharacterCreation.selectCommunity"}}
                         {{/"systems/daggerheart/templates/components/card-preview.hbs"}}
                     </div>
                 </div>
@@ -42,10 +42,10 @@
 
         {{#if (gte visibility 3)}}
             <fieldset class="section-container">
-                <legend>{{localize "DAGGERHEART.CharacterCreation.TraitIncreases"}} {{traits.nrSelected}}/{{traits.nrTotal}}</legend>
+                <legend>{{localize "DAGGERHEART.Applications.CharacterCreation.traitIncreases"}} {{traits.nrSelected}}/{{traits.nrTotal}}</legend>
                 <div class="traits-container">
                     <fieldset class="section-inner-container">
-                        <legend>{{localize "DAGGERHEART.CharacterCreation.SuggestedTraits"}}</legend>
+                        <legend>{{localize "DAGGERHEART.Applications.CharacterCreation.suggestedTraits"}}</legend>
                         <div class="suggested-traits-container">
                             {{#each suggestedTraits}}
                                 <div class="suggested-trait-container">{{this}}</div>
@@ -69,11 +69,11 @@
 
         {{#if (gte visibility 4)}}
             <fieldset class="section-container">
-                <legend>{{localize "DAGGERHEART.CharacterCreation.InitialExperiences"}} {{experience.nrSelected}}/{{experience.nrTotal}}</legend>
+                <legend>{{localize "DAGGERHEART.Applications.CharacterCreation.initialExperiences"}} {{experience.nrSelected}}/{{experience.nrTotal}}</legend>
                 <div class="experiences-inner-container">
                     {{#each experience.values as |experience id|}}
                         <div class="experience-container">
-                            <input class="experience-description" type="text" name="{{concat "experiences." id ".description" }}" value="{{experience.description}}" placeholder="{{localize "DAGGERHEART.CharacterCreation.NewExperience"}}" />
+                            <input class="experience-description" type="text" name="{{concat "experiences." id ".description" }}" value="{{experience.description}}" placeholder="{{localize "DAGGERHEART.Applications.CharacterCreation.newExperience"}}" />
                             <div class="experience-value">{{numberFormat this.value sign=true}}</div>
                         </div>
                     {{/each}}
@@ -89,7 +89,7 @@
                         <div class="selections-container domain-card" data-card="{{id}}"> 
                             {{#> "systems/daggerheart/templates/components/card-preview.hbs" domainCard }}
                                 {{#each @root.class.system.domains }}
-                                    <div>{{localize (concat "DAGGERHEART.Domains." this ".label")}}</div>
+                                    <div>{{localize (concat "DAGGERHEART.General.Domain." this ".label")}}</div>
                                 {{/each}}
                             {{/"systems/daggerheart/templates/components/card-preview.hbs"}}
                         </div>

--- a/templates/dialogs/beastformDialog.hbs
+++ b/templates/dialogs/beastformDialog.hbs
@@ -13,6 +13,6 @@
         {{/each}}
     </div>
     <footer>
-        <button type="button" data-action="submitBeastform" {{#if (not canSubmit)}}disabled{{/if}}>{{localize "DAGGERHEART.Sheets.Beastform.transform"}}</button>
+        <button type="button" data-action="submitBeastform" {{#if (not canSubmit)}}disabled{{/if}}>{{localize "DAGGERHEART.Items.Beastform.transform"}}</button>
     </footer>
 </div>

--- a/templates/dialogs/beastformDialog.hbs
+++ b/templates/dialogs/beastformDialog.hbs
@@ -13,6 +13,6 @@
         {{/each}}
     </div>
     <footer>
-        <button type="button" data-action="submitBeastform" {{#if (not canSubmit)}}disabled{{/if}}>{{localize "DAGGERHEART.Items.Beastform.transform"}}</button>
+        <button type="button" data-action="submitBeastform" {{#if (not canSubmit)}}disabled{{/if}}>{{localize "DAGGERHEART.ITEMS.Beastform.transform"}}</button>
     </footer>
 </div>

--- a/templates/dialogs/damageReduction.hbs
+++ b/templates/dialogs/damageReduction.hbs
@@ -2,12 +2,12 @@
     <div class="section-container padded">
         <div class="resources-container">
             <div class="resource-container">
-                <h4 class="armor-title">{{localize "DAGGERHEART.DamageReduction.ArmorMarks"}}</h4>
+                <h4 class="armor-title">{{localize "DAGGERHEART.Applications.DamageReduction.armorMarks"}}</h4>
                 <div class="markers-subtitle">{{armorMarks}}/{{armorScore}}</div>
             </div>
             {{#if this.stress}}
                 <div class="resource-container">
-                    <h4 class="armor-title">{{localize "DAGGERHEART.DamageReduction.Stress"}}</h4>
+                    <h4 class="armor-title">{{localize "DAGGERHEART.Applications.DamageReduction.stress"}}</h4>
                     <div class="markers-subtitle">{{this.stress.value}}/{{this.stress.maxTotal}}</div>
                 </div>
             {{/if}}
@@ -30,19 +30,19 @@
                 {{#each marks.stress}}
                     <div 
                         class="mark-container {{#if this.selected}}selected{{/if}} {{#if (not @root.basicMarksUsed)}}inactive{{/if}}" 
-                        {{#if @root.basicMarksUsed}}data-action="setMarks"{{/if}} data-key="{{@key}}" data-type="stress" data-tooltip="{{#if @root.basicMarksUsed}}{{localize "DAGGERHEART.DamageReduction.ArmorWithStress"}}{{else}}{{localize "DAGGERHEART.DamageReduction.UnncessaryStress"}}{{/if}}"
+                        {{#if @root.basicMarksUsed}}data-action="setMarks"{{/if}} data-key="{{@key}}" data-type="stress" data-tooltip="{{#if @root.basicMarksUsed}}{{localize "DAGGERHEART.Applications.DamageReduction.armorWithStress"}}{{else}}{{localize "DAGGERHEART.Applications.DamageReduction.unncessaryStress"}}{{/if}}"
                     >
                         <i class="fa-solid fa-bolt"></i>
                     </div>
                 {{/each}}
             </div>
         </h4>
-        <div class="markers-subtitle bold">{{localize "DAGGERHEART.DamageReduction.UsedMarks"}}</div>
+        <div class="markers-subtitle bold">{{localize "DAGGERHEART.Applications.DamageReduction.usedMarks"}}</div>
     </div>
 
     <div class="resources-container">
         <div class="resource-container">
-            <h4 class="armor-title">{{localize "DAGGERHEART.DamageReduction.StressReduction"}}</h4>
+            <h4 class="armor-title">{{localize "DAGGERHEART.Applications.DamageReduction.stressReduction"}}</h4>
         </div>
     </div>
 

--- a/templates/dialogs/damageReduction.hbs
+++ b/templates/dialogs/damageReduction.hbs
@@ -2,12 +2,12 @@
     <div class="section-container padded">
         <div class="resources-container">
             <div class="resource-container">
-                <h4 class="armor-title">{{localize "DAGGERHEART.Applications.DamageReduction.armorMarks"}}</h4>
+                <h4 class="armor-title">{{localize "DAGGERHEART.APPLICATIONS.DamageReduction.armorMarks"}}</h4>
                 <div class="markers-subtitle">{{armorMarks}}/{{armorScore}}</div>
             </div>
             {{#if this.stress}}
                 <div class="resource-container">
-                    <h4 class="armor-title">{{localize "DAGGERHEART.Applications.DamageReduction.stress"}}</h4>
+                    <h4 class="armor-title">{{localize "DAGGERHEART.APPLICATIONS.DamageReduction.stress"}}</h4>
                     <div class="markers-subtitle">{{this.stress.value}}/{{this.stress.maxTotal}}</div>
                 </div>
             {{/if}}
@@ -30,19 +30,19 @@
                 {{#each marks.stress}}
                     <div 
                         class="mark-container {{#if this.selected}}selected{{/if}} {{#if (not @root.basicMarksUsed)}}inactive{{/if}}" 
-                        {{#if @root.basicMarksUsed}}data-action="setMarks"{{/if}} data-key="{{@key}}" data-type="stress" data-tooltip="{{#if @root.basicMarksUsed}}{{localize "DAGGERHEART.Applications.DamageReduction.armorWithStress"}}{{else}}{{localize "DAGGERHEART.Applications.DamageReduction.unncessaryStress"}}{{/if}}"
+                        {{#if @root.basicMarksUsed}}data-action="setMarks"{{/if}} data-key="{{@key}}" data-type="stress" data-tooltip="{{#if @root.basicMarksUsed}}{{localize "DAGGERHEART.APPLICATIONS.DamageReduction.armorWithStress"}}{{else}}{{localize "DAGGERHEART.APPLICATIONS.DamageReduction.unncessaryStress"}}{{/if}}"
                     >
                         <i class="fa-solid fa-bolt"></i>
                     </div>
                 {{/each}}
             </div>
         </h4>
-        <div class="markers-subtitle bold">{{localize "DAGGERHEART.Applications.DamageReduction.usedMarks"}}</div>
+        <div class="markers-subtitle bold">{{localize "DAGGERHEART.APPLICATIONS.DamageReduction.usedMarks"}}</div>
     </div>
 
     <div class="resources-container">
         <div class="resource-container">
-            <h4 class="armor-title">{{localize "DAGGERHEART.Applications.DamageReduction.stressReduction"}}</h4>
+            <h4 class="armor-title">{{localize "DAGGERHEART.APPLICATIONS.DamageReduction.stressReduction"}}</h4>
         </div>
     </div>
 

--- a/templates/dialogs/deathMove.hbs
+++ b/templates/dialogs/deathMove.hbs
@@ -13,7 +13,7 @@
         {{/each}}
     </div>
     <footer class="flexrow">
-        <button data-action="takeMove" {{#if (not this.selectedMove)}}disabled{{/if}}>{{localize "DAGGERHEART.Applications.DeathMove.takeMove"}}</button>
+        <button data-action="takeMove" {{#if (not this.selectedMove)}}disabled{{/if}}>{{localize "DAGGERHEART.APPLICATIONS.DeathMove.takeMove"}}</button>
         <button data-action="close">{{localize "DAGGERHEART.Application.Cancel"}}</button>
     </footer>
 </div>

--- a/templates/dialogs/deathMove.hbs
+++ b/templates/dialogs/deathMove.hbs
@@ -13,7 +13,7 @@
         {{/each}}
     </div>
     <footer class="flexrow">
-        <button data-action="takeMove" {{#if (not this.selectedMove)}}disabled{{/if}}>{{localize "DAGGERHEART.Application.DeathMove.TakeMove"}}</button>
+        <button data-action="takeMove" {{#if (not this.selectedMove)}}disabled{{/if}}>{{localize "DAGGERHEART.Applications.DeathMove.takeMove"}}</button>
         <button data-action="close">{{localize "DAGGERHEART.Application.Cancel"}}</button>
     </footer>
 </div>

--- a/templates/dialogs/dice-roll/rollSelection.hbs
+++ b/templates/dialogs/dice-roll/rollSelection.hbs
@@ -97,7 +97,7 @@
                             {{else}}
                                 <span><i class="fa-regular fa-circle"></i></span>
                             {{/if}}
-                            <span class="label">{{localize "DAGGERHEART.General.Advantage.full"}}</span>
+                            <span class="label">{{localize "DAGGERHEART.GENERAL.Advantage.full"}}</span>
                         </button>
                         <button class="disadvantage-chip flex1 {{#if (eq advantage -1)}}selected{{/if}}" data-action="updateIsAdvantage" data-advantage="-1">
                             {{#if (eq advantage -1)}}
@@ -105,7 +105,7 @@
                             {{else}}
                                 <span><i class="fa-regular fa-circle"></i></span>
                             {{/if}}
-                            <span class="label">{{localize "DAGGERHEART.General.Disadvantage.full"}}</span>
+                            <span class="label">{{localize "DAGGERHEART.GENERAL.Disadvantage.full"}}</span>
                         </button>
                         {{#unless (eq @root.rollType 'D20Roll')}}
                             <select name="roll.dice.advantageFaces">

--- a/templates/dialogs/dice-roll/rollSelection.hbs
+++ b/templates/dialogs/dice-roll/rollSelection.hbs
@@ -97,7 +97,7 @@
                             {{else}}
                                 <span><i class="fa-regular fa-circle"></i></span>
                             {{/if}}
-                            <span class="label">{{localize "DAGGERHEART.General.Advantage.Full"}}</span>
+                            <span class="label">{{localize "DAGGERHEART.General.Advantage.full"}}</span>
                         </button>
                         <button class="disadvantage-chip flex1 {{#if (eq advantage -1)}}selected{{/if}}" data-action="updateIsAdvantage" data-advantage="-1">
                             {{#if (eq advantage -1)}}
@@ -105,7 +105,7 @@
                             {{else}}
                                 <span><i class="fa-regular fa-circle"></i></span>
                             {{/if}}
-                            <span class="label">{{localize "DAGGERHEART.General.Disadvantage.Full"}}</span>
+                            <span class="label">{{localize "DAGGERHEART.General.Disadvantage.full"}}</span>
                         </button>
                         {{#unless (eq @root.rollType 'D20Roll')}}
                             <select name="roll.dice.advantageFaces">

--- a/templates/dialogs/downtime.hbs
+++ b/templates/dialogs/downtime.hbs
@@ -1,6 +1,6 @@
 <div>
     <div class="downtime-container">
-        <h2 class="downtime-header">{{localize "DAGGERHEART.Downtime.DowntimeHeader" current=nrCurrentChoices  max=moveData.nrChoices}}</h2>
+        <h2 class="downtime-header">{{localize "DAGGERHEART.Applications.Downtime.downtimeHeader" current=nrCurrentChoices  max=moveData.nrChoices}}</h2>
         {{#each moveData.moves as |move key|}}
             <div class="activity-container">
                 <div class="activity-title">

--- a/templates/dialogs/downtime.hbs
+++ b/templates/dialogs/downtime.hbs
@@ -1,6 +1,6 @@
 <div>
     <div class="downtime-container">
-        <h2 class="downtime-header">{{localize "DAGGERHEART.Applications.Downtime.downtimeHeader" current=nrCurrentChoices  max=moveData.nrChoices}}</h2>
+        <h2 class="downtime-header">{{localize "DAGGERHEART.APPLICATIONS.Downtime.downtimeHeader" current=nrCurrentChoices  max=moveData.nrChoices}}</h2>
         {{#each moveData.moves as |move key|}}
             <div class="activity-container">
                 <div class="activity-title">

--- a/templates/dialogs/ownershipSelection.hbs
+++ b/templates/dialogs/ownershipSelection.hbs
@@ -1,7 +1,7 @@
 <div class="ownership-outer-container">
     <div class="form-group">
         <div class="form-fields">
-            <label>{{localize "DAGGERHEART.OwnershipSelection.Default"}}</label>
+            <label>{{localize "DAGGERHEART.Applications.OwnershipSelection.Default"}}</label>
             <select name="ownership.default" data-dtype="Number">
                 {{selectOptions @root.ownershipOptions selected=ownership.default  labelAttr="label" valueAttr="value" }}
             </select>

--- a/templates/dialogs/ownershipSelection.hbs
+++ b/templates/dialogs/ownershipSelection.hbs
@@ -1,7 +1,7 @@
 <div class="ownership-outer-container">
     <div class="form-group">
         <div class="form-fields">
-            <label>{{localize "DAGGERHEART.Applications.OwnershipSelection.Default"}}</label>
+            <label>{{localize "DAGGERHEART.APPLICATIONS.OwnershipSelection.Default"}}</label>
             <select name="ownership.default" data-dtype="Number">
                 {{selectOptions @root.ownershipOptions selected=ownership.default  labelAttr="label" valueAttr="value" }}
             </select>

--- a/templates/levelup/tabs/selections.hbs
+++ b/templates/levelup/tabs/selections.hbs
@@ -6,12 +6,12 @@
     <div class="section-container levelup-selections-container">
         {{#if (gt this.newExperiences.length 0)}}
             <div>
-                <h3>{{localize "DAGGERHEART.Applications.Levelup.summary.newExperiences"}}</h3>
+                <h3>{{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.newExperiences"}}</h3>
                 <div class="achievement-experience-cards">
                     {{#each this.newExperiences}}
                         <div class="achievement-experience-card">
                             <div class="flexrow">
-                                <input type="text" name="{{concat "levelup.levels." this.level ".achievements.experiences." this.key ".name"}}" value="{{this.name}}" placeholder="{{localize "DAGGERHEART.Applications.Levelup.summary.experiencePlaceholder"}}" />
+                                <input type="text" name="{{concat "levelup.levels." this.level ".achievements.experiences." this.key ".name"}}" value="{{this.name}}" placeholder="{{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.experiencePlaceholder"}}" />
                                 <div class="flex0">{{numberFormat this.modifier sign=true}}</div>
                             </div>
                             <div class="achievement-experience-marker">
@@ -26,7 +26,7 @@
         {{#if this.traits.active}}
             <div>
                 <h3 class="levelup-selections-title">
-                    <div>{{localize "DAGGERHEART.Applications.Levelup.summary.traits"}}</div>
+                    <div>{{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.traits"}}</div>
                     <div>{{this.traits.progress.selected}}/{{this.traits.progress.max}}</div>
                 </h3>
 
@@ -37,7 +37,7 @@
         {{#if this.experienceIncreases.active}}
             <div>
                 <h3 class="levelup-selections-title">
-                    <div>{{localize "DAGGERHEART.Applications.Levelup.summary.experienceIncreases"}}</div>
+                    <div>{{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.experienceIncreases"}}</div>
                     <div>{{this.experienceIncreases.progress.selected}}/{{this.experienceIncreases.progress.max}}</div>
                 </h3>
 
@@ -47,7 +47,7 @@
 
         {{#if (gt this.domainCards.length 0)}}
             <div>
-                <h3>{{localize "DAGGERHEART.Applications.Levelup.summary.domainCards"}}</h3>
+                <h3>{{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.domainCards"}}</h3>
 
                 <div class="levelup-card-selection domain-cards">
                     {{#each this.domainCards}}
@@ -63,7 +63,7 @@
 
         {{#if (gt this.subclassCards.length 0)}}
             <div>
-                <h3>{{localize "DAGGERHEART.Applications.Levelup.summary.subclass"}}</h3>
+                <h3>{{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.subclass"}}</h3>
 
                 <div class="levelup-card-selection subclass-cards">
                     {{#each this.subclassCards}}
@@ -75,7 +75,7 @@
 
         {{#if this.multiclass}}
             <div>
-                <h3>{{localize "DAGGERHEART.Applications.Levelup.summary.multiclass"}}</h3>
+                <h3>{{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.multiclass"}}</h3>
 
                 <div class="levelup-card-selection multiclass-cards" data-path="{{this.multiclass.path}}" data-tier="{{this.multiclass.tier}}" data-min-cost="{{this.multiclass.minCost}}" data-amount="{{this.multiclass.amount}}" data-value="{{this.multiclass.value}}" data-type="{{this.multiclass.type}}">
                     {{#> "systems/daggerheart/templates/components/card-preview.hbs" this.multiclass }}
@@ -114,7 +114,7 @@
 
         {{#if this.vicious}}
             <div>
-                <h3>{{localize "DAGGERHEART.Applications.Levelup.summary.vicious"}}</h3>
+                <h3>{{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.vicious"}}</h3>
                 {{#each this.vicious}}
                     <div class="levelup-radio-choices">
                         {{radioBoxes (concat "levelup." this.path ".data") @root.viciousChoices checked=(lookup this.data 0)}}

--- a/templates/levelup/tabs/selections.hbs
+++ b/templates/levelup/tabs/selections.hbs
@@ -6,12 +6,12 @@
     <div class="section-container levelup-selections-container">
         {{#if (gt this.newExperiences.length 0)}}
             <div>
-                <h3>{{localize "DAGGERHEART.Application.LevelUp.summary.newExperiences"}}</h3>
+                <h3>{{localize "DAGGERHEART.Applications.Levelup.summary.newExperiences"}}</h3>
                 <div class="achievement-experience-cards">
                     {{#each this.newExperiences}}
                         <div class="achievement-experience-card">
                             <div class="flexrow">
-                                <input type="text" name="{{concat "levelup.levels." this.level ".achievements.experiences." this.key ".name"}}" value="{{this.name}}" placeholder="{{localize "DAGGERHEART.Application.LevelUp.summary.experiencePlaceholder"}}" />
+                                <input type="text" name="{{concat "levelup.levels." this.level ".achievements.experiences." this.key ".name"}}" value="{{this.name}}" placeholder="{{localize "DAGGERHEART.Applications.Levelup.summary.experiencePlaceholder"}}" />
                                 <div class="flex0">{{numberFormat this.modifier sign=true}}</div>
                             </div>
                             <div class="achievement-experience-marker">
@@ -26,7 +26,7 @@
         {{#if this.traits.active}}
             <div>
                 <h3 class="levelup-selections-title">
-                    <div>{{localize "DAGGERHEART.Application.LevelUp.summary.traits"}}</div>
+                    <div>{{localize "DAGGERHEART.Applications.Levelup.summary.traits"}}</div>
                     <div>{{this.traits.progress.selected}}/{{this.traits.progress.max}}</div>
                 </h3>
 
@@ -37,7 +37,7 @@
         {{#if this.experienceIncreases.active}}
             <div>
                 <h3 class="levelup-selections-title">
-                    <div>{{localize "DAGGERHEART.Application.LevelUp.summary.experienceIncreases"}}</div>
+                    <div>{{localize "DAGGERHEART.Applications.Levelup.summary.experienceIncreases"}}</div>
                     <div>{{this.experienceIncreases.progress.selected}}/{{this.experienceIncreases.progress.max}}</div>
                 </h3>
 
@@ -47,7 +47,7 @@
 
         {{#if (gt this.domainCards.length 0)}}
             <div>
-                <h3>{{localize "DAGGERHEART.Application.LevelUp.summary.domainCards"}}</h3>
+                <h3>{{localize "DAGGERHEART.Applications.Levelup.summary.domainCards"}}</h3>
 
                 <div class="levelup-card-selection domain-cards">
                     {{#each this.domainCards}}
@@ -63,7 +63,7 @@
 
         {{#if (gt this.subclassCards.length 0)}}
             <div>
-                <h3>{{localize "DAGGERHEART.Application.LevelUp.summary.subclass"}}</h3>
+                <h3>{{localize "DAGGERHEART.Applications.Levelup.summary.subclass"}}</h3>
 
                 <div class="levelup-card-selection subclass-cards">
                     {{#each this.subclassCards}}
@@ -75,7 +75,7 @@
 
         {{#if this.multiclass}}
             <div>
-                <h3>{{localize "DAGGERHEART.Application.LevelUp.summary.multiclass"}}</h3>
+                <h3>{{localize "DAGGERHEART.Applications.Levelup.summary.multiclass"}}</h3>
 
                 <div class="levelup-card-selection multiclass-cards" data-path="{{this.multiclass.path}}" data-tier="{{this.multiclass.tier}}" data-min-cost="{{this.multiclass.minCost}}" data-amount="{{this.multiclass.amount}}" data-value="{{this.multiclass.value}}" data-type="{{this.multiclass.type}}">
                     {{#> "systems/daggerheart/templates/components/card-preview.hbs" this.multiclass }}
@@ -114,7 +114,7 @@
 
         {{#if this.vicious}}
             <div>
-                <h3>{{localize "DAGGERHEART.Application.LevelUp.summary.vicious"}}</h3>
+                <h3>{{localize "DAGGERHEART.Applications.Levelup.summary.vicious"}}</h3>
                 {{#each this.vicious}}
                     <div class="levelup-radio-choices">
                         {{radioBoxes (concat "levelup." this.path ".data") @root.viciousChoices checked=(lookup this.data 0)}}

--- a/templates/levelup/tabs/summary.hbs
+++ b/templates/levelup/tabs/summary.hbs
@@ -6,13 +6,13 @@
     <div class="section-container levelup-summary-container">
         {{#if this.achievements}}
             <fieldset>
-                <legend>{{localize "DAGGERHEART.Applications.Levelup.summary.levelAchievements"}}</legend>
+                <legend>{{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.levelAchievements"}}</legend>
 
                 <div class="level-achievements-container">
                     {{#if this.achievements.proficiency.shown}}
                         <div>
                             <div class="increase-container">
-                                {{localize "DAGGERHEART.Applications.Levelup.summary.proficiencyIncrease" proficiency=this.achievements.proficiency.old }}
+                                {{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.proficiencyIncrease" proficiency=this.achievements.proficiency.old }}
                                 <i class="fa-solid fa-arrow-right-long"></i>
                                 {{this.achievements.proficiency.new}}
                             </div>
@@ -20,14 +20,14 @@
                     {{/if}}
                     {{#if this.achievements.damageThresholds}}
                         <div>
-                            <h5 class="summary-section">{{localize "DAGGERHEART.Applications.Levelup.summary.damageThresholds"}}{{#if this.levelAchievements.damageThresholds.unarmored}}({{localize "DAGGERHEART.General.unarmored"}}){{/if}}</h5>
+                            <h5 class="summary-section">{{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.damageThresholds"}}{{#if this.levelAchievements.damageThresholds.unarmored}}({{localize "DAGGERHEART.GENERAL.unarmored"}}){{/if}}</h5>
                             <div class="increase-container">
-                                {{localize "DAGGERHEART.Applications.Levelup.summary.damageThresholdMajorIncrease" threshold=this.achievements.damageThresholds.major.old }}
+                                {{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.damageThresholdMajorIncrease" threshold=this.achievements.damageThresholds.major.old }}
                                 <i class="fa-solid fa-arrow-right-long"></i>
                                 {{this.achievements.damageThresholds.major.new}}
                             </div>
                             <div class="increase-container">
-                                {{localize "DAGGERHEART.Applications.Levelup.summary.damageThresholdSevereIncrease" threshold=this.achievements.damageThresholds.severe.old }}
+                                {{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.damageThresholdSevereIncrease" threshold=this.achievements.damageThresholds.severe.old }}
                                 <i class="fa-solid fa-arrow-right-long"></i>
                                 {{this.achievements.damageThresholds.severe.new}}
                             </div>
@@ -35,7 +35,7 @@
                     {{/if}}
                     {{#if this.achievements.domainCards.shown}}
                         <div>
-                            <h5>{{localize "DAGGERHEART.Applications.Levelup.summary.domainCards"}}</h5>
+                            <h5>{{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.domainCards"}}</h5>
                             <div class="summary-selection-container">
                                 {{#each this.achievements.domainCards.values}}
                                     <div class="summary-selection">{{this.name}}</div>
@@ -45,7 +45,7 @@
                     {{/if}}
                     {{#if this.achievements.experiences.shown}}
                         <div>
-                            <h5>{{localize "DAGGERHEART.Applications.Levelup.summary.newExperiences"}}</h5>
+                            <h5>{{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.newExperiences"}}</h5>
                             <div class="summary-selection-container">
                                 {{#each this.achievements.experiences.values}}
                                     <div class="summary-selection">{{this.name}} {{numberFormat this.modifier sign=true}}</div>
@@ -57,14 +57,14 @@
             </fieldset>
         {{/if}}
         <fieldset>
-            <legend>{{localize "DAGGERHEART.Applications.Levelup.summary.levelAdvancements"}}</legend>
+            <legend>{{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.levelAdvancements"}}</legend>
 
             <div class="level-advancements-container">
                 {{#if this.advancements.statistics.shown}}
                     <div>
                         {{#if this.advancements.statistics.proficiency.shown}}
                             <div class="increase-container">
-                                {{localize "DAGGERHEART.Applications.Levelup.summary.proficiencyIncrease" proficiency=this.advancements.statistics.proficiency.old }}
+                                {{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.proficiencyIncrease" proficiency=this.advancements.statistics.proficiency.old }}
                                 <i class="fa-solid fa-arrow-right-long"></i>
                                 {{this.advancements.statistics.proficiency.new}}
                             </div>
@@ -72,7 +72,7 @@
 
                         {{#if this.advancements.statistics.hitPoints.shown}}
                             <div class="increase-container">
-                                {{localize "DAGGERHEART.Applications.Levelup.summary.hpIncrease" hitPoints=this.advancements.statistics.hitPoints.old }}
+                                {{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.hpIncrease" hitPoints=this.advancements.statistics.hitPoints.old }}
                                 <i class="fa-solid fa-arrow-right-long"></i>
                                 {{this.advancements.statistics.hitPoints.new}}
                             </div>
@@ -80,14 +80,14 @@
 
                         {{#if this.advancements.statistics.stress.shown}}
                             <div class="increase-container">
-                                {{localize "DAGGERHEART.Applications.Levelup.summary.stressIncrease" stress=this.advancements.statistics.stress.old }}
+                                {{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.stressIncrease" stress=this.advancements.statistics.stress.old }}
                                 <i class="fa-solid fa-arrow-right-long"></i>
                                 {{this.advancements.statistics.stress.new}}
                             </div>
                         {{/if}}
                         {{#if this.advancements.statistics.evasion.shown}}
                             <div class="increase-container">
-                                {{localize "DAGGERHEART.Applications.Levelup.summary.evasionIncrease" evasion=this.advancements.statistics.evasion.old }}
+                                {{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.evasionIncrease" evasion=this.advancements.statistics.evasion.old }}
                                 <i class="fa-solid fa-arrow-right-long"></i>
                                 {{this.advancements.statistics.evasion.new}}
                             </div>
@@ -97,7 +97,7 @@
 
                 {{#if this.advancements.traits}}
                     <div>
-                        <h5>{{localize "DAGGERHEART.Applications.Levelup.summary.traits"}}</h5>
+                        <h5>{{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.traits"}}</h5>
   
                             {{#each this.advancements.traits}}
                                 <div class="increase-container">
@@ -111,7 +111,7 @@
 
                 {{#if this.advancements.domainCards}}
                     <div>
-                        <h5>{{localize "DAGGERHEART.Applications.Levelup.summary.domainCards"}}</h5>
+                        <h5>{{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.domainCards"}}</h5>
                         <div class="summary-selection-container">
                             {{#each this.advancements.domainCards}}
                                 <div class="summary-selection">{{this.name}}</div>
@@ -122,7 +122,7 @@
 
                 {{#if this.advancements.experiences}}
                     <div>
-                        <h5>{{localize "DAGGERHEART.Applications.Levelup.summary.experienceIncreases"}}</h5>
+                        <h5>{{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.experienceIncreases"}}</h5>
                         <div class="summary-selection-container">
                             {{#each this.advancements.experiences}}
                                 <div class="summary-selection">{{this.name}} {{numberFormat this.modifier sign=true}}</div>
@@ -133,7 +133,7 @@
 
                 {{#if this.advancements.subclass}}
                     <div>
-                        <h5>{{localize "DAGGERHEART.Applications.Levelup.summary.subclass"}}</h5>
+                        <h5>{{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.subclass"}}</h5>
                         <div class="summary-selection-container">
                             {{#each this.advancements.subclass}}
                                 <div class="summary-selection">{{this.name}} - {{this.featureLabel}}</div>
@@ -145,7 +145,7 @@
                 {{#if this.advancements.multiclass}}
                     {{#with this.advancements.multiclass}}
                         <div>
-                            <h5>{{localize "DAGGERHEART.Applications.Levelup.summary.multiclass"}}</h5>
+                            <h5>{{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.multiclass"}}</h5>
                             <div class="summary-selection-container">
                                 <div class="summary-selection">{{this.name}}</div>
                                 <div class="summary-selection">{{this.domain}}</div>
@@ -157,21 +157,21 @@
 
                 {{#if this.advancements.vicious.damage}}
                      <div class="increase-container">
-                        {{localize "DAGGERHEART.Applications.Levelup.summary.damageIncreased" damage=this.advancements.vicious.damage.old }}
+                        {{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.damageIncreased" damage=this.advancements.vicious.damage.old }}
                         <i class="fa-solid fa-arrow-right-long"></i>
                         {{this.advancements.vicious.damage.new}}
                     </div>     
                 {{/if}}
                 {{#if this.advancements.vicious.range}}
                      <div class="increase-container">
-                        {{localize "DAGGERHEART.Applications.Levelup.summary.rangeIncreased" range=this.advancements.vicious.range.old }}
+                        {{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.rangeIncreased" range=this.advancements.vicious.range.old }}
                         <i class="fa-solid fa-arrow-right-long"></i>
                         {{this.advancements.vicious.range.new}}
                     </div>     
                 {{/if}}
                 {{#each this.advancements.simple}}
                     <div class="summary-selection-container">
-                        <div class="summary-selection">{{localize "DAGGERHEART.Applications.Levelup.summary.simpleFeature" feature=this}}</div>
+                        <div class="summary-selection">{{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.simpleFeature" feature=this}}</div>
                     </div>
                 {{/each}}
             </div>

--- a/templates/levelup/tabs/summary.hbs
+++ b/templates/levelup/tabs/summary.hbs
@@ -6,13 +6,13 @@
     <div class="section-container levelup-summary-container">
         {{#if this.achievements}}
             <fieldset>
-                <legend>{{localize "DAGGERHEART.Application.LevelUp.summary.levelAchievements"}}</legend>
+                <legend>{{localize "DAGGERHEART.Applications.Levelup.summary.levelAchievements"}}</legend>
 
                 <div class="level-achievements-container">
                     {{#if this.achievements.proficiency.shown}}
                         <div>
                             <div class="increase-container">
-                                {{localize "DAGGERHEART.Application.LevelUp.summary.proficiencyIncrease" proficiency=this.achievements.proficiency.old }}
+                                {{localize "DAGGERHEART.Applications.Levelup.summary.proficiencyIncrease" proficiency=this.achievements.proficiency.old }}
                                 <i class="fa-solid fa-arrow-right-long"></i>
                                 {{this.achievements.proficiency.new}}
                             </div>
@@ -20,14 +20,14 @@
                     {{/if}}
                     {{#if this.achievements.damageThresholds}}
                         <div>
-                            <h5 class="summary-section">{{localize "DAGGERHEART.Application.LevelUp.summary.damageThresholds"}}{{#if this.levelAchievements.damageThresholds.unarmored}}({{localize "DAGGERHEART.General.unarmored"}}){{/if}}</h5>
+                            <h5 class="summary-section">{{localize "DAGGERHEART.Applications.Levelup.summary.damageThresholds"}}{{#if this.levelAchievements.damageThresholds.unarmored}}({{localize "DAGGERHEART.General.unarmored"}}){{/if}}</h5>
                             <div class="increase-container">
-                                {{localize "DAGGERHEART.Application.LevelUp.summary.damageThresholdMajorIncrease" threshold=this.achievements.damageThresholds.major.old }}
+                                {{localize "DAGGERHEART.Applications.Levelup.summary.damageThresholdMajorIncrease" threshold=this.achievements.damageThresholds.major.old }}
                                 <i class="fa-solid fa-arrow-right-long"></i>
                                 {{this.achievements.damageThresholds.major.new}}
                             </div>
                             <div class="increase-container">
-                                {{localize "DAGGERHEART.Application.LevelUp.summary.damageThresholdSevereIncrease" threshold=this.achievements.damageThresholds.severe.old }}
+                                {{localize "DAGGERHEART.Applications.Levelup.summary.damageThresholdSevereIncrease" threshold=this.achievements.damageThresholds.severe.old }}
                                 <i class="fa-solid fa-arrow-right-long"></i>
                                 {{this.achievements.damageThresholds.severe.new}}
                             </div>
@@ -35,7 +35,7 @@
                     {{/if}}
                     {{#if this.achievements.domainCards.shown}}
                         <div>
-                            <h5>{{localize "DAGGERHEART.Application.LevelUp.summary.domainCards"}}</h5>
+                            <h5>{{localize "DAGGERHEART.Applications.Levelup.summary.domainCards"}}</h5>
                             <div class="summary-selection-container">
                                 {{#each this.achievements.domainCards.values}}
                                     <div class="summary-selection">{{this.name}}</div>
@@ -45,7 +45,7 @@
                     {{/if}}
                     {{#if this.achievements.experiences.shown}}
                         <div>
-                            <h5>{{localize "DAGGERHEART.Application.LevelUp.summary.newExperiences"}}</h5>
+                            <h5>{{localize "DAGGERHEART.Applications.Levelup.summary.newExperiences"}}</h5>
                             <div class="summary-selection-container">
                                 {{#each this.achievements.experiences.values}}
                                     <div class="summary-selection">{{this.name}} {{numberFormat this.modifier sign=true}}</div>
@@ -57,14 +57,14 @@
             </fieldset>
         {{/if}}
         <fieldset>
-            <legend>{{localize "DAGGERHEART.Application.LevelUp.summary.levelAdvancements"}}</legend>
+            <legend>{{localize "DAGGERHEART.Applications.Levelup.summary.levelAdvancements"}}</legend>
 
             <div class="level-advancements-container">
                 {{#if this.advancements.statistics.shown}}
                     <div>
                         {{#if this.advancements.statistics.proficiency.shown}}
                             <div class="increase-container">
-                                {{localize "DAGGERHEART.Application.LevelUp.summary.proficiencyIncrease" proficiency=this.advancements.statistics.proficiency.old }}
+                                {{localize "DAGGERHEART.Applications.Levelup.summary.proficiencyIncrease" proficiency=this.advancements.statistics.proficiency.old }}
                                 <i class="fa-solid fa-arrow-right-long"></i>
                                 {{this.advancements.statistics.proficiency.new}}
                             </div>
@@ -72,7 +72,7 @@
 
                         {{#if this.advancements.statistics.hitPoints.shown}}
                             <div class="increase-container">
-                                {{localize "DAGGERHEART.Application.LevelUp.summary.hpIncrease" hitPoints=this.advancements.statistics.hitPoints.old }}
+                                {{localize "DAGGERHEART.Applications.Levelup.summary.hpIncrease" hitPoints=this.advancements.statistics.hitPoints.old }}
                                 <i class="fa-solid fa-arrow-right-long"></i>
                                 {{this.advancements.statistics.hitPoints.new}}
                             </div>
@@ -80,14 +80,14 @@
 
                         {{#if this.advancements.statistics.stress.shown}}
                             <div class="increase-container">
-                                {{localize "DAGGERHEART.Application.LevelUp.summary.stressIncrease" stress=this.advancements.statistics.stress.old }}
+                                {{localize "DAGGERHEART.Applications.Levelup.summary.stressIncrease" stress=this.advancements.statistics.stress.old }}
                                 <i class="fa-solid fa-arrow-right-long"></i>
                                 {{this.advancements.statistics.stress.new}}
                             </div>
                         {{/if}}
                         {{#if this.advancements.statistics.evasion.shown}}
                             <div class="increase-container">
-                                {{localize "DAGGERHEART.Application.LevelUp.summary.evasionIncrease" evasion=this.advancements.statistics.evasion.old }}
+                                {{localize "DAGGERHEART.Applications.Levelup.summary.evasionIncrease" evasion=this.advancements.statistics.evasion.old }}
                                 <i class="fa-solid fa-arrow-right-long"></i>
                                 {{this.advancements.statistics.evasion.new}}
                             </div>
@@ -97,7 +97,7 @@
 
                 {{#if this.advancements.traits}}
                     <div>
-                        <h5>{{localize "DAGGERHEART.Application.LevelUp.summary.traits"}}</h5>
+                        <h5>{{localize "DAGGERHEART.Applications.Levelup.summary.traits"}}</h5>
   
                             {{#each this.advancements.traits}}
                                 <div class="increase-container">
@@ -111,7 +111,7 @@
 
                 {{#if this.advancements.domainCards}}
                     <div>
-                        <h5>{{localize "DAGGERHEART.Application.LevelUp.summary.domainCards"}}</h5>
+                        <h5>{{localize "DAGGERHEART.Applications.Levelup.summary.domainCards"}}</h5>
                         <div class="summary-selection-container">
                             {{#each this.advancements.domainCards}}
                                 <div class="summary-selection">{{this.name}}</div>
@@ -122,7 +122,7 @@
 
                 {{#if this.advancements.experiences}}
                     <div>
-                        <h5>{{localize "DAGGERHEART.Application.LevelUp.summary.experienceIncreases"}}</h5>
+                        <h5>{{localize "DAGGERHEART.Applications.Levelup.summary.experienceIncreases"}}</h5>
                         <div class="summary-selection-container">
                             {{#each this.advancements.experiences}}
                                 <div class="summary-selection">{{this.name}} {{numberFormat this.modifier sign=true}}</div>
@@ -133,7 +133,7 @@
 
                 {{#if this.advancements.subclass}}
                     <div>
-                        <h5>{{localize "DAGGERHEART.Application.LevelUp.summary.subclass"}}</h5>
+                        <h5>{{localize "DAGGERHEART.Applications.Levelup.summary.subclass"}}</h5>
                         <div class="summary-selection-container">
                             {{#each this.advancements.subclass}}
                                 <div class="summary-selection">{{this.name}} - {{this.featureLabel}}</div>
@@ -145,7 +145,7 @@
                 {{#if this.advancements.multiclass}}
                     {{#with this.advancements.multiclass}}
                         <div>
-                            <h5>{{localize "DAGGERHEART.Application.LevelUp.summary.multiclass"}}</h5>
+                            <h5>{{localize "DAGGERHEART.Applications.Levelup.summary.multiclass"}}</h5>
                             <div class="summary-selection-container">
                                 <div class="summary-selection">{{this.name}}</div>
                                 <div class="summary-selection">{{this.domain}}</div>
@@ -157,21 +157,21 @@
 
                 {{#if this.advancements.vicious.damage}}
                      <div class="increase-container">
-                        {{localize "DAGGERHEART.Application.LevelUp.summary.damageIncreased" damage=this.advancements.vicious.damage.old }}
+                        {{localize "DAGGERHEART.Applications.Levelup.summary.damageIncreased" damage=this.advancements.vicious.damage.old }}
                         <i class="fa-solid fa-arrow-right-long"></i>
                         {{this.advancements.vicious.damage.new}}
                     </div>     
                 {{/if}}
                 {{#if this.advancements.vicious.range}}
                      <div class="increase-container">
-                        {{localize "DAGGERHEART.Application.LevelUp.summary.rangeIncreased" range=this.advancements.vicious.range.old }}
+                        {{localize "DAGGERHEART.Applications.Levelup.summary.rangeIncreased" range=this.advancements.vicious.range.old }}
                         <i class="fa-solid fa-arrow-right-long"></i>
                         {{this.advancements.vicious.range.new}}
                     </div>     
                 {{/if}}
                 {{#each this.advancements.simple}}
                     <div class="summary-selection-container">
-                        <div class="summary-selection">{{localize "DAGGERHEART.Application.LevelUp.summary.simpleFeature" feature=this}}</div>
+                        <div class="summary-selection">{{localize "DAGGERHEART.Applications.Levelup.summary.simpleFeature" feature=this}}</div>
                     </div>
                 {{/each}}
             </div>

--- a/templates/levelup/tabs/tab-navigation.hbs
+++ b/templates/levelup/tabs/tab-navigation.hbs
@@ -19,7 +19,7 @@
         {{/if}}
         <div class="levelup-navigation-actions {{#if (not this.showTabs)}}test{{/if}}">       
             {{#if this.navigate.previous.fromSummary}}
-                <button data-action="activatePart" data-part="advancements">{{localize "DAGGERHEART.Applications.Levelup.navigateToLevelup"}}</button>
+                <button data-action="activatePart" data-part="advancements">{{localize "DAGGERHEART.APPLICATIONS.Levelup.navigateToLevelup"}}</button>
             {{else}}
                 {{#if (not this.navigate.previous.disabled)}}
                     <button data-action="updateCurrentLevel" >{{this.navigate.previous.label}}</button>
@@ -27,7 +27,7 @@
             {{/if}}
             {{#if this.navigate.next.show}}
                 {{#if this.navigate.next.toSummary}}
-                    <button data-action="activatePart" data-part="summary"  {{#if this.navigate.next.disabled}}disabled{{/if}}>{{localize "DAGGERHEART.Applications.Levelup.navigateToSummary"}}</button>
+                    <button data-action="activatePart" data-part="summary"  {{#if this.navigate.next.disabled}}disabled{{/if}}>{{localize "DAGGERHEART.APPLICATIONS.Levelup.navigateToSummary"}}</button>
                 {{else}}
                     <button data-action="updateCurrentLevel" data-forward="true" {{#if this.navigate.next.disabled}}disabled{{/if}}>{{this.navigate.next.label}}</button>
                 {{/if}}

--- a/templates/levelup/tabs/tab-navigation.hbs
+++ b/templates/levelup/tabs/tab-navigation.hbs
@@ -19,7 +19,7 @@
         {{/if}}
         <div class="levelup-navigation-actions {{#if (not this.showTabs)}}test{{/if}}">       
             {{#if this.navigate.previous.fromSummary}}
-                <button data-action="activatePart" data-part="advancements">{{localize "DAGGERHEART.Application.LevelUp.navigateToLevelup"}}</button>
+                <button data-action="activatePart" data-part="advancements">{{localize "DAGGERHEART.Applications.Levelup.navigateToLevelup"}}</button>
             {{else}}
                 {{#if (not this.navigate.previous.disabled)}}
                     <button data-action="updateCurrentLevel" >{{this.navigate.previous.label}}</button>
@@ -27,7 +27,7 @@
             {{/if}}
             {{#if this.navigate.next.show}}
                 {{#if this.navigate.next.toSummary}}
-                    <button data-action="activatePart" data-part="summary"  {{#if this.navigate.next.disabled}}disabled{{/if}}>{{localize "DAGGERHEART.Application.LevelUp.navigateToSummary"}}</button>
+                    <button data-action="activatePart" data-part="summary"  {{#if this.navigate.next.disabled}}disabled{{/if}}>{{localize "DAGGERHEART.Applications.Levelup.navigateToSummary"}}</button>
                 {{else}}
                     <button data-action="updateCurrentLevel" data-forward="true" {{#if this.navigate.next.disabled}}disabled{{/if}}>{{this.navigate.next.label}}</button>
                 {{/if}}

--- a/templates/settings/appearance-settings.hbs
+++ b/templates/settings/appearance-settings.hbs
@@ -2,104 +2,104 @@
     {{formGroup settingFields.schema.fields.displayFear value=settingFields._source.displayFear localize=true}}
 
     <fieldset>
-        <legend>{{localize "DAGGERHEART.Settings.Menu.Appearance.duality"}}</legend>
+        <legend>{{localize "DAGGERHEART.Settings.Menu.appearance.duality"}}</legend>
 
         {{formInput settingFields.schema.fields.dualityColorScheme value=settingFields._source.dualityColorScheme localize=true}}
 
-        <h2>{{localize "DAGGERHEART.Settings.Menu.Appearance.DiceSoNice.title"}}</h2>
-        <div class="title-hint">{{localize "DAGGERHEART.Settings.Menu.Appearance.DiceSoNice.hint"}}</div>
+        <h2>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.title"}}</h2>
+        <div class="title-hint">{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.hint"}}</div>
 
         <fieldset>
-            <legend>{{localize "DAGGERHEART.General.Hope"}}</legend>
+            <legend>{{localize "DAGGERHEART.General.hope"}}</legend>
 
             <div class="field-section">
                 <div class="split-section">
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.Appearance.DiceSoNice.foreground"}}</label>
+                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.foreground"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.hope.fields.foreground value=settingFields._source.diceSoNice.hope.foreground localize=true}}
                     </div>
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.Appearance.DiceSoNice.background"}}</label>
+                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.background"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.hope.fields.background value=settingFields._source.diceSoNice.hope.background localize=true}}
                     </div>
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.Appearance.DiceSoNice.outline"}}</label>
+                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.outline"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.hope.fields.outline value=settingFields._source.diceSoNice.hope.outline localize=true}}
                     </div>
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.Appearance.DiceSoNice.edge"}}</label>
+                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.edge"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.hope.fields.edge value=settingFields._source.diceSoNice.hope.edge localize=true}}
                     </div>
                 </div>
             </div>
         </fieldset>
         <fieldset>
-            <legend>{{localize "DAGGERHEART.General.Fear"}}</legend>
+            <legend>{{localize "DAGGERHEART.General.fear"}}</legend>
 
             <div class="field-section">
                 <div class="split-section">
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.Appearance.DiceSoNice.foreground"}}</label>
+                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.foreground"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.fear.fields.foreground value=settingFields._source.diceSoNice.fear.foreground localize=true}}
                     </div>
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.Appearance.DiceSoNice.background"}}</label>
+                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.background"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.fear.fields.background value=settingFields._source.diceSoNice.fear.background localize=true}}
                     </div>
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.Appearance.DiceSoNice.outline"}}</label>
+                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.outline"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.fear.fields.outline value=settingFields._source.diceSoNice.fear.outline localize=true}}
                     </div>
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.Appearance.DiceSoNice.edge"}}</label>
+                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.edge"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.fear.fields.edge value=settingFields._source.diceSoNice.fear.edge localize=true}}
                     </div>
                 </div>
             </div>
         </fieldset>
         <fieldset>
-            <legend>{{localize "DAGGERHEART.General.Advantage.Full"}}</legend>
+            <legend>{{localize "DAGGERHEART.General.Advantage.full"}}</legend>
 
             <div class="field-section">
                 <div class="split-section">
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.Appearance.DiceSoNice.foreground"}}</label>
+                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.foreground"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.advantage.fields.foreground value=settingFields._source.diceSoNice.advantage.foreground localize=true}}
                     </div>
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.Appearance.DiceSoNice.background"}}</label>
+                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.background"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.advantage.fields.background value=settingFields._source.diceSoNice.advantage.background localize=true}}
                     </div>
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.Appearance.DiceSoNice.outline"}}</label>
+                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.outline"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.advantage.fields.outline value=settingFields._source.diceSoNice.advantage.outline localize=true}}
                     </div>
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.Appearance.DiceSoNice.edge"}}</label>
+                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.edge"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.advantage.fields.edge value=settingFields._source.diceSoNice.advantage.edge localize=true}}
                     </div>
                 </div>
             </div>
         </fieldset>
         <fieldset>
-            <legend>{{localize "DAGGERHEART.General.Disadvantage.Full"}}</legend>
+            <legend>{{localize "DAGGERHEART.General.Disadvantage.full"}}</legend>
 
             <div class="field-section">
                 <div class="split-section">
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.Appearance.DiceSoNice.foreground"}}</label>
+                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.foreground"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.disadvantage.fields.foreground value=settingFields._source.diceSoNice.disadvantage.foreground localize=true}}
                     </div>
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.Appearance.DiceSoNice.background"}}</label>
+                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.background"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.disadvantage.fields.background value=settingFields._source.diceSoNice.disadvantage.background localize=true}}
                     </div>
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.Appearance.DiceSoNice.outline"}}</label>
+                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.outline"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.disadvantage.fields.outline value=settingFields._source.diceSoNice.disadvantage.outline localize=true}}
                     </div>
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.Appearance.DiceSoNice.edge"}}</label>
+                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.edge"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.disadvantage.fields.edge value=settingFields._source.diceSoNice.disadvantage.edge localize=true}}
                     </div>
                 </div>

--- a/templates/settings/appearance-settings.hbs
+++ b/templates/settings/appearance-settings.hbs
@@ -2,104 +2,104 @@
     {{formGroup settingFields.schema.fields.displayFear value=settingFields._source.displayFear localize=true}}
 
     <fieldset>
-        <legend>{{localize "DAGGERHEART.Settings.Menu.appearance.duality"}}</legend>
+        <legend>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.duality"}}</legend>
 
         {{formInput settingFields.schema.fields.dualityColorScheme value=settingFields._source.dualityColorScheme localize=true}}
 
-        <h2>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.title"}}</h2>
-        <div class="title-hint">{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.hint"}}</div>
+        <h2>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.title"}}</h2>
+        <div class="title-hint">{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.hint"}}</div>
 
         <fieldset>
-            <legend>{{localize "DAGGERHEART.General.hope"}}</legend>
+            <legend>{{localize "DAGGERHEART.GENERAL.hope"}}</legend>
 
             <div class="field-section">
                 <div class="split-section">
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.foreground"}}</label>
+                        <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.foreground"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.hope.fields.foreground value=settingFields._source.diceSoNice.hope.foreground localize=true}}
                     </div>
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.background"}}</label>
+                        <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.background"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.hope.fields.background value=settingFields._source.diceSoNice.hope.background localize=true}}
                     </div>
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.outline"}}</label>
+                        <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.outline"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.hope.fields.outline value=settingFields._source.diceSoNice.hope.outline localize=true}}
                     </div>
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.edge"}}</label>
+                        <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.edge"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.hope.fields.edge value=settingFields._source.diceSoNice.hope.edge localize=true}}
                     </div>
                 </div>
             </div>
         </fieldset>
         <fieldset>
-            <legend>{{localize "DAGGERHEART.General.fear"}}</legend>
+            <legend>{{localize "DAGGERHEART.GENERAL.fear"}}</legend>
 
             <div class="field-section">
                 <div class="split-section">
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.foreground"}}</label>
+                        <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.foreground"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.fear.fields.foreground value=settingFields._source.diceSoNice.fear.foreground localize=true}}
                     </div>
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.background"}}</label>
+                        <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.background"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.fear.fields.background value=settingFields._source.diceSoNice.fear.background localize=true}}
                     </div>
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.outline"}}</label>
+                        <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.outline"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.fear.fields.outline value=settingFields._source.diceSoNice.fear.outline localize=true}}
                     </div>
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.edge"}}</label>
+                        <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.edge"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.fear.fields.edge value=settingFields._source.diceSoNice.fear.edge localize=true}}
                     </div>
                 </div>
             </div>
         </fieldset>
         <fieldset>
-            <legend>{{localize "DAGGERHEART.General.Advantage.full"}}</legend>
+            <legend>{{localize "DAGGERHEART.GENERAL.Advantage.full"}}</legend>
 
             <div class="field-section">
                 <div class="split-section">
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.foreground"}}</label>
+                        <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.foreground"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.advantage.fields.foreground value=settingFields._source.diceSoNice.advantage.foreground localize=true}}
                     </div>
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.background"}}</label>
+                        <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.background"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.advantage.fields.background value=settingFields._source.diceSoNice.advantage.background localize=true}}
                     </div>
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.outline"}}</label>
+                        <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.outline"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.advantage.fields.outline value=settingFields._source.diceSoNice.advantage.outline localize=true}}
                     </div>
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.edge"}}</label>
+                        <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.edge"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.advantage.fields.edge value=settingFields._source.diceSoNice.advantage.edge localize=true}}
                     </div>
                 </div>
             </div>
         </fieldset>
         <fieldset>
-            <legend>{{localize "DAGGERHEART.General.Disadvantage.full"}}</legend>
+            <legend>{{localize "DAGGERHEART.GENERAL.Disadvantage.full"}}</legend>
 
             <div class="field-section">
                 <div class="split-section">
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.foreground"}}</label>
+                        <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.foreground"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.disadvantage.fields.foreground value=settingFields._source.diceSoNice.disadvantage.foreground localize=true}}
                     </div>
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.background"}}</label>
+                        <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.background"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.disadvantage.fields.background value=settingFields._source.diceSoNice.disadvantage.background localize=true}}
                     </div>
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.outline"}}</label>
+                        <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.outline"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.disadvantage.fields.outline value=settingFields._source.diceSoNice.disadvantage.outline localize=true}}
                     </div>
                     <div class="label-container">
-                        <label>{{localize "DAGGERHEART.Settings.Menu.appearance.diceSoNice.edge"}}</label>
+                        <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.edge"}}</label>
                         {{formInput settingFields.schema.fields.diceSoNice.fields.disadvantage.fields.edge value=settingFields._source.diceSoNice.disadvantage.edge localize=true}}
                     </div>
                 </div>

--- a/templates/settings/automation-settings.hbs
+++ b/templates/settings/automation-settings.hbs
@@ -1,18 +1,18 @@
 <div>
     <div class="form-group">
-        <label>{{localize "DAGGERHEART.Settings.Automation.FIELDS.hope.label"}}</label>
+        <label>{{localize "DAGGERHEART.SETTINGS.Automation.FIELDS.hope.label"}}</label>
         <div class="form-fields">
             {{formInput settingFields.schema.fields.hope value=settingFields._source.hope }}
         </div>
     </div>
     <div class="form-group">
-        <label>{{localize "DAGGERHEART.Settings.Automation.FIELDS.actionPoints.label"}}</label>
+        <label>{{localize "DAGGERHEART.SETTINGS.Automation.FIELDS.actionPoints.label"}}</label>
         <div class="form-fields">
             {{formInput settingFields.schema.fields.actionPoints value=settingFields._source.actionPoints }}
         </div>
     </div>
     <div class="form-group">
-        <label>{{localize "DAGGERHEART.Settings.Automation.FIELDS.countdowns.label"}}</label>
+        <label>{{localize "DAGGERHEART.SETTINGS.Automation.FIELDS.countdowns.label"}}</label>
         <div class="form-fields">
             {{formInput settingFields.schema.fields.countdowns value=settingFields._source.countdowns }}
         </div>

--- a/templates/settings/homebrew-settings.hbs
+++ b/templates/settings/homebrew-settings.hbs
@@ -5,7 +5,7 @@
     <div class="trait-array-container">
         {{#each settingFields._source.traitArray as |trait index|}}
             <div class="trait-array-item">
-                <label>{{localize "DAGGERHEART.General.Modifier"}} {{add index 1}}</label>
+                <label>{{localize "DAGGERHEART.General.modifier"}} {{add index 1}}</label>
                 <input type="text" data-dtype="Number" name="{{concat "traitArray." index}}" value="{{this}}" />
             </div>
         {{/each}}
@@ -13,7 +13,7 @@
 
     <fieldset>
         <legend>
-            {{localize "DAGGERHEART.Settings.Homebrew.Currency.title"}} 
+            {{localize "DAGGERHEART.Settings.Homebrew.currency.title"}} 
         </legend>
         {{formGroup settingFields.schema.fields.currency.fields.enabled value=settingFields._source.currency.enabled localize=true}}
         {{formGroup settingFields.schema.fields.currency.fields.title value=settingFields._source.currency.title localize=true}}
@@ -25,17 +25,17 @@
     </fieldset>
 
     <fieldset class="two-columns even">
-        <legend>{{localize "DAGGERHEART.Settings.Homebrew.DowntimeMoves"}}</legend>
+        <legend>{{localize "DAGGERHEART.Settings.Homebrew.downtimeMoves"}}</legend>
 
         <fieldset>
             <legend>
-                {{localize "DAGGERHEART.Downtime.LongRest.title"}} 
+                {{localize "DAGGERHEART.Applications.Downtime.longRest.title"}} 
                 <a data-action="addItem" data-type="longRest"><i class="fa-solid fa-plus"></i></a>
                 <a data-action="resetMoves" data-type="longRest"><i class="fa-solid fa-arrow-rotate-left"></i></a>
             </legend>
 
             <div class="form-group setting-group-field">
-                <label>{{localize "DAGGERHEART.Settings.Homebrew.NrChoices"}}</label>
+                <label>{{localize "DAGGERHEART.Settings.Homebrew.nrChoices"}}</label>
                 <div class="form-fields">
                     <input type="text" name="restMoves.longRest.nrChoices" value="{{settingFields._source.restMoves.longRest.nrChoices}}" />
                 </div>
@@ -50,13 +50,13 @@
 
         <fieldset>
             <legend>
-                {{localize "DAGGERHEART.Downtime.ShortRest.title"}}
+                {{localize "DAGGERHEART.Applications.Downtime.shortRest.title"}}
                 <a data-action="addItem" data-type="shortRest"><i class="fa-solid fa-plus"></i></a>
                 <a data-action="resetMoves" data-type="shortRest"><i class="fa-solid fa-arrow-rotate-left"></i></a>
             </legend>
 
             <div class="form-group setting-group-field">
-                <label>{{localize "DAGGERHEART.Settings.Homebrew.NrChoices"}}</label>
+                <label>{{localize "DAGGERHEART.Settings.Homebrew.nrChoices"}}</label>
                 <div class="form-fields">
                     <input type="text" name="restMoves.shortRest.nrChoices" value="{{settingFields._source.restMoves.shortRest.nrChoices}}" />
                 </div>

--- a/templates/settings/homebrew-settings.hbs
+++ b/templates/settings/homebrew-settings.hbs
@@ -1,11 +1,11 @@
 <div class="scrollable">
     {{formGroup settingFields.schema.fields.maxFear value=settingFields._source.maxFear localize=true}}
 
-    <h4>{{localize "DAGGERHEART.Settings.Homebrew.FIELDS.traitArray.label"}}</h4>
+    <h4>{{localize "DAGGERHEART.SETTINGS.Homebrew.FIELDS.traitArray.label"}}</h4>
     <div class="trait-array-container">
         {{#each settingFields._source.traitArray as |trait index|}}
             <div class="trait-array-item">
-                <label>{{localize "DAGGERHEART.General.modifier"}} {{add index 1}}</label>
+                <label>{{localize "DAGGERHEART.GENERAL.modifier"}} {{add index 1}}</label>
                 <input type="text" data-dtype="Number" name="{{concat "traitArray." index}}" value="{{this}}" />
             </div>
         {{/each}}
@@ -13,7 +13,7 @@
 
     <fieldset>
         <legend>
-            {{localize "DAGGERHEART.Settings.Homebrew.currency.title"}} 
+            {{localize "DAGGERHEART.SETTINGS.Homebrew.currency.title"}} 
         </legend>
         {{formGroup settingFields.schema.fields.currency.fields.enabled value=settingFields._source.currency.enabled localize=true}}
         {{formGroup settingFields.schema.fields.currency.fields.title value=settingFields._source.currency.title localize=true}}
@@ -25,17 +25,17 @@
     </fieldset>
 
     <fieldset class="two-columns even">
-        <legend>{{localize "DAGGERHEART.Settings.Homebrew.downtimeMoves"}}</legend>
+        <legend>{{localize "DAGGERHEART.SETTINGS.Homebrew.downtimeMoves"}}</legend>
 
         <fieldset>
             <legend>
-                {{localize "DAGGERHEART.Applications.Downtime.longRest.title"}} 
+                {{localize "DAGGERHEART.APPLICATIONS.Downtime.longRest.title"}} 
                 <a data-action="addItem" data-type="longRest"><i class="fa-solid fa-plus"></i></a>
                 <a data-action="resetMoves" data-type="longRest"><i class="fa-solid fa-arrow-rotate-left"></i></a>
             </legend>
 
             <div class="form-group setting-group-field">
-                <label>{{localize "DAGGERHEART.Settings.Homebrew.nrChoices"}}</label>
+                <label>{{localize "DAGGERHEART.SETTINGS.Homebrew.nrChoices"}}</label>
                 <div class="form-fields">
                     <input type="text" name="restMoves.longRest.nrChoices" value="{{settingFields._source.restMoves.longRest.nrChoices}}" />
                 </div>
@@ -50,13 +50,13 @@
 
         <fieldset>
             <legend>
-                {{localize "DAGGERHEART.Applications.Downtime.shortRest.title"}}
+                {{localize "DAGGERHEART.APPLICATIONS.Downtime.shortRest.title"}}
                 <a data-action="addItem" data-type="shortRest"><i class="fa-solid fa-plus"></i></a>
                 <a data-action="resetMoves" data-type="shortRest"><i class="fa-solid fa-arrow-rotate-left"></i></a>
             </legend>
 
             <div class="form-group setting-group-field">
-                <label>{{localize "DAGGERHEART.Settings.Homebrew.nrChoices"}}</label>
+                <label>{{localize "DAGGERHEART.SETTINGS.Homebrew.nrChoices"}}</label>
                 <div class="form-fields">
                     <input type="text" name="restMoves.shortRest.nrChoices" value="{{settingFields._source.restMoves.shortRest.nrChoices}}" />
                 </div>

--- a/templates/settings/variant-rules.hbs
+++ b/templates/settings/variant-rules.hbs
@@ -1,6 +1,6 @@
 <div>
     <div class="form-group">
-        <label>{{localize "DAGGERHEART.Settings.Menu.variantRules.actionTokens"}}</label>
+        <label>{{localize "DAGGERHEART.SETTINGS.Menu.variantRules.actionTokens"}}</label>
 
         <div class="form-fields">
             {{formGroup settingFields.schema.fields.actionTokens.fields.enabled value=settingFields._source.actionTokens.enabled localize=true}}

--- a/templates/settings/variant-rules.hbs
+++ b/templates/settings/variant-rules.hbs
@@ -1,6 +1,6 @@
 <div>
     <div class="form-group">
-        <label>{{localize "DAGGERHEART.Settings.Menu.VariantRules.actionTokens"}}</label>
+        <label>{{localize "DAGGERHEART.Settings.Menu.variantRules.actionTokens"}}</label>
 
         <div class="form-fields">
             {{formGroup settingFields.schema.fields.actionTokens.fields.enabled value=settingFields._source.actionTokens.enabled localize=true}}

--- a/templates/sheets-settings/adversary-settings/attack.hbs
+++ b/templates/sheets-settings/adversary-settings/attack.hbs
@@ -4,12 +4,12 @@
     data-group="{{tabs.attack.group}}"
 >
     <fieldset class="one-column">
-        <legend>{{localize "DAGGERHEART.General.basics"}}</legend>
+        <legend>{{localize "DAGGERHEART.GENERAL.basics"}}</legend>
         {{formGroup systemFields.attack.fields.img value=document.system.attack.img label="Image Path" name="system.attack.img"}}
         {{formGroup systemFields.attack.fields.name value=document.system.attack.name label="Attack Name" name="system.attack.name"}}
     </fieldset>
     <fieldset class="flex">
-        <legend>{{localize "DAGGERHEART.General.attack"}}</legend>
+        <legend>{{localize "DAGGERHEART.GENERAL.attack"}}</legend>
             {{formField systemFields.attack.fields.roll.fields.bonus value=document.system.attack.roll.bonus label="Attack Bonus" name="system.attack.roll.bonus"}}
             {{formField systemFields.attack.fields.range value=document.system.attack.range label="Range" name="system.attack.range" localize=true}}
             {{#if systemFields.attack.fields.target.fields}}

--- a/templates/sheets-settings/adversary-settings/attack.hbs
+++ b/templates/sheets-settings/adversary-settings/attack.hbs
@@ -9,7 +9,7 @@
         {{formGroup systemFields.attack.fields.name value=document.system.attack.name label="Attack Name" name="system.attack.name"}}
     </fieldset>
     <fieldset class="flex">
-        <legend>{{localize "DAGGERHEART.Sheets.Adversary.Attack"}}</legend>
+        <legend>{{localize "DAGGERHEART.General.attack"}}</legend>
             {{formField systemFields.attack.fields.roll.fields.bonus value=document.system.attack.roll.bonus label="Attack Bonus" name="system.attack.roll.bonus"}}
             {{formField systemFields.attack.fields.range value=document.system.attack.range label="Range" name="system.attack.range" localize=true}}
             {{#if systemFields.attack.fields.target.fields}}

--- a/templates/sheets-settings/adversary-settings/details.hbs
+++ b/templates/sheets-settings/adversary-settings/details.hbs
@@ -4,34 +4,34 @@
     data-group='{{tabs.details.group}}'
 >
     <fieldset class="one-column">
-        <legend>{{localize 'DAGGERHEART.General.basics'}}</legend>
+        <legend>{{localize 'DAGGERHEART.GENERAL.basics'}}</legend>
         <div class="nest-inputs">
             {{formGroup systemFields.tier value=document.system.tier localize=true}}
             {{formGroup systemFields.type value=document.system.type localize=true}}
             {{#if (eq document.system.type 'horde')}}
-                {{formGroup systemFields.hordeHp value=document.system.hordeHp label=(localize "DAGGERHEART.Actors.Adversary.horderHp")}}
+                {{formGroup systemFields.hordeHp value=document.system.hordeHp label=(localize "DAGGERHEART.ACTORS.Adversary.horderHp")}}
             {{/if}}
             {{formGroup systemFields.difficulty value=document.system.difficulty localize=true}}
         </div>
-        {{formField systemFields.description value=document.system.description label=(localize "DAGGERHEART.Actors.Adversary.FIELDS.description.label")}}
-        {{formField systemFields.motivesAndTactics value=document.system.motivesAndTactics label=(localize "DAGGERHEART.Actors.Adversary.FIELDS.motivesAndTactics.label")}}
+        {{formField systemFields.description value=document.system.description label=(localize "DAGGERHEART.ACTORS.Adversary.FIELDS.description.label")}}
+        {{formField systemFields.motivesAndTactics value=document.system.motivesAndTactics label=(localize "DAGGERHEART.ACTORS.Adversary.FIELDS.motivesAndTactics.label")}}
     </fieldset>
 
     <div class="fieldsets-section">
         <fieldset class="flex">
-            <legend>{{localize "DAGGERHEART.General.hitPoints"}}</legend>
+            <legend>{{localize "DAGGERHEART.GENERAL.hitPoints"}}</legend>
             {{formGroup systemFields.resources.fields.hitPoints.fields.value value=document.system.resources.hitPoints.value}}
             {{formGroup systemFields.resources.fields.hitPoints.fields.max value=document.system.resources.hitPoints.max}}
         </fieldset>
         <fieldset class="flex">
-            <legend>{{localize "DAGGERHEART.General.stress"}}</legend>
+            <legend>{{localize "DAGGERHEART.GENERAL.stress"}}</legend>
             {{formGroup systemFields.resources.fields.stress.fields.value value=document.system.resources.stress.value}}
             {{formGroup systemFields.resources.fields.stress.fields.max value=document.system.resources.stress.max}}
         </fieldset>
     </div>
 
     <fieldset class="flex">
-        <legend>{{localize "DAGGERHEART.General.DamageThresholds.title"}}</legend>
+        <legend>{{localize "DAGGERHEART.GENERAL.DamageThresholds.title"}}</legend>
         {{formGroup systemFields.damageThresholds.fields.major value=document.system.damageThresholds.major}}
         {{formGroup systemFields.damageThresholds.fields.severe value=document.system.damageThresholds.severe}}
     </fieldset>

--- a/templates/sheets-settings/adversary-settings/details.hbs
+++ b/templates/sheets-settings/adversary-settings/details.hbs
@@ -9,29 +9,29 @@
             {{formGroup systemFields.tier value=document.system.tier localize=true}}
             {{formGroup systemFields.type value=document.system.type localize=true}}
             {{#if (eq document.system.type 'horde')}}
-                {{formGroup systemFields.hordeHp value=document.system.hordeHp label=(localize "DAGGERHEART.Sheets.Adversary.horderHp")}}
+                {{formGroup systemFields.hordeHp value=document.system.hordeHp label=(localize "DAGGERHEART.Actors.Adversary.horderHp")}}
             {{/if}}
             {{formGroup systemFields.difficulty value=document.system.difficulty localize=true}}
         </div>
-        {{formField systemFields.description value=document.system.description label=(localize "DAGGERHEART.Sheets.Adversary.FIELDS.description.label")}}
-        {{formField systemFields.motivesAndTactics value=document.system.motivesAndTactics label=(localize "DAGGERHEART.Sheets.Adversary.FIELDS.motivesAndTactics.label")}}
+        {{formField systemFields.description value=document.system.description label=(localize "DAGGERHEART.Actors.Adversary.FIELDS.description.label")}}
+        {{formField systemFields.motivesAndTactics value=document.system.motivesAndTactics label=(localize "DAGGERHEART.Actors.Adversary.FIELDS.motivesAndTactics.label")}}
     </fieldset>
 
     <div class="fieldsets-section">
         <fieldset class="flex">
-            <legend>{{localize "DAGGERHEART.Sheets.Adversary.HitPoints"}}</legend>
+            <legend>{{localize "DAGGERHEART.General.hitPoints"}}</legend>
             {{formGroup systemFields.resources.fields.hitPoints.fields.value value=document.system.resources.hitPoints.value}}
             {{formGroup systemFields.resources.fields.hitPoints.fields.max value=document.system.resources.hitPoints.max}}
         </fieldset>
         <fieldset class="flex">
-            <legend>{{localize "DAGGERHEART.Sheets.Adversary.Stress"}}</legend>
+            <legend>{{localize "DAGGERHEART.General.stress"}}</legend>
             {{formGroup systemFields.resources.fields.stress.fields.value value=document.system.resources.stress.value}}
             {{formGroup systemFields.resources.fields.stress.fields.max value=document.system.resources.stress.max}}
         </fieldset>
     </div>
 
     <fieldset class="flex">
-        <legend>{{localize "DAGGERHEART.Sheets.Adversary.DamageThresholds"}}</legend>
+        <legend>{{localize "DAGGERHEART.General.DamageThresholds.title"}}</legend>
         {{formGroup systemFields.damageThresholds.fields.major value=document.system.damageThresholds.major}}
         {{formGroup systemFields.damageThresholds.fields.severe value=document.system.damageThresholds.severe}}
     </fieldset>

--- a/templates/sheets-settings/adversary-settings/experiences.hbs
+++ b/templates/sheets-settings/adversary-settings/experiences.hbs
@@ -14,7 +14,7 @@
                 <li class="experience-item">
                     <input class="name" type="text" name="system.experiences.{{key}}.name" value="{{experience.name}}" />
                     <input class="modifier" type="text" name="system.experiences.{{key}}.modifier" value="{{experience.modifier}}" data-dtype="Number" />
-                    <a data-action="removeExperience" data-experience="{{key}}" data-tooltip="{{localize 'DAGGERHEART.Tooltip.delete'}}"><i class="fa-solid fa-trash"></i></a>
+                    <a data-action="removeExperience" data-experience="{{key}}" data-tooltip="{{localize 'CONTROLS.CommonDelete'}}"><i class="fa-solid fa-trash"></i></a>
                 </li>
             {{/each}}
         </ul>

--- a/templates/sheets-settings/adversary-settings/features.hbs
+++ b/templates/sheets-settings/adversary-settings/features.hbs
@@ -17,7 +17,7 @@
                     </div>
                     <div class="controls">
                         <a data-action="editFeature" id="{{feature.id}}" data-tooltip="{{localize 'DAGGERHEART.Tooltip.edit'}}"><i class="fa-solid fa-pen-to-square"></i></a>
-                        <a data-action="removeFeature" id="{{feature.id}}" data-tooltip="{{localize 'DAGGERHEART.Tooltip.delete'}}"><i class="fa-solid fa-trash"></i></a>
+                        <a data-action="removeFeature" id="{{feature.id}}" data-tooltip="{{localize 'CONTROLS.CommonDelete'}}"><i class="fa-solid fa-trash"></i></a>
                     </div>
                 </li>
             {{/each}}

--- a/templates/sheets-settings/companion-settings/attack.hbs
+++ b/templates/sheets-settings/companion-settings/attack.hbs
@@ -4,12 +4,12 @@
     data-group="{{tabs.attack.group}}"
 >
     <fieldset class="one-column">
-        <legend>{{localize "DAGGERHEART.General.basics"}}</legend>
+        <legend>{{localize "DAGGERHEART.GENERAL.basics"}}</legend>
         {{formGroup systemFields.attack.fields.img value=document.system.attack.img label="Image Path" name="system.attack.img"}}
         {{formGroup systemFields.attack.fields.name value=document.system.attack.name label="Attack Name" name="system.attack.name"}}
     </fieldset>
     <fieldset class="flex">
-        <legend>{{localize "DAGGERHEART.General.attack"}}</legend>
+        <legend>{{localize "DAGGERHEART.GENERAL.attack"}}</legend>
             {{formField systemFields.attack.fields.range value=document.system.attack.range label="Range" name="system.attack.range" localize=true}}
             {{#if systemFields.attack.fields.target.fields}}
                 {{ formField systemFields.attack.fields.target.fields.type value=document.system.attack.target.type label="Target" name="system.attack.target.type" localize=true }}

--- a/templates/sheets-settings/companion-settings/attack.hbs
+++ b/templates/sheets-settings/companion-settings/attack.hbs
@@ -9,7 +9,7 @@
         {{formGroup systemFields.attack.fields.name value=document.system.attack.name label="Attack Name" name="system.attack.name"}}
     </fieldset>
     <fieldset class="flex">
-        <legend>{{localize "DAGGERHEART.Sheets.Adversary.Attack"}}</legend>
+        <legend>{{localize "DAGGERHEART.General.attack"}}</legend>
             {{formField systemFields.attack.fields.range value=document.system.attack.range label="Range" name="system.attack.range" localize=true}}
             {{#if systemFields.attack.fields.target.fields}}
                 {{ formField systemFields.attack.fields.target.fields.type value=document.system.attack.target.type label="Target" name="system.attack.target.type" localize=true }}

--- a/templates/sheets-settings/companion-settings/details.hbs
+++ b/templates/sheets-settings/companion-settings/details.hbs
@@ -12,7 +12,7 @@
         </div>
         <div class="form-group">
         <div class="form-fields">
-            <label>{{localize "DAGGERHEART.Sheets.Companion.FIELDS.partner.label"}}</label>
+            <label>{{localize "DAGGERHEART.Actors.Companion.FIELDS.partner.label"}}</label>
             <select class="partner-value">
                 {{selectOptions playerCharacters selected=document.system.partner.uuid labelAttr="name" valueAttr="key" blank=""}}
             </select>

--- a/templates/sheets-settings/companion-settings/details.hbs
+++ b/templates/sheets-settings/companion-settings/details.hbs
@@ -4,7 +4,7 @@
     data-group='{{tabs.details.group}}'
 >
     <fieldset class="one-column">
-        <legend>{{localize 'DAGGERHEART.General.basics'}}</legend>
+        <legend>{{localize 'DAGGERHEART.GENERAL.basics'}}</legend>
         <div class="nest-inputs">
             {{formGroup systemFields.evasion.fields.value value=document.system.evasion.value localize=true}}
             {{formGroup systemFields.resources.fields.stress.fields.value value=document.system.resources.stress.value label='Current Stress'}}
@@ -12,7 +12,7 @@
         </div>
         <div class="form-group">
         <div class="form-fields">
-            <label>{{localize "DAGGERHEART.Actors.Companion.FIELDS.partner.label"}}</label>
+            <label>{{localize "DAGGERHEART.ACTORS.Companion.FIELDS.partner.label"}}</label>
             <select class="partner-value">
                 {{selectOptions playerCharacters selected=document.system.partner.uuid labelAttr="name" valueAttr="key" blank=""}}
             </select>

--- a/templates/sheets-settings/environment-settings/adversaries.hbs
+++ b/templates/sheets-settings/environment-settings/adversaries.hbs
@@ -11,7 +11,7 @@
             <legend>{{this.label}}</legend>
             <div class="category-name">
                 <input type="text" name="{{concat "system.potentialAdversaries." @key ".label" }}" value="{{this.label}}" />
-                <a><i class="fa-solid fa-trash" data-action="deleteProperty" data-path="system.potentialAdversaries" id={{@key}} data-tooltip='{{localize "DAGGERHEART.Tooltip.delete"}}'></i></a>
+                <a><i class="fa-solid fa-trash" data-action="deleteProperty" data-path="system.potentialAdversaries" id={{@key}} data-tooltip='{{localize "CONTROLS.CommonDelete"}}'></i></a>
             </div>
             <div class="adversaries-container">
                 {{#each this.adversaries as |adversary|}}

--- a/templates/sheets-settings/environment-settings/details.hbs
+++ b/templates/sheets-settings/environment-settings/details.hbs
@@ -10,7 +10,7 @@
             {{formGroup systemFields.type value=document.system.type localize=true}}
             {{formGroup systemFields.difficulty value=document.system.difficulty localize=true}}
         </div>
-        {{formField systemFields.description value=document.system.description label=(localize "DAGGERHEART.Sheets.Environment.FIELDS.description.label")}}
-        {{formField systemFields.impulses value=document.system.impulses label=(localize "DAGGERHEART.Sheets.Environment.FIELDS.impulses.label")}}
+        {{formField systemFields.description value=document.system.description label=(localize "DAGGERHEART.Actors.Environment.FIELDS.description.label")}}
+        {{formField systemFields.impulses value=document.system.impulses label=(localize "DAGGERHEART.Actors.Environment.FIELDS.impulses.label")}}
     </fieldset>
 </section>

--- a/templates/sheets-settings/environment-settings/details.hbs
+++ b/templates/sheets-settings/environment-settings/details.hbs
@@ -4,13 +4,13 @@
     data-group='{{tabs.details.group}}'
 >
     <fieldset class="one-column">
-        <legend>{{localize 'DAGGERHEART.General.basics'}}</legend>
+        <legend>{{localize 'DAGGERHEART.GENERAL.basics'}}</legend>
         <div class="nest-inputs">
             {{formGroup systemFields.tier value=document.system.tier localize=true}}
             {{formGroup systemFields.type value=document.system.type localize=true}}
             {{formGroup systemFields.difficulty value=document.system.difficulty localize=true}}
         </div>
-        {{formField systemFields.description value=document.system.description label=(localize "DAGGERHEART.Actors.Environment.FIELDS.description.label")}}
-        {{formField systemFields.impulses value=document.system.impulses label=(localize "DAGGERHEART.Actors.Environment.FIELDS.impulses.label")}}
+        {{formField systemFields.description value=document.system.description label=(localize "DAGGERHEART.ACTORS.Environment.FIELDS.description.label")}}
+        {{formField systemFields.impulses value=document.system.impulses label=(localize "DAGGERHEART.ACTORS.Environment.FIELDS.impulses.label")}}
     </fieldset>
 </section>

--- a/templates/sheets-settings/environment-settings/features.hbs
+++ b/templates/sheets-settings/environment-settings/features.hbs
@@ -17,7 +17,7 @@
                     </div>
                     <div class="controls">
                         <a data-action="editFeature" id="{{feature.id}}" data-tooltip="{{localize 'DAGGERHEART.Tooltip.edit'}}"><i class="fa-solid fa-pen-to-square"></i></a>
-                        <a data-action="removeFeature" id="{{feature.id}}" data-tooltip="{{localize 'DAGGERHEART.Tooltip.delete'}}"><i class="fa-solid fa-trash"></i></a>
+                        <a data-action="removeFeature" id="{{feature.id}}" data-tooltip="{{localize 'CONTROLS.CommonDelete'}}"><i class="fa-solid fa-trash"></i></a>
                     </div>
                 </li>
             {{/each}}

--- a/templates/sheets/actors/adversary/effects.hbs
+++ b/templates/sheets/actors/adversary/effects.hbs
@@ -3,6 +3,6 @@
     data-tab='{{tabs.effects.id}}'
     data-group='{{tabs.effects.group}}'
 >
-    {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.General.activeEffects') type='effect'}}
-    {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.General.inactiveEffects') type='effect'}}
+    {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.GENERAL.activeEffects') type='effect'}}
+    {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.GENERAL.inactiveEffects') type='effect'}}
 </section>

--- a/templates/sheets/actors/adversary/effects.hbs
+++ b/templates/sheets/actors/adversary/effects.hbs
@@ -3,6 +3,6 @@
     data-tab='{{tabs.effects.id}}'
     data-group='{{tabs.effects.group}}'
 >
-    {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.Sheets.Global.activeEffects') type='effect'}}
-    {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.Sheets.Global.inactiveEffects') type='effect'}}
+    {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.General.activeEffects') type='effect'}}
+    {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.General.inactiveEffects') type='effect'}}
 </section>

--- a/templates/sheets/actors/adversary/header.hbs
+++ b/templates/sheets/actors/adversary/header.hbs
@@ -9,12 +9,12 @@
     <div class="tags">
         <div class="tag">
             <span>
-                {{localize (concat 'DAGGERHEART.Tiers.' source.system.tier)}}
+                {{localize (concat 'DAGGERHEART.General.Tiers.' source.system.tier)}}
             </span>
         </div>
         <div class="tag">
             <span>
-                {{localize (concat 'DAGGERHEART.Adversary.Type.' source.system.type '.label')}}
+                {{localize (concat 'DAGGERHEART.Config.AdversaryType.' source.system.type '.label')}}
             </span>
         </div>
         {{#if (eq source.system.type 'horde')}}
@@ -30,7 +30,7 @@
             <i>{{source.system.description}}</i>
         </div>
         <div class="motives-and-tatics">
-            <b>{{localize 'DAGGERHEART.Sheets.Adversary.FIELDS.motivesAndTactics.label'}}: </b>{{{source.system.motivesAndTactics}}}
+            <b>{{localize 'DAGGERHEART.Actors.Adversary.FIELDS.motivesAndTactics.label'}}: </b>{{{source.system.motivesAndTactics}}}
         </div>
     </div>
 

--- a/templates/sheets/actors/adversary/header.hbs
+++ b/templates/sheets/actors/adversary/header.hbs
@@ -9,12 +9,12 @@
     <div class="tags">
         <div class="tag">
             <span>
-                {{localize (concat 'DAGGERHEART.General.Tiers.' source.system.tier)}}
+                {{localize (concat 'DAGGERHEART.GENERAL.Tiers.' source.system.tier)}}
             </span>
         </div>
         <div class="tag">
             <span>
-                {{localize (concat 'DAGGERHEART.Config.AdversaryType.' source.system.type '.label')}}
+                {{localize (concat 'DAGGERHEART.CONFIG.AdversaryType.' source.system.type '.label')}}
             </span>
         </div>
         {{#if (eq source.system.type 'horde')}}
@@ -30,7 +30,7 @@
             <i>{{source.system.description}}</i>
         </div>
         <div class="motives-and-tatics">
-            <b>{{localize 'DAGGERHEART.Actors.Adversary.FIELDS.motivesAndTactics.label'}}: </b>{{{source.system.motivesAndTactics}}}
+            <b>{{localize 'DAGGERHEART.ACTORS.Adversary.FIELDS.motivesAndTactics.label'}}: </b>{{{source.system.motivesAndTactics}}}
         </div>
     </div>
 

--- a/templates/sheets/actors/adversary/sidebar.hbs
+++ b/templates/sheets/actors/adversary/sidebar.hbs
@@ -40,11 +40,11 @@
         </div>
         <div class="status-section">
             <div class="threshold-section">
-            <h4 class="threshold-label">{{localize "DAGGERHEART.General.DamageThresholds.minor"}}</h4>
+            <h4 class="threshold-label">{{localize "DAGGERHEART.GENERAL.DamageThresholds.minor"}}</h4>
             <h4 class="threshold-value">{{document.system.damageThresholds.major}}</h4>
-            <h4 class="threshold-label">{{localize "DAGGERHEART.General.DamageThresholds.major"}}</h4>
+            <h4 class="threshold-label">{{localize "DAGGERHEART.GENERAL.DamageThresholds.major"}}</h4>
             <h4 class="threshold-value">{{document.system.damageThresholds.severe}}</h4>
-            <h4 class="threshold-label">{{localize "DAGGERHEART.General.DamageThresholds.severe"}}</h4>
+            <h4 class="threshold-label">{{localize "DAGGERHEART.GENERAL.DamageThresholds.severe"}}</h4>
         </div>
         </div>
         <div class="status-section">

--- a/templates/sheets/actors/adversary/sidebar.hbs
+++ b/templates/sheets/actors/adversary/sidebar.hbs
@@ -1,7 +1,7 @@
 <aside class="adversary-sidebar-sheet">
     <div class="portrait {{#if (gte source.system.resources.hitPoints.value source.system.resources.hitPoints.maxTotal)}}death-roll{{/if}}">
         <img src="{{source.img}}" alt="{{source.name}}" data-action='editImage' data-edit="img">
-        <a class="death-roll-btn" data-tooltip="{{localize "DAGGERHEART.Sheets.PC.Health.DeathMoveTooltip"}}" data-action="makeDeathMove"><i class="fas fa-skull death-save" ></i></a>
+        <a class="death-roll-btn" data-tooltip="{{localize "DAGGERHEART.UI.Tooltip.makeDeathMove"}}" data-action="makeDeathMove"><i class="fas fa-skull death-save" ></i></a>
     </div>
     
     <div class="info-section">
@@ -40,11 +40,11 @@
         </div>
         <div class="status-section">
             <div class="threshold-section">
-            <h4 class="threshold-label">{{localize "DAGGERHEART.Sheets.PC.Health.Minor"}}</h4>
+            <h4 class="threshold-label">{{localize "DAGGERHEART.General.DamageThresholds.minor"}}</h4>
             <h4 class="threshold-value">{{document.system.damageThresholds.major}}</h4>
-            <h4 class="threshold-label">{{localize "DAGGERHEART.Sheets.PC.Health.Major"}}</h4>
+            <h4 class="threshold-label">{{localize "DAGGERHEART.General.DamageThresholds.major"}}</h4>
             <h4 class="threshold-value">{{document.system.damageThresholds.severe}}</h4>
-            <h4 class="threshold-label">{{localize "DAGGERHEART.Sheets.PC.Health.Severe"}}</h4>
+            <h4 class="threshold-label">{{localize "DAGGERHEART.General.DamageThresholds.severe"}}</h4>
         </div>
         </div>
         <div class="status-section">

--- a/templates/sheets/actors/character/biography.hbs
+++ b/templates/sheets/actors/character/biography.hbs
@@ -6,30 +6,30 @@
 
     <div class="items-section">
         <fieldset class="flex">
-            <legend>{{localize 'DAGGERHEART.Actors.Character.story.characteristics'}}</legend>
+            <legend>{{localize 'DAGGERHEART.ACTORS.Character.story.characteristics'}}</legend>
             
             <div class="input">
-                <span>{{localize 'DAGGERHEART.Actors.Character.pronouns'}}</span>
+                <span>{{localize 'DAGGERHEART.ACTORS.Character.pronouns'}}</span>
                 {{formInput systemFields.biography.fields.characteristics.fields.pronouns value=source.system.biography.characteristics.pronouns enriched=source.system.biography.characteristics.pronouns localize=true toggled=true}}
             </div>
 
             <div class="input">
-                <span>{{localize 'DAGGERHEART.Actors.Character.age'}}</span>
+                <span>{{localize 'DAGGERHEART.ACTORS.Character.age'}}</span>
                 {{formInput systemFields.biography.fields.characteristics.fields.age value=source.system.biography.characteristics.age enriched=source.system.biography.characteristics.age localize=true toggled=true}}
             </div>
 
             <div class="input">
-                <span>{{localize 'DAGGERHEART.Actors.Character.faith'}}</span>
+                <span>{{localize 'DAGGERHEART.ACTORS.Character.faith'}}</span>
                 {{formInput systemFields.biography.fields.characteristics.fields.faith value=source.system.biography.characteristics.faith enriched=source.system.biography.characteristics.faith localize=true toggled=true}}
             </div>
 
         </fieldset>
         <fieldset>
-            <legend>{{localize 'DAGGERHEART.Actors.Character.story.backgroundTitle'}}</legend>
+            <legend>{{localize 'DAGGERHEART.ACTORS.Character.story.backgroundTitle'}}</legend>
             {{formInput systemFields.biography.fields.background value=source.system.biography.background enriched=source.system.biography.background localize=true toggled=true}}
         </fieldset>
         <fieldset>
-            <legend>{{localize 'DAGGERHEART.Actors.Character.story.connectionsTitle'}}</legend>
+            <legend>{{localize 'DAGGERHEART.ACTORS.Character.story.connectionsTitle'}}</legend>
             {{formInput systemFields.biography.fields.connections value=source.system.biography.connections enriched=source.system.biography.connections localize=true toggled=true}}
         </fieldset>
     </div>

--- a/templates/sheets/actors/character/biography.hbs
+++ b/templates/sheets/actors/character/biography.hbs
@@ -6,30 +6,30 @@
 
     <div class="items-section">
         <fieldset class="flex">
-            <legend>{{localize 'DAGGERHEART.Sheets.PC.Story.characteristics'}}</legend>
+            <legend>{{localize 'DAGGERHEART.Actors.Character.story.characteristics'}}</legend>
             
             <div class="input">
-                <span>{{localize 'DAGGERHEART.Sheets.PC.Pronouns'}}</span>
+                <span>{{localize 'DAGGERHEART.Actors.Character.pronouns'}}</span>
                 {{formInput systemFields.biography.fields.characteristics.fields.pronouns value=source.system.biography.characteristics.pronouns enriched=source.system.biography.characteristics.pronouns localize=true toggled=true}}
             </div>
 
             <div class="input">
-                <span>{{localize 'DAGGERHEART.Sheets.PC.age'}}</span>
+                <span>{{localize 'DAGGERHEART.Actors.Character.age'}}</span>
                 {{formInput systemFields.biography.fields.characteristics.fields.age value=source.system.biography.characteristics.age enriched=source.system.biography.characteristics.age localize=true toggled=true}}
             </div>
 
             <div class="input">
-                <span>{{localize 'DAGGERHEART.Sheets.PC.faith'}}</span>
+                <span>{{localize 'DAGGERHEART.Actors.Character.faith'}}</span>
                 {{formInput systemFields.biography.fields.characteristics.fields.faith value=source.system.biography.characteristics.faith enriched=source.system.biography.characteristics.faith localize=true toggled=true}}
             </div>
 
         </fieldset>
         <fieldset>
-            <legend>{{localize 'DAGGERHEART.Sheets.PC.Story.BackgroundTitle'}}</legend>
+            <legend>{{localize 'DAGGERHEART.Actors.Character.story.backgroundTitle'}}</legend>
             {{formInput systemFields.biography.fields.background value=source.system.biography.background enriched=source.system.biography.background localize=true toggled=true}}
         </fieldset>
         <fieldset>
-            <legend>{{localize 'DAGGERHEART.Sheets.PC.Story.ConnectionsTitle'}}</legend>
+            <legend>{{localize 'DAGGERHEART.Actors.Character.story.connectionsTitle'}}</legend>
             {{formInput systemFields.biography.fields.connections value=source.system.biography.connections enriched=source.system.biography.connections localize=true toggled=true}}
         </fieldset>
     </div>

--- a/templates/sheets/actors/character/effects.hbs
+++ b/templates/sheets/actors/character/effects.hbs
@@ -3,6 +3,6 @@
     data-tab='{{tabs.effects.id}}'
     data-group='{{tabs.effects.group}}'
 >
-    {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.General.activeEffects') type='effect'}}
-    {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.General.inactiveEffects') type='effect'}}
+    {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.GENERAL.activeEffects') type='effect'}}
+    {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.GENERAL.inactiveEffects') type='effect'}}
 </section>

--- a/templates/sheets/actors/character/effects.hbs
+++ b/templates/sheets/actors/character/effects.hbs
@@ -3,6 +3,6 @@
     data-tab='{{tabs.effects.id}}'
     data-group='{{tabs.effects.group}}'
 >
-    {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.Sheets.Global.activeEffects') type='effect'}}
-    {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.Sheets.Global.inactiveEffects') type='effect'}}
+    {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.General.activeEffects') type='effect'}}
+    {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.General.inactiveEffects') type='effect'}}
 </section>

--- a/templates/sheets/actors/character/features.hbs
+++ b/templates/sheets/actors/character/features.hbs
@@ -9,23 +9,5 @@
                 {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=this.title values=this.values}}
             {{/if}}
         {{/each}}
-        {{!-- {{#if document.system.class.value}}
-            {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(concat (localize 'TYPES.Item.class') ' - ' document.system.class.value.name) type='class'}}
-        {{/if}}
-        {{#if document.system.class.subclass}}
-            {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(concat (localize 'TYPES.Item.subclass') ' - ' document.system.class.subclass.name) type='subclass'}}
-        {{/if}}
-        {{#if document.system.features}}
-            {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize "DAGGERHEART.Sheets.PC.Features") type='features'}}
-        {{/if}}
-        {{#if document.system.companionFeatures}}
-            {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize "DAGGERHEART.Sheets.PC.CompanionFeatures") type='companionFeatures'}}
-        {{/if}}
-        {{#if document.system.community}}
-            {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(concat (localize 'TYPES.Item.community') ' - ' document.system.community.name) type='community'}}
-        {{/if}}
-        {{#if document.system.ancestry}}
-            {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(concat (localize 'TYPES.Item.ancestry') ' - ' document.system.ancestry.name) type='ancestry'}}
-        {{/if}} --}}
     </div>
 </section>

--- a/templates/sheets/actors/character/header.hbs
+++ b/templates/sheets/actors/character/header.hbs
@@ -14,13 +14,13 @@
             <h3 class='label'>
                 {{#if (or document.system.needsCharacterSetup document.system.levelData.canLevelUp)}}
                     <button 
-                        class="level-button glow" data-tooltip="{{#if document.system.needsCharacterSetup}}{{localize "DAGGERHEART.Sheets.PC.CharacterSetup"}}{{else}}{{localize "DAGGERHEART.Actors.Character.levelUp"}}{{/if}}"
+                        class="level-button glow" data-tooltip="{{#if document.system.needsCharacterSetup}}{{localize "DAGGERHEART.Sheets.PC.CharacterSetup"}}{{else}}{{localize "DAGGERHEART.ACTORS.Character.levelUp"}}{{/if}}"
                         data-action="levelManagement"
                     >
                         <i class="fa-solid fa-triangle-exclamation"></i>
                     </button>
                 {{/if}}
-                {{localize 'DAGGERHEART.General.level'}}
+                {{localize 'DAGGERHEART.GENERAL.level'}}
                 <input type="text" data-dtype="Number" class="level-value" value={{#if document.system.needsCharacterSetup}}0{{else}}{{document.system.levelData.level.changed}}{{/if}} {{#if document.system.needsCharacterSetup}}disabled{{/if}} />
             </h3>
         </div>
@@ -57,7 +57,7 @@
                 {{#if document.system.multiclass.value}}
                     <span data-action="viewObject" data-value="{{document.system.multiclass.value.uuid}}">{{document.system.multiclass.value.name}}</span>
                 {{else}}
-                    <span>{{localize 'DAGGERHEART.General.multiclass'}}</span>
+                    <span>{{localize 'DAGGERHEART.GENERAL.multiclass'}}</span>
                 {{/if}}
                 <span class="dot">•</span>
                 {{#if document.system.multiclass.subclass}}
@@ -73,7 +73,7 @@
 
     <div class="character-row">
         <div class="hope-section">
-            <h4>{{localize "DAGGERHEART.General.hope"}}</h4>
+            <h4>{{localize "DAGGERHEART.GENERAL.hope"}}</h4>
             {{#times document.system.resources.hope.max}}
                 <span class='hope-value' data-action='toggleHope' data-value="{{add this 1}}">
                     {{#if (gte ../document.system.resources.hope.value (add this 1))}}
@@ -85,11 +85,11 @@
             {{/times}}
         </div>
         <div class="threshold-section">
-            <h4 class="threshold-label">{{localize "DAGGERHEART.General.DamageThresholds.minor"}}</h4>
+            <h4 class="threshold-label">{{localize "DAGGERHEART.GENERAL.DamageThresholds.minor"}}</h4>
             <h4 class="threshold-value">{{document.system.damageThresholds.major}}</h4>
-            <h4 class="threshold-label">{{localize "DAGGERHEART.General.DamageThresholds.major"}}</h4>
+            <h4 class="threshold-label">{{localize "DAGGERHEART.GENERAL.DamageThresholds.major"}}</h4>
             <h4 class="threshold-value">{{document.system.damageThresholds.severe}}</h4>
-            <h4 class="threshold-label">{{localize "DAGGERHEART.General.DamageThresholds.severe"}}</h4>
+            <h4 class="threshold-label">{{localize "DAGGERHEART.GENERAL.DamageThresholds.severe"}}</h4>
         </div>
     </div>
 
@@ -97,7 +97,7 @@
         {{#each this.attributes as |attribute key|}}
             <div class="trait" data-tooltip="{{#each attribute.verbs}}{{this}}<br>{{/each}}" data-action="attributeRoll" data-attribute="{{key}}" data-value="{{attribute.total}}">
                 <div class="trait-name">
-                    <span>{{localize (concat 'DAGGERHEART.Config.Traits.' key '.short')}}</span>
+                    <span>{{localize (concat 'DAGGERHEART.CONFIG.Traits.' key '.short')}}</span>
                     {{#if attribute.tierMarked}}
                         <i class='fa-solid fa-circle'></i>
                     {{else}}

--- a/templates/sheets/actors/character/header.hbs
+++ b/templates/sheets/actors/character/header.hbs
@@ -14,13 +14,13 @@
             <h3 class='label'>
                 {{#if (or document.system.needsCharacterSetup document.system.levelData.canLevelUp)}}
                     <button 
-                        class="level-button glow" data-tooltip="{{#if document.system.needsCharacterSetup}}{{localize "DAGGERHEART.Sheets.PC.CharacterSetup"}}{{else}}{{localize "DAGGERHEART.Sheets.PC.LevelUp"}}{{/if}}"
+                        class="level-button glow" data-tooltip="{{#if document.system.needsCharacterSetup}}{{localize "DAGGERHEART.Sheets.PC.CharacterSetup"}}{{else}}{{localize "DAGGERHEART.Actors.Character.levelUp"}}{{/if}}"
                         data-action="levelManagement"
                     >
                         <i class="fa-solid fa-triangle-exclamation"></i>
                     </button>
                 {{/if}}
-                {{localize 'DAGGERHEART.Sheets.PC.Level'}}
+                {{localize 'DAGGERHEART.General.level'}}
                 <input type="text" data-dtype="Number" class="level-value" value={{#if document.system.needsCharacterSetup}}0{{else}}{{document.system.levelData.level.changed}}{{/if}} {{#if document.system.needsCharacterSetup}}disabled{{/if}} />
             </h3>
         </div>
@@ -57,7 +57,7 @@
                 {{#if document.system.multiclass.value}}
                     <span data-action="viewObject" data-value="{{document.system.multiclass.value.uuid}}">{{document.system.multiclass.value.name}}</span>
                 {{else}}
-                    <span>{{localize 'DAGGERHEART.Sheets.PC.Heritage.Multiclass'}}</span>
+                    <span>{{localize 'DAGGERHEART.General.multiclass'}}</span>
                 {{/if}}
                 <span class="dot">•</span>
                 {{#if document.system.multiclass.subclass}}
@@ -73,7 +73,7 @@
 
     <div class="character-row">
         <div class="hope-section">
-            <h4>{{localize "DAGGERHEART.General.Hope"}}</h4>
+            <h4>{{localize "DAGGERHEART.General.hope"}}</h4>
             {{#times document.system.resources.hope.max}}
                 <span class='hope-value' data-action='toggleHope' data-value="{{add this 1}}">
                     {{#if (gte ../document.system.resources.hope.value (add this 1))}}
@@ -85,11 +85,11 @@
             {{/times}}
         </div>
         <div class="threshold-section">
-            <h4 class="threshold-label">{{localize "DAGGERHEART.Sheets.PC.Health.Minor"}}</h4>
+            <h4 class="threshold-label">{{localize "DAGGERHEART.General.DamageThresholds.minor"}}</h4>
             <h4 class="threshold-value">{{document.system.damageThresholds.major}}</h4>
-            <h4 class="threshold-label">{{localize "DAGGERHEART.Sheets.PC.Health.Major"}}</h4>
+            <h4 class="threshold-label">{{localize "DAGGERHEART.General.DamageThresholds.major"}}</h4>
             <h4 class="threshold-value">{{document.system.damageThresholds.severe}}</h4>
-            <h4 class="threshold-label">{{localize "DAGGERHEART.Sheets.PC.Health.Severe"}}</h4>
+            <h4 class="threshold-label">{{localize "DAGGERHEART.General.DamageThresholds.severe"}}</h4>
         </div>
     </div>
 
@@ -97,7 +97,7 @@
         {{#each this.attributes as |attribute key|}}
             <div class="trait" data-tooltip="{{#each attribute.verbs}}{{this}}<br>{{/each}}" data-action="attributeRoll" data-attribute="{{key}}" data-value="{{attribute.total}}">
                 <div class="trait-name">
-                    <span>{{localize (concat 'DAGGERHEART.Abilities.' key '.short')}}</span>
+                    <span>{{localize (concat 'DAGGERHEART.Config.Traits.' key '.short')}}</span>
                     {{#if attribute.tierMarked}}
                         <i class='fa-solid fa-circle'></i>
                     {{else}}

--- a/templates/sheets/actors/character/loadout.hbs
+++ b/templates/sheets/actors/character/loadout.hbs
@@ -25,15 +25,15 @@
 
     <div class="items-section">
         {{#if this.abilities.loadout.listView}}
-        {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.Sheets.PC.Tabs.Loadout') type='domainCard' isGlassy=true cardView='list'}}
+        {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.General.Tabs.loadout') type='domainCard' isGlassy=true cardView='list'}}
         {{else}}
-        {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.Sheets.PC.Tabs.Loadout') type='domainCard' isGlassy=true cardView='card'}}
+        {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.General.Tabs.loadout') type='domainCard' isGlassy=true cardView='card'}}
         {{/if}}
 
         {{#if this.abilities.loadout.listView}}
-        {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.Sheets.PC.Tabs.Vault') type='domainCard' isVault=true isGlassy=true cardView='list'}}
+        {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.General.Tabs.vault') type='domainCard' isVault=true isGlassy=true cardView='list'}}
         {{else}}
-        {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.Sheets.PC.Tabs.Vault') type='domainCard' isVault=true isGlassy=true cardView='card'}}
+        {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.General.Tabs.vault') type='domainCard' isVault=true isGlassy=true cardView='card'}}
         {{/if}}
         
         

--- a/templates/sheets/actors/character/loadout.hbs
+++ b/templates/sheets/actors/character/loadout.hbs
@@ -25,15 +25,15 @@
 
     <div class="items-section">
         {{#if this.abilities.loadout.listView}}
-        {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.General.Tabs.loadout') type='domainCard' isGlassy=true cardView='list'}}
+        {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.GENERAL.Tabs.loadout') type='domainCard' isGlassy=true cardView='list'}}
         {{else}}
-        {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.General.Tabs.loadout') type='domainCard' isGlassy=true cardView='card'}}
+        {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.GENERAL.Tabs.loadout') type='domainCard' isGlassy=true cardView='card'}}
         {{/if}}
 
         {{#if this.abilities.loadout.listView}}
-        {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.General.Tabs.vault') type='domainCard' isVault=true isGlassy=true cardView='list'}}
+        {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.GENERAL.Tabs.vault') type='domainCard' isVault=true isGlassy=true cardView='list'}}
         {{else}}
-        {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.General.Tabs.vault') type='domainCard' isVault=true isGlassy=true cardView='card'}}
+        {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.GENERAL.Tabs.vault') type='domainCard' isVault=true isGlassy=true cardView='card'}}
         {{/if}}
         
         

--- a/templates/sheets/actors/character/sidebar.hbs
+++ b/templates/sheets/actors/character/sidebar.hbs
@@ -1,7 +1,7 @@
 <aside class="character-sidebar-sheet">
     <div class="portrait {{#if document.system.deathMoveViable}}death-roll{{/if}}">
         <img src="{{document.img}}" alt="{{document.name}}" data-action='editImage' data-edit="img">
-        <a class="death-roll-btn" data-tooltip="{{localize "DAGGERHEART.Sheets.PC.Health.DeathMoveTooltip"}}" data-action="makeDeathMove"><i class="fas fa-skull death-save" ></i></a>
+        <a class="death-roll-btn" data-tooltip="{{localize "DAGGERHEART.UI.Tooltip.makeDeathMove"}}" data-action="makeDeathMove"><i class="fas fa-skull death-save" ></i></a>
     </div>
     
     <div class="info-section">

--- a/templates/sheets/actors/companion/details.hbs
+++ b/templates/sheets/actors/companion/details.hbs
@@ -14,7 +14,7 @@
                 {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-item.hbs' item=document.system.partner type='actor' isSidebar=true isActor=true noTooltip=true}}
             </ul>
         {{else}}
-            <span class="partner-placeholder">{{localize "DAGGERHEART.Sheets.Companion.noPartner"}}</span>
+            <span class="partner-placeholder">{{localize "DAGGERHEART.Actors.Companion.noPartner"}}</span>
         {{/if}}
     </div>
     <div class="attack-section">

--- a/templates/sheets/actors/companion/details.hbs
+++ b/templates/sheets/actors/companion/details.hbs
@@ -14,7 +14,7 @@
                 {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-item.hbs' item=document.system.partner type='actor' isSidebar=true isActor=true noTooltip=true}}
             </ul>
         {{else}}
-            <span class="partner-placeholder">{{localize "DAGGERHEART.Actors.Companion.noPartner"}}</span>
+            <span class="partner-placeholder">{{localize "DAGGERHEART.ACTORS.Companion.noPartner"}}</span>
         {{/if}}
     </div>
     <div class="attack-section">

--- a/templates/sheets/actors/companion/effects.hbs
+++ b/templates/sheets/actors/companion/effects.hbs
@@ -3,6 +3,6 @@
     data-tab='{{tabs.effects.id}}'
     data-group='{{tabs.effects.group}}'
 >
-    {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.General.activeEffects') type='effect'}}
-    {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.General.inactiveEffects') type='effect'}}
+    {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.GENERAL.activeEffects') type='effect'}}
+    {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.GENERAL.inactiveEffects') type='effect'}}
 </section>

--- a/templates/sheets/actors/companion/effects.hbs
+++ b/templates/sheets/actors/companion/effects.hbs
@@ -3,6 +3,6 @@
     data-tab='{{tabs.effects.id}}'
     data-group='{{tabs.effects.group}}'
 >
-    {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.Sheets.Global.activeEffects') type='effect'}}
-    {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.Sheets.Global.inactiveEffects') type='effect'}}
+    {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.General.activeEffects') type='effect'}}
+    {{> 'systems/daggerheart/templates/sheets/global/partials/inventory-fieldset-items.hbs' title=(localize 'DAGGERHEART.General.inactiveEffects') type='effect'}}
 </section>

--- a/templates/sheets/actors/companion/header.hbs
+++ b/templates/sheets/actors/companion/header.hbs
@@ -33,7 +33,7 @@
             </div>
         </div>
         <h3 class="level-up-label">
-            {{localize "DAGGERHEART.General.level"}}
+            {{localize "DAGGERHEART.GENERAL.level"}}
             {{source.system.levelData.level.changed}}
         </h3>
     </div>

--- a/templates/sheets/actors/companion/header.hbs
+++ b/templates/sheets/actors/companion/header.hbs
@@ -33,7 +33,7 @@
             </div>
         </div>
         <h3 class="level-up-label">
-            {{localize "DAGGERHEART.Sheets.Companion.Level"}}
+            {{localize "DAGGERHEART.General.level"}}
             {{source.system.levelData.level.changed}}
         </h3>
     </div>

--- a/templates/sheets/actors/companion/tempMain.hbs
+++ b/templates/sheets/actors/companion/tempMain.hbs
@@ -2,7 +2,7 @@
     <img class="profile" src="{{document.img}}" alt="{{document.name}}" data-action='editImage' data-edit="img">
     <div class="form-group">
         <div class="form-fields">
-            <label>{{localize "DAGGERHEART.Actors.Companion.FIELDS.partner.label"}}</label>
+            <label>{{localize "DAGGERHEART.ACTORS.Companion.FIELDS.partner.label"}}</label>
             <select class="partner-value">
                 {{selectOptions playerCharacters selected=source.system.partner.uuid labelAttr="name" valueAttr="key" blank=""}}
             </select>
@@ -12,7 +12,7 @@
     {{formGroup systemFields.resources.fields.stress.fields.value value=source.system.resources.stress.value localize=true }}
     {{formGroup systemFields.evasion.fields.value value=source.system.evasion.value localize=true }}
     
-    <div>{{localize "DAGGERHEART.General.Experience.plural"}}</div>
+    <div>{{localize "DAGGERHEART.GENERAL.Experience.plural"}}</div>
     <div class="flexcol">
         {{#each source.system.experiences as |experience key|}}
             <div class="flexrow">
@@ -25,7 +25,7 @@
     <div class="flexrow">
         <div class="form-group">
             <div class="form-fields">
-                <label>{{localize "DAGGERHEART.Actors.Companion.FIELDS.attack.name.label"}}</label>
+                <label>{{localize "DAGGERHEART.ACTORS.Companion.FIELDS.attack.name.label"}}</label>
                 <input type="text" name="system.attack.name" value="{{source.system.attack.name}}" />
                 <button data-action="attackRoll">Attack</button>
             </div>
@@ -35,7 +35,7 @@
     <div class="flexrow">
         <div class="form-group">
             <div class="form-fields">
-                <label>{{localize "DAGGERHEART.General.level"}}</label>
+                <label>{{localize "DAGGERHEART.GENERAL.level"}}</label>
                 <div>{{source.system.levelData.level.changed}}</div>
                 <button data-action="levelUp" {{#if (not source.system.levelData.canLevelUp)}}disabled{{/if}}>Level Up</button>
             </div>

--- a/templates/sheets/actors/companion/tempMain.hbs
+++ b/templates/sheets/actors/companion/tempMain.hbs
@@ -2,7 +2,7 @@
     <img class="profile" src="{{document.img}}" alt="{{document.name}}" data-action='editImage' data-edit="img">
     <div class="form-group">
         <div class="form-fields">
-            <label>{{localize "DAGGERHEART.Sheets.Companion.FIELDS.partner.label"}}</label>
+            <label>{{localize "DAGGERHEART.Actors.Companion.FIELDS.partner.label"}}</label>
             <select class="partner-value">
                 {{selectOptions playerCharacters selected=source.system.partner.uuid labelAttr="name" valueAttr="key" blank=""}}
             </select>
@@ -12,7 +12,7 @@
     {{formGroup systemFields.resources.fields.stress.fields.value value=source.system.resources.stress.value localize=true }}
     {{formGroup systemFields.evasion.fields.value value=source.system.evasion.value localize=true }}
     
-    <div>{{localize "DAGGERHEART.Sheets.Companion.Experiences"}}</div>
+    <div>{{localize "DAGGERHEART.General.Experience.plural"}}</div>
     <div class="flexcol">
         {{#each source.system.experiences as |experience key|}}
             <div class="flexrow">
@@ -25,7 +25,7 @@
     <div class="flexrow">
         <div class="form-group">
             <div class="form-fields">
-                <label>{{localize "DAGGERHEART.Sheets.Companion.FIELDS.attack.name.label"}}</label>
+                <label>{{localize "DAGGERHEART.Actors.Companion.FIELDS.attack.name.label"}}</label>
                 <input type="text" name="system.attack.name" value="{{source.system.attack.name}}" />
                 <button data-action="attackRoll">Attack</button>
             </div>
@@ -35,7 +35,7 @@
     <div class="flexrow">
         <div class="form-group">
             <div class="form-fields">
-                <label>{{localize "DAGGERHEART.Sheets.Companion.Level"}}</label>
+                <label>{{localize "DAGGERHEART.General.level"}}</label>
                 <div>{{source.system.levelData.level.changed}}</div>
                 <button data-action="levelUp" {{#if (not source.system.levelData.canLevelUp)}}disabled{{/if}}>Level Up</button>
             </div>

--- a/templates/sheets/actors/environment/header.hbs
+++ b/templates/sheets/actors/environment/header.hbs
@@ -6,13 +6,13 @@
             <div class="tags">
                 <div class="tag">
                     <span>
-                        {{localize (concat 'DAGGERHEART.General.Tiers.' source.system.tier)}}
+                        {{localize (concat 'DAGGERHEART.GENERAL.Tiers.' source.system.tier)}}
                     </span>
                 </div>
                 {{#if source.system.type}}
                     <div class="tag">
                         <span>
-                            {{localize (concat 'Daggerheart.Config.EnvironmentType.' source.system.type '.label')}}
+                            {{localize (concat 'DAGGERHEART.CONFIG.EnvironmentType.' source.system.type '.label')}}
                         </span>
                     </div>
                 {{/if}}
@@ -37,7 +37,7 @@
             <i>{{source.system.description}}</i>
         </div>
         <div class="impulses">
-            <b>{{localize 'DAGGERHEART.Actors.Environment.FIELDS.impulses.label'}}: </b>{{{source.system.impulses}}}
+            <b>{{localize 'DAGGERHEART.ACTORS.Environment.FIELDS.impulses.label'}}: </b>{{{source.system.impulses}}}
         </div>
     </div>
     <div class="environment-navigation">

--- a/templates/sheets/actors/environment/header.hbs
+++ b/templates/sheets/actors/environment/header.hbs
@@ -6,13 +6,13 @@
             <div class="tags">
                 <div class="tag">
                     <span>
-                        {{localize (concat 'DAGGERHEART.Tiers.' source.system.tier)}}
+                        {{localize (concat 'DAGGERHEART.General.Tiers.' source.system.tier)}}
                     </span>
                 </div>
                 {{#if source.system.type}}
                     <div class="tag">
                         <span>
-                            {{localize (concat 'DAGGERHEART.Environment.Type.' source.system.type '.label')}}
+                            {{localize (concat 'Daggerheart.Config.EnvironmentType.' source.system.type '.label')}}
                         </span>
                     </div>
                 {{/if}}
@@ -37,7 +37,7 @@
             <i>{{source.system.description}}</i>
         </div>
         <div class="impulses">
-            <b>{{localize 'DAGGERHEART.Sheets.Environment.FIELDS.impulses.label'}}: </b>{{{source.system.impulses}}}
+            <b>{{localize 'DAGGERHEART.Actors.Environment.FIELDS.impulses.label'}}: </b>{{{source.system.impulses}}}
         </div>
     </div>
     <div class="environment-navigation">

--- a/templates/sheets/global/partials/action-item.hbs
+++ b/templates/sheets/global/partials/action-item.hbs
@@ -10,7 +10,7 @@
         </div> --}}
     </div>
     <div class="controls">
-        <a data-action="toChat" data-tooltip="{{localize 'DAGGERHEART.Tooltip.sendToChat'}}"><i class="fa-regular fa-message"></i></a>
-        <a data-action="triggerContextMenu" data-tooltip="{{localize 'DAGGERHEART.Tooltip.moreOptions'}}"><i class="fa-solid fa-ellipsis-vertical"></i></a>
+        <a data-action="toChat" data-tooltip="{{localize 'DAGGERHEART.UI.Tooltip.sendToChat'}}"><i class="fa-regular fa-message"></i></a>
+        <a data-action="triggerContextMenu" data-tooltip="{{localize 'DAGGERHEART.UI.Tooltip.moreOptions'}}"><i class="fa-solid fa-ellipsis-vertical"></i></a>
     </div>
 </li>

--- a/templates/sheets/global/partials/domain-card-item.hbs
+++ b/templates/sheets/global/partials/domain-card-item.hbs
@@ -3,29 +3,29 @@
     <div class="card-label">
         <div class="controls">
             {{#if (eq type 'weapon')}}
-                <a class="{{#unless item.system.equipped}}unequipped{{/unless}}" data-action="toggleEquipItem" id="{{item.id}}" data-tooltip="{{#unless item.system.equipped}}{{localize 'DAGGERHEART.Tooltip.equip'}}{{else}}{{localize 'DAGGERHEART.Tooltip.unequip'}}{{/unless}}">
+                <a class="{{#unless item.system.equipped}}unequipped{{/unless}}" data-action="toggleEquipItem" id="{{item.id}}" data-tooltip="{{#unless item.system.equipped}}{{localize 'CONTROLS.CommonEdit'}}{{else}}{{localize 'DAGGERHEART.UI.Tooltip.unequip'}}{{/unless}}">
                     <i class="fa-solid fa-hands"></i>
                 </a>
             {{/if}}
             {{#if (eq type 'armor')}}
-                <a class="{{#unless item.system.equipped}}unequipped{{/unless}}" data-action="toggleEquipItem" id="{{item.id}}" data-tooltip="{{#unless item.system.equipped}}{{localize 'DAGGERHEART.Tooltip.equip'}}{{else}}{{localize 'DAGGERHEART.Tooltip.unequip'}}{{/unless}}">
+                <a class="{{#unless item.system.equipped}}unequipped{{/unless}}" data-action="toggleEquipItem" id="{{item.id}}" data-tooltip="{{#unless item.system.equipped}}{{localize 'CONTROLS.CommonEdit'}}{{else}}{{localize 'DAGGERHEART.UI.Tooltip.unequip'}}{{/unless}}">
                 <i class="fa-solid fa-shield"></i>
                 </a>
             {{/if}}
             {{#if (eq type 'domainCard')}}
                 {{#unless item.system.inVault}}
-                    <a data-action="toggleVault" data-tooltip="{{localize 'DAGGERHEART.Tooltip.sendToVault'}}">
+                    <a data-action="toggleVault" data-tooltip="{{localize 'DAGGERHEART.UI.Tooltip.sendToVault'}}">
                         <i class="fa-solid fa-arrow-down"></i>
                     </a>
                 {{else}}
-                    <a data-action="toggleVault" data-tooltip="{{localize 'DAGGERHEART.Tooltip.sendToLoadout'}}">
+                    <a data-action="toggleVault" data-tooltip="{{localize 'DAGGERHEART.UI.Tooltip.sendToLoadout'}}">
                         <i class="fa-solid fa-arrow-up"></i>
                     </a>
                 {{/unless}}
                 
             {{/if}}
-            <a data-action="toChat" data-tooltip="{{localize 'DAGGERHEART.Tooltip.sendToChat'}}"><i class="fa-regular fa-message"></i></a>
-            <a data-action="triggerContextMenu" data-tooltip="{{localize 'DAGGERHEART.Tooltip.moreOptions'}}"><i class="fa-solid fa-ellipsis-vertical"></i></a>
+            <a data-action="toChat" data-tooltip="{{localize 'DAGGERHEART.UI.Tooltip.sendToChat'}}"><i class="fa-regular fa-message"></i></a>
+            <a data-action="triggerContextMenu" data-tooltip="{{localize 'DAGGERHEART.UI.Tooltip.moreOptions'}}"><i class="fa-solid fa-ellipsis-vertical"></i></a>
         </div>
         <div class="card-name">{{item.name}}</div>
     </div>

--- a/templates/sheets/global/partials/feature-section-item.hbs
+++ b/templates/sheets/global/partials/feature-section-item.hbs
@@ -11,7 +11,7 @@
                     data-action='editFeature'
                     data-feature='{{feature._id}}'
                     data-type='{{type}}'
-                    data-tooltip='{{localize "DAGGERHEART.Tooltip.openItemWorld"}}'
+                    data-tooltip='{{localize "DAGGERHEART.UI.Tooltip.openItemWorld"}}'
                 >
                     <i class="fa-solid fa-globe"></i>
                 </a>
@@ -20,7 +20,7 @@
                     data-action='deleteFeature'
                     data-feature='{{feature._id}}'
                     data-type='{{type}}'
-                    data-tooltip='{{localize "DAGGERHEART.Tooltip.delete"}}'
+                    data-tooltip='{{localize "CONTROLS.CommonDelete"}}'
                 >
                     <i class='fas fa-trash'></i>
                 </a>

--- a/templates/sheets/global/partials/inventory-item.hbs
+++ b/templates/sheets/global/partials/inventory-item.hbs
@@ -11,24 +11,24 @@
                 {{#if isSidebar}}
                     <div class="item-labels">
                         <div class="label">
-                            {{localize (concat 'DAGGERHEART.Config.Traits.' item.system.trait '.name')}}
-                            {{localize (concat 'DAGGERHEART.Config.Range.' item.system.range '.name')}}
+                            {{localize (concat 'DAGGERHEART.CONFIG.Traits.' item.system.trait '.name')}}
+                            {{localize (concat 'DAGGERHEART.CONFIG.Range.' item.system.range '.name')}}
                             <span> - </span>
                             {{item.system.damage.value}}
-                            ({{localize (concat 'DAGGERHEART.Config.DamageType.' item.system.damage.type '.abbreviation')}})
+                            ({{localize (concat 'DAGGERHEART.CONFIG.DamageType.' item.system.damage.type '.abbreviation')}})
                         </div>
                     </div>
                 {{else}}
                     <div class="tag">
-                        {{localize (concat 'DAGGERHEART.Config.Traits.' item.system.trait '.name')}}
-                        {{localize (concat 'DAGGERHEART.Config.Range.' item.system.range '.name')}}
+                        {{localize (concat 'DAGGERHEART.CONFIG.Traits.' item.system.trait '.name')}}
+                        {{localize (concat 'DAGGERHEART.CONFIG.Range.' item.system.range '.name')}}
                     </div>
                     <div class="tag">
                         {{item.system.damage.value}}
-                        ({{localize (concat 'DAGGERHEART.Config.DamageType.' item.system.damage.type '.abbreviation')}})
+                        ({{localize (concat 'DAGGERHEART.CONFIG.DamageType.' item.system.damage.type '.abbreviation')}})
                     </div>
                     <div class="tag">
-                        {{localize (concat 'DAGGERHEART.Config.Burden.' item.system.burden)}}
+                        {{localize (concat 'DAGGERHEART.CONFIG.Burden.' item.system.burden)}}
                     </div>
                 {{/if}}
             </div>
@@ -37,18 +37,18 @@
             {{#if isSidebar}}
                 <div class="item-labels">
                     <div class="label">
-                        {{localize "DAGGERHEART.Items.Armor.baseScore"}}:
+                        {{localize "DAGGERHEART.ITEMS.Armor.baseScore"}}:
                         {{item.system.baseScore}}
                     </div>
                 </div>
             {{else}}
                 <div class="item-tags">
                     <div class="tag">
-                        {{localize "DAGGERHEART.Items.Armor.baseScore"}}:
+                        {{localize "DAGGERHEART.ITEMS.Armor.baseScore"}}:
                         {{item.system.baseScore}}
                     </div>
                     <div class="tag">
-                        {{localize "DAGGERHEART.Items.Armor.baseThresholds.base"}}:
+                        {{localize "DAGGERHEART.ITEMS.Armor.baseThresholds.base"}}:
                         {{item.system.baseThresholds.major}}
                         <span>/</span>
                         {{item.system.baseThresholds.severe}}
@@ -60,9 +60,9 @@
             {{#if isSidebar}}
                 <div class="item-labels">
                     <div class="label">
-                        {{localize (concat 'DAGGERHEART.Config.DomainCardTypes.' item.system.type)}}
+                        {{localize (concat 'DAGGERHEART.CONFIG.DomainCardTypes.' item.system.type)}}
                         <span> - </span>
-                        {{localize (concat 'DAGGERHEART.General.Domain.' item.system.domain '.label')}}
+                        {{localize (concat 'DAGGERHEART.GENERAL.Domain.' item.system.domain '.label')}}
                         <span> - </span>
                         <span class="recall-value">{{item.system.recallCost}}</span>
                         <i class="fa-solid fa-bolt"></i>
@@ -71,13 +71,13 @@
             {{else}}
                 <div class="item-tags">
                     <div class="tag">
-                        {{localize (concat 'DAGGERHEART.Config.DomainCardTypes.' item.system.type)}}
+                        {{localize (concat 'DAGGERHEART.CONFIG.DomainCardTypes.' item.system.type)}}
                     </div>
                     <div class="tag">
-                        {{localize (concat 'DAGGERHEART.General.Domain.' item.system.domain '.label')}}
+                        {{localize (concat 'DAGGERHEART.GENERAL.Domain.' item.system.domain '.label')}}
                     </div>
                     <div class="tag">
-                        <span class="recall-label">{{localize "DAGGERHEART.Items.DomainCard.recallCost"}}: </span>
+                        <span class="recall-label">{{localize "DAGGERHEART.ITEMS.DomainCard.recallCost"}}: </span>
                         <span class="recall-value">{{item.system.recallCost}}</span>
                     </div>
                 </div>
@@ -92,14 +92,14 @@
                 </div>
                 <div class="tag">
                     {{#if item.duration.duration}}
-                        {{localize 'DAGGERHEART.Effects.Duration.temporary'}}
+                        {{localize 'DAGGERHEART.EFFECTS.Duration.temporary'}}
                     {{else}}
-                        {{localize 'DAGGERHEART.Effects.Duration.passive'}}
+                        {{localize 'DAGGERHEART.EFFECTS.Duration.passive'}}
                     {{/if}}
                 </div>
                 {{#each item.statuses as |status|}}
                     <div class="tag">
-                        {{localize (concat 'DAGGERHEART.Config.Condition.' status '.name')}}
+                        {{localize (concat 'DAGGERHEART.CONFIG.Condition.' status '.name')}}
                     </div>
                 {{/each}}
             </div>
@@ -107,10 +107,10 @@
         {{#if  (eq type 'action')}}
             <div class="item-tags">
                 <div class="tag">
-                    {{localize (concat 'DAGGERHEART.Actions.Types.' item.type '.name')}}
+                    {{localize (concat 'DAGGERHEART.ACTIONS.TYPES.' item.type '.name')}}
                 </div>
                 <div class="tag">
-                    {{localize (concat 'DAGGERHEART.Config.ActionType.' item.actionType)}}
+                    {{localize (concat 'DAGGERHEART.CONFIG.ActionType.' item.actionType)}}
                 </div>
             </div>
         {{/if}}

--- a/templates/sheets/global/partials/inventory-item.hbs
+++ b/templates/sheets/global/partials/inventory-item.hbs
@@ -11,24 +11,24 @@
                 {{#if isSidebar}}
                     <div class="item-labels">
                         <div class="label">
-                            {{localize (concat 'DAGGERHEART.Abilities.' item.system.trait '.name')}}
-                            {{localize (concat 'DAGGERHEART.Range.' item.system.range '.name')}}
+                            {{localize (concat 'DAGGERHEART.Config.Traits.' item.system.trait '.name')}}
+                            {{localize (concat 'DAGGERHEART.Config.Range.' item.system.range '.name')}}
                             <span> - </span>
                             {{item.system.damage.value}}
-                            ({{localize (concat 'DAGGERHEART.DamageType.' item.system.damage.type '.abbreviation')}})
+                            ({{localize (concat 'DAGGERHEART.Config.DamageType.' item.system.damage.type '.abbreviation')}})
                         </div>
                     </div>
                 {{else}}
                     <div class="tag">
-                        {{localize (concat 'DAGGERHEART.Abilities.' item.system.trait '.name')}}
-                        {{localize (concat 'DAGGERHEART.Range.' item.system.range '.name')}}
+                        {{localize (concat 'DAGGERHEART.Config.Traits.' item.system.trait '.name')}}
+                        {{localize (concat 'DAGGERHEART.Config.Range.' item.system.range '.name')}}
                     </div>
                     <div class="tag">
                         {{item.system.damage.value}}
-                        ({{localize (concat 'DAGGERHEART.DamageType.' item.system.damage.type '.abbreviation')}})
+                        ({{localize (concat 'DAGGERHEART.Config.DamageType.' item.system.damage.type '.abbreviation')}})
                     </div>
                     <div class="tag">
-                        {{localize (concat 'DAGGERHEART.Burden.' item.system.burden)}}
+                        {{localize (concat 'DAGGERHEART.Config.Burden.' item.system.burden)}}
                     </div>
                 {{/if}}
             </div>
@@ -37,18 +37,18 @@
             {{#if isSidebar}}
                 <div class="item-labels">
                     <div class="label">
-                        {{localize "DAGGERHEART.Sheets.Armor.baseScore"}}:
+                        {{localize "DAGGERHEART.Items.Armor.baseScore"}}:
                         {{item.system.baseScore}}
                     </div>
                 </div>
             {{else}}
                 <div class="item-tags">
                     <div class="tag">
-                        {{localize "DAGGERHEART.Sheets.Armor.baseScore"}}:
+                        {{localize "DAGGERHEART.Items.Armor.baseScore"}}:
                         {{item.system.baseScore}}
                     </div>
                     <div class="tag">
-                        {{localize "DAGGERHEART.Sheets.Armor.baseThresholds.base"}}:
+                        {{localize "DAGGERHEART.Items.Armor.baseThresholds.base"}}:
                         {{item.system.baseThresholds.major}}
                         <span>/</span>
                         {{item.system.baseThresholds.severe}}
@@ -60,9 +60,9 @@
             {{#if isSidebar}}
                 <div class="item-labels">
                     <div class="label">
-                        {{localize (concat 'DAGGERHEART.Domain.CardTypes.' item.system.type)}}
+                        {{localize (concat 'DAGGERHEART.Config.DomainCardTypes.' item.system.type)}}
                         <span> - </span>
-                        {{localize (concat 'DAGGERHEART.Domains.' item.system.domain '.label')}}
+                        {{localize (concat 'DAGGERHEART.General.Domain.' item.system.domain '.label')}}
                         <span> - </span>
                         <span class="recall-value">{{item.system.recallCost}}</span>
                         <i class="fa-solid fa-bolt"></i>
@@ -71,13 +71,13 @@
             {{else}}
                 <div class="item-tags">
                     <div class="tag">
-                        {{localize (concat 'DAGGERHEART.Domain.CardTypes.' item.system.type)}}
+                        {{localize (concat 'DAGGERHEART.Config.DomainCardTypes.' item.system.type)}}
                     </div>
                     <div class="tag">
-                        {{localize (concat 'DAGGERHEART.Domains.' item.system.domain '.label')}}
+                        {{localize (concat 'DAGGERHEART.General.Domain.' item.system.domain '.label')}}
                     </div>
                     <div class="tag">
-                        <span class="recall-label">{{localize "DAGGERHEART.Sheets.DomainCard.RecallCost"}}: </span>
+                        <span class="recall-label">{{localize "DAGGERHEART.Items.DomainCard.recallCost"}}: </span>
                         <span class="recall-value">{{item.system.recallCost}}</span>
                     </div>
                 </div>
@@ -92,14 +92,14 @@
                 </div>
                 <div class="tag">
                     {{#if item.duration.duration}}
-                        {{localize 'DAGGERHEART.Effects.duration.temporary'}}
+                        {{localize 'DAGGERHEART.Effects.Duration.temporary'}}
                     {{else}}
-                        {{localize 'DAGGERHEART.Effects.duration.passive'}}
+                        {{localize 'DAGGERHEART.Effects.Duration.passive'}}
                     {{/if}}
                 </div>
                 {{#each item.statuses as |status|}}
                     <div class="tag">
-                        {{localize (concat 'DAGGERHEART.Condition.' status '.name')}}
+                        {{localize (concat 'DAGGERHEART.Config.Condition.' status '.name')}}
                     </div>
                 {{/each}}
             </div>
@@ -110,7 +110,7 @@
                     {{localize (concat 'DAGGERHEART.Actions.Types.' item.type '.name')}}
                 </div>
                 <div class="tag">
-                    {{localize (concat 'DAGGERHEART.ActionType.' item.actionType)}}
+                    {{localize (concat 'DAGGERHEART.Config.ActionType.' item.actionType)}}
                 </div>
             </div>
         {{/if}}
@@ -119,15 +119,15 @@
         {{#if isActor}}
             <div class="controls">
                 {{#if (eq type 'actor')}}
-                    <a data-action="viewActor" data-potential-adversary="{{categoryAdversary}}" data-adversary="{{item.uuid}}" data-tooltip='{{localize "DAGGERHEART.Tooltip.openActorWorld"}}'>
+                    <a data-action="viewActor" data-potential-adversary="{{categoryAdversary}}" data-adversary="{{item.uuid}}" data-tooltip='{{localize "DAGGERHEART.UI.Tooltip.openActorWorld"}}'>
                         <i class="fa-solid fa-globe"></i>
                     </a>
                 {{/if}}
                 {{#if (eq type 'adversary')}}
-                    <a data-action="viewAdversary" data-potential-adversary="{{categoryAdversary}}" data-adversary="{{item.uuid}}" data-tooltip='{{localize "DAGGERHEART.Tooltip.openActorWorld"}}'>
+                    <a data-action="viewAdversary" data-potential-adversary="{{categoryAdversary}}" data-adversary="{{item.uuid}}" data-tooltip='{{localize "DAGGERHEART.UI.Tooltip.openActorWorld"}}'>
                         <i class="fa-solid fa-globe"></i>
                     </a>
-                    <a data-action='deleteAdversary' data-potential-adversary="{{categoryAdversary}}" data-adversary="{{item.uuid}}" data-tooltip='{{localize "DAGGERHEART.Tooltip.delete"}}'>
+                    <a data-action='deleteAdversary' data-potential-adversary="{{categoryAdversary}}" data-adversary="{{item.uuid}}" data-tooltip='{{localize "CONTROLS.CommonDelete"}}'>
                         <i class='fas fa-trash'></i>
                     </a>
                 {{/if}}
@@ -135,29 +135,29 @@
         {{else}}
             <div class="controls">
                 {{#if (eq type 'weapon')}}
-                    <a class="{{#unless item.system.equipped}}unequipped{{/unless}}" data-action="toggleEquipItem" data-tooltip="{{#unless item.system.equipped}}{{localize 'DAGGERHEART.Tooltip.equip'}}{{else}}{{localize 'DAGGERHEART.Tooltip.unequip'}}{{/unless}}">
+                    <a class="{{#unless item.system.equipped}}unequipped{{/unless}}" data-action="toggleEquipItem" data-tooltip="{{#unless item.system.equipped}}{{localize 'CONTROLS.CommonEdit'}}{{else}}{{localize 'DAGGERHEART.UI.Tooltip.unequip'}}{{/unless}}">
                         <i class="fa-solid fa-hands"></i>
                     </a>
                 {{/if}}
                 {{#if (eq type 'armor')}}
-                    <a class="{{#unless item.system.equipped}}unequipped{{/unless}}" data-action="toggleEquipItem" data-tooltip="{{#unless item.system.equipped}}{{localize 'DAGGERHEART.Tooltip.equip'}}{{else}}{{localize 'DAGGERHEART.Tooltip.unequip'}}{{/unless}}">
+                    <a class="{{#unless item.system.equipped}}unequipped{{/unless}}" data-action="toggleEquipItem" data-tooltip="{{#unless item.system.equipped}}{{localize 'CONTROLS.CommonEdit'}}{{else}}{{localize 'DAGGERHEART.UI.Tooltip.unequip'}}{{/unless}}">
                     <i class="fa-solid fa-shield"></i>
                     </a>
                 {{/if}}
                 {{#if (eq type 'domainCard')}}
                     {{#unless item.system.inVault}}
-                        <a data-action="toggleVault" data-tooltip="{{localize 'DAGGERHEART.Tooltip.sendToVault'}}">
+                        <a data-action="toggleVault" data-tooltip="{{localize 'DAGGERHEART.UI.Tooltip.sendToVault'}}">
                             <i class="fa-solid fa-arrow-down"></i>
                         </a>
                     {{else}}
-                        <a data-action="toggleVault" data-tooltip="{{localize 'DAGGERHEART.Tooltip.sendToLoadout'}}">
+                        <a data-action="toggleVault" data-tooltip="{{localize 'DAGGERHEART.UI.Tooltip.sendToLoadout'}}">
                             <i class="fa-solid fa-arrow-up"></i>
                         </a>
                     {{/unless}}
                     
                 {{/if}}
-                <a data-action="toChat" data-tooltip="{{localize 'DAGGERHEART.Tooltip.sendToChat'}}"><i class="fa-regular fa-message"></i></a>
-                <a data-action="triggerContextMenu" data-tooltip="{{localize 'DAGGERHEART.Tooltip.moreOptions'}}"><i class="fa-solid fa-ellipsis-vertical"></i></a>
+                <a data-action="toChat" data-tooltip="{{localize 'DAGGERHEART.UI.Tooltip.sendToChat'}}"><i class="fa-regular fa-message"></i></a>
+                <a data-action="triggerContextMenu" data-tooltip="{{localize 'DAGGERHEART.UI.Tooltip.moreOptions'}}"><i class="fa-solid fa-ellipsis-vertical"></i></a>
             </div>
         {{/if}}
     {{else}}

--- a/templates/sheets/global/tabs/tab-actions.hbs
+++ b/templates/sheets/global/tabs/tab-actions.hbs
@@ -4,7 +4,7 @@
     data-group='{{tabs.actions.group}}'
 >
     <fieldset class="one-column">
-        <legend>{{localize "DAGGERHEART.General.Action.plural"}} <a><i class="fa-solid fa-plus icon-button" data-action="addAction"></i></a></legend>
+        <legend>{{localize "DAGGERHEART.GENERAL.Action.plural"}} <a><i class="fa-solid fa-plus icon-button" data-action="addAction"></i></a></legend>
         <div class="actions-list">
             {{#each document.system.actions as |action index|}}
                 <div class="action-item"

--- a/templates/sheets/global/tabs/tab-actions.hbs
+++ b/templates/sheets/global/tabs/tab-actions.hbs
@@ -4,7 +4,7 @@
     data-group='{{tabs.actions.group}}'
 >
     <fieldset class="one-column">
-        <legend>{{localize "DAGGERHEART.Sheets.Global.Actions"}} <a><i class="fa-solid fa-plus icon-button" data-action="addAction"></i></a></legend>
+        <legend>{{localize "DAGGERHEART.General.Action.plural"}} <a><i class="fa-solid fa-plus icon-button" data-action="addAction"></i></a></legend>
         <div class="actions-list">
             {{#each document.system.actions as |action index|}}
                 <div class="action-item"

--- a/templates/sheets/global/tabs/tab-description.hbs
+++ b/templates/sheets/global/tabs/tab-description.hbs
@@ -4,7 +4,7 @@
     data-group='{{tabs.description.group}}'
 >
     <fieldset>
-        <legend>{{localize "DAGGERHEART.General.description"}}</legend>
+        <legend>{{localize "DAGGERHEART.GENERAL.description"}}</legend>
         {{formInput systemFields.description value=document.system.description enriched=enrichedDescription toggled=true}}
     </fieldset>
 </section>

--- a/templates/sheets/global/tabs/tab-description.hbs
+++ b/templates/sheets/global/tabs/tab-description.hbs
@@ -4,7 +4,7 @@
     data-group='{{tabs.description.group}}'
 >
     <fieldset>
-        <legend>{{localize "DAGGERHEART.Sheets.Feature.Description"}}</legend>
+        <legend>{{localize "DAGGERHEART.General.description"}}</legend>
         {{formInput systemFields.description value=document.system.description enriched=enrichedDescription toggled=true}}
     </fieldset>
 </section>

--- a/templates/sheets/global/tabs/tab-effects.hbs
+++ b/templates/sheets/global/tabs/tab-effects.hbs
@@ -4,7 +4,7 @@
     data-group='{{tabs.effects.group}}'
 >
     <fieldset class="one-column">
-            <legend>{{localize "DAGGERHEART.General.Effect.plural"}} <a><i class="fa-solid fa-plus icon-button" data-action="addEffect"></i></a></legend>
+            <legend>{{localize "DAGGERHEART.GENERAL.Effect.plural"}} <a><i class="fa-solid fa-plus icon-button" data-action="addEffect"></i></a></legend>
         <div class="effects-list">
             {{#each document.effects as |effect|}}
                 <div class="effect-item">

--- a/templates/sheets/global/tabs/tab-effects.hbs
+++ b/templates/sheets/global/tabs/tab-effects.hbs
@@ -4,7 +4,7 @@
     data-group='{{tabs.effects.group}}'
 >
     <fieldset class="one-column">
-            <legend>{{localize "DAGGERHEART.Sheets.Global.Effects"}} <a><i class="fa-solid fa-plus icon-button" data-action="addEffect"></i></a></legend>
+            <legend>{{localize "DAGGERHEART.General.Effect.plural"}} <a><i class="fa-solid fa-plus icon-button" data-action="addEffect"></i></a></legend>
         <div class="effects-list">
             {{#each document.effects as |effect|}}
                 <div class="effect-item">

--- a/templates/sheets/global/tabs/tab-feature-section.hbs
+++ b/templates/sheets/global/tabs/tab-feature-section.hbs
@@ -4,7 +4,7 @@
     data-group='{{tabs.features.group}}'
 >
     <fieldset>
-        <legend>{{localize "DAGGERHEART.General.Tabs.features"}}</legend>
+        <legend>{{localize "DAGGERHEART.GENERAL.Tabs.features"}}</legend>
         <div class="feature-list">
             {{#each source.system.abilities as |feature key|}}
                 {{> 'systems/daggerheart/templates/sheets/global/partials/feature-section-item.hbs' feature=feature}}

--- a/templates/sheets/global/tabs/tab-feature-section.hbs
+++ b/templates/sheets/global/tabs/tab-feature-section.hbs
@@ -4,7 +4,7 @@
     data-group='{{tabs.features.group}}'
 >
     <fieldset>
-        <legend>{{localize "DAGGERHEART.Sheets.Feature.Tabs.Features"}}</legend>
+        <legend>{{localize "DAGGERHEART.General.Tabs.features"}}</legend>
         <div class="feature-list">
             {{#each source.system.abilities as |feature key|}}
                 {{> 'systems/daggerheart/templates/sheets/global/partials/feature-section-item.hbs' feature=feature}}

--- a/templates/sheets/global/tabs/tab-features.hbs
+++ b/templates/sheets/global/tabs/tab-features.hbs
@@ -4,7 +4,7 @@
     data-group='{{tabs.features.group}}'
 >
     <fieldset class="one-column drop-section">
-        <legend>{{localize "DAGGERHEART.General.features"}} <a><i data-action="addFeature" class="fa-solid fa-plus icon-button"></i></a></legend>
+        <legend>{{localize "DAGGERHEART.GENERAL.features"}} <a><i data-action="addFeature" class="fa-solid fa-plus icon-button"></i></a></legend>
         <div class="features-list">
             {{#each document.system.features as |feature|}}
                 <div class="feature-item"

--- a/templates/sheets/global/tabs/tab-features.hbs
+++ b/templates/sheets/global/tabs/tab-features.hbs
@@ -4,7 +4,7 @@
     data-group='{{tabs.features.group}}'
 >
     <fieldset class="one-column drop-section">
-        <legend>{{localize "DAGGERHEART.Sheets.Global.Features"}} <a><i data-action="addFeature" class="fa-solid fa-plus icon-button"></i></a></legend>
+        <legend>{{localize "DAGGERHEART.General.features"}} <a><i data-action="addFeature" class="fa-solid fa-plus icon-button"></i></a></legend>
         <div class="features-list">
             {{#each document.system.features as |feature|}}
                 <div class="feature-item"

--- a/templates/sheets/items/armor/header.hbs
+++ b/templates/sheets/items/armor/header.hbs
@@ -8,10 +8,10 @@
                 {{localize 'TYPES.Item.armor'}}
             </h3>
             <h3>
-                {{localize "DAGGERHEART.Items.Armor.baseScore"}}:
+                {{localize "DAGGERHEART.ITEMS.Armor.baseScore"}}:
                 {{source.system.baseScore}}
                 <span>-</span>
-                {{localize "DAGGERHEART.Items.Armor.baseThresholds.base"}}:
+                {{localize "DAGGERHEART.ITEMS.Armor.baseThresholds.base"}}:
                 {{source.system.baseThresholds.major}}
                 <span>/</span>
                 {{source.system.baseThresholds.severe}}

--- a/templates/sheets/items/armor/header.hbs
+++ b/templates/sheets/items/armor/header.hbs
@@ -8,10 +8,10 @@
                 {{localize 'TYPES.Item.armor'}}
             </h3>
             <h3>
-                {{localize "DAGGERHEART.Sheets.Armor.baseScore"}}:
+                {{localize "DAGGERHEART.Items.Armor.baseScore"}}:
                 {{source.system.baseScore}}
                 <span>-</span>
-                {{localize "DAGGERHEART.Sheets.Armor.baseThresholds.base"}}:
+                {{localize "DAGGERHEART.Items.Armor.baseThresholds.base"}}:
                 {{source.system.baseThresholds.major}}
                 <span>/</span>
                 {{source.system.baseThresholds.severe}}

--- a/templates/sheets/items/armor/settings.hbs
+++ b/templates/sheets/items/armor/settings.hbs
@@ -5,18 +5,18 @@
 >
     <fieldset class="two-columns">
         <legend>{{localize tabs.settings.label}}</legend>
-        <span>{{localize "DAGGERHEART.General.Tiers.singular"}}</span>
+        <span>{{localize "DAGGERHEART.GENERAL.Tiers.singular"}}</span>
         {{formField systemFields.tier value=source.system.tier}}
-        <span>{{localize "DAGGERHEART.Items.Armor.baseScore"}}</span>
+        <span>{{localize "DAGGERHEART.ITEMS.Armor.baseScore"}}</span>
         {{formField systemFields.baseScore value=source.system.baseScore}}
 
         <span>{{localize "TYPES.Item.feature"}}</span>
         <input type="text" class="features-input" value="{{features}}" />
 
-        <span>{{localize "DAGGERHEART.Items.Armor.baseThresholds.base"}}</span>
+        <span>{{localize "DAGGERHEART.ITEMS.Armor.baseThresholds.base"}}</span>
         <div class="nest-inputs">
-            {{ formField systemFields.baseThresholds.fields.major value=source.system.baseThresholds.major label=(localize "DAGGERHEART.Items.Armor.baseThresholds.major") }}
-            {{ formField systemFields.baseThresholds.fields.severe value=source.system.baseThresholds.severe label=(localize "DAGGERHEART.Items.Armor.baseThresholds.severe") }}
+            {{ formField systemFields.baseThresholds.fields.major value=source.system.baseThresholds.major label=(localize "DAGGERHEART.ITEMS.Armor.baseThresholds.major") }}
+            {{ formField systemFields.baseThresholds.fields.severe value=source.system.baseThresholds.severe label=(localize "DAGGERHEART.ITEMS.Armor.baseThresholds.severe") }}
         </div>
     </fieldset>
 </section>

--- a/templates/sheets/items/armor/settings.hbs
+++ b/templates/sheets/items/armor/settings.hbs
@@ -5,18 +5,18 @@
 >
     <fieldset class="two-columns">
         <legend>{{localize tabs.settings.label}}</legend>
-        <span>{{localize "DAGGERHEART.Tiers.singular"}}</span>
+        <span>{{localize "DAGGERHEART.General.Tiers.singular"}}</span>
         {{formField systemFields.tier value=source.system.tier}}
-        <span>{{localize "DAGGERHEART.Sheets.Armor.baseScore"}}</span>
+        <span>{{localize "DAGGERHEART.Items.Armor.baseScore"}}</span>
         {{formField systemFields.baseScore value=source.system.baseScore}}
 
-        <span>{{localize "DAGGERHEART.Sheets.Armor.feature"}}</span>
+        <span>{{localize "TYPES.Item.feature"}}</span>
         <input type="text" class="features-input" value="{{features}}" />
 
-        <span>{{localize "DAGGERHEART.Sheets.Armor.baseThresholds.base"}}</span>
+        <span>{{localize "DAGGERHEART.Items.Armor.baseThresholds.base"}}</span>
         <div class="nest-inputs">
-            {{ formField systemFields.baseThresholds.fields.major value=source.system.baseThresholds.major label=(localize "DAGGERHEART.Sheets.Armor.baseThresholds.major") }}
-            {{ formField systemFields.baseThresholds.fields.severe value=source.system.baseThresholds.severe label=(localize "DAGGERHEART.Sheets.Armor.baseThresholds.severe") }}
+            {{ formField systemFields.baseThresholds.fields.major value=source.system.baseThresholds.major label=(localize "DAGGERHEART.Items.Armor.baseThresholds.major") }}
+            {{ formField systemFields.baseThresholds.fields.severe value=source.system.baseThresholds.severe label=(localize "DAGGERHEART.Items.Armor.baseThresholds.severe") }}
         </div>
     </fieldset>
 </section>

--- a/templates/sheets/items/beastform/settings.hbs
+++ b/templates/sheets/items/beastform/settings.hbs
@@ -9,19 +9,19 @@
     </div>
 
      <fieldset class="two-columns">
-        <legend>{{localize "DAGGERHEART.Sheets.Beastform.FIELDS.advantageOn.label"}}</legend>
+        <legend>{{localize "DAGGERHEART.Items.Beastform.FIELDS.advantageOn.label"}}</legend>
         
         {{!-- {{formGroup systemFields.examples value=source.system.examples localize=true}} --}}
     </fieldset>
 
     <fieldset class="two-columns even">
-        <legend>{{localize "DAGGERHEART.Sheets.Beastform.tokenTitle"}}</legend>
+        <legend>{{localize "DAGGERHEART.Items.Beastform.tokenTitle"}}</legend>
 
         <div class="full-width">
             {{formGroup systemFields.tokenImg value=source.system.tokenImg localize=true}}
         </div>
 
-        {{formGroup systemFields.tokenSize.fields.height value=source.system.tokenSize.height localize=true placeholder=(localize "DAGGERHEART.Sheets.Beastform.FIELDS.tokenSize.placeholder") }}
-        {{formGroup systemFields.tokenSize.fields.width value=source.system.tokenSize.width localize=true placeholder=(localize "DAGGERHEART.Sheets.Beastform.FIELDS.tokenSize.placeholder")}}
+        {{formGroup systemFields.tokenSize.fields.height value=source.system.tokenSize.height localize=true placeholder=(localize "DAGGERHEART.Items.Beastform.FIELDS.tokenSize.placeholder") }}
+        {{formGroup systemFields.tokenSize.fields.width value=source.system.tokenSize.width localize=true placeholder=(localize "DAGGERHEART.Items.Beastform.FIELDS.tokenSize.placeholder")}}
     </fieldset>
 </section>

--- a/templates/sheets/items/beastform/settings.hbs
+++ b/templates/sheets/items/beastform/settings.hbs
@@ -9,19 +9,19 @@
     </div>
 
      <fieldset class="two-columns">
-        <legend>{{localize "DAGGERHEART.Items.Beastform.FIELDS.advantageOn.label"}}</legend>
+        <legend>{{localize "DAGGERHEART.ITEMS.Beastform.FIELDS.advantageOn.label"}}</legend>
         
         {{!-- {{formGroup systemFields.examples value=source.system.examples localize=true}} --}}
     </fieldset>
 
     <fieldset class="two-columns even">
-        <legend>{{localize "DAGGERHEART.Items.Beastform.tokenTitle"}}</legend>
+        <legend>{{localize "DAGGERHEART.ITEMS.Beastform.tokenTitle"}}</legend>
 
         <div class="full-width">
             {{formGroup systemFields.tokenImg value=source.system.tokenImg localize=true}}
         </div>
 
-        {{formGroup systemFields.tokenSize.fields.height value=source.system.tokenSize.height localize=true placeholder=(localize "DAGGERHEART.Items.Beastform.FIELDS.tokenSize.placeholder") }}
-        {{formGroup systemFields.tokenSize.fields.width value=source.system.tokenSize.width localize=true placeholder=(localize "DAGGERHEART.Items.Beastform.FIELDS.tokenSize.placeholder")}}
+        {{formGroup systemFields.tokenSize.fields.height value=source.system.tokenSize.height localize=true placeholder=(localize "DAGGERHEART.ITEMS.Beastform.FIELDS.tokenSize.placeholder") }}
+        {{formGroup systemFields.tokenSize.fields.width value=source.system.tokenSize.width localize=true placeholder=(localize "DAGGERHEART.ITEMS.Beastform.FIELDS.tokenSize.placeholder")}}
     </fieldset>
 </section>

--- a/templates/sheets/items/class/features.hbs
+++ b/templates/sheets/items/class/features.hbs
@@ -5,7 +5,7 @@
 >
     <div class="two-columns even">
         <fieldset>
-            <legend>{{localize "DAGGERHEART.Items.Class.hopeFeatures"}} <a><i class="fa-solid fa-plus icon-button" data-type="hope" data-action="addFeature"></i></a></legend>
+            <legend>{{localize "DAGGERHEART.ITEMS.Class.hopeFeatures"}} <a><i class="fa-solid fa-plus icon-button" data-type="hope" data-action="addFeature"></i></a></legend>
             <div class="feature-list">
                 {{#each source.system.hopeFeatures as |feature|}}
                     {{> 'systems/daggerheart/templates/sheets/global/partials/feature-section-item.hbs' type='hope' feature=feature}}
@@ -14,7 +14,7 @@
         </fieldset>
 
         <fieldset>
-            <legend>{{localize "DAGGERHEART.Items.Class.classFeatures"}} <a><i class="fa-solid fa-plus icon-button" data-type="class" data-action="addFeature"></i></a></legend>
+            <legend>{{localize "DAGGERHEART.ITEMS.Class.classFeatures"}} <a><i class="fa-solid fa-plus icon-button" data-type="class" data-action="addFeature"></i></a></legend>
             <div class="feature-list">
                 {{#each source.system.classFeatures as |feature|}}
                     {{> 'systems/daggerheart/templates/sheets/global/partials/feature-section-item.hbs' type='class' feature=feature}}

--- a/templates/sheets/items/class/features.hbs
+++ b/templates/sheets/items/class/features.hbs
@@ -5,7 +5,7 @@
 >
     <div class="two-columns even">
         <fieldset>
-            <legend>{{localize "DAGGERHEART.Sheets.Class.HopeFeatures"}} <a><i class="fa-solid fa-plus icon-button" data-type="hope" data-action="addFeature"></i></a></legend>
+            <legend>{{localize "DAGGERHEART.Items.Class.hopeFeatures"}} <a><i class="fa-solid fa-plus icon-button" data-type="hope" data-action="addFeature"></i></a></legend>
             <div class="feature-list">
                 {{#each source.system.hopeFeatures as |feature|}}
                     {{> 'systems/daggerheart/templates/sheets/global/partials/feature-section-item.hbs' type='hope' feature=feature}}
@@ -14,7 +14,7 @@
         </fieldset>
 
         <fieldset>
-            <legend>{{localize "DAGGERHEART.Sheets.Class.ClassFeatures"}} <a><i class="fa-solid fa-plus icon-button" data-type="class" data-action="addFeature"></i></a></legend>
+            <legend>{{localize "DAGGERHEART.Items.Class.classFeatures"}} <a><i class="fa-solid fa-plus icon-button" data-type="class" data-action="addFeature"></i></a></legend>
             <div class="feature-list">
                 {{#each source.system.classFeatures as |feature|}}
                     {{> 'systems/daggerheart/templates/sheets/global/partials/feature-section-item.hbs' type='class' feature=feature}}
@@ -38,7 +38,7 @@
                                 class='effect-control'
                                 data-action='viewDoc'
                                 data-uuid={{subclass.uuid}}
-                                data-tooltip='{{localize "DAGGERHEART.Tooltip.openItemWorld"}}'
+                                data-tooltip='{{localize "DAGGERHEART.UI.Tooltip.openItemWorld"}}'
                             >
                                 <i class="fa-solid fa-globe"></i>
                             </a>
@@ -47,7 +47,7 @@
                                 data-action='removeItemFromCollection'
                                 data-target="subclasses"
                                 data-uuid={{subclass.uuid}}
-                                data-tooltip='{{localize "DAGGERHEART.Tooltip.delete"}}'
+                                data-tooltip='{{localize "CONTROLS.CommonDelete"}}'
                             >
                                 <i class='fas fa-trash'></i>
                             </a>

--- a/templates/sheets/items/class/header.hbs
+++ b/templates/sheets/items/class/header.hbs
@@ -5,7 +5,7 @@
         <div class='item-description'>
             <h3>{{localize 'TYPES.Item.class'}}</h3>
             <h3 class="form-fields domain-section">
-                <span>{{localize "DAGGERHEART.Sheets.Class.Domains"}}</span>
+                <span>{{localize "DAGGERHEART.General.Domain.plural"}}</span>
                 <input class="domain-input" value="{{domains}}" />
             </h3>
         </div>

--- a/templates/sheets/items/class/header.hbs
+++ b/templates/sheets/items/class/header.hbs
@@ -5,7 +5,7 @@
         <div class='item-description'>
             <h3>{{localize 'TYPES.Item.class'}}</h3>
             <h3 class="form-fields domain-section">
-                <span>{{localize "DAGGERHEART.General.Domain.plural"}}</span>
+                <span>{{localize "DAGGERHEART.GENERAL.Domain.plural"}}</span>
                 <input class="domain-input" value="{{domains}}" />
             </h3>
         </div>

--- a/templates/sheets/items/class/settings.hbs
+++ b/templates/sheets/items/class/settings.hbs
@@ -11,31 +11,31 @@
 
     <div class="fieldsets-section">
         <fieldset class="drop-section two-columns">
-            <legend>{{localize "DAGGERHEART.Sheets.Class.Guide.Suggestions.Traits.Title"}}</legend>
+            <legend>{{localize "DAGGERHEART.General.Trait.plural"}}</legend>
 
-            <span>{{localize "DAGGERHEART.Abilities.agility.name"}}</span>
+            <span>{{localize "DAGGERHEART.Config.Traits.agility.name"}}</span>
             <input type="text" name="system.characterGuide.suggestedTraits.agility" value="{{source.system.characterGuide.suggestedTraits.agility}}" />
 
-            <span>{{localize "DAGGERHEART.Abilities.strength.name"}}</span>
+            <span>{{localize "DAGGERHEART.Config.Traits.strength.name"}}</span>
             <input type="text" name="system.characterGuide.suggestedTraits.strength" value="{{source.system.characterGuide.suggestedTraits.strength}}" />
 
-            <span>{{localize "DAGGERHEART.Abilities.finesse.name"}}</span>
+            <span>{{localize "DAGGERHEART.Config.Traits.finesse.name"}}</span>
             <input type="text" name="system.characterGuide.suggestedTraits.finesse" value="{{source.system.characterGuide.suggestedTraits.finesse}}" />
 
-            <span>{{localize "DAGGERHEART.Abilities.instinct.name"}}</span>
+            <span>{{localize "DAGGERHEART.Config.Traits.instinct.name"}}</span>
             <input type="text" name="system.characterGuide.suggestedTraits.instinct" value="{{source.system.characterGuide.suggestedTraits.instinct}}" />
 
-            <span>{{localize "DAGGERHEART.Abilities.presence.name"}}</span>
+            <span>{{localize "DAGGERHEART.Config.Traits.presence.name"}}</span>
             <input type="text" name="system.characterGuide.suggestedTraits.presence" value="{{source.system.characterGuide.suggestedTraits.presence}}" />
 
-            <span>{{localize "DAGGERHEART.Abilities.knowledge.name"}}</span>
+            <span>{{localize "DAGGERHEART.Config.Traits.knowledge.name"}}</span>
             <input type="text" name="system.characterGuide.suggestedTraits.knowledge" value="{{source.system.characterGuide.suggestedTraits.knowledge}}" />
         </fieldset>
 
         <fieldset class="one-column">
-            <legend>{{localize "DAGGERHEART.Sheets.Class.Guide.Suggestions.Title"}}</legend>
+            <legend>{{localize "DAGGERHEART.Items.Class.guide.suggestedEquipment"}}</legend>
             <fieldset class="one-column drop-section primary-weapon-section">
-                <legend>{{localize "DAGGERHEART.Sheets.Class.Guide.SuggestedPrimaryWeaponTitle"}}</legend>
+                <legend>{{localize "DAGGERHEART.Items.Class.guide.suggestedPrimaryWeaponTitle"}}</legend>
                 <div class="drop-section-body list-items">
                     {{#if document.system.characterGuide.suggestedPrimaryWeapon}}
                         <div class="suggested-item item-line" data-action="viewDoc" data-uuid="{{document.system.characterGuide.suggestedPrimaryWeapon.uuid}}">
@@ -50,7 +50,7 @@
             </fieldset>
 
             <fieldset class="one-column drop-section secondary-weapon-section">
-                <legend>{{localize "DAGGERHEART.Sheets.Class.Guide.SuggestedSecondaryWeaponTitle"}}</legend>
+                <legend>{{localize "DAGGERHEART.Items.Class.guide.suggestedSecondaryWeaponTitle"}}</legend>
                 <div class="drop-section-body list-items">
                     {{#if document.system.characterGuide.suggestedSecondaryWeapon}}
                         <div class="suggested-item item-line" data-action="viewDoc" data-uuid="{{system.system.characterGuide.suggestedSecondaryWeapon.uuid}}">
@@ -65,7 +65,7 @@
             </fieldset>
 
             <fieldset class="one-column drop-section armor-section">
-                <legend>{{localize "DAGGERHEART.Sheets.Class.Guide.SuggestedArmorTitle"}}</legend>
+                <legend>{{localize "DAGGERHEART.Items.Class.guide.suggestedArmorTitle"}}</legend>
                 <div class="drop-section-body list-items">
                     {{#if document.system.characterGuide.suggestedArmor}}
                         <div class="suggested-item item-line" data-action="viewDoc" data-uuid="{{document.system.characterGuide.suggestedArmor.uuid}}">
@@ -81,9 +81,9 @@
         </fieldset>
 
         <fieldset class="one-column">
-            <legend>{{localize "DAGGERHEART.Sheets.Class.Guide.Inventory.Title"}}</legend>
+            <legend>{{localize "DAGGERHEART.General.inventory"}}</legend>
             <fieldset class="one-column drop-section take-section">
-                <legend>{{localize "DAGGERHEART.Sheets.Class.Guide.Inventory.Take"}}</legend>
+                <legend>{{localize "DAGGERHEART.General.take"}}</legend>
                 <div class="drop-section-body list-items">
                     {{#each source.system.inventory.take}}
                         <div class="suggested-item item-line" data-action="viewDoc" data-uuid="{{this.uuid}}">
@@ -98,7 +98,7 @@
             </fieldset>
 
             <fieldset class="one-column drop-section choice-a-section">
-                <legend>{{localize "DAGGERHEART.Sheets.Class.Guide.Inventory.ThenChoose"}}</legend>
+                <legend>{{localize "DAGGERHEART.Items.Class.guide.inventory.thenChoose"}}</legend>
                 <div class="drop-section-body list-items">
                     {{#each source.system.inventory.choiceA}}
                         <div class="suggested-item item-line" data-action="viewDoc" data-uuid="{{this.uuid}}">
@@ -113,7 +113,7 @@
             </fieldset>
 
             <fieldset class="one-column drop-section choice-b-section">
-                <legend>{{localize "DAGGERHEART.Sheets.Class.Guide.Inventory.AndEither"}}</legend>
+                <legend>{{localize "DAGGERHEART.Items.Class.guide.inventory.andEither"}}</legend>
                 <div class="drop-section-body list-items">
                     {{#each source.system.inventory.choiceB}}
                         <div class="suggested-item item-line" data-action="viewDoc" data-uuid="{{this.uuid}}">

--- a/templates/sheets/items/class/settings.hbs
+++ b/templates/sheets/items/class/settings.hbs
@@ -11,31 +11,31 @@
 
     <div class="fieldsets-section">
         <fieldset class="drop-section two-columns">
-            <legend>{{localize "DAGGERHEART.General.Trait.plural"}}</legend>
+            <legend>{{localize "DAGGERHEART.GENERAL.Trait.plural"}}</legend>
 
-            <span>{{localize "DAGGERHEART.Config.Traits.agility.name"}}</span>
+            <span>{{localize "DAGGERHEART.CONFIG.Traits.agility.name"}}</span>
             <input type="text" name="system.characterGuide.suggestedTraits.agility" value="{{source.system.characterGuide.suggestedTraits.agility}}" />
 
-            <span>{{localize "DAGGERHEART.Config.Traits.strength.name"}}</span>
+            <span>{{localize "DAGGERHEART.CONFIG.Traits.strength.name"}}</span>
             <input type="text" name="system.characterGuide.suggestedTraits.strength" value="{{source.system.characterGuide.suggestedTraits.strength}}" />
 
-            <span>{{localize "DAGGERHEART.Config.Traits.finesse.name"}}</span>
+            <span>{{localize "DAGGERHEART.CONFIG.Traits.finesse.name"}}</span>
             <input type="text" name="system.characterGuide.suggestedTraits.finesse" value="{{source.system.characterGuide.suggestedTraits.finesse}}" />
 
-            <span>{{localize "DAGGERHEART.Config.Traits.instinct.name"}}</span>
+            <span>{{localize "DAGGERHEART.CONFIG.Traits.instinct.name"}}</span>
             <input type="text" name="system.characterGuide.suggestedTraits.instinct" value="{{source.system.characterGuide.suggestedTraits.instinct}}" />
 
-            <span>{{localize "DAGGERHEART.Config.Traits.presence.name"}}</span>
+            <span>{{localize "DAGGERHEART.CONFIG.Traits.presence.name"}}</span>
             <input type="text" name="system.characterGuide.suggestedTraits.presence" value="{{source.system.characterGuide.suggestedTraits.presence}}" />
 
-            <span>{{localize "DAGGERHEART.Config.Traits.knowledge.name"}}</span>
+            <span>{{localize "DAGGERHEART.CONFIG.Traits.knowledge.name"}}</span>
             <input type="text" name="system.characterGuide.suggestedTraits.knowledge" value="{{source.system.characterGuide.suggestedTraits.knowledge}}" />
         </fieldset>
 
         <fieldset class="one-column">
-            <legend>{{localize "DAGGERHEART.Items.Class.guide.suggestedEquipment"}}</legend>
+            <legend>{{localize "DAGGERHEART.ITEMS.Class.guide.suggestedEquipment"}}</legend>
             <fieldset class="one-column drop-section primary-weapon-section">
-                <legend>{{localize "DAGGERHEART.Items.Class.guide.suggestedPrimaryWeaponTitle"}}</legend>
+                <legend>{{localize "DAGGERHEART.ITEMS.Class.guide.suggestedPrimaryWeaponTitle"}}</legend>
                 <div class="drop-section-body list-items">
                     {{#if document.system.characterGuide.suggestedPrimaryWeapon}}
                         <div class="suggested-item item-line" data-action="viewDoc" data-uuid="{{document.system.characterGuide.suggestedPrimaryWeapon.uuid}}">
@@ -50,7 +50,7 @@
             </fieldset>
 
             <fieldset class="one-column drop-section secondary-weapon-section">
-                <legend>{{localize "DAGGERHEART.Items.Class.guide.suggestedSecondaryWeaponTitle"}}</legend>
+                <legend>{{localize "DAGGERHEART.ITEMS.Class.guide.suggestedSecondaryWeaponTitle"}}</legend>
                 <div class="drop-section-body list-items">
                     {{#if document.system.characterGuide.suggestedSecondaryWeapon}}
                         <div class="suggested-item item-line" data-action="viewDoc" data-uuid="{{system.system.characterGuide.suggestedSecondaryWeapon.uuid}}">
@@ -65,7 +65,7 @@
             </fieldset>
 
             <fieldset class="one-column drop-section armor-section">
-                <legend>{{localize "DAGGERHEART.Items.Class.guide.suggestedArmorTitle"}}</legend>
+                <legend>{{localize "DAGGERHEART.ITEMS.Class.guide.suggestedArmorTitle"}}</legend>
                 <div class="drop-section-body list-items">
                     {{#if document.system.characterGuide.suggestedArmor}}
                         <div class="suggested-item item-line" data-action="viewDoc" data-uuid="{{document.system.characterGuide.suggestedArmor.uuid}}">
@@ -81,9 +81,9 @@
         </fieldset>
 
         <fieldset class="one-column">
-            <legend>{{localize "DAGGERHEART.General.inventory"}}</legend>
+            <legend>{{localize "DAGGERHEART.GENERAL.inventory"}}</legend>
             <fieldset class="one-column drop-section take-section">
-                <legend>{{localize "DAGGERHEART.General.take"}}</legend>
+                <legend>{{localize "DAGGERHEART.GENERAL.take"}}</legend>
                 <div class="drop-section-body list-items">
                     {{#each source.system.inventory.take}}
                         <div class="suggested-item item-line" data-action="viewDoc" data-uuid="{{this.uuid}}">
@@ -98,7 +98,7 @@
             </fieldset>
 
             <fieldset class="one-column drop-section choice-a-section">
-                <legend>{{localize "DAGGERHEART.Items.Class.guide.inventory.thenChoose"}}</legend>
+                <legend>{{localize "DAGGERHEART.ITEMS.Class.guide.inventory.thenChoose"}}</legend>
                 <div class="drop-section-body list-items">
                     {{#each source.system.inventory.choiceA}}
                         <div class="suggested-item item-line" data-action="viewDoc" data-uuid="{{this.uuid}}">
@@ -113,7 +113,7 @@
             </fieldset>
 
             <fieldset class="one-column drop-section choice-b-section">
-                <legend>{{localize "DAGGERHEART.Items.Class.guide.inventory.andEither"}}</legend>
+                <legend>{{localize "DAGGERHEART.ITEMS.Class.guide.inventory.andEither"}}</legend>
                 <div class="drop-section-body list-items">
                     {{#each source.system.inventory.choiceB}}
                         <div class="suggested-item item-line" data-action="viewDoc" data-uuid="{{this.uuid}}">

--- a/templates/sheets/items/consumable/settings.hbs
+++ b/templates/sheets/items/consumable/settings.hbs
@@ -5,10 +5,10 @@
 >
     <fieldset class="two-columns">
         <legend>{{localize tabs.settings.label}}</legend>
-        <span>{{localize "DAGGERHEART.General.quantity"}}</span>
+        <span>{{localize "DAGGERHEART.GENERAL.quantity"}}</span>
         {{formField systemFields.quantity value=source.system.quantity}}
 
-        <span>{{localize "DAGGERHEART.Items.Consumable.consumeOnUse"}}</span>
+        <span>{{localize "DAGGERHEART.ITEMS.Consumable.consumeOnUse"}}</span>
         {{formField systemFields.consumeOnUse value=source.system.consumeOnUse}}
     </fieldset>
 </section>

--- a/templates/sheets/items/consumable/settings.hbs
+++ b/templates/sheets/items/consumable/settings.hbs
@@ -5,10 +5,10 @@
 >
     <fieldset class="two-columns">
         <legend>{{localize tabs.settings.label}}</legend>
-        <span>{{localize "DAGGERHEART.Sheets.Consumable.Quantity"}}</span>
+        <span>{{localize "DAGGERHEART.General.quantity"}}</span>
         {{formField systemFields.quantity value=source.system.quantity}}
 
-        <span>{{localize "DAGGERHEART.Sheets.Consumable.ConsumeOnUse"}}</span>
+        <span>{{localize "DAGGERHEART.Items.Consumable.consumeOnUse"}}</span>
         {{formField systemFields.consumeOnUse value=source.system.consumeOnUse}}
     </fieldset>
 </section>

--- a/templates/sheets/items/domainCard/header.hbs
+++ b/templates/sheets/items/domainCard/header.hbs
@@ -2,7 +2,7 @@
     <img class='profile' src='{{source.img}}' data-action='editImage' data-edit='img' />
     <div class="item-icons-list">
         <span class="item-icon">
-            <span class="recall-label">{{localize "DAGGERHEART.Sheets.DomainCard.RecallCost"}}</span>
+            <span class="recall-label">{{localize "DAGGERHEART.Items.DomainCard.recallCost"}}</span>
             <span class="recall-value">{{source.system.recallCost}}</span>
             <i class="fa-solid fa-bolt"></i>
         </span>
@@ -12,11 +12,11 @@
         <div class='item-description'>
             <h3>{{localize 'TYPES.Item.domainCard'}}</h3>
             <h3>
-                {{localize (concat 'DAGGERHEART.Domain.CardTypes.' source.system.type)}}
+                {{localize (concat 'DAGGERHEART.Config.DomainCardTypes.' source.system.type)}}
                 <span>-</span>
-                {{localize (concat 'DAGGERHEART.Domains.' source.system.domain '.label')}}
+                {{localize (concat 'DAGGERHEART.General.Domain.' source.system.domain '.label')}}
                 <span>-</span>
-                {{localize "DAGGERHEART.Sheets.DomainCard.Level"}}:
+                {{localize "DAGGERHEART.General.level"}}:
                 {{source.system.level}}
             </h3>
         </div>

--- a/templates/sheets/items/domainCard/header.hbs
+++ b/templates/sheets/items/domainCard/header.hbs
@@ -2,7 +2,7 @@
     <img class='profile' src='{{source.img}}' data-action='editImage' data-edit='img' />
     <div class="item-icons-list">
         <span class="item-icon">
-            <span class="recall-label">{{localize "DAGGERHEART.Items.DomainCard.recallCost"}}</span>
+            <span class="recall-label">{{localize "DAGGERHEART.ITEMS.DomainCard.recallCost"}}</span>
             <span class="recall-value">{{source.system.recallCost}}</span>
             <i class="fa-solid fa-bolt"></i>
         </span>
@@ -12,11 +12,11 @@
         <div class='item-description'>
             <h3>{{localize 'TYPES.Item.domainCard'}}</h3>
             <h3>
-                {{localize (concat 'DAGGERHEART.Config.DomainCardTypes.' source.system.type)}}
+                {{localize (concat 'DAGGERHEART.CONFIG.DomainCardTypes.' source.system.type)}}
                 <span>-</span>
-                {{localize (concat 'DAGGERHEART.General.Domain.' source.system.domain '.label')}}
+                {{localize (concat 'DAGGERHEART.GENERAL.Domain.' source.system.domain '.label')}}
                 <span>-</span>
-                {{localize "DAGGERHEART.General.level"}}:
+                {{localize "DAGGERHEART.GENERAL.level"}}:
                 {{source.system.level}}
             </h3>
         </div>

--- a/templates/sheets/items/domainCard/settings.hbs
+++ b/templates/sheets/items/domainCard/settings.hbs
@@ -6,15 +6,15 @@
     <fieldset class="two-columns">
         <legend>{{localize tabs.settings.label}}</legend>
 
-        <span>{{localize "DAGGERHEART.General.type"}}</span>
+        <span>{{localize "DAGGERHEART.GENERAL.type"}}</span>
         {{formField systemFields.type value=source.system.type localize=true}}
-        <span>{{localize "DAGGERHEART.Items.DomainCard.foundation"}}</span>
+        <span>{{localize "DAGGERHEART.ITEMS.DomainCard.foundation"}}</span>
         {{formField systemFields.foundation value=source.system.foundation }}
-        <span>{{localize "DAGGERHEART.General.Domain.single"}}</span>
+        <span>{{localize "DAGGERHEART.GENERAL.Domain.single"}}</span>
         {{formField systemFields.domain value=source.system.domain localize=true}}
-        <span>{{localize "DAGGERHEART.General.level"}}</span>
+        <span>{{localize "DAGGERHEART.GENERAL.level"}}</span>
         {{formField systemFields.level value=source.system.level data-dtype="Number"}}
-        <span>{{localize "DAGGERHEART.Items.DomainCard.recallCost"}}</span>
+        <span>{{localize "DAGGERHEART.ITEMS.DomainCard.recallCost"}}</span>
         {{formField systemFields.recallCost value=source.system.recallCost data-dtype="Number"}}
     </fieldset>
 </section>

--- a/templates/sheets/items/domainCard/settings.hbs
+++ b/templates/sheets/items/domainCard/settings.hbs
@@ -6,15 +6,15 @@
     <fieldset class="two-columns">
         <legend>{{localize tabs.settings.label}}</legend>
 
-        <span>{{localize "DAGGERHEART.Sheets.DomainCard.Type"}}</span>
+        <span>{{localize "DAGGERHEART.General.type"}}</span>
         {{formField systemFields.type value=source.system.type localize=true}}
-        <span>{{localize "DAGGERHEART.Sheets.DomainCard.Foundation"}}</span>
+        <span>{{localize "DAGGERHEART.Items.DomainCard.foundation"}}</span>
         {{formField systemFields.foundation value=source.system.foundation }}
-        <span>{{localize "DAGGERHEART.Sheets.DomainCard.Domain"}}</span>
+        <span>{{localize "DAGGERHEART.General.Domain.single"}}</span>
         {{formField systemFields.domain value=source.system.domain localize=true}}
-        <span>{{localize "DAGGERHEART.Sheets.DomainCard.Level"}}</span>
+        <span>{{localize "DAGGERHEART.General.level"}}</span>
         {{formField systemFields.level value=source.system.level data-dtype="Number"}}
-        <span>{{localize "DAGGERHEART.Sheets.DomainCard.RecallCost"}}</span>
+        <span>{{localize "DAGGERHEART.Items.DomainCard.recallCost"}}</span>
         {{formField systemFields.recallCost value=source.system.recallCost data-dtype="Number"}}
     </fieldset>
 </section>

--- a/templates/sheets/items/miscellaneous/settings.hbs
+++ b/templates/sheets/items/miscellaneous/settings.hbs
@@ -5,7 +5,7 @@
 >
     <fieldset class="two-columns">
         <legend>{{localize tabs.settings.label}}</legend>
-        <span>{{localize "DAGGERHEART.General.quantity"}}</span>
+        <span>{{localize "DAGGERHEART.GENERAL.quantity"}}</span>
         {{formField systemFields.quantity value=source.system.quantity}}
     </fieldset>
 </section>

--- a/templates/sheets/items/miscellaneous/settings.hbs
+++ b/templates/sheets/items/miscellaneous/settings.hbs
@@ -5,7 +5,7 @@
 >
     <fieldset class="two-columns">
         <legend>{{localize tabs.settings.label}}</legend>
-        <span>{{localize "DAGGERHEART.Sheets.Miscellaneous.Quantity"}}</span>
+        <span>{{localize "DAGGERHEART.General.quantity"}}</span>
         {{formField systemFields.quantity value=source.system.quantity}}
     </fieldset>
 </section>

--- a/templates/sheets/items/subclass/features.hbs
+++ b/templates/sheets/items/subclass/features.hbs
@@ -5,7 +5,7 @@
 >
     <fieldset class="drop-section" data-type="foundationFeature">
         <legend>
-            {{localize "DAGGERHEART.Sheets.Subclass.Tabs.Foundation"}} 
+            {{localize "DAGGERHEART.General.Tabs.foundation"}} 
             <a {{#if source.system.foundationFeature}}disabled{{/if}}><i data-action="addFeature" data-type="foundationFeature" class="fa-solid fa-plus icon-button {{#if source.system.foundationFeature}}disabled{{/if}}"></i></a>
         </legend>
 
@@ -18,7 +18,7 @@
 
     <fieldset class="drop-section" data-type="specializationFeature">
         <legend>
-            {{localize "DAGGERHEART.Sheets.Subclass.Tabs.Specialization"}} 
+            {{localize "DAGGERHEART.General.Tabs.specialization"}} 
             <a {{#if source.system.specializationFeature}}disabled{{/if}}><i data-action="addFeature" data-type="specializationFeature" class="fa-solid fa-plus icon-button {{#if source.system.specializationFeature}}disabled{{/if}}"></i></a>
         </legend>
 
@@ -31,7 +31,7 @@
 
     <fieldset class="drop-section" data-type="masteryFeature">
         <legend>
-            {{localize "DAGGERHEART.Sheets.Subclass.Tabs.Mastery"}} 
+            {{localize "DAGGERHEART.General.Tabs.mastery"}} 
             <a {{#if source.system.masteryFeature}}disabled{{/if}}><i data-action="addFeature" data-type="masteryFeature" class="fa-solid fa-plus icon-button {{#if source.system.masteryFeature}}disabled{{/if}}"></i></a>
         </legend>
 

--- a/templates/sheets/items/subclass/features.hbs
+++ b/templates/sheets/items/subclass/features.hbs
@@ -5,7 +5,7 @@
 >
     <fieldset class="drop-section" data-type="foundationFeature">
         <legend>
-            {{localize "DAGGERHEART.General.Tabs.foundation"}} 
+            {{localize "DAGGERHEART.GENERAL.Tabs.foundation"}} 
             <a {{#if source.system.foundationFeature}}disabled{{/if}}><i data-action="addFeature" data-type="foundationFeature" class="fa-solid fa-plus icon-button {{#if source.system.foundationFeature}}disabled{{/if}}"></i></a>
         </legend>
 
@@ -18,7 +18,7 @@
 
     <fieldset class="drop-section" data-type="specializationFeature">
         <legend>
-            {{localize "DAGGERHEART.General.Tabs.specialization"}} 
+            {{localize "DAGGERHEART.GENERAL.Tabs.specialization"}} 
             <a {{#if source.system.specializationFeature}}disabled{{/if}}><i data-action="addFeature" data-type="specializationFeature" class="fa-solid fa-plus icon-button {{#if source.system.specializationFeature}}disabled{{/if}}"></i></a>
         </legend>
 
@@ -31,7 +31,7 @@
 
     <fieldset class="drop-section" data-type="masteryFeature">
         <legend>
-            {{localize "DAGGERHEART.General.Tabs.mastery"}} 
+            {{localize "DAGGERHEART.GENERAL.Tabs.mastery"}} 
             <a {{#if source.system.masteryFeature}}disabled{{/if}}><i data-action="addFeature" data-type="masteryFeature" class="fa-solid fa-plus icon-button {{#if source.system.masteryFeature}}disabled{{/if}}"></i></a>
         </legend>
 

--- a/templates/sheets/items/subclass/header.hbs
+++ b/templates/sheets/items/subclass/header.hbs
@@ -4,7 +4,7 @@
         <h1 class='item-name'><input type='text' name='name' value='{{source.name}}' /></h1>
         <div class='item-description'>
             <h3>{{localize 'TYPES.Item.subclass'}}</h3>
-            {{#if source.system.spellcastingTrait}}<h3>{{localize (concat 'DAGGERHEART.Config.Traits.' source.system.spellcastingTrait '.name')}}</h3>{{/if}}
+            {{#if source.system.spellcastingTrait}}<h3>{{localize (concat 'DAGGERHEART.CONFIG.Traits.' source.system.spellcastingTrait '.name')}}</h3>{{/if}}
         </div>
     </div>
 </header>

--- a/templates/sheets/items/subclass/header.hbs
+++ b/templates/sheets/items/subclass/header.hbs
@@ -4,7 +4,7 @@
         <h1 class='item-name'><input type='text' name='name' value='{{source.name}}' /></h1>
         <div class='item-description'>
             <h3>{{localize 'TYPES.Item.subclass'}}</h3>
-            {{#if source.system.spellcastingTrait}}<h3>{{localize (concat 'DAGGERHEART.Abilities.' source.system.spellcastingTrait '.name')}}</h3>{{/if}}
+            {{#if source.system.spellcastingTrait}}<h3>{{localize (concat 'DAGGERHEART.Config.Traits.' source.system.spellcastingTrait '.name')}}</h3>{{/if}}
         </div>
     </div>
 </header>

--- a/templates/sheets/items/subclass/settings.hbs
+++ b/templates/sheets/items/subclass/settings.hbs
@@ -6,7 +6,7 @@
 
     <fieldset class="two-columns">
         <legend>{{localize tabs.settings.label}}</legend>
-        <span>{{localize "DAGGERHEART.Items.Subclass.spellcastingTrait"}}</span>
+        <span>{{localize "DAGGERHEART.ITEMS.Subclass.spellcastingTrait"}}</span>
         {{formField systemFields.spellcastingTrait value=source.system.spellcastingTrait localize=true}}
     </fieldset>
 </section>

--- a/templates/sheets/items/subclass/settings.hbs
+++ b/templates/sheets/items/subclass/settings.hbs
@@ -6,7 +6,7 @@
 
     <fieldset class="two-columns">
         <legend>{{localize tabs.settings.label}}</legend>
-        <span>{{localize "DAGGERHEART.Sheets.Subclass.SpellcastingTrait"}}</span>
+        <span>{{localize "DAGGERHEART.Items.Subclass.spellcastingTrait"}}</span>
         {{formField systemFields.spellcastingTrait value=source.system.spellcastingTrait localize=true}}
     </fieldset>
 </section>

--- a/templates/sheets/items/weapon/header.hbs
+++ b/templates/sheets/items/weapon/header.hbs
@@ -5,20 +5,20 @@
         <h1 class='item-name'><input type='text' name='name' value='{{source.name}}' /></h1>
         <div class='item-description'>
             {{#if source.system.secondary}}
-                <h3>{{localize "DAGGERHEART.Sheets.Weapon.SecondaryWeapon"}}</h3>
+                <h3>{{localize "DAGGERHEART.Items.Weapon.secondaryWeapon"}}</h3>
             {{else}}
-                <h3>{{localize "DAGGERHEART.Sheets.Weapon.PrimaryWeapon"}}</h3>
+                <h3>{{localize "DAGGERHEART.Items.Weapon.primaryWeapon"}}</h3>
             {{/if}}
             <h3>
-                {{localize (concat 'DAGGERHEART.Abilities.' source.system.trait '.short')}}
+                {{localize (concat 'DAGGERHEART.Config.Traits.' source.system.trait '.short')}}
                 <span>-</span>
-                {{localize (concat 'DAGGERHEART.Range.' source.system.range '.name')}}
+                {{localize (concat 'DAGGERHEART.Config.Range.' source.system.range '.name')}}
                 <span>-</span>
                 {{log this}}
                 {{source.system.damage.dice}} + {{source.system.damage.bonus}}
-                ({{localize (concat 'DAGGERHEART.DamageType.' source.system.damage.type '.abbreviation')}})
+                ({{localize (concat 'DAGGERHEART.Config.DamageType.' source.system.damage.type '.abbreviation')}})
                 <span>-</span>
-                {{localize (concat 'DAGGERHEART.Burden.' source.system.burden)}}
+                {{localize (concat 'DAGGERHEART.Config.Burden.' source.system.burden)}}
             </h3>
         </div>
     </div>

--- a/templates/sheets/items/weapon/header.hbs
+++ b/templates/sheets/items/weapon/header.hbs
@@ -5,20 +5,20 @@
         <h1 class='item-name'><input type='text' name='name' value='{{source.name}}' /></h1>
         <div class='item-description'>
             {{#if source.system.secondary}}
-                <h3>{{localize "DAGGERHEART.Items.Weapon.secondaryWeapon"}}</h3>
+                <h3>{{localize "DAGGERHEART.ITEMS.Weapon.secondaryWeapon"}}</h3>
             {{else}}
-                <h3>{{localize "DAGGERHEART.Items.Weapon.primaryWeapon"}}</h3>
+                <h3>{{localize "DAGGERHEART.ITEMS.Weapon.primaryWeapon"}}</h3>
             {{/if}}
             <h3>
-                {{localize (concat 'DAGGERHEART.Config.Traits.' source.system.trait '.short')}}
+                {{localize (concat 'DAGGERHEART.CONFIG.Traits.' source.system.trait '.short')}}
                 <span>-</span>
-                {{localize (concat 'DAGGERHEART.Config.Range.' source.system.range '.name')}}
+                {{localize (concat 'DAGGERHEART.CONFIG.Range.' source.system.range '.name')}}
                 <span>-</span>
                 {{log this}}
                 {{source.system.damage.dice}} + {{source.system.damage.bonus}}
-                ({{localize (concat 'DAGGERHEART.Config.DamageType.' source.system.damage.type '.abbreviation')}})
+                ({{localize (concat 'DAGGERHEART.CONFIG.DamageType.' source.system.damage.type '.abbreviation')}})
                 <span>-</span>
-                {{localize (concat 'DAGGERHEART.Config.Burden.' source.system.burden)}}
+                {{localize (concat 'DAGGERHEART.CONFIG.Burden.' source.system.burden)}}
             </h3>
         </div>
     </div>

--- a/templates/sheets/items/weapon/settings.hbs
+++ b/templates/sheets/items/weapon/settings.hbs
@@ -5,30 +5,30 @@
 >
     <fieldset class="two-columns">
         <legend>{{localize tabs.settings.label}}</legend>
-        <span>{{localize "DAGGERHEART.Tiers.singular"}}</span>
+        <span>{{localize "DAGGERHEART.General.Tiers.singular"}}</span>
         {{formField systemFields.tier value=source.system.tier}}
-        <span>{{localize "DAGGERHEART.Sheets.Weapon.SecondaryWeapon"}}</span>
+        <span>{{localize "DAGGERHEART.Items.Weapon.secondaryWeapon"}}</span>
         {{formField systemFields.secondary value=source.system.secondary}}
-        <span>{{localize "DAGGERHEART.Sheets.Weapon.Trait"}}</span>
+        <span>{{localize "DAGGERHEART.General.Trait.single"}}</span>
         {{formField systemFields.trait value=source.system.trait localize=true}}
-        <span>{{localize "DAGGERHEART.Sheets.Weapon.Range"}}</span>
+        <span>{{localize "DAGGERHEART.General.range"}}</span>
         {{formField systemFields.range value=source.system.range localize=true}}
-        <span>{{localize "DAGGERHEART.Sheets.Weapon.Burden"}}</span>
+        <span>{{localize "DAGGERHEART.General.burden"}}</span>
         {{formField systemFields.burden value=source.system.burden localize=true}}
     </fieldset>
 
     <fieldset class="two-columns">
-        <legend>{{localize "DAGGERHEART.Sheets.Weapon.Damage.Title"}}</legend>
-        <span>{{localize "DAGGERHEART.Sheets.Weapon.Damage.Die"}}</span>
+        <legend>{{localize "DAGGERHEART.General.title"}}</legend>
+        <span>{{localize "DAGGERHEART.General.Dice.single"}}</span>
         {{formGroup systemFields.damage.fields.dice value=source.system.damage.dice}}
-        <span>{{localize "DAGGERHEART.Sheets.Weapon.Damage.Bonus"}}</span>
+        <span>{{localize "DAGGERHEART.General.bonus"}}</span>
         {{formGroup systemFields.damage.fields.bonus value=source.system.damage.bonus}}
-        <span>{{localize "DAGGERHEART.Sheets.Weapon.Damage.Type"}}</span>
+        <span>{{localize "DAGGERHEART.General.type"}}</span>
         {{formGroup systemFields.damage.fields.type value=source.system.damage.type localize=true}}
     </fieldset>
     <fieldset class="two-columns">
-        <legend>{{localize "DAGGERHEART.Sheets.Weapon.Feature"}}</legend>
-        <span>{{localize "DAGGERHEART.Sheets.Weapon.Feature"}}</span>
+        <legend>{{localize "TYPES.Item.feature"}}</legend>
+        <span>{{localize "TYPES.Item.feature"}}</span>
         <input type="text" class="features-input" value="{{features}}" />
     </fieldset>
 </section>

--- a/templates/sheets/items/weapon/settings.hbs
+++ b/templates/sheets/items/weapon/settings.hbs
@@ -5,25 +5,25 @@
 >
     <fieldset class="two-columns">
         <legend>{{localize tabs.settings.label}}</legend>
-        <span>{{localize "DAGGERHEART.General.Tiers.singular"}}</span>
+        <span>{{localize "DAGGERHEART.GENERAL.Tiers.singular"}}</span>
         {{formField systemFields.tier value=source.system.tier}}
-        <span>{{localize "DAGGERHEART.Items.Weapon.secondaryWeapon"}}</span>
+        <span>{{localize "DAGGERHEART.ITEMS.Weapon.secondaryWeapon"}}</span>
         {{formField systemFields.secondary value=source.system.secondary}}
-        <span>{{localize "DAGGERHEART.General.Trait.single"}}</span>
+        <span>{{localize "DAGGERHEART.GENERAL.Trait.single"}}</span>
         {{formField systemFields.trait value=source.system.trait localize=true}}
-        <span>{{localize "DAGGERHEART.General.range"}}</span>
+        <span>{{localize "DAGGERHEART.GENERAL.range"}}</span>
         {{formField systemFields.range value=source.system.range localize=true}}
-        <span>{{localize "DAGGERHEART.General.burden"}}</span>
+        <span>{{localize "DAGGERHEART.GENERAL.burden"}}</span>
         {{formField systemFields.burden value=source.system.burden localize=true}}
     </fieldset>
 
     <fieldset class="two-columns">
-        <legend>{{localize "DAGGERHEART.General.title"}}</legend>
-        <span>{{localize "DAGGERHEART.General.Dice.single"}}</span>
+        <legend>{{localize "DAGGERHEART.GENERAL.title"}}</legend>
+        <span>{{localize "DAGGERHEART.GENERAL.Dice.single"}}</span>
         {{formGroup systemFields.damage.fields.dice value=source.system.damage.dice}}
-        <span>{{localize "DAGGERHEART.General.bonus"}}</span>
+        <span>{{localize "DAGGERHEART.GENERAL.bonus"}}</span>
         {{formGroup systemFields.damage.fields.bonus value=source.system.damage.bonus}}
-        <span>{{localize "DAGGERHEART.General.type"}}</span>
+        <span>{{localize "DAGGERHEART.GENERAL.type"}}</span>
         {{formGroup systemFields.damage.fields.type value=source.system.damage.type localize=true}}
     </fieldset>
     <fieldset class="two-columns">

--- a/templates/ui/chat/adversary-attack-roll.hbs
+++ b/templates/ui/chat/adversary-attack-roll.hbs
@@ -1,5 +1,5 @@
 <div class="dice-roll daggerheart chat roll" data-action="expandRoll">
-    <div class="dice-flavor">{{localize "DAGGERHEART.Chat.AttackRoll.Title" attack=this.title}}</div>
+    <div class="dice-flavor">{{localize "DAGGERHEART.UI.Chat.attackRoll.title" attack=this.title}}</div>
     <div class="dice-result">
         <div class="dice-formula">{{roll.formula}}</div>
         <div class="dice-tooltip">
@@ -17,7 +17,7 @@
                                         <li class="roll die {{../denomination}}{{#if discarded}} discarded{{/if}} min">{{result}}</li>
                                     {{/each}}
                                 </ol>
-                                <div class="attack-roll-advantage-container">{{#if ../advantageState}}{{localize "DAGGERHEART.General.Advantage.Full"}}{{/if}}{{#if (eq ../advantageState false)}}{{localize "DAGGERHEART.General.Disadvantage.Full"}}{{/if}}</div>
+                                <div class="attack-roll-advantage-container">{{#if ../advantageState}}{{localize "DAGGERHEART.General.Advantage.full"}}{{/if}}{{#if (eq ../advantageState false)}}{{localize "DAGGERHEART.General.Disadvantage.full"}}{{/if}}</div>
                             </div>
                         {{/each}}
                     </div>

--- a/templates/ui/chat/adversary-attack-roll.hbs
+++ b/templates/ui/chat/adversary-attack-roll.hbs
@@ -17,7 +17,7 @@
                                         <li class="roll die {{../denomination}}{{#if discarded}} discarded{{/if}} min">{{result}}</li>
                                     {{/each}}
                                 </ol>
-                                <div class="attack-roll-advantage-container">{{#if ../advantageState}}{{localize "DAGGERHEART.General.Advantage.full"}}{{/if}}{{#if (eq ../advantageState false)}}{{localize "DAGGERHEART.General.Disadvantage.full"}}{{/if}}</div>
+                                <div class="attack-roll-advantage-container">{{#if ../advantageState}}{{localize "DAGGERHEART.GENERAL.Advantage.full"}}{{/if}}{{#if (eq ../advantageState false)}}{{localize "DAGGERHEART.GENERAL.Disadvantage.full"}}{{/if}}</div>
                             </div>
                         {{/each}}
                     </div>

--- a/templates/ui/chat/adversary-roll.hbs
+++ b/templates/ui/chat/adversary-roll.hbs
@@ -19,7 +19,7 @@
                                 </ol>
                                 {{#if (eq index 0)}}
                                 <div class="attack-roll-advantage-container">
-                                    {{#if (eq ../roll.advantage.type 1)}}{{localize "DAGGERHEART.General.Advantage.full"}}{{/if}}{{#if (eq ../roll.advantage.type -1)}}{{localize "DAGGERHEART.General.Disadvantage.full"}}{{/if}}
+                                    {{#if (eq ../roll.advantage.type 1)}}{{localize "DAGGERHEART.GENERAL.Advantage.full"}}{{/if}}{{#if (eq ../roll.advantage.type -1)}}{{localize "DAGGERHEART.GENERAL.Disadvantage.full"}}{{/if}}
                                 </div>
                                 {{/if}}
                             </div>

--- a/templates/ui/chat/adversary-roll.hbs
+++ b/templates/ui/chat/adversary-roll.hbs
@@ -19,7 +19,7 @@
                                 </ol>
                                 {{#if (eq index 0)}}
                                 <div class="attack-roll-advantage-container">
-                                    {{#if (eq ../roll.advantage.type 1)}}{{localize "DAGGERHEART.General.Advantage.Full"}}{{/if}}{{#if (eq ../roll.advantage.type -1)}}{{localize "DAGGERHEART.General.Disadvantage.Full"}}{{/if}}
+                                    {{#if (eq ../roll.advantage.type 1)}}{{localize "DAGGERHEART.General.Advantage.full"}}{{/if}}{{#if (eq ../roll.advantage.type -1)}}{{localize "DAGGERHEART.General.Disadvantage.full"}}{{/if}}
                                 </div>
                                 {{/if}}
                             </div>
@@ -49,12 +49,11 @@
     <div class="dice-result">
         {{#if damage.roll}}
         <div class="dice-actions">
-            {{!-- <button class="damage-button" data-target-hit="true" {{#if (eq targets.length 0)}}disabled{{/if}}>{{localize "DAGGERHEART.Chat.DamageRoll.DealDamageToTargets"}}</button>   --}}
-            <button class="damage-button">{{localize "DAGGERHEART.Chat.DamageRoll.DealDamage"}}</button>  
+            <button class="damage-button">{{localize "DAGGERHEART.UI.Chat.DamageRoll.dealDamage"}}</button>  
         </div>
         {{else}}
         <div class="flexrow">
-            <button class="duality-action duality-action-damage" data-value="{{roll.total}}"><span>{{localize "DAGGERHEART.Chat.DamageRoll.RollDamage"}}</span></button>  
+            <button class="duality-action duality-action-damage" data-value="{{roll.total}}"><span>{{localize "DAGGERHEART.UI.Chat.damageRoll.rollDamage"}}</span></button>  
         </div>
         {{/if}}
     </div>

--- a/templates/ui/chat/apply-effects.hbs
+++ b/templates/ui/chat/apply-effects.hbs
@@ -3,7 +3,7 @@
     <div>{{{description}}}</div>
     <div class="dice-result">
         <div class="dice-actions">
-            <button class="duality-action-effect">{{localize "DAGGERHEART.Chat.AttackRoll.ApplyEffect"}}</button>
+            <button class="duality-action-effect">{{localize "DAGGERHEART.UI.Chat.attackRoll.applyEffect"}}</button>
         </div>
     </div>
 </div>

--- a/templates/ui/chat/damage-roll.hbs
+++ b/templates/ui/chat/damage-roll.hbs
@@ -3,7 +3,7 @@
 <div class="dice-roll daggerheart chat roll">
     <div class="dice-result">
         <div class="dice-actions">
-            <button class="damage-button" data-target-hit="true" {{#if (eq targets.length 0)}}disabled{{/if}}>{{localize "DAGGERHEART.Chat.DamageRoll.DealDamageToTargets"}}</button>  
+            <button class="damage-button" data-target-hit="true" {{#if (eq targets.length 0)}}disabled{{/if}}>{{localize "DAGGERHEART.UI.Chat.damageRoll.dealDamageToTargets"}}</button>  
             <button class="damage-button">{{localize "DAGGERHEART.Chat.DamageRoll.DealDamage"}}</button>  
         </div>
     </div>

--- a/templates/ui/chat/deathMove.hbs
+++ b/templates/ui/chat/deathMove.hbs
@@ -1,6 +1,6 @@
 <div class="daggerheart chat downtime">
     <h2 class="downtime-title-container">
-        <div>{{this.player}} {{localize "DAGGERHEART.Chat.DeathMove.Title"}}</div>
+        <div>{{this.player}} {{localize "DAGGERHEART.UI.Chat.deathMove.title"}}</div>
         <div class="downtime-subtitle">{{this.title}}</div>
     </h2>
     <img class="downtime-image" src="{{this.img}}" />

--- a/templates/ui/chat/duality-roll.hbs
+++ b/templates/ui/chat/duality-roll.hbs
@@ -8,12 +8,12 @@
         {{/each}}
         {{#if (eq roll.advantage.type 1)}}
             <div class="duality-modifier">
-                {{localize "DAGGERHEART.General.Advantage.full"}}
+                {{localize "DAGGERHEART.GENERAL.Advantage.full"}}
             </div>
         {{/if}}
         {{#if (eq roll.advantage.type -1)}}
             <div class="duality-modifier">
-                {{localize "DAGGERHEART.General.Disadvantage.full"}}
+                {{localize "DAGGERHEART.GENERAL.Disadvantage.full"}}
             </div>
         {{/if}}
     </div>
@@ -33,10 +33,10 @@
                         </header>
                         <div class="flexrow">
                             <ol class="dice-rolls duality">
-                                <li class="roll die {{roll.hope.dice}}" title="{{localize "DAGGERHEART.General.hope"}}">
+                                <li class="roll die {{roll.hope.dice}}" title="{{localize "DAGGERHEART.GENERAL.hope"}}">
                                     <div class="dice-container">
-                                        <div class="dice-title">{{localize "DAGGERHEART.General.hope"}}</div>
-                                        <div class="dice-inner-container hope" title="{{localize "DAGGERHEART.General.hope"}}">
+                                        <div class="dice-title">{{localize "DAGGERHEART.GENERAL.hope"}}</div>
+                                        <div class="dice-inner-container hope" title="{{localize "DAGGERHEART.GENERAL.hope"}}">
                                             <div class="dice-wrapper">
                                                 <img class="dice" src="../icons/svg/d12-grey.svg"/>
                                             </div>
@@ -44,10 +44,10 @@
                                         </div>
                                     </div>
                                 </li>
-                                <li class="roll die {{roll.fear.dice}}" title="{{localize "DAGGERHEART.General.fear"}}">
+                                <li class="roll die {{roll.fear.dice}}" title="{{localize "DAGGERHEART.GENERAL.fear"}}">
                                     <div class="dice-container">
-                                        <div class="dice-title">{{localize "DAGGERHEART.General.fear"}}</div>
-                                        <div class="dice-inner-container fear" title="{{localize "DAGGERHEART.General.fear"}}">
+                                        <div class="dice-title">{{localize "DAGGERHEART.GENERAL.fear"}}</div>
+                                        <div class="dice-inner-container fear" title="{{localize "DAGGERHEART.GENERAL.fear"}}">
                                             <div class="dice-wrapper">
                                                 <img class="dice" src="../icons/svg/d12-grey.svg"/>
                                             </div>

--- a/templates/ui/chat/duality-roll.hbs
+++ b/templates/ui/chat/duality-roll.hbs
@@ -8,12 +8,12 @@
         {{/each}}
         {{#if (eq roll.advantage.type 1)}}
             <div class="duality-modifier">
-                {{localize "DAGGERHEART.General.Advantage.Full"}}
+                {{localize "DAGGERHEART.General.Advantage.full"}}
             </div>
         {{/if}}
         {{#if (eq roll.advantage.type -1)}}
             <div class="duality-modifier">
-                {{localize "DAGGERHEART.General.Disadvantage.Full"}}
+                {{localize "DAGGERHEART.General.Disadvantage.full"}}
             </div>
         {{/if}}
     </div>
@@ -33,10 +33,10 @@
                         </header>
                         <div class="flexrow">
                             <ol class="dice-rolls duality">
-                                <li class="roll die {{roll.hope.dice}}" title="{{localize "DAGGERHEART.General.Hope"}}">
+                                <li class="roll die {{roll.hope.dice}}" title="{{localize "DAGGERHEART.General.hope"}}">
                                     <div class="dice-container">
-                                        <div class="dice-title">{{localize "DAGGERHEART.General.Hope"}}</div>
-                                        <div class="dice-inner-container hope" title="{{localize "DAGGERHEART.General.Hope"}}">
+                                        <div class="dice-title">{{localize "DAGGERHEART.General.hope"}}</div>
+                                        <div class="dice-inner-container hope" title="{{localize "DAGGERHEART.General.hope"}}">
                                             <div class="dice-wrapper">
                                                 <img class="dice" src="../icons/svg/d12-grey.svg"/>
                                             </div>
@@ -44,10 +44,10 @@
                                         </div>
                                     </div>
                                 </li>
-                                <li class="roll die {{roll.fear.dice}}" title="{{localize "DAGGERHEART.General.Fear"}}">
+                                <li class="roll die {{roll.fear.dice}}" title="{{localize "DAGGERHEART.General.fear"}}">
                                     <div class="dice-container">
-                                        <div class="dice-title">{{localize "DAGGERHEART.General.Fear"}}</div>
-                                        <div class="dice-inner-container fear" title="{{localize "DAGGERHEART.General.Fear"}}">
+                                        <div class="dice-title">{{localize "DAGGERHEART.General.fear"}}</div>
+                                        <div class="dice-inner-container fear" title="{{localize "DAGGERHEART.General.fear"}}">
                                             <div class="dice-wrapper">
                                                 <img class="dice" src="../icons/svg/d12-grey.svg"/>
                                             </div>
@@ -136,15 +136,15 @@
                 {{#if damage.roll}}
                     <button class="duality-action damage-button" data-target-hit="true" data-value="{{roll.total}}"><span>Deal Damage</span></button>
                 {{else}}
-                    <button class="duality-action duality-action-damage" data-value="{{roll.total}}"><span>{{localize "DAGGERHEART.Chat.AttackRoll.RollDamage"}}</span></button>
+                    <button class="duality-action duality-action-damage" data-value="{{roll.total}}"><span>{{localize "DAGGERHEART.UI.Chat.attackRoll.rollDamage"}}</span></button>
                 {{/if}}
             {{else}}
                 {{#if hasHealing}}
-                    <button class="duality-action duality-action-healing" data-value="{{roll.total}}"><span>{{localize "DAGGERHEART.Chat.AttackRoll.RollHealing"}}</span></button>
+                    <button class="duality-action duality-action-healing" data-value="{{roll.total}}"><span>{{localize "DAGGERHEART.UI.Chat.attackRoll.rollHealing"}}</span></button>
                 {{/if}}
             {{/if}}
             {{#if hasEffect}}
-                    <button class="duality-action{{#if (or hasDamage hasHealing)}} duality-action-effect{{/if}}" data-value="{{roll.total}}"><span>{{localize "DAGGERHEART.Chat.AttackRoll.ApplyEffect"}}</span></button>
+                    <button class="duality-action{{#if (or hasDamage hasHealing)}} duality-action-effect{{/if}}" data-value="{{roll.total}}"><span>{{localize "DAGGERHEART.UI.Chat.attackRoll.applyEffect"}}</span></button>
             {{/if}}
             <div class="duality-result">
                 <div>{{roll.total}} {{#if (eq roll.result.duality 1)}}With Hope{{else}}{{#if (eq roll.result.duality -1)}}With Fear{{else}}Critical Success{{/if}}{{/if}}</div>

--- a/templates/ui/chat/healing-roll.hbs
+++ b/templates/ui/chat/healing-roll.hbs
@@ -23,7 +23,7 @@
         </div>
         <div class="dice-total">{{roll.total}}</div>
         <div class="flexrow">
-            <button class="healing-button"><span>{{localize "DAGGERHEART.Chat.HealingRoll.Heal"}}</span></button>  
+            <button class="healing-button"><span>{{localize "DAGGERHEART.UI.Chat.healingRoll.heal"}}</span></button>  
         </div>
     </div>
 </div>

--- a/templates/ui/chat/parts/target-chat.hbs
+++ b/templates/ui/chat/parts/target-chat.hbs
@@ -5,8 +5,8 @@
         <div class="dice-tooltip">
             <div class="wrapper">
                 <div class="target-selection">
-                    <label class="button-target-selection{{#if @root.targetSelection}} target-selected{{/if}}" data-target-hit="true">{{localize "DAGGERHEART.Chat.DamageRoll.HitTarget"}}</label>
-                    <label class="button-target-selection{{#unless @root.targetSelection}} target-selected{{/unless}}">{{localize "DAGGERHEART.Chat.DamageRoll.SelectedTarget"}}</label>
+                    <label class="button-target-selection{{#if @root.targetSelection}} target-selected{{/if}}" data-target-hit="true">{{localize "DAGGERHEART.UI.Chat.damageRoll.hitTarget"}}</label>
+                    <label class="button-target-selection{{#unless @root.targetSelection}} target-selected{{/unless}}">{{localize "DAGGERHEART.UI.Chat.damageRoll.selectedTarget"}}</label>
                 </div>
                 {{#if (and hasSave @root.targetSelection @root.hasHitTarget)}}
                     <button class="inner-button inner-button-right roll-all-save-button">Roll All <i class="fa-solid fa-shield"></i></button>

--- a/templates/ui/combatTracker/combatTracker.hbs
+++ b/templates/ui/combatTracker/combatTracker.hbs
@@ -1,8 +1,8 @@
 <div class="combat-tracker">
     {{#if (gt this.characters.length 0)}}
-        {{> 'systems/daggerheart/templates/ui/combat/combatTrackerSection.hbs' this title=(localize "DAGGERHEART.General.Character.Plural") turns=this.characters}}
+        {{> 'systems/daggerheart/templates/ui/combat/combatTrackerSection.hbs' this title=(localize "DAGGERHEART.General.Character.plural") turns=this.characters}}
     {{/if}}
     {{#if (gt this.adversaries.length 0)}}
-        {{> 'systems/daggerheart/templates/ui/combat/combatTrackerSection.hbs' this title=(localize "DAGGERHEART.General.Adversary.Plural") turns=this.adversaries}}
+        {{> 'systems/daggerheart/templates/ui/combat/combatTrackerSection.hbs' this title=(localize "DAGGERHEART.General.Adversary.plural") turns=this.adversaries}}
     {{/if}}
 </div>

--- a/templates/ui/combatTracker/combatTracker.hbs
+++ b/templates/ui/combatTracker/combatTracker.hbs
@@ -1,8 +1,8 @@
 <div class="combat-tracker">
     {{#if (gt this.characters.length 0)}}
-        {{> 'systems/daggerheart/templates/ui/combat/combatTrackerSection.hbs' this title=(localize "DAGGERHEART.General.Character.plural") turns=this.characters}}
+        {{> 'systems/daggerheart/templates/ui/combat/combatTrackerSection.hbs' this title=(localize "DAGGERHEART.GENERAL.Character.plural") turns=this.characters}}
     {{/if}}
     {{#if (gt this.adversaries.length 0)}}
-        {{> 'systems/daggerheart/templates/ui/combat/combatTrackerSection.hbs' this title=(localize "DAGGERHEART.General.Adversary.plural") turns=this.adversaries}}
+        {{> 'systems/daggerheart/templates/ui/combat/combatTrackerSection.hbs' this title=(localize "DAGGERHEART.GENERAL.Adversary.plural") turns=this.adversaries}}
     {{/if}}
 </div>

--- a/templates/ui/combatTracker/combatTrackerHeader.hbs
+++ b/templates/ui/combatTracker/combatTrackerHeader.hbs
@@ -60,7 +60,7 @@
                     </div>
                     <div>{{fear}}</div>
                 </div>
-                <a class="encounter-countdowns" data-tooltip="{{localize "DAGGERHEART.Applications.Countdown.Title" type=(localize "DAGGERHEART.Applications.Countdown.types.encounter")}}" data-action="openCountdowns"><i class="fa-solid fa-stopwatch"></i></a>
+                <a class="encounter-countdowns" data-tooltip="{{localize "DAGGERHEART.APPLICATIONS.Countdown.Title" type=(localize "DAGGERHEART.APPLICATIONS.Countdown.types.encounter")}}" data-action="openCountdowns"><i class="fa-solid fa-stopwatch"></i></a>
             </div>
         {{/if}}
 
@@ -68,7 +68,7 @@
         <strong class="encounter-title">
             {{#if combats.length}}
             {{#if combat.round}}
-            {{ localize "DAGGERHEART.Applications.CombatTracker.combatStarted" }}
+            {{ localize "DAGGERHEART.APPLICATIONS.CombatTracker.combatStarted" }}
             {{else}}
             {{ localize "COMBAT.NotStarted" }}
             {{/if}}

--- a/templates/ui/combatTracker/combatTrackerHeader.hbs
+++ b/templates/ui/combatTracker/combatTrackerHeader.hbs
@@ -60,7 +60,7 @@
                     </div>
                     <div>{{fear}}</div>
                 </div>
-                <a class="encounter-countdowns" data-tooltip="{{localize "DAGGERHEART.Countdown.Title" type=(localize "DAGGERHEART.Countdown.Types.combat")}}" data-action="openCountdowns"><i class="fa-solid fa-stopwatch"></i></a>
+                <a class="encounter-countdowns" data-tooltip="{{localize "DAGGERHEART.Applications.Countdown.Title" type=(localize "DAGGERHEART.Applications.Countdown.types.encounter")}}" data-action="openCountdowns"><i class="fa-solid fa-stopwatch"></i></a>
             </div>
         {{/if}}
 
@@ -68,7 +68,7 @@
         <strong class="encounter-title">
             {{#if combats.length}}
             {{#if combat.round}}
-            {{ localize "DAGGERHEART.Combat.combatStarted" }}
+            {{ localize "DAGGERHEART.Applications.CombatTracker.combatStarted" }}
             {{else}}
             {{ localize "COMBAT.NotStarted" }}
             {{/if}}

--- a/templates/ui/combatTracker/combatTrackerSection.hbs
+++ b/templates/ui/combatTracker/combatTrackerSection.hbs
@@ -50,12 +50,12 @@
                 {{#if @root.user.isGM}}
                     <button 
                         type="button" class="inline-control spotlight-control discrete icon fa-solid {{#if system.spotlight.requesting}}fa-hand-sparkles requesting{{else}}fa-hand{{/if}}" 
-                        data-action="toggleSpotlight" data-combatant-id="{{id}}" data-tooltip aria-label="{{localize "DAGGERHEART.Combat.giveSpotlight"}}"
+                        data-action="toggleSpotlight" data-combatant-id="{{id}}" data-tooltip aria-label="{{localize "DAGGERHEART.Applications.CombatTracker.giveSpotlight"}}"
                     ></button>
                 {{else}}
                     <button 
                         type="button" class="inline-control spotlight-control discrete icon fa-solid {{#if system.spotlight.requesting}}fa-hand-sparkles requesting{{else}}fa-hand{{/if}}" 
-                        data-action="requestSpotlight" data-combatant-id="{{id}}" data-tooltip aria-label="{{#if system.spotlight.requesting}}{{localize "DAGGERHEART.Combat.requestingSpotlight"}}{{else}}{{localize "DAGGERHEART.Combat.requestSpotlight"}}{{/if}}"
+                        data-action="requestSpotlight" data-combatant-id="{{id}}" data-tooltip aria-label="{{#if system.spotlight.requesting}}{{localize "DAGGERHEART.Applications.CombatTracker.requestingSpotlight"}}{{else}}{{localize "DAGGERHEART.Applications.CombatTracker.requestSpotlight"}}{{/if}}"
                     ></button>
                 {{/if}}
             </li>

--- a/templates/ui/combatTracker/combatTrackerSection.hbs
+++ b/templates/ui/combatTracker/combatTrackerSection.hbs
@@ -50,12 +50,12 @@
                 {{#if @root.user.isGM}}
                     <button 
                         type="button" class="inline-control spotlight-control discrete icon fa-solid {{#if system.spotlight.requesting}}fa-hand-sparkles requesting{{else}}fa-hand{{/if}}" 
-                        data-action="toggleSpotlight" data-combatant-id="{{id}}" data-tooltip aria-label="{{localize "DAGGERHEART.Applications.CombatTracker.giveSpotlight"}}"
+                        data-action="toggleSpotlight" data-combatant-id="{{id}}" data-tooltip aria-label="{{localize "DAGGERHEART.APPLICATIONS.CombatTracker.giveSpotlight"}}"
                     ></button>
                 {{else}}
                     <button 
                         type="button" class="inline-control spotlight-control discrete icon fa-solid {{#if system.spotlight.requesting}}fa-hand-sparkles requesting{{else}}fa-hand{{/if}}" 
-                        data-action="requestSpotlight" data-combatant-id="{{id}}" data-tooltip aria-label="{{#if system.spotlight.requesting}}{{localize "DAGGERHEART.Applications.CombatTracker.requestingSpotlight"}}{{else}}{{localize "DAGGERHEART.Applications.CombatTracker.requestSpotlight"}}{{/if}}"
+                        data-action="requestSpotlight" data-combatant-id="{{id}}" data-tooltip aria-label="{{#if system.spotlight.requesting}}{{localize "DAGGERHEART.APPLICATIONS.CombatTracker.requestingSpotlight"}}{{else}}{{localize "DAGGERHEART.APPLICATIONS.CombatTracker.requestSpotlight"}}{{/if}}"
                     ></button>
                 {{/if}}
             </li>

--- a/templates/ui/countdowns.hbs
+++ b/templates/ui/countdowns.hbs
@@ -12,8 +12,8 @@
     {{else}}
         <div class="expanded-view">
             <div class="countdowns-menu">
-                {{#if canCreate}}<button class="flex" data-action="addCountdown">{{localize "DAGGERHEART.Applications.Countdown.addCountdown"}}</button>{{/if}}
-                {{#if isGM}}<button data-action="openOwnership" data-tooltip="{{localize "DAGGERHEART.Applications.Countdown.openOwnership"}}"><i class="fa-solid fa-users"></i></button>{{/if}}
+                {{#if canCreate}}<button class="flex" data-action="addCountdown">{{localize "DAGGERHEART.APPLICATIONS.Countdown.addCountdown"}}</button>{{/if}}
+                {{#if isGM}}<button data-action="openOwnership" data-tooltip="{{localize "DAGGERHEART.APPLICATIONS.Countdown.openOwnership"}}"><i class="fa-solid fa-users"></i></button>{{/if}}
             </div>
 
             <div class="countdowns-container">
@@ -22,7 +22,7 @@
                         <legend>
                             {{this.name}} 
                             {{#if this.canEdit}}<a><i class="fa-solid fa-trash icon-button" data-action="removeCountdown" data-countdown="{{@key}}"></i></a>{{/if}}
-                            {{#if @root.isGM}}<a><i class="fa-solid fa-users icon-button" data-action="openCountdownOwnership" data-countdown="{{@key}}" data-tooltip="{{localize "DAGGERHEART.Applications.Countdown.openOwnership"}}"></i></a>{{/if}}
+                            {{#if @root.isGM}}<a><i class="fa-solid fa-users icon-button" data-action="openCountdownOwnership" data-countdown="{{@key}}" data-tooltip="{{localize "DAGGERHEART.APPLICATIONS.Countdown.openOwnership"}}"></i></a>{{/if}}
                         </legend>
 
                         

--- a/templates/ui/countdowns.hbs
+++ b/templates/ui/countdowns.hbs
@@ -12,8 +12,8 @@
     {{else}}
         <div class="expanded-view">
             <div class="countdowns-menu">
-                {{#if canCreate}}<button class="flex" data-action="addCountdown">{{localize "DAGGERHEART.Countdown.AddCountdown"}}</button>{{/if}}
-                {{#if isGM}}<button data-action="openOwnership" data-tooltip="{{localize "DAGGERHEART.Countdown.OpenOwnership"}}"><i class="fa-solid fa-users"></i></button>{{/if}}
+                {{#if canCreate}}<button class="flex" data-action="addCountdown">{{localize "DAGGERHEART.Applications.Countdown.addCountdown"}}</button>{{/if}}
+                {{#if isGM}}<button data-action="openOwnership" data-tooltip="{{localize "DAGGERHEART.Applications.Countdown.openOwnership"}}"><i class="fa-solid fa-users"></i></button>{{/if}}
             </div>
 
             <div class="countdowns-container">
@@ -22,7 +22,7 @@
                         <legend>
                             {{this.name}} 
                             {{#if this.canEdit}}<a><i class="fa-solid fa-trash icon-button" data-action="removeCountdown" data-countdown="{{@key}}"></i></a>{{/if}}
-                            {{#if @root.isGM}}<a><i class="fa-solid fa-users icon-button" data-action="openCountdownOwnership" data-countdown="{{@key}}" data-tooltip="{{localize "DAGGERHEART.Countdown.OpenOwnership"}}"></i></a>{{/if}}
+                            {{#if @root.isGM}}<a><i class="fa-solid fa-users icon-button" data-action="openCountdownOwnership" data-countdown="{{@key}}" data-tooltip="{{localize "DAGGERHEART.Applications.Countdown.openOwnership"}}"></i></a>{{/if}}
                         </legend>
 
                         


### PR DESCRIPTION
- Organized `en.json`
- Implemented correct camelcasing for translation titles
- Updated all useage of translation strings to match the new organization (could always have missed something, but we'll notice it with time in that case)