### PR TITLE
[Feature] Advantage/Disadvantage Tooltips

### DIFF
--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -87,6 +87,8 @@ export default class DhCharacter extends BaseDataActor {
                 value: new ForeignDocumentUUIDField({ type: 'Item', nullable: true }),
                 subclass: new ForeignDocumentUUIDField({ type: 'Item', nullable: true })
             }),
+            advantageSources: new fields.ArrayField(new fields.StringField()),
+            disadvantageSources: new fields.ArrayField(new fields.StringField()),
             levelData: new fields.EmbeddedDataField(DhLevelData),
             bonuses: new fields.SchemaField({
                 roll: new fields.SchemaField({

--- a/module/data/item/beastform.mjs
+++ b/module/data/item/beastform.mjs
@@ -69,6 +69,7 @@ export default class DHBeastform extends BaseDataItem {
 
         const beastformEffect = this.parent.effects.find(x => x.type === 'beastform');
         await beastformEffect.updateSource({
+            changes: [...beastformEffect.changes, { key: 'system.advantageSources', mode: 2, value: this.advantageOn }],
             system: {
                 characterTokenData: {
                     tokenImg: this.parent.parent.prototypeToken.texture.src,

--- a/module/documents/tooltipManager.mjs
+++ b/module/documents/tooltipManager.mjs
@@ -21,6 +21,24 @@ export default class DhTooltipManager extends foundry.helpers.interaction.Toolti
                 this.tooltip.innerHTML = html;
                 options.direction = this._determineItemTooltipDirection(element);
             }
+        } else {
+            const isAdvantage = element.dataset.tooltip?.startsWith('#advantage#');
+            const isDisadvantage = element.dataset.tooltip?.startsWith('#disadvantage#');
+            if (isAdvantage || isDisadvantage) {
+                const actorUuid = element.dataset.tooltip.slice(isAdvantage ? 11 : 14);
+                const actor = await foundry.utils.fromUuid(actorUuid);
+
+                if (actor) {
+                    html = await foundry.applications.handlebars.renderTemplate(
+                        `systems/daggerheart/templates/ui/tooltip/advantage.hbs`,
+                        {
+                            sources: isAdvantage ? actor.system.advantageSources : actor.system.disadvantageSources
+                        }
+                    );
+
+                    this.tooltip.innerHTML = html;
+                }
+            }
         }
 
         super.activate(element, { ...options, html: html });

--- a/styles/less/dialog/dice-roll/roll-selection.less
+++ b/styles/less/dialog/dice-roll/roll-selection.less
@@ -100,6 +100,10 @@
                     font-size: 14px;
                     line-height: 17px;
                 }
+
+                .advantage-chip-tooltip {
+                    pointer-events: all;
+                }
             }
 
             .advantage-chip {

--- a/templates/dialogs/dice-roll/rollSelection.hbs
+++ b/templates/dialogs/dice-roll/rollSelection.hbs
@@ -98,6 +98,9 @@
                                 <span><i class="fa-regular fa-circle"></i></span>
                             {{/if}}
                             <span class="label">{{localize "DAGGERHEART.GENERAL.Advantage.full"}}</span>
+                            {{#if @root.rollConfig.data.advantageSources.length}}
+                                <span class="advantage-chip-tooltip" data-tooltip="{{concat "#advantage#" @root.rollConfig.source.actor}}"><i class="fa-solid fa-circle-info"></i></span>
+                            {{/if}}
                         </button>
                         <button class="disadvantage-chip flex1 {{#if (eq advantage -1)}}selected{{/if}}" data-action="updateIsAdvantage" data-advantage="-1">
                             {{#if (eq advantage -1)}}
@@ -106,6 +109,9 @@
                                 <span><i class="fa-regular fa-circle"></i></span>
                             {{/if}}
                             <span class="label">{{localize "DAGGERHEART.GENERAL.Disadvantage.full"}}</span>
+                            {{#if @root.rollConfig.data.disadvantageSources.length}}
+                                <span class="advantage-chip-tooltip" data-tooltip="{{concat "#disadvantage#" @root.rollConfig.source.actor}}"><i class="fa-solid fa-circle-info"></i></span>
+                            {{/if}}
                         </button>
                         {{#unless (eq @root.rollType 'D20Roll')}}
                             <select name="roll.dice.advantageFaces">

--- a/templates/ui/tooltip/advantage.hbs
+++ b/templates/ui/tooltip/advantage.hbs
@@ -1,0 +1,5 @@
+<div class="daggerheart dh-style tooltip">
+    {{#each sources as | source |}}
+        <div>{{{source}}}</div>
+    {{/each}}
+</div>


### PR DESCRIPTION
- Added `character.system.advantageSources` and `character.system.disadvantageSources`
- These arrays of strings are shown in a tooltip on hovering an info icon in roll dialogs to remind you of your advantages and disadvantages.
- ActiveEffects can add to these arrays, making for a good way for Community Features and more to add their advantages.
- Beastforms apply an activeEffect with the forms `advantageOn`
<img width="682" height="610" alt="image" src="https://github.com/user-attachments/assets/712f14e4-73e2-44d5-962a-2810a7ab17dc" />
