### PR TITLE
[Fix] ActiveEffect Eval

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -775,7 +775,7 @@
             "WeaponFeature": {
                 "barrier": {
                     "name": "Barrier",
-                    "description": "+{armorScore} to Armor Score; -1 to Evasion"
+                    "description": "Gain your character's Tier + 1 to Armor Score; -1 to Evasion"
                 },
                 "bonded": {
                     "name": "Bonded",
@@ -891,7 +891,7 @@
                 },
                 "paired": {
                     "name": "Paired",
-                    "description": "+{bonusDamage} to primary weapon damage to targets within Melee range"
+                    "description": "Add your character's Tier + 1 to primary weapon damage against targets within Melee range"
                 },
                 "parry": {
                     "name": "Parry",
@@ -911,7 +911,7 @@
                 },
                 "protective": {
                     "name": "Protective",
-                    "description": "+{tier} to Armor Score"
+                    "description": "Add your character's Tier to your Armor Score"
                 },
                 "quick": {
                     "name": "Quick",
@@ -960,10 +960,6 @@
                 "timebending": {
                     "name": "Timebending",
                     "description": "You can choose the target of your attack after making your attack roll."
-                },
-                "versatile": {
-                    "name": "Versatile",
-                    "description": "This weapon can also be used with these statistics—{characterTrait}, {range}, {damage}."
                 }
             }
         },

--- a/module/config/itemConfig.mjs
+++ b/module/config/itemConfig.mjs
@@ -439,7 +439,7 @@ export const weaponFeatures = {
                     {
                         key: 'system.bonuses.damage.primaryWeapon.bonus',
                         mode: 2,
-                        value: '@system.levelData.levels.current'
+                        value: '@system.levelData.level.current'
                     }
                 ]
             }
@@ -1261,15 +1261,6 @@ export const weaponFeatures = {
     timebending: {
         label: 'DAGGERHEART.CONFIG.WeaponFeature.timebending.name',
         description: 'DAGGERHEART.CONFIG.WeaponFeature.timebending.description'
-    },
-    versatile: {
-        label: 'DAGGERHEART.CONFIG.WeaponFeature.versatile.name',
-        description: 'DAGGERHEART.CONFIG.WeaponFeature.versatile.description'
-        // versatile: {
-        //     characterTrait: '',
-        //     range: '',
-        //     damage: ''
-        // }
     }
 };
 

--- a/module/documents/activeEffect.mjs
+++ b/module/documents/activeEffect.mjs
@@ -55,8 +55,22 @@ export default class DhActiveEffect extends ActiveEffect {
     }
 
     static applyField(model, change, field) {
-        change.value = itemAbleRollParse(change.value, model, change.effect.parent);
+        change.value = this.effectSafeEval(itemAbleRollParse(change.value, model, change.effect.parent));
         super.applyField(model, change, field);
+    }
+
+    /* Altered Foundry safeEval to allow non-numeric returns */
+    static effectSafeEval(expression) {
+        let result;
+        try {
+            // eslint-disable-next-line no-new-func
+            const evl = new Function('sandbox', `with (sandbox) { return ${expression}}`);
+            result = evl(Roll.MATH_PROXY);
+        } catch (err) {
+            return expression;
+        }
+
+        return result;
     }
 
     async toChat(origin) {


### PR DESCRIPTION
- Fixed so active effects can handle expressions again with an alternate `safeEval` function that allows string returns.
- Removed versatile as a WeaponFeature. It will be handled by adding a `Versatile Attack` action on items instead.