### PR TITLE
Fix character sheet sidebar translation key.

### DIFF
--- a/templates/sheets/actors/character/sidebar.hbs
+++ b/templates/sheets/actors/character/sidebar.hbs
@@ -132,7 +132,7 @@
     <div class="experience-section">
         <div class="title">
             <side-line-div class="invert"></side-line-div>
-            <h3>{{localize "DAGGERHEART.GENERAL.experience.Single"}}</h3>
+            <h3>{{localize "DAGGERHEART.GENERAL.Experience.single"}}</h3>
             <side-line-div></side-line-div>
         </div>
         <div class="experience-list">


### PR DESCRIPTION
## Description

Small tweak to fix a bad translation key in the character sheet sidebar.

## Type of Change

Please check the relevant options:

- [x] Bug fix
- [ ] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x] Manual testing
- [ ] Other:

## Screenshots (if applicable)

Before:

<img width="463" height="88" alt="Screenshot showing the bug: the character sheet sidebar contains a raw translation key" src="https://github.com/user-attachments/assets/43c4aaeb-11f6-4ef8-ac01-26f3e026dbd6" />

After:

<img width="268" height="68" alt="Screenshot showing the fix: the character sheet sidebar contains properly translated text" src="https://github.com/user-attachments/assets/79d8400d-d287-4056-8c4e-5b706aa6966d" />

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [ ] New and existing tests pass locally with my changes

## Additional Comments

Add any other context or questions here.

---

> Thank you for your contribution! 🎉
