### PR TITLE
Fix ctrl+clicking on a downtime action on macOS

### DIFF
--- a/module/applications/dialogs/downtime.mjs
+++ b/module/applications/dialogs/downtime.mjs
@@ -113,10 +113,9 @@ export default class DhpDowntime extends HandlebarsApplicationMixin(ApplicationV
 
     deselectMove(event) {
         const button = event.target.closest('.activity-container');
-        const move = button.dataset.move;
-        this.moveData[button.dataset.category].moves[move].selected = this.moveData[button.dataset.category].moves[move]
-            .selected
-            ? this.moveData[button.dataset.category].moves[move].selected - 1
+        const { move, category } = button.dataset;
+        this.moveData[category].moves[move].selected = this.moveData[category].moves[move].selected
+            ? this.moveData[category].moves[move].selected - 1
             : 0;
 
         this.render();

--- a/module/applications/dialogs/downtime.mjs
+++ b/module/applications/dialogs/downtime.mjs
@@ -119,6 +119,18 @@ export default class DhpDowntime extends HandlebarsApplicationMixin(ApplicationV
             : 0;
 
         this.render();
+
+        // On macOS with a single-button mouse (e.g. a laptop trackpad),
+        // right-click is triggered with ctrl+click, which triggers both a
+        // `contextmenu` event and a regular click event. We need to stop
+        // event propagation to prevent the click event from triggering the
+        // `selectMove` function and undoing the change we just made.
+        event.stopPropagation();
+
+        // Having stopped propagation, we're no longer subject to Foundry's
+        // default `contextmenu` handler, so we also have to prevent the
+        // default behaviour to prevent a context menu from appearing.
+        event.preventDefault();
     }
 
     static async takeDowntime() {


### PR DESCRIPTION
## Description

While working on https://github.com/Foundryborne/daggerheart/issues/374 I realised that I couldn't deselect downtime moves by ctrl+clicking on macOS.

Macs traditionally only had one mouse button, and used ctrl+click to simulate a right-click.

These days we mostly have proper multi-button mice or the two-finger-click gesture on a trackpad, both already worked as expected, but the ctrl+click muscle memory is strong and I was very confused why this seemed to suddenly stopped working when I was away from my desk and defaulted to using ctrl+click on my laptop 😅 

Turned out that the pointer event from a ctrl+click was firing both the `contextmenu` event and the regular click events, so both the `deselectMove` and `selectMove` handlers were firing and cancelling each other out.

This PR avoids that problem by stopping the event from propagating after running the `deselectMove` handler.

While I was in the area, I did a tiny bit of refactoring (initially just to make some `console.log` debugging easier, but the change seemed good).

## Type of Change

Please check the relevant options:

- [x] Bug fix
- [ ] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x] Manual testing
- [ ] Other:

## Screenshots (if applicable)

Include screenshots or GIFs to help explain your changes visually.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [ ] New and existing tests pass locally with my changes

## Additional Comments

Add any other context or questions here.

---

> Thank you for your contribution! 🎉
