### PR TITLE
321 - ChatLog Popout

### DIFF
--- a/module/applications/ui/chatLog.mjs
+++ b/module/applications/ui/chatLog.mjs
@@ -1,6 +1,6 @@
 export default class DhpChatLog extends foundry.applications.sidebar.tabs.ChatLog {
-    constructor() {
-        super();
+    constructor(options) {
+        super(options);
 
         this.targetTemplate = {
             activeLayer: undefined,
@@ -14,6 +14,8 @@ export default class DhpChatLog extends foundry.applications.sidebar.tabs.ChatLo
     }
 
     addChatListeners = async (app, html, data) => {
+        super.addChatListeners(app, html, data);
+
         html.querySelectorAll('.duality-action-damage').forEach(element =>
             element.addEventListener('click', event => this.onRollDamage(event, data.message))
         );
@@ -64,10 +66,10 @@ export default class DhpChatLog extends foundry.applications.sidebar.tabs.ChatLo
         Hooks.on('renderChatMessageHTML', this.addChatListeners.bind());
     }
 
-    close(options) {
-        Hooks.off('renderChatMessageHTML', this.addChatListeners);
-        super.close(options);
-    }
+    // close(options) {
+    //     Hooks.off('renderChatMessageHTML', this.addChatListeners);
+    //     super.close(options);
+    // }
 
     async getActor(id) {
         // return game.actors.get(id);


### PR DESCRIPTION
## Description
- The app options weren't being passed on in the constructor, making popout break. Fixed.
- Can't replicate any old timestamps. Hopefully this was also due to the options.

- Closes #321 

## Type of Change
- [x] Bug fix

## How Has This Been Tested?
- [x] Manual testing
- [ ] Other:

## Screenshots (if applicable)
<img width="919" height="690" alt="image" src="https://github.com/user-attachments/assets/d6266ad5-70a1-45dd-8e26-1a3fa56a53b6" />
