### PR TITLE
[Fix] Automation Fixes

### DIFF
--- a/daggerheart.mjs
+++ b/daggerheart.mjs
@@ -5,7 +5,7 @@ import * as documents from './module/documents/_module.mjs';
 import RegisterHandlebarsHelpers from './module/helpers/handlebarsHelper.mjs';
 import { DhDualityRollEnricher, DhTemplateEnricher } from './module/enrichers/_module.mjs';
 import { getCommandTarget, rollCommandToJSON } from './module/helpers/utils.mjs';
-import { NarrativeCountdowns, registerCountdownApplicationHooks } from './module/applications/ui/countdowns.mjs';
+import { NarrativeCountdowns } from './module/applications/ui/countdowns.mjs';
 import { DualityRollColor } from './module/data/settings/Appearance.mjs';
 import { DHRoll, DualityRoll, D20Roll, DamageRoll, DualityDie } from './module/dice/_module.mjs';
 import { renderDualityButton } from './module/enrichers/DualityRollEnricher.mjs';
@@ -160,7 +160,6 @@ Hooks.on('ready', () => {
 
     registerCountdownHooks();
     socketRegistration.registerSocketHooks();
-    registerCountdownApplicationHooks();
     registerRollDiceHooks();
     registerDHActorHooks();
 });

--- a/lang/en.json
+++ b/lang/en.json
@@ -1271,9 +1271,10 @@
                     "hint": "Automatically increase the GM's fear pool on a fear duality roll result."
                 },
                 "FIELDS": {
-                    "hope": {
-                        "label": "Hope",
-                        "hint": "Automatically increase a character's hope on a hope duality roll result."
+                    "hopeFear": {
+                        "label": "Hope & Fear",
+                        "gm": { "label": "GM" },
+                        "players": { "label": "Players" }
                     },
                     "actionPoints": {
                         "label": "Action Points",

--- a/module/applications/hud/tokenHUD.mjs
+++ b/module/applications/hud/tokenHUD.mjs
@@ -1,4 +1,4 @@
-export default class DHTokenHUD extends TokenHUD {
+export default class DHTokenHUD extends foundry.applications.hud.TokenHUD {
     static DEFAULT_OPTIONS = {
         classes: ['daggerheart']
     };

--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -654,10 +654,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
         } else if (item instanceof ActiveEffect) {
             item.toChat(this);
         } else {
-            const wasUsed = await item.use(event);
-            if (wasUsed && item.type === 'weapon') {
-                Hooks.callAll(CONFIG.DH.HOOKS.characterAttack, {});
-            }
+            item.use(event);
         }
     }
 

--- a/module/applications/ui/chatLog.mjs
+++ b/module/applications/ui/chatLog.mjs
@@ -14,8 +14,6 @@ export default class DhpChatLog extends foundry.applications.sidebar.tabs.ChatLo
     }
 
     addChatListeners = async (app, html, data) => {
-        super.addChatListeners(app, html, data);
-
         html.querySelectorAll('.duality-action-damage').forEach(element =>
             element.addEventListener('click', event => this.onRollDamage(event, data.message))
         );

--- a/module/applications/ui/combatTracker.mjs
+++ b/module/applications/ui/combatTracker.mjs
@@ -73,7 +73,10 @@ export default class DhCombatTracker extends foundry.applications.sidebar.tabs.C
             .map(x => x.id)
             .indexOf(combatantId);
 
-        if (this.viewed.turn !== toggleTurn) Hooks.callAll(CONFIG.DH.HOOKS.spotlight, {});
+        if (this.viewed.turn !== toggleTurn) {
+            const { updateCountdowns } = game.system.api.applications.ui.DhCountdowns;
+            await updateCountdowns(CONFIG.DH.GENERAL.countdownTypes.spotlight.id);
+        }
 
         await this.viewed.update({ turn: this.viewed.turn === toggleTurn ? null : toggleTurn });
         await combatant.update({ 'system.spotlight.requesting': false });

--- a/module/config/_module.mjs
+++ b/module/config/_module.mjs
@@ -4,7 +4,6 @@ export * as domainConfig from './domainConfig.mjs';
 export * as effectConfig from './effectConfig.mjs';
 export * as flagsConfig from './flagsConfig.mjs';
 export * as generalConfig from './generalConfig.mjs';
-export * as hooksConfig from './hooksConfig.mjs';
 export * as itemConfig from './itemConfig.mjs';
 export * as settingsConfig from './settingsConfig.mjs';
 export * as systemConfig from './system.mjs';

--- a/module/config/generalConfig.mjs
+++ b/module/config/generalConfig.mjs
@@ -376,15 +376,15 @@ export const abilityCosts = {
 export const countdownTypes = {
     spotlight: {
         id: 'spotlight',
-        label: 'DAGGERHEART.CONFIG.CountdownTypes.Spotlight'
+        label: 'DAGGERHEART.CONFIG.CountdownType.spotlight'
     },
     characterAttack: {
         id: 'characterAttack',
-        label: 'DAGGERHEART.CONFIG.CountdownTypes.CharacterAttack'
+        label: 'DAGGERHEART.CONFIG.CountdownType.characterAttack'
     },
     custom: {
         id: 'custom',
-        label: 'DAGGERHEART.CONFIG.CountdownTypes.Custom'
+        label: 'DAGGERHEART.CONFIG.CountdownType.custom'
     }
 };
 export const rollTypes = {

--- a/module/config/hooksConfig.mjs
+++ b/module/config/hooksConfig.mjs
@@ -1,4 +1,0 @@
-export const hooks = {
-    characterAttack: 'characterAttackHook',
-    spotlight: 'spotlightHook'
-};

--- a/module/config/system.mjs
+++ b/module/config/system.mjs
@@ -3,7 +3,6 @@ import * as DOMAIN from './domainConfig.mjs';
 import * as ACTOR from './actorConfig.mjs';
 import * as ITEM from './itemConfig.mjs';
 import * as SETTINGS from './settingsConfig.mjs';
-import { hooks as HOOKS } from './hooksConfig.mjs';
 import * as EFFECTS from './effectConfig.mjs';
 import * as ACTIONS from './actionConfig.mjs';
 import * as FLAGS from './flagsConfig.mjs';
@@ -17,7 +16,6 @@ export const SYSTEM = {
     ACTOR,
     ITEM,
     SETTINGS,
-    HOOKS,
     EFFECTS,
     ACTIONS,
     FLAGS

--- a/module/data/action/attackAction.mjs
+++ b/module/data/action/attackAction.mjs
@@ -37,4 +37,13 @@ export default class DHAttackAction extends DHDamageAction {
             base: true
         };
     }
+
+    async use(event, ...args) {
+        const result = await super.use(event, args);
+
+        const { updateCountdowns } = game.system.api.applications.ui.DhCountdowns;
+        await updateCountdowns(CONFIG.DH.GENERAL.countdownTypes.characterAttack.id);
+
+        return result;
+    }
 }

--- a/module/data/countdowns.mjs
+++ b/module/data/countdowns.mjs
@@ -102,7 +102,7 @@ class DhCountdown extends foundry.abstract.DataModel {
                     value: new fields.StringField({
                         required: true,
                         choices: CONFIG.DH.GENERAL.countdownTypes,
-                        initial: CONFIG.DH.GENERAL.countdownTypes.spotlight.id,
+                        initial: CONFIG.DH.GENERAL.countdownTypes.custom.id,
                         label: 'DAGGERHEART.APPLICATIONS.Countdown.FIELDS.countdowns.element.progress.type.value.label'
                     }),
                     label: new fields.StringField({
@@ -132,7 +132,13 @@ class DhCountdown extends foundry.abstract.DataModel {
 export const registerCountdownHooks = () => {
     Hooks.on(socketEvent.Refresh, ({ refreshType, application }) => {
         if (refreshType === RefreshType.Countdown) {
-            foundry.applications.instances.get(application)?.render();
+            if (application) {
+                foundry.applications.instances.get(application)?.render();
+            } else {
+                foundry.applications.instances.get('narrative-countdowns').render();
+                foundry.applications.instances.get('encounter-countdowns').render();
+            }
+
             return false;
         }
     });

--- a/module/data/settings/Automation.mjs
+++ b/module/data/settings/Automation.mjs
@@ -8,12 +8,12 @@ export default class DhAutomation extends foundry.abstract.DataModel {
                 gm: new fields.BooleanField({
                     required: true,
                     initial: false,
-                    label: 'DAGGERHEART.SETTINGS.Automation.FIELDS.hope.label'
+                    label: 'DAGGERHEART.SETTINGS.Automation.FIELDS.hopeFear.gm.label'
                 }),
                 players: new fields.BooleanField({
                     required: true,
                     initial: false,
-                    label: 'DAGGERHEART.SETTINGS.Automation.FIELDS.hope.label'
+                    label: 'DAGGERHEART.SETTINGS.Automation.FIELDS.hopeFear.players.label'
                 })
             }),
             actionPoints: new fields.BooleanField({

--- a/module/data/settings/Automation.mjs
+++ b/module/data/settings/Automation.mjs
@@ -4,20 +4,22 @@ export default class DhAutomation extends foundry.abstract.DataModel {
     static defineSchema() {
         const fields = foundry.data.fields;
         return {
-            hope: new fields.BooleanField({
-                required: true,
-                initial: false,
-                label: 'DAGGERHEART.SETTINGS.Automation.FIELDS.hope.label'
-            }), // Label need to be updated into something like "Duality Roll Auto Gain" + a hint
+            hopeFear: new fields.SchemaField({
+                gm: new fields.BooleanField({
+                    required: true,
+                    initial: false,
+                    label: 'DAGGERHEART.SETTINGS.Automation.FIELDS.hope.label'
+                }),
+                players: new fields.BooleanField({
+                    required: true,
+                    initial: false,
+                    label: 'DAGGERHEART.SETTINGS.Automation.FIELDS.hope.label'
+                })
+            }),
             actionPoints: new fields.BooleanField({
                 required: true,
                 initial: false,
                 label: 'DAGGERHEART.SETTINGS.Automation.FIELDS.actionPoints.label'
-            }),
-            countdowns: new fields.BooleanField({
-                requireD: true,
-                initial: false,
-                label: 'DAGGERHEART.SETTINGS.Automation.FIELDS.countdowns.label'
             })
         };
     }

--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -148,9 +148,9 @@ export const registerRollDiceHooks = () => {
         const actor = await fromUuid(config.source.actor),
             updates = [];
         if (!actor) return;
-        if (config.roll.isCritical || config.roll.result.duality === 1) updates.push({ type: 'hope', value: 1 });
-        if (config.roll.isCritical) updates.push({ type: 'stress', value: -1 });
-        if (config.roll.result.duality === -1) updates.push({ type: 'fear', value: 1 });
+        if (config.roll.isCritical || config.roll.result.duality === 1) updates.push({ key: 'hope', value: 1 });
+        if (config.roll.isCritical) updates.push({ key: 'stress', value: -1 });
+        if (config.roll.result.duality === -1) updates.push({ key: 'fear', value: 1 });
 
         if (updates.length) actor.modifyResource(updates);
 

--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -138,9 +138,10 @@ export default class DHRoll extends Roll {
 
 export const registerRollDiceHooks = () => {
     Hooks.on(`${CONFIG.DH.id}.postRollDuality`, async (config, message) => {
+        const hopeFearAutomation = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Automation).hopeFear;
         if (
             !config.source?.actor ||
-            !game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Automation).hope ||
+            (game.user.isGM ? !hopeFearAutomation.gm : !hopeFearAutomation.players) ||
             config.roll.type === 'reaction'
         )
             return;

--- a/module/helpers/handlebarsHelper.mjs
+++ b/module/helpers/handlebarsHelper.mjs
@@ -40,7 +40,9 @@ export default class RegisterHandlebarsHelpers {
 
     static damageSymbols(damageParts) {
         const symbols = new Set();
-        damageParts.forEach(part => symbols.add(...CONFIG.DH.GENERAL.damageTypes[part.type].icon));
+        damageParts.forEach(part =>
+            part.type.values().forEach(type => symbols.add(CONFIG.DH.GENERAL.damageTypes[type].icon))
+        );
         return new Handlebars.SafeString(Array.from(symbols).map(symbol => `<i class="fa-solid ${symbol}"></i>`));
     }
 

--- a/templates/settings/automation-settings.hbs
+++ b/templates/settings/automation-settings.hbs
@@ -1,5 +1,10 @@
 <div>
-    {{formGroup settingFields.schema.fields.hope value=settingFields._source.hope localize=true}}
+    <div class="form-group">
+        <label>{{localize "DAGGERHEART.SETTINGS.Automation.FIELDS.hopeFear.label"}}</label>
+        {{formGroup settingFields.schema.fields.hopeFear.fields.gm value=settingFields._source.hopeFear.gm localize=true}}
+        {{formGroup settingFields.schema.fields.hopeFear.fields.players value=settingFields._source.hopeFear.players localize=true}}
+
+    </div>
     {{formGroup settingFields.schema.fields.actionPoints value=settingFields._source.actionPoints localize=true}}
     {{formGroup settingFields.schema.fields.countdowns value=settingFields._source.countdowns localize=true}}
     


### PR DESCRIPTION
## Description
- Split the automation setting for Hope/Fear into two, one for GM and one for Players.
- Removed Countdown automation setting. It was unncessary.
- Removed countdown hooks. Auto update is now handled directly using a static method defined in DhCountdowns.