### PR TITLE
Move downtime move tooltip from top to right.

### DIFF
--- a/module/documents/tooltipManager.mjs
+++ b/module/documents/tooltipManager.mjs
@@ -40,7 +40,7 @@ export default class DhTooltipManager extends foundry.helpers.interaction.Toolti
                 this.tooltip.innerHTML = html;
                 options.direction = this._determineItemTooltipDirection(
                     element,
-                    this.constructor.TOOLTIP_DIRECTIONS.UP
+                    this.constructor.TOOLTIP_DIRECTIONS.RIGHT
                 );
             }
 


### PR DESCRIPTION
## Description

While working on https://github.com/Foundryborne/daggerheart/issues/374, I noticed that the tooltip describing downtime moves can obscure potentially useful information, like the number of remaining moves.

This PR moves the downtown dialog's move tooltip to the right so that the full downtime dialog remains visible.

## Type of Change

Please check the relevant options:

- [ ] Bug fix
- [ ] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [x] Other (please describe): proposed UI improvement

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x] Manual testing
- [ ] Other:

## Screenshots (if applicable)

Before, the tooltip hides potentially useful information:

<img width="344" height="338" alt="Screenshot showing the downtime move dialog with the mouse hovering over the 'repair armor' move. The previous two moves and the heading describing the number of available moves are hidden behind a tooltip describing the details of the 'repair armor' move." src="https://github.com/user-attachments/assets/e3e870bb-b338-436f-977d-c7ea5887b615" />

After, the tooltip is off to the side:

<img width="630" height="336" alt="Screenshot showing the downtime move dialog with the mouse hovering over the 'repair armor' move. This time, the full contents of the dialog are visible, and the tooltip describing the details of the 'repair armor' move is off to the right hand side." src="https://github.com/user-attachments/assets/7ed9f4f2-a68b-4cc2-945d-1985d0ab6496" />


## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [ ] New and existing tests pass locally with my changes

## Additional Comments

Add any other context or questions here.

---

> Thank you for your contribution! 🎉
