### PR TITLE
Feature/349 items actions macro use

### DIFF
--- a/daggerheart.mjs
+++ b/daggerheart.mjs
@@ -139,6 +139,7 @@ Hooks.once('init', () => {
     CONFIG.Combat.documentClass = documents.DhpCombat;
     CONFIG.ui.combat = applications.ui.DhCombatTracker;
     CONFIG.ui.chat = applications.ui.DhChatLog;
+    CONFIG.ui.hotbar = applications.ui.DhHotbar;
     CONFIG.Token.rulerClass = placeables.DhTokenRuler;
 
     CONFIG.ui.resources = applications.ui.DhFearTracker;

--- a/lang/en.json
+++ b/lang/en.json
@@ -1520,7 +1520,9 @@
                 "damageIgnore": "{character} did not take damage",
                 "featureIsMissing": "Feature is missing",
                 "actionIsMissing": "Action is missing",
-                "unownedActionMacro": "Cannot make a Use macro for an Action not on your character"
+                "attackIsMissing": "Attack is missing",
+                "unownedActionMacro": "Cannot make a Use macro for an Action not on your character",
+                "unownedAttackMacro": "Cannot make a Use macro for an Attack that doesn't belong to one of your characters"
             },
             "Tooltip": {
                 "openItemWorld": "Open Item World",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1518,7 +1518,9 @@
                 "noAvailableArmorMarks": "You have no more available armor marks",
                 "notEnoughStress": "You don't have enough stress",
                 "damageIgnore": "{character} did not take damage",
-                "featureIsMissing": "Feature is missing"
+                "featureIsMissing": "Feature is missing",
+                "actionIsMissing": "Action is missing",
+                "unownedActionMacro": "Cannot make a Use macro for an Action not on your character"
             },
             "Tooltip": {
                 "openItemWorld": "Open Item World",

--- a/module/applications/sheets/api/base-actor.mjs
+++ b/module/applications/sheets/api/base-actor.mjs
@@ -23,7 +23,7 @@ export default class DHBaseActorSheet extends DHApplicationMixin(ActorSheetV2) {
         actions: {
             openSettings: DHBaseActorSheet.#openSettings
         },
-        dragDrop: []
+        dragDrop: [{ dragSelector: '.inventory-item[data-type="attack"]', dropSelector: null }]
     };
 
     /**@type {typeof DHBaseActorSettings}*/
@@ -48,5 +48,27 @@ export default class DHBaseActorSheet extends DHApplicationMixin(ActorSheetV2) {
      */
     static async #openSettings() {
         await this.settingSheet.render({ force: true });
+    }
+
+    /* -------------------------------------------- */
+    /*  Application Drag/Drop                       */
+    /* -------------------------------------------- */
+
+    /**
+     * On dragStart on the item.
+     * @param {DragEvent} event - The drag event
+     */
+    async _onDragStart(event) {
+        const attackItem = event.currentTarget.closest('.inventory-item[data-type="attack"]');
+
+        if (attackItem) {
+            const attackData = {
+                type: 'Attack',
+                actorUuid: this.document.uuid,
+                fromInternal: true
+            };
+            event.dataTransfer.setData('text/plain', JSON.stringify(attackData));
+            event.dataTransfer.setDragImage(attackItem.querySelector('img'), 60, 0);
+        }
     }
 }

--- a/module/applications/sheets/api/base-actor.mjs
+++ b/module/applications/sheets/api/base-actor.mjs
@@ -65,6 +65,7 @@ export default class DHBaseActorSheet extends DHApplicationMixin(ActorSheetV2) {
             const attackData = {
                 type: 'Attack',
                 actorUuid: this.document.uuid,
+                img: this.document.system.attack.img,
                 fromInternal: true
             };
             event.dataTransfer.setData('text/plain', JSON.stringify(attackData));

--- a/module/applications/sheets/api/base-item.mjs
+++ b/module/applications/sheets/api/base-item.mjs
@@ -30,7 +30,8 @@ export default class DHBaseItemSheet extends DHApplicationMixin(ItemSheetV2) {
         },
         dragDrop: [
             { dragSelector: null, dropSelector: '.tab.features .drop-section' },
-            { dragSelector: '.feature-item', dropSelector: null }
+            { dragSelector: '.feature-item', dropSelector: null },
+            { dragSelector: '.action-item', dropSelector: null }
         ]
     };
 
@@ -258,6 +259,23 @@ export default class DHBaseItemSheet extends DHApplicationMixin(ItemSheetV2) {
             const featureData = { type: 'Item', data: { ...feature.toObject(), _id: null }, fromInternal: true };
             event.dataTransfer.setData('text/plain', JSON.stringify(featureData));
             event.dataTransfer.setDragImage(featureItem.querySelector('img'), 60, 0);
+        } else {
+            const actionItem = event.currentTarget.closest('.action-item');
+            if (actionItem) {
+                const action = this.document.system.actions[actionItem.dataset.index];
+                if (!action) {
+                    ui.notifications.warn(game.i18n.localize('DAGGERHEART.UI.Notifications.actionIsMissing'));
+                    return;
+                }
+
+                const actionData = {
+                    type: 'Action',
+                    data: { ...action.toObject(), id: action.id, itemUuid: this.document.uuid },
+                    fromInternal: true
+                };
+                event.dataTransfer.setData('text/plain', JSON.stringify(actionData));
+                event.dataTransfer.setDragImage(actionItem.querySelector('img'), 60, 0);
+            }
         }
     }
 

--- a/module/applications/ui/_module.mjs
+++ b/module/applications/ui/_module.mjs
@@ -2,3 +2,4 @@ export { default as DhChatLog } from './chatLog.mjs';
 export { default as DhCombatTracker } from './combatTracker.mjs';
 export * as DhCountdowns from './countdowns.mjs';
 export { default as DhFearTracker } from './fearTracker.mjs';
+export { default as DhHotbar } from './hotbar.mjs';

--- a/module/applications/ui/hotbar.mjs
+++ b/module/applications/ui/hotbar.mjs
@@ -1,0 +1,52 @@
+export default class DhHotbar extends Hotbar {
+    constructor(options) {
+        super(options);
+
+        this.setupHooks();
+    }
+
+    static async useItem(uuid) {
+        const item = await fromUuid(uuid);
+        if (!item) {
+            return ui.notifications.warn('WARNING.ObjectDoesNotExist', {
+                format: {
+                    name: game.i18n.localize('Document'),
+                    identifier: uuid
+                }
+            });
+        }
+
+        await item.use({});
+    }
+
+    setupHooks() {
+        Hooks.on('hotbarDrop', (bar, data, slot) => {
+            if (['Item'].includes(data.type)) {
+                const item = foundry.utils.fromUuidSync(data.uuid);
+                if (typeof item === 'string') return true;
+
+                switch (item.type) {
+                    case 'ancestry':
+                    case 'community':
+                    case 'class':
+                    case 'subclass':
+                        return true;
+                    default:
+                        this.createItemMacro(data, slot);
+                        return false;
+                }
+            }
+        });
+    }
+
+    async createItemMacro(data, slot) {
+        const macro = await Macro.implementation.create({
+            name: `${game.i18n.localize('Display')} ${name}`,
+            type: CONST.MACRO_TYPES.SCRIPT,
+            img: 'icons/svg/book.svg',
+            command: `await game.system.api.applications.ui.DhHotbar.useItem("${data.uuid}");`
+        });
+        await game.user.assignHotbarMacro(macro, slot);
+        return false;
+    }
+}

--- a/module/applications/ui/hotbar.mjs
+++ b/module/applications/ui/hotbar.mjs
@@ -38,6 +38,25 @@ export default class DhHotbar extends foundry.applications.ui.Hotbar {
         await action.use({});
     }
 
+    static async useAttack(actorUuid) {
+        const actor = await foundry.utils.fromUuid(actorUuid);
+        if (!actor) {
+            return ui.notifications.warn('WARNING.ObjectDoesNotExist', {
+                format: {
+                    name: game.i18n.localize('Document'),
+                    identifier: actorUuid
+                }
+            });
+        }
+
+        const attack = actor.system.attack;
+        if (!attack) {
+            return ui.notifications.warn('DAGGERHEART.UI.Notifications.attackIsMissing');
+        }
+
+        await attack.use({});
+    }
+
     setupHooks() {
         Hooks.on('hotbarDrop', (bar, data, slot) => {
             if (data.type === 'Item') {
@@ -64,6 +83,16 @@ export default class DhHotbar extends foundry.applications.ui.Hotbar {
 
                 this.createActionMacro(data, slot);
                 return false;
+            } else if (data.type === 'Attack') {
+                const actor = foundry.utils.fromUuidSync(data.actorUuid);
+                if (actor.uuid.startsWith('Compendium')) return true;
+                if (!actor.isOwner) {
+                    ui.notifications.warn(game.i18n.localize('DAGGERHEART.UI.Notifications.unownedAttackMacro'));
+                    return false;
+                }
+
+                this.createAttackMacro(data, slot);
+                return false;
             }
         });
     }
@@ -76,7 +105,6 @@ export default class DhHotbar extends foundry.applications.ui.Hotbar {
             command: `await game.system.api.applications.ui.DhHotbar.useItem("${data.uuid}");`
         });
         await game.user.assignHotbarMacro(macro, slot);
-        return false;
     }
 
     async createActionMacro(data, slot) {
@@ -87,6 +115,15 @@ export default class DhHotbar extends foundry.applications.ui.Hotbar {
             command: `await game.system.api.applications.ui.DhHotbar.useAction("${data.data.itemUuid}", "${data.data.id}");`
         });
         await game.user.assignHotbarMacro(macro, slot);
-        return false;
+    }
+
+    async createAttackMacro(data, slot) {
+        const macro = await Macro.implementation.create({
+            name: `${game.i18n.localize('Display')} ${name}`,
+            type: CONST.MACRO_TYPES.SCRIPT,
+            img: 'icons/svg/book.svg',
+            command: `await game.system.api.applications.ui.DhHotbar.useAttack("${data.actorUuid}");`
+        });
+        await game.user.assignHotbarMacro(macro, slot);
     }
 }

--- a/module/applications/ui/hotbar.mjs
+++ b/module/applications/ui/hotbar.mjs
@@ -70,7 +70,7 @@ export default class DhHotbar extends foundry.applications.ui.Hotbar {
                     case 'subclass':
                         return true;
                     default:
-                        this.createItemMacro(data, slot);
+                        this.createItemMacro(item, slot);
                         return false;
                 }
             } else if (data.type === 'Action') {
@@ -101,7 +101,7 @@ export default class DhHotbar extends foundry.applications.ui.Hotbar {
         const macro = await Macro.implementation.create({
             name: `${game.i18n.localize('Display')} ${name}`,
             type: CONST.MACRO_TYPES.SCRIPT,
-            img: 'icons/svg/book.svg',
+            img: data.img,
             command: `await game.system.api.applications.ui.DhHotbar.useItem("${data.uuid}");`
         });
         await game.user.assignHotbarMacro(macro, slot);
@@ -111,7 +111,7 @@ export default class DhHotbar extends foundry.applications.ui.Hotbar {
         const macro = await Macro.implementation.create({
             name: `${game.i18n.localize('Display')} ${name}`,
             type: CONST.MACRO_TYPES.SCRIPT,
-            img: 'icons/svg/book.svg',
+            img: data.data.img,
             command: `await game.system.api.applications.ui.DhHotbar.useAction("${data.data.itemUuid}", "${data.data.id}");`
         });
         await game.user.assignHotbarMacro(macro, slot);
@@ -121,7 +121,7 @@ export default class DhHotbar extends foundry.applications.ui.Hotbar {
         const macro = await Macro.implementation.create({
             name: `${game.i18n.localize('Display')} ${name}`,
             type: CONST.MACRO_TYPES.SCRIPT,
-            img: 'icons/svg/book.svg',
+            img: data.img,
             command: `await game.system.api.applications.ui.DhHotbar.useAttack("${data.actorUuid}");`
         });
         await game.user.assignHotbarMacro(macro, slot);

--- a/module/applications/ui/hotbar.mjs
+++ b/module/applications/ui/hotbar.mjs
@@ -1,4 +1,4 @@
-export default class DhHotbar extends Hotbar {
+export default class DhHotbar extends foundry.applications.ui.Hotbar {
     constructor(options) {
         super(options);
 
@@ -19,6 +19,25 @@ export default class DhHotbar extends Hotbar {
         await item.use({});
     }
 
+    static async useAction(itemUuid, actionId) {
+        const item = await foundry.utils.fromUuid(itemUuid);
+        if (!item) {
+            return ui.notifications.warn('WARNING.ObjectDoesNotExist', {
+                format: {
+                    name: game.i18n.localize('Document'),
+                    identifier: itemUuid
+                }
+            });
+        }
+
+        const action = item.system.actions.find(x => x.id === actionId);
+        if (!action) {
+            return ui.notifications.warn('DAGGERHEART.UI.Notifications.actionIsMissing');
+        }
+
+        await action.use({});
+    }
+
     setupHooks() {
         Hooks.on('hotbarDrop', (bar, data, slot) => {
             if (data.type === 'Item') {
@@ -35,6 +54,16 @@ export default class DhHotbar extends Hotbar {
                         this.createItemMacro(data, slot);
                         return false;
                 }
+            } else if (data.type === 'Action') {
+                const item = foundry.utils.fromUuidSync(data.data.itemUuid);
+                if (item.uuid.startsWith('Compendium')) return true;
+                if (!item.isOwned || !item.isOwner) {
+                    ui.notifications.warn(game.i18n.localize('DAGGERHEART.UI.Notifications.unownedActionMacro'));
+                    return false;
+                }
+
+                this.createActionMacro(data, slot);
+                return false;
             }
         });
     }
@@ -45,6 +74,17 @@ export default class DhHotbar extends Hotbar {
             type: CONST.MACRO_TYPES.SCRIPT,
             img: 'icons/svg/book.svg',
             command: `await game.system.api.applications.ui.DhHotbar.useItem("${data.uuid}");`
+        });
+        await game.user.assignHotbarMacro(macro, slot);
+        return false;
+    }
+
+    async createActionMacro(data, slot) {
+        const macro = await Macro.implementation.create({
+            name: `${game.i18n.localize('Display')} ${name}`,
+            type: CONST.MACRO_TYPES.SCRIPT,
+            img: 'icons/svg/book.svg',
+            command: `await game.system.api.applications.ui.DhHotbar.useAction("${data.data.itemUuid}", "${data.data.id}");`
         });
         await game.user.assignHotbarMacro(macro, slot);
         return false;

--- a/module/applications/ui/hotbar.mjs
+++ b/module/applications/ui/hotbar.mjs
@@ -21,9 +21,9 @@ export default class DhHotbar extends Hotbar {
 
     setupHooks() {
         Hooks.on('hotbarDrop', (bar, data, slot) => {
-            if (['Item'].includes(data.type)) {
+            if (data.type === 'Item') {
                 const item = foundry.utils.fromUuidSync(data.uuid);
-                if (typeof item === 'string') return true;
+                if (item.uuid.startsWith('Compendium') || !item.isOwned || !item.isOwner) return true;
 
                 switch (item.type) {
                     case 'ancestry':

--- a/module/data/countdowns.mjs
+++ b/module/data/countdowns.mjs
@@ -135,8 +135,8 @@ export const registerCountdownHooks = () => {
             if (application) {
                 foundry.applications.instances.get(application)?.render();
             } else {
-                foundry.applications.instances.get('narrative-countdowns').render();
-                foundry.applications.instances.get('encounter-countdowns').render();
+                foundry.applications.instances.get('narrative-countdowns')?.render();
+                foundry.applications.instances.get('encounter-countdowns')?.render();
             }
 
             return false;


### PR DESCRIPTION
## Description
- All Items except for `Ancestry`, `Community`, `Class`, `Subclass` create a `UseItem` macro when dragged to the macrobar.
- All actions create a `UseAction` macro when dragged to the macrobar.
- All attacks (companion, adversary) create a `UseAttack` macro when dragged to the macrobar.

- Closes #349 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?
- [x] Manual testing
- [ ] Other: