### PR TITLE
set to use dh ranges by default and made setting world, not client.

### DIFF
--- a/module/data/settings/RangeMeasurement.mjs
+++ b/module/data/settings/RangeMeasurement.mjs
@@ -2,7 +2,7 @@ export default class DhRangeMeasurement extends foundry.abstract.DataModel {
     static defineSchema() {
         const fields = foundry.data.fields;
         return {
-            enabled: new fields.BooleanField({ required: true, initial: false, label: 'DAGGERHEART.GENERAL.enabled' }),
+            enabled: new fields.BooleanField({ required: true, initial: true, label: 'DAGGERHEART.GENERAL.enabled' }),
             melee: new fields.NumberField({ required: true, initial: 5, label: 'DAGGERHEART.CONFIG.Range.melee.name' }),
             veryClose: new fields.NumberField({
                 required: true,

--- a/module/systemRegistration/settings.mjs
+++ b/module/systemRegistration/settings.mjs
@@ -60,7 +60,7 @@ const registerMenuSettings = () => {
     });
 
     game.settings.register(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.RangeMeasurement, {
-        scope: 'client',
+        scope: 'world',
         config: false,
         type: DhRangeMeasurement
     });


### PR DESCRIPTION
## Description
Updated the range measurement to use the DH ranges by default. Scoped the setting to World since users can not change it. 

- Fixes #320 
- Closes #320 

## Type of Change

Please check the relevant options:

- [x] Bug fix
- [ ] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x] Manual testing
- [ ] Other:

I did load up both gm and user in different browsers and verified the following:

User are unable to update the setting.
GM's can update the setting, and that setting applies to players on save. 

## Screenshots (if applicable)

Include screenshots or GIFs to help explain your changes visually.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [ ] New and existing tests pass locally with my changes

## Additional Comments

Add any other context or questions here.

---

> Thank you for your contribution! 🎉
