### PR TITLE
[Bug] Evasion Not Shown On Character Sheet

### DIFF
--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -323,6 +323,8 @@ export default class DhCharacter extends BaseDataActor {
     }
 
     prepareBaseData() {
+        this.evasion = this.class.value?.system?.evasion ?? 0;
+
         const currentLevel = this.levelData.level.current;
         const currentTier =
             currentLevel === 1


### PR DESCRIPTION
## Description
Evasion property setting in Character data had disappeared during reworks. Returned it.

- Closes #333 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?
- [x] Manual testing
- [ ] Other:
