### PR TITLE
Apply the first downtime move before picking the second one

### DIFF
--- a/module/applications/dialogs/downtime.mjs
+++ b/module/applications/dialogs/downtime.mjs
@@ -64,14 +64,8 @@ export default class DhpDowntime extends HandlebarsApplicationMixin(ApplicationV
         context.selectedActivity = this.selectedActivity;
         context.moveData = this.moveData;
 
-        const shortRestMovesSelected = Object.values(this.moveData.shortRest.moves).reduce(
-            (acc, x) => acc + (x.selected ?? 0),
-            0
-        );
-        const longRestMovesSelected = Object.values(this.moveData.longRest.moves).reduce(
-            (acc, x) => acc + (x.selected ?? 0),
-            0
-        );
+        const shortRestMovesSelected = this.#nrSelectedMoves('shortRest');
+        const longRestMovesSelected = this.#nrSelectedMoves('longRest');
         context.nrChoices = {
             ...this.nrChoices,
             shortRest: {
@@ -95,7 +89,7 @@ export default class DhpDowntime extends HandlebarsApplicationMixin(ApplicationV
     static selectMove(_, target) {
         const { category, move } = target.dataset;
 
-        const nrSelected = Object.values(this.moveData[category].moves).reduce((acc, x) => acc + (x.selected ?? 0), 0);
+        const nrSelected = this.#nrSelectedMoves(category);
 
         if (nrSelected + this.nrChoices[category].taken >= this.nrChoices[category].max) {
             ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.noMoreMoves'));
@@ -180,5 +174,9 @@ export default class DhpDowntime extends HandlebarsApplicationMixin(ApplicationV
     static async updateData(event, element, formData) {
         this.customActivity = foundry.utils.mergeObject(this.customActivity, formData.object);
         this.render();
+    }
+
+    #nrSelectedMoves(category) {
+        return Object.values(this.moveData[category].moves).reduce((acc, x) => acc + (x.selected ?? 0), 0);
     }
 }


### PR DESCRIPTION
## Description

- Fixes https://github.com/Foundryborne/daggerheart/issues/374

Some downtime moves require a roll to see how successful they are. In these cases, the player might want to see how their first move works out before they select their next one.

This commit updates the downtime dialog to allow for this behaviour:

- The "Take Downtime" button is enabled whenever any moves are selected.
- Clicking the button only closes the dialog when all moves have been made.

To keep track of this, the `nrChoices` object has been expanded to include a `taken` counter for each category, which is increased whenever a move is taken.

After making one move the selection is reset, but the number of moves displayed in the dialog header and the number of permitted selections both take the number of taken moves into account.

While I was in the area, I also fixed the short rest chat message heading, which previously said "long rest", and did a bit of minor tidying up to remove unused context data.

## Type of Change

Please check the relevant options:

- [ ] Bug fix
- [x] New feature
- [x] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x] Manual testing
- [ ] Other:

## Screenshots (if applicable)

![Animated GIF showing submitting downtime moves either one by one or all together](https://github.com/user-attachments/assets/8485193f-34c4-4517-ba6e-91a2082d6df7)

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [ ] New and existing tests pass locally with my changes

## Additional Comments

Add any other context or questions here.

---

> Thank you for your contribution! 🎉
