### PR TITLE
259 - Missing Status Effects

### DIFF
--- a/daggerheart.mjs
+++ b/daggerheart.mjs
@@ -41,10 +41,14 @@ Hooks.once('init', () => {
         ]
     );
 
-    CONFIG.statusEffects = Object.values(SYSTEM.GENERAL.conditions).map(x => ({
-        ...x,
-        name: game.i18n.localize(x.name)
-    }));
+    CONFIG.statusEffects = [
+        ...CONFIG.statusEffects,
+        ...Object.values(SYSTEM.GENERAL.conditions).map(x => ({
+            ...x,
+            name: game.i18n.localize(x.name),
+            systemEffect: true
+        }))
+    ];
 
     CONFIG.Dice.daggerheart = {
         DualityDie: DualityDie,
@@ -107,6 +111,8 @@ Hooks.once('init', () => {
             makeDefault: true
         }
     );
+
+    CONFIG.Token.hudClass = applications.hud.DHTokenHUD;
 
     CONFIG.Combat.dataModels = {
         base: models.DhCombat

--- a/lang/en.json
+++ b/lang/en.json
@@ -279,6 +279,11 @@
                     }
                 }
             },
+            "HUD": {
+                "tokenHUD": {
+                    "genericEffects": "Foundry Effects"
+                }
+            },
             "Levelup": {
                 "actions": {
                     "creatureComfort": {
@@ -1180,7 +1185,8 @@
         "SETTINGS": {
             "Appearance": {
                 "FIELDS": {
-                    "displayFear": { "label": "Fear Display" }
+                    "displayFear": { "label": "Fear Display" },
+                    "showGenericStatusEffects": { "label": "Show Foundry Status Effects" }
                 },
                 "fearDisplay": {
                     "token": "Tokens",

--- a/module/applications/_module.mjs
+++ b/module/applications/_module.mjs
@@ -1,5 +1,6 @@
 export * as characterCreation from './characterCreation/_module.mjs';
 export * as dialogs from './dialogs/_module.mjs';
+export * as hud from './hud/_module.mjs';
 export * as levelup from './levelup/_module.mjs';
 export * as settings from './settings/_module.mjs';
 export * as sheets from './sheets/_module.mjs';

--- a/module/applications/hud/_module.mjs
+++ b/module/applications/hud/_module.mjs
@@ -1,0 +1,1 @@
+export { default as DHTokenHUD } from './tokenHud.mjs';

--- a/module/applications/hud/tokenHUD.mjs
+++ b/module/applications/hud/tokenHUD.mjs
@@ -1,0 +1,84 @@
+export default class DHTokenHUD extends TokenHUD {
+    static DEFAULT_OPTIONS = {
+        classes: ['daggerheart']
+    };
+
+    /** @override */
+    static PARTS = {
+        hud: {
+            root: true,
+            template: 'systems/daggerheart/templates/hud/tokenHUD.hbs'
+        }
+    };
+
+    async _prepareContext(options) {
+        const context = await super._prepareContext(options);
+        context.systemStatusEffects = Object.keys(context.statusEffects).reduce((acc, key) => {
+            const effect = context.statusEffects[key];
+            if (effect.systemEffect) acc[key] = effect;
+
+            return acc;
+        }, {});
+
+        const useGeneric = game.settings.get(
+            CONFIG.DH.id,
+            CONFIG.DH.SETTINGS.gameSettings.appearance
+        ).showGenericStatusEffects;
+        context.genericStatusEffects = useGeneric
+            ? Object.keys(context.statusEffects).reduce((acc, key) => {
+                  const effect = context.statusEffects[key];
+                  if (!effect.systemEffect) acc[key] = effect;
+
+                  return acc;
+              }, {})
+            : null;
+
+        return context;
+    }
+
+    _getStatusEffectChoices() {
+        // Include all HUD-enabled status effects
+        const choices = {};
+        for (const status of CONFIG.statusEffects) {
+            if (
+                status.hud === false ||
+                (foundry.utils.getType(status.hud) === 'Object' &&
+                    status.hud.actorTypes?.includes(this.document.actor.type) === false)
+            ) {
+                continue;
+            }
+            choices[status.id] = {
+                _id: status._id,
+                id: status.id,
+                systemEffect: status.systemEffect,
+                title: game.i18n.localize(status.name ?? /** @deprecated since v12 */ status.label),
+                src: status.img ?? /** @deprecated since v12 */ status.icon,
+                isActive: false,
+                isOverlay: false
+            };
+        }
+
+        // Update the status of effects which are active for the token actor
+        const activeEffects = this.actor?.effects || [];
+        for (const effect of activeEffects) {
+            for (const statusId of effect.statuses) {
+                const status = choices[statusId];
+                if (!status) continue;
+                if (status._id) {
+                    if (status._id !== effect.id) continue;
+                } else {
+                    if (effect.statuses.size !== 1) continue;
+                }
+                status.isActive = true;
+                if (effect.getFlag('core', 'overlay')) status.isOverlay = true;
+                break;
+            }
+        }
+
+        // Flag status CSS class
+        for (const status of Object.values(choices)) {
+            status.cssClass = [status.isActive ? 'active' : null, status.isOverlay ? 'overlay' : null].filterJoin(' ');
+        }
+        return choices;
+    }
+}

--- a/module/data/settings/Appearance.mjs
+++ b/module/data/settings/Appearance.mjs
@@ -40,6 +40,10 @@ export default class DhAppearance extends foundry.abstract.DataModel {
                     outline: new fields.ColorField({ required: true, initial: '#ffffff' }),
                     edge: new fields.ColorField({ required: true, initial: '#000000' })
                 })
+            }),
+            showGenericStatusEffects: new fields.BooleanField({
+                initial: true,
+                label: 'DAGGERHEART.SETTINGS.Appearance.FIELDS.showGenericStatusEffects.label'
             })
         };
     }

--- a/styles/daggerheart.less
+++ b/styles/daggerheart.less
@@ -3,6 +3,8 @@
 
 @import './less/dialog/index.less';
 
+@import './less//hud/index.less';
+
 @import './less/utils/colors.less';
 @import './less/utils/fonts.less';
 

--- a/styles/less/hud/index.less
+++ b/styles/less/hud/index.less
@@ -1,0 +1,1 @@
+@import './token-hud/token-hud.less';

--- a/styles/less/hud/token-hud/token-hud.less
+++ b/styles/less/hud/token-hud/token-hud.less
@@ -1,0 +1,10 @@
+.daggerheart.placeable-hud {
+    .col.right {
+        .palette {
+            .palette-category-title {
+                grid-column: span var(--effect-columns);
+                font-weight: bold;
+            }
+        }
+    }
+}

--- a/templates/hud/tokenHUD.hbs
+++ b/templates/hud/tokenHUD.hbs
@@ -1,0 +1,78 @@
+<div class="col left">
+    <div class="attribute elevation" data-tooltip="HUD.Elevation">
+        <i class="fas fa-angle-up"></i>
+        <input type="text" name="elevation" value="{{elevation}}" {{disabled (or locked (and isGamePaused (not isGM)))}}>
+    </div>
+
+    <button type="button" class="control-icon" data-action="sort" data-direction="up" data-tooltip="HUD.ToFront">
+        <img src="{{icons.up}}">
+    </button>
+
+    <button type="button" class="control-icon" data-action="sort" data-direction="down" data-tooltip="HUD.ToBack">
+        <img src="{{icons.down}}">
+    </button>
+
+    {{#if canConfigure}}
+    <button type="button" class="control-icon" data-action="config" data-tooltip="HUD.OpenConfig">
+        <i class="fa-solid fa-gear" inert></i>
+    </button>
+    {{/if}}
+</div>
+
+<div class="col middle">
+    <div class="attribute bar2">
+        {{#if displayBar2}}
+        <input type="text" name="bar2" value="{{bar2Data.value}}" {{#unless bar2Data.editable}}disabled{{/unless}}>
+        {{/if}}
+    </div>
+
+    <div class="attribute bar1">
+        {{#if displayBar1}}
+        <input type="text" name="bar1" value="{{bar1Data.value}}" {{#unless bar1Data.editable}}disabled{{/unless}}>
+        {{/if}}
+    </div>
+</div>
+
+<div class="col right">
+    {{#if isGM}}
+    <button type="button" class="control-icon {{visibilityClass}}" data-action="visibility" data-tooltip="HUD.ToggleVis">
+        <img src="{{icons.visibility}}">
+    </button>
+    {{/if}}
+
+    <button type="button" class="control-icon" data-action="togglePalette" data-palette="effects" data-tooltip="HUD.AssignStatusEffects">
+        <img src="{{icons.effects}}">
+    </button>
+    <div class="palette status-effects" data-palette="effects">
+        {{#each systemStatusEffects as |status|}}
+            <img class="effect-control {{status.cssClass}}" src="{{status.src}}" data-action="effect" data-status-id="{{status.id}}" {{#if status.title}}data-tooltip-text="{{status.title}}"{{/if}}>
+        {{/each}}
+        {{#if genericStatusEffects}}
+            <label class="palette-category-title">{{localize "DAGGERHEART.APPLICATIONS.HUD.tokenHUD.genericEffects"}}</label>
+            {{#each genericStatusEffects as |status|}}
+                <img class="effect-control {{status.cssClass}}" src="{{status.src}}" data-action="effect" data-status-id="{{status.id}}" {{#if status.title}}data-tooltip-text="{{status.title}}"{{/if}}>
+            {{/each}}
+        {{/if}}
+    </div>
+
+    <button type="button" class="control-icon" data-action="togglePalette" data-palette="movementActions" data-tooltip="HUD.SelectMovementAction">
+        <i class="{{movementActionsIcon}}" inert></i>
+    </button>
+    <div class="palette movement-actions" data-palette="movementActions">
+        {{#each movementActions as |action|}}
+        <a class="movement-action-control {{action.cssClass}}" data-action="movementAction" data-movement-action="{{action.id}}">
+            <span>{{#if action.icon}}<i class="{{action.icon}} fa-fw" inert></i>{{/if}} {{action.label}}</span>
+        </a>
+        {{/each}}
+    </div>
+
+    <button type="button" class="control-icon {{targetClass}}" data-action="target" data-tooltip="HUD.ToggleTargetState">
+        <i class="fa-solid fa-bullseye" inert></i>
+    </button>
+
+    {{#if canToggleCombat}}
+    <button type="button" class="control-icon {{combatClass}}" data-action="combat" data-tooltip="HUD.ToggleCombatState">
+        <img src="{{icons.combat}}">
+    </button>
+    {{/if}}
+</div>

--- a/templates/settings/appearance-settings.hbs
+++ b/templates/settings/appearance-settings.hbs
@@ -1,5 +1,6 @@
 <div>
     {{formGroup settingFields.schema.fields.displayFear value=settingFields._source.displayFear localize=true}}
+    {{formGroup settingFields.schema.fields.showGenericStatusEffects value=settingFields._source.showGenericStatusEffects localize=true}}
 
     <fieldset>
         <legend>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.duality"}}</legend>


### PR DESCRIPTION
## Description
Added a separation of system effects and generic effects on token status effects. Can be turned off in settings.

- Fixes #(issue)
- Closes #259 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?
- [x] Manual testing
- [ ] Other:

## Screenshots (if applicable)
<img width="854" height="646" alt="image" src="https://github.com/user-attachments/assets/d0bbc7ed-e2c6-4941-95b9-4be4fd15b595" />