### PR TITLE
[Bug] Companion Trait Useage

### DIFF
--- a/daggerheart.mjs
+++ b/daggerheart.mjs
@@ -43,7 +43,7 @@ Hooks.once('init', () => {
     );
 
     CONFIG.statusEffects = [
-        ...CONFIG.statusEffects,
+        ...CONFIG.statusEffects.filter(x => !['dead', 'unconscious'].includes(x.id)),
         ...Object.values(SYSTEM.GENERAL.conditions).map(x => ({
             ...x,
             name: game.i18n.localize(x.name),

--- a/lang/en.json
+++ b/lang/en.json
@@ -559,9 +559,9 @@
                 "twoHanded": "Two-Handed"
             },
             "Condition": {
-                "vulnerable": {
-                    "name": "Vulnerable",
-                    "description": "While a creature is Vulnerable, all rolls targeting them have advantage.\nA creature who is already Vulnerable can’t be made to take the condition again."
+                "dead": {
+                    "name": "Dead",
+                    "description": "The character is dead"
                 },
                 "hidden": {
                     "name": "Hidden",
@@ -570,6 +570,14 @@
                 "restrained": {
                     "name": "Restrained",
                     "description": "When an effect makes a creature Restrained, it means they cannot move until this condition is cleared.\nThey can still take actions from their current position."
+                },
+                "unconcious": {
+                    "name": "Unconcious",
+                    "description": "Your character can’t move or act while unconscious, they can’t be targeted by an attack."
+                },
+                "vulnerable": {
+                    "name": "Vulnerable",
+                    "description": "While a creature is Vulnerable, all rolls targeting them have advantage.\nA creature who is already Vulnerable can’t be made to take the condition again."
                 }
             },
             "CountdownType": {

--- a/module/config/generalConfig.mjs
+++ b/module/config/generalConfig.mjs
@@ -110,6 +110,18 @@ export const conditions = {
         name: 'DAGGERHEART.CONFIG.Condition.restrained.name',
         icon: 'icons/magic/control/debuff-chains-shackle-movement-red.webp',
         description: 'DAGGERHEART.CONFIG.Condition.restrained.description'
+    },
+    unconcious: {
+        id: 'unconcious',
+        name: 'DAGGERHEART.CONFIG.Condition.unconcious.name',
+        icon: 'icons/magic/control/sleep-bubble-purple.webp',
+        description: 'DAGGERHEART.CONFIG.Condition.unconcious.description'
+    },
+    dead: {
+        id: 'dead',
+        name: 'DAGGERHEART.CONFIG.Condition.dead.name',
+        icon: 'icons/magic/death/grave-tombstone-glow-teal.webp',
+        description: 'DAGGERHEART.CONFIG.Condition.dead.description'
     }
 };
 

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -407,7 +407,8 @@ export default class DhCharacter extends BaseDataActor {
     }
 
     prepareDerivedData() {
-        this.resources.hope.value = Math.min(this.resources.hope.value, this.resources.hope.max);
+        const baseHope = this.resources.hope.value + (this.companion?.system?.resources?.hope ?? 0);
+        this.resources.hope.value = Math.min(baseHope, this.resources.hope.max);
     }
 
     getRollData() {

--- a/module/data/actor/companion.mjs
+++ b/module/data/actor/companion.mjs
@@ -124,12 +124,6 @@ export default class DhCompanion extends BaseDataActor {
         }
     }
 
-    prepareDerivedData() {
-        if (this.partner) {
-            this.partner.system.resources.hope.max += this.resources.hope;
-        }
-    }
-
     async _preDelete() {
         if (this.partner) {
             await this.partner.update({ 'system.companion': null });

--- a/module/data/actor/companion.mjs
+++ b/module/data/actor/companion.mjs
@@ -60,8 +60,7 @@ export default class DhCompanion extends BaseDataActor {
                     },
                     roll: {
                         type: 'attack',
-                        bonus: 0,
-                        trait: 'instinct'
+                        bonus: 0
                     },
                     damage: {
                         parts: [
@@ -84,12 +83,6 @@ export default class DhCompanion extends BaseDataActor {
                     magical: bonusField('DAGGERHEART.GENERAL.Damage.magicalDamage')
                 })
             })
-        };
-    }
-
-    get traits() {
-        return {
-            instinct: { value: this.attack.roll.bonus }
         };
     }
 

--- a/module/data/actor/companion.mjs
+++ b/module/data/actor/companion.mjs
@@ -91,9 +91,7 @@ export default class DhCompanion extends BaseDataActor {
     }
 
     prepareBaseData() {
-        const partnerSpellcastingModifier = this.partner?.system?.spellcastModifier;
-        const spellcastingModifier = this.partner?.system?.traits?.[partnerSpellcastingModifier]?.value;
-        this.attack.roll.bonus = spellcastingModifier ?? 0; // Needs to expand on which modifier it is that should be used because of multiclassing;
+        this.attack.roll.bonus = this.partner?.system?.spellcastModifier ?? 0;
 
         for (let levelKey in this.levelData.levelups) {
             const level = this.levelData.levelups[levelKey];

--- a/module/dice/d20Roll.mjs
+++ b/module/dice/d20Roll.mjs
@@ -130,9 +130,9 @@ export default class D20Roll extends DHRoll {
                 value: this.options.roll.bonus
             });
 
-        modifiers.push(...this.getBonus(`roll.${this.options.type}`, `${this.options.type.capitalize()} Bonus`));
+        modifiers.push(...this.getBonus(`roll.${this.options.type}`, `${this.options.type?.capitalize()} Bonus`));
         modifiers.push(
-            ...this.getBonus(`roll.${this.options.roll.type}`, `${this.options.roll.type.capitalize()} Bonus`)
+            ...this.getBonus(`roll.${this.options.roll.type}`, `${this.options.roll.type?.capitalize()} Bonus`)
         );
 
         return modifiers;

--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -191,7 +191,7 @@ export const registerRollDiceHooks = () => {
         if (config.roll.result.duality === -1) updates.push({ key: 'fear', value: 1 });
 
         if (updates.length) {
-            const target = actor.system.partner ? actor.system.partner : actor;
+            const target = actor.system.partner ?? actor;
             target.modifyResource(updates);
         }
 

--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -184,11 +184,20 @@ export const registerRollDiceHooks = () => {
             return;
 
         const actor = await fromUuid(config.source.actor),
-            updates = [];
+            updates = [],
+            hopeUpdates = [];
         if (!actor) return;
-        if (config.roll.isCritical || config.roll.result.duality === 1) updates.push({ key: 'hope', value: 1 });
+        if (config.roll.isCritical || config.roll.result.duality === 1) hopeUpdates.push({ key: 'hope', value: 1 });
         if (config.roll.isCritical) updates.push({ key: 'stress', value: -1 });
         if (config.roll.result.duality === -1) updates.push({ key: 'fear', value: 1 });
+
+        if (hopeUpdates.length) {
+            if (actor.system.partner) {
+                actor.system.partner.modifyResource(hopeUpdates);
+            } else {
+                updates.push(...hopeUpdates);
+            }
+        }
 
         if (updates.length) actor.modifyResource(updates);
 

--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -184,22 +184,16 @@ export const registerRollDiceHooks = () => {
             return;
 
         const actor = await fromUuid(config.source.actor),
-            updates = [],
-            hopeUpdates = [];
+            updates = [];
         if (!actor) return;
-        if (config.roll.isCritical || config.roll.result.duality === 1) hopeUpdates.push({ key: 'hope', value: 1 });
+        if (config.roll.isCritical || config.roll.result.duality === 1) updates.push({ key: 'hope', value: 1 });
         if (config.roll.isCritical) updates.push({ key: 'stress', value: -1 });
         if (config.roll.result.duality === -1) updates.push({ key: 'fear', value: 1 });
 
-        if (hopeUpdates.length) {
-            if (actor.system.partner) {
-                actor.system.partner.modifyResource(hopeUpdates);
-            } else {
-                updates.push(...hopeUpdates);
-            }
+        if (updates.length) {
+            const target = actor.system.partner ? actor.system.partner : actor;
+            target.modifyResource(updates);
         }
-
-        if (updates.length) actor.modifyResource(updates);
 
         if (!config.roll.hasOwnProperty('success') && !config.targets?.length) return;
 

--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -192,7 +192,9 @@ export const registerRollDiceHooks = () => {
 
         if (updates.length) {
             const target = actor.system.partner ?? actor;
-            target.modifyResource(updates);
+            if (!['dead', 'unconcious'].some(x => actor.statuses.has(x))) {
+                target.modifyResource(updates);
+            }
         }
 
         if (!config.roll.hasOwnProperty('success') && !config.targets?.length) return;


### PR DESCRIPTION
- Removed trait useage for companion attack. Uneeded and was causing errors
- Fixed so bonus hope is calculated on the Character and not on the Companion.
- Companions rolling with hope now give hope to the Character.