### PR TITLE
Bugfix - Companion Levelup Features

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -107,7 +107,8 @@
                     "sendToChat": "Send To Chat",
                     "toLoadout": "Send to Loadout",
                     "toVault": "Send to Vault",
-                    "unequip": "Unequip"
+                    "unequip": "Unequip",
+                    "useItem": "Use Item"
                 },
                 "faith": "Faith",
                 "levelUp": "You can level up",

--- a/module/applications/levelup/levelup.mjs
+++ b/module/applications/levelup/levelup.mjs
@@ -128,7 +128,7 @@ export default class DhlevelUp extends HandlebarsApplicationMixin(ApplicationV2)
                 context.tabs.advancements.progress = { selected: selections, max: currentLevel.maxSelections };
                 context.showTabs = this.tabGroups.primary !== 'summary';
                 break;
-                const { current: currentActorLevel, changed: changedActorLevel } = this.actor.system.levelData.level;
+
                 const actorArmor = this.actor.system.armor;
                 const levelKeys = Object.keys(this.levelup.levels);
                 let achivementProficiency = 0;

--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -202,7 +202,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
 
         return [
             {
-                name: 'DAGGERHEART.Sheets.PC.ContextMenu.UseItem',
+                name: 'DAGGERHEART.ACTORS.Character.contextMenu.useItem',
                 icon: '<i class="fa-solid fa-burst"></i>',
                 condition: el => {
                     const item = getItem(el);
@@ -211,7 +211,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
                 callback: (button, event) => CharacterSheet.useItem.call(this, event, button)
             },
             {
-                name: 'DAGGERHEART.Sheets.PC.ContextMenu.Equip',
+                name: 'DAGGERHEART.ACTORS.Character.contextMenu.equip',
                 icon: '<i class="fa-solid fa-hands"></i>',
                 condition: el => {
                     const item = getItem(el);
@@ -220,7 +220,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
                 callback: CharacterSheet.#toggleEquipItem.bind(this)
             },
             {
-                name: 'DAGGERHEART.Sheets.PC.ContextMenu.Unequip',
+                name: 'DAGGERHEART.ACTORS.Character.contextMenu.unequip',
                 icon: '<i class="fa-solid fa-hands"></i>',
                 condition: el => {
                     const item = getItem(el);
@@ -229,7 +229,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
                 callback: CharacterSheet.#toggleEquipItem.bind(this)
             },
             {
-                name: 'DAGGERHEART.Sheets.PC.ContextMenu.ToLoadout',
+                name: 'DAGGERHEART.ACTORS.Character.contextMenu.toLoadout',
                 icon: '<i class="fa-solid fa-arrow-up"></i>',
                 condition: el => {
                     const item = getItem(el);
@@ -238,7 +238,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
                 callback: target => getItem(target).update({ 'system.inVault': false })
             },
             {
-                name: 'DAGGERHEART.Sheets.PC.ContextMenu.ToVault',
+                name: 'DAGGERHEART.ACTORS.Character.contextMenu.toVault',
                 icon: '<i class="fa-solid fa-arrow-down"></i>',
                 condition: el => {
                     const item = getItem(el);
@@ -247,17 +247,17 @@ export default class CharacterSheet extends DHBaseActorSheet {
                 callback: target => getItem(target).update({ 'system.inVault': true })
             },
             {
-                name: 'DAGGERHEART.Sheets.PC.ContextMenu.SendToChat',
+                name: 'DAGGERHEART.ACTORS.Character.contextMenu.sendToChat',
                 icon: '<i class="fa-regular fa-message"></i>',
                 callback: CharacterSheet.toChat.bind(this)
             },
             {
-                name: 'DAGGERHEART.Sheets.PC.ContextMenu.Edit',
+                name: 'CONTROLS.CommonEdit',
                 icon: '<i class="fa-solid fa-pen-to-square"></i>',
                 callback: target => getItem(target).sheet.render({ force: true })
             },
             {
-                name: 'DAGGERHEART.Sheets.PC.ContextMenu.Delete',
+                name: 'CONTROLS.CommonDelete',
                 icon: '<i class="fa-solid fa-trash"></i>',
                 callback: async el => {
                     const item = getItem(el);

--- a/module/data/levelData.mjs
+++ b/module/data/levelData.mjs
@@ -43,16 +43,17 @@ export default class DhLevelData extends foundry.abstract.DataModel {
                             data: new fields.ArrayField(new fields.StringField({ required: true })),
                             secondaryData: new fields.TypedObjectField(new fields.StringField({ required: true })),
                             itemUuid: new fields.DocumentUUIDField({ required: true }),
-                            featureIds: new fields.ArrayField(new fields.StringField())
+                            features: new fields.ArrayField(
+                                new fields.SchemaField({
+                                    onPartner: new fields.BooleanField(),
+                                    id: new fields.StringField()
+                                })
+                            )
                         })
                     )
                 })
             )
         };
-    }
-
-    get actions() {
-        return Object.values(this.levelups).flatMap(level => level.selections.flatMap(s => s.actions));
     }
 
     get canLevelUp() {

--- a/module/data/levelTier.mjs
+++ b/module/data/levelTier.mjs
@@ -70,7 +70,8 @@ export const CompanionLevelOptionType = {
             {
                 name: 'DAGGERHEART.APPLICATIONS.Levelup.actions.creatureComfort.name',
                 img: 'icons/magic/life/heart-cross-purple-orange.webp',
-                description: 'DAGGERHEART.APPLICATIONS.Levelup.actions.creatureComfort.description'
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.actions.creatureComfort.description',
+                toPartner: true
             }
         ]
     },
@@ -81,7 +82,8 @@ export const CompanionLevelOptionType = {
             {
                 name: 'DAGGERHEART.APPLICATIONS.Levelup.actions.armored.name',
                 img: 'icons/equipment/shield/kite-wooden-oak-glow.webp',
-                description: 'DAGGERHEART.APPLICATIONS.Levelup.actions.armored.description'
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.actions.armored.description',
+                toPartner: true
             }
         ]
     },
@@ -100,7 +102,8 @@ export const CompanionLevelOptionType = {
             {
                 name: 'DAGGERHEART.APPLICATIONS.Levelup.actions.bonded.name',
                 img: 'icons/magic/life/heart-red-blue.webp',
-                description: 'DAGGERHEART.APPLICATIONS.Levelup.actions.bonded.description'
+                description: 'DAGGERHEART.APPLICATIONS.Levelup.actions.bonded.description',
+                toPartner: true
             }
         ]
     },

--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -139,6 +139,7 @@ export default class DHRoll extends Roll {
 export const registerRollDiceHooks = () => {
     Hooks.on(`${CONFIG.DH.id}.postRollDuality`, async (config, message) => {
         if (
+            !config.source?.actor ||
             !game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Automation).hope ||
             config.roll.type === 'reaction'
         )


### PR DESCRIPTION
- Fixed so that features gained from companion levelup show up on the character sheet again.
- Changed so that these Feature items are actually embedded onto the character itself, rather than trying to use it from the companions item list. This is much more robust.
- The features list in the levelup data tracks if the levelup feature is in the partner's item list so it can be removed on delevel.