### PR TITLE
[Fix] Feature Deletion Handling

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1603,13 +1603,7 @@
                 "attackIsMissing": "Attack is missing",
                 "unownedActionMacro": "Cannot make a Use macro for an Action not on your character",
                 "unownedAttackMacro": "Cannot make a Use macro for an Attack that doesn't belong to one of your characters",
-                "featureNotHope": "This feature is used as something else than a Hope feature and cannot be used here.",
-                "featureNotClass": "This feature is used as something else than a Class feature and cannot be used here.",
-                "featureNotPrimary": "This feature is used as something else than a Primary feature and cannot be used here.",
-                "featureNotSecondary": "This feature is used as something else than a Secondary feature and cannot be used here.",
-                "featureNotFoundation": "This feature is used as something else than a Foundation feature and cannot be used here.",
-                "featureNotSpecialization": "This feature is used as something else than a Specialization feature and cannot be used here.",
-                "featureNotMastery": "This feature is used as something else than a Mastery feature and cannot be used here."
+                "featureAlreadyLinked": "{name} is already linked to {origin}. Remove it from there if you want to link it elsewhere."
             },
             "Tooltip": {
                 "disableEffect": "Disable Effect",

--- a/module/applications/sheets/api/application-mixin.mjs
+++ b/module/applications/sheets/api/application-mixin.mjs
@@ -84,24 +84,26 @@ export default function DHApplicationMixin(Base) {
                 useItem: DHSheetV2.#useItem,
                 useAction: DHSheetV2.#useAction,
                 toggleEffect: DHSheetV2.#toggleEffect,
-                toggleExtended: DHSheetV2.#toggleExtended,
+                toggleExtended: DHSheetV2.#toggleExtended
             },
-            contextMenus: [{
-                handler: DHSheetV2.#getEffectContextOptions,
-                selector: '[data-item-uuid][data-type="effect"]',
-                options: {
-                    parentClassHooks: false,
-                    fixed: true
+            contextMenus: [
+                {
+                    handler: DHSheetV2.#getEffectContextOptions,
+                    selector: '[data-item-uuid][data-type="effect"]',
+                    options: {
+                        parentClassHooks: false,
+                        fixed: true
+                    }
                 },
-            },
-            {
-                handler: DHSheetV2.#getActionContextOptions,
-                selector: '[data-item-uuid][data-type="action"]',
-                options: {
-                    parentClassHooks: false,
-                    fixed: true
+                {
+                    handler: DHSheetV2.#getActionContextOptions,
+                    selector: '[data-item-uuid][data-type="action"]',
+                    options: {
+                        parentClassHooks: false,
+                        fixed: true
+                    }
                 }
-            }],
+            ],
             dragDrop: [],
             tagifyConfigs: []
         };
@@ -132,13 +134,13 @@ export default function DHApplicationMixin(Base) {
         /**@inheritdoc */
         _syncPartState(partId, newElement, priorElement, state) {
             super._syncPartState(partId, newElement, priorElement, state);
-            for (const el of priorElement.querySelectorAll(".extensible.extended")) {
+            for (const el of priorElement.querySelectorAll('.extensible.extended')) {
                 const { actionId, itemUuid } = el.parentElement.dataset;
                 const selector = `${actionId ? `[data-action-id="${actionId}"]` : `[data-item-uuid="${itemUuid}"]`} .extensible`;
                 const newExtensible = newElement.querySelector(selector);
 
                 if (!newExtensible) continue;
-                newExtensible.classList.add("extended");
+                newExtensible.classList.add('extended');
                 const descriptionElement = newExtensible.querySelector('.invetory-description');
                 if (descriptionElement) {
                     this.#prepareInventoryDescription(newExtensible, descriptionElement);
@@ -209,14 +211,14 @@ export default function DHApplicationMixin(Base) {
          * @param {DragEvent} event
          * @protected
          */
-        _onDragStart(event) { }
+        _onDragStart(event) {}
 
         /**
          * Handle drop event.
          * @param {DragEvent} event
          * @protected
          */
-        _onDrop(event) { }
+        _onDrop(event) {}
 
         /* -------------------------------------------- */
         /*  Context Menu                                */
@@ -251,7 +253,7 @@ export default function DHApplicationMixin(Base) {
                     icon: 'fa-regular fa-lightbulb',
                     condition: target => getDocFromElement(target).disabled,
                     callback: target => getDocFromElement(target).update({ disabled: false })
-                },
+                }
             ].map(option => ({
                 ...option,
                 name: `DAGGERHEART.APPLICATIONS.ContextMenu.${option.name}`,
@@ -269,7 +271,7 @@ export default function DHApplicationMixin(Base) {
          */
         static #getActionContextOptions() {
             /**@type {import('@client/applications/ux/context-menu.mjs').ContextMenuEntry[]} */
-            const getAction = (target) => {
+            const getAction = target => {
                 const { actionId } = target.closest('[data-action-id]').dataset;
                 const { actions, attack } = this.document.system;
                 return attack?.id === actionId ? attack : actions?.find(a => a.id === actionId);
@@ -279,30 +281,31 @@ export default function DHApplicationMixin(Base) {
                 {
                     name: 'DAGGERHEART.APPLICATIONS.ContextMenu.useItem',
                     icon: 'fa-solid fa-burst',
-                    condition: this.document instanceof foundry.documents.Actor ||
+                    condition:
+                        this.document instanceof foundry.documents.Actor ||
                         (this.document instanceof foundry.documents.Item && this.document.parent),
-                    callback: (target, event) => getAction(target).use(event),
+                    callback: (target, event) => getAction(target).use(event)
                 },
                 {
                     name: 'DAGGERHEART.APPLICATIONS.ContextMenu.sendToChat',
                     icon: 'fa-solid fa-message',
-                    callback: (target) => getAction(target).toChat(this.document.id),
+                    callback: target => getAction(target).toChat(this.document.id)
                 },
                 {
                     name: 'CONTROLS.CommonEdit',
                     icon: 'fa-solid fa-pen-to-square',
-                    callback: (target) => new DHActionConfig(getAction(target)).render({ force: true })
+                    callback: target => new DHActionConfig(getAction(target)).render({ force: true })
                 },
                 {
                     name: 'CONTROLS.CommonDelete',
                     icon: 'fa-solid fa-trash',
-                    condition: (target) => {
+                    condition: target => {
                         const { actionId } = target.closest('[data-action-id]').dataset;
                         const { attack } = this.document.system;
-                        return attack?.id !== actionId
+                        return attack?.id !== actionId;
                     },
-                    callback: async (target) => {
-                        const action = getAction(target)
+                    callback: async target => {
+                        const action = getAction(target);
                         const confirmed = await foundry.applications.api.DialogV2.confirm({
                             window: {
                                 title: game.i18n.format('DAGGERHEART.APPLICATIONS.DeleteConfirmation.title', {
@@ -310,12 +313,14 @@ export default function DHApplicationMixin(Base) {
                                     name: action.name
                                 })
                             },
-                            content: game.i18n.format('DAGGERHEART.APPLICATIONS.DeleteConfirmation.text', { name: action.name })
+                            content: game.i18n.format('DAGGERHEART.APPLICATIONS.DeleteConfirmation.text', {
+                                name: action.name
+                            })
                         });
                         if (!confirmed) return;
 
                         return this.document.update({
-                            'system.actions': this.document.system.actions.filter((a) => a.id !== action.id)
+                            'system.actions': this.document.system.actions.filter(a => a.id !== action.id)
                         });
                     }
                 }
@@ -337,35 +342,38 @@ export default function DHApplicationMixin(Base) {
                     name: 'CONTROLS.CommonEdit',
                     icon: 'fa-solid fa-pen-to-square',
                     callback: target => getDocFromElement(target).sheet.render({ force: true })
-                },
+                }
             ];
 
-            if (usable) options.unshift({
-                name: 'DAGGERHEART.APPLICATIONS.ContextMenu.useItem',
-                icon: 'fa-solid fa-burst',
-                callback: (target, event) => getDocFromElement(target).use(event),
-            });
+            if (usable)
+                options.unshift({
+                    name: 'DAGGERHEART.APPLICATIONS.ContextMenu.useItem',
+                    icon: 'fa-solid fa-burst',
+                    callback: (target, event) => getDocFromElement(target).use(event)
+                });
 
-            if (toChat) options.unshift({
-                name: 'DAGGERHEART.APPLICATIONS.ContextMenu.sendToChat',
-                icon: 'fa-solid fa-message',
-                callback: (target) => getDocFromElement(target).toChat(this.document.id),
-            });
+            if (toChat)
+                options.unshift({
+                    name: 'DAGGERHEART.APPLICATIONS.ContextMenu.sendToChat',
+                    icon: 'fa-solid fa-message',
+                    callback: target => getDocFromElement(target).toChat(this.document.id)
+                });
 
-            if (deletable) options.push({
-                name: 'CONTROLS.CommonDelete',
-                icon: 'fa-solid fa-trash',
-                callback: (target, event) => {
-                    const doc = getDocFromElement(target);
-                    if (event.shiftKey) return doc.delete();
-                    else return doc.deleteDialog();
-                }
-            })
+            if (deletable)
+                options.push({
+                    name: 'CONTROLS.CommonDelete',
+                    icon: 'fa-solid fa-trash',
+                    callback: (target, event) => {
+                        const doc = getDocFromElement(target);
+                        if (event.shiftKey) return doc.delete();
+                        else return doc.deleteDialog();
+                    }
+                });
 
             return options.map(option => ({
                 ...option,
                 icon: `<i class="${option.icon}"></i>`
-            }))
+            }));
         }
 
         /* -------------------------------------------- */
@@ -400,17 +408,20 @@ export default function DHApplicationMixin(Base) {
             const doc = itemUuid
                 ? getDocFromElement(extensibleElement)
                 : this.document.system.attack?.id === actionId
-                    ? this.document.system.attack
-                    : this.document.system.actions?.find(a => a.id === actionId);
+                  ? this.document.system.attack
+                  : this.document.system.actions?.find(a => a.id === actionId);
             if (!doc) return;
 
             const description = doc.system?.description ?? doc.description;
             const isAction = !!actionId;
-            descriptionElement.innerHTML = await foundry.applications.ux.TextEditor.implementation.enrichHTML(description, {
-                relativeTo: isAction ? doc.parent : doc,
-                rollData: doc.getRollData?.(),
-                secrets: isAction ? doc.parent.isOwner : doc.isOwner
-            });
+            descriptionElement.innerHTML = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
+                description,
+                {
+                    relativeTo: isAction ? doc.parent : doc,
+                    rollData: doc.getRollData?.(),
+                    secrets: isAction ? doc.parent.isOwner : doc.isOwner
+                }
+            );
         }
 
         /* -------------------------------------------- */
@@ -427,26 +438,28 @@ export default function DHApplicationMixin(Base) {
             const parent = parentIsItem && documentClass === 'Item' ? null : this.document;
 
             if (type === 'action') {
-                const { type: actionType } = await foundry.applications.api.DialogV2.input({
-                    window: { title: 'Select Action Type' },
-                    content: await foundry.applications.handlebars.renderTemplate(
-                        'systems/daggerheart/templates/actionTypes/actionType.hbs',
-                        { types: CONFIG.DH.ACTIONS.actionTypes }
-                    ),
-                    ok: {
-                        label: game.i18n.format('DOCUMENT.Create', {
-                            type: game.i18n.localize('DAGGERHEART.GENERAL.Action.single')
-                        }),
-                    }
-                }) ?? {};
+                const { type: actionType } =
+                    (await foundry.applications.api.DialogV2.input({
+                        window: { title: 'Select Action Type' },
+                        content: await foundry.applications.handlebars.renderTemplate(
+                            'systems/daggerheart/templates/actionTypes/actionType.hbs',
+                            { types: CONFIG.DH.ACTIONS.actionTypes }
+                        ),
+                        ok: {
+                            label: game.i18n.format('DOCUMENT.Create', {
+                                type: game.i18n.localize('DAGGERHEART.GENERAL.Action.single')
+                            })
+                        }
+                    })) ?? {};
                 if (!actionType) return;
-                const cls = game.system.api.models.actions.actionsTypes[actionType]
-                const action = new cls({
-                    _id: foundry.utils.randomID(),
-                    type: actionType,
-                    name: game.i18n.localize(CONFIG.DH.ACTIONS.actionTypes[actionType].name),
-                    ...cls.getSourceConfig(this.document)
-                },
+                const cls = game.system.api.models.actions.actionsTypes[actionType];
+                const action = new cls(
+                    {
+                        _id: foundry.utils.randomID(),
+                        type: actionType,
+                        name: game.i18n.localize(CONFIG.DH.ACTIONS.actionTypes[actionType].name),
+                        ...cls.getSourceConfig(this.document)
+                    },
                     {
                         parent: this.document
                     }
@@ -456,25 +469,32 @@ export default function DHApplicationMixin(Base) {
                     force: true
                 });
                 return action;
-
             } else {
                 const cls = getDocumentClass(documentClass);
                 const data = {
                     name: cls.defaultName({ type, parent }),
-                    type,
-                }
-                if (inVault) data["system.inVault"] = true;
+                    type
+                };
+                if (inVault) data['system.inVault'] = true;
                 if (disabled) data.disabled = true;
 
+                const isItemFeature = parentIsItem && type === 'feature';
+                if (isItemFeature) {
+                    data.system = {
+                        originItemType: CONFIG.DH.ITEM.featureTypes[this.document.type].id,
+                        originId: this.document.uuid
+                    };
+                }
+
                 const doc = await cls.create(data, { parent, renderSheet: !event.shiftKey });
-                if (parentIsItem && type === 'feature') {
+
+                if (isItemFeature) {
                     await this.document.update({
                         'system.features': this.document.system.toObject().features.concat(doc.uuid)
                     });
                 }
                 return doc;
             }
-
         }
 
         /**
@@ -489,7 +509,7 @@ export default function DHApplicationMixin(Base) {
             const { actionId } = target.closest('[data-action-id]').dataset;
             const { actions, attack } = this.document.system;
             const action = attack?.id === actionId ? attack : actions?.find(a => a.id === actionId);
-            new DHActionConfig(action).render({ force: true })
+            new DHActionConfig(action).render({ force: true });
         }
 
         /**
@@ -500,8 +520,8 @@ export default function DHApplicationMixin(Base) {
             const doc = getDocFromElement(target);
 
             if (doc) {
-                if (event.shiftKey) return doc.delete()
-                else return await doc.deleteDialog()
+                if (event.shiftKey) return doc.delete();
+                else return await doc.deleteDialog();
             }
 
             // TODO: REDO this
@@ -524,7 +544,7 @@ export default function DHApplicationMixin(Base) {
             }
 
             return await this.document.update({
-                'system.actions': actions.filter((a) => a.id !== action.id)
+                'system.actions': actions.filter(a => a.id !== action.id)
             });
         }
 
@@ -555,7 +575,7 @@ export default function DHApplicationMixin(Base) {
                 const { actionId } = target.closest('[data-action-id]').dataset;
                 const { actions, attack } = this.document.system;
                 doc = attack?.id === actionId ? attack : actions?.find(a => a.id === actionId);
-                if(this.document instanceof foundry.documents.Item && !this.document.parent) return;
+                if (this.document instanceof foundry.documents.Item && !this.document.parent) return;
             }
 
             await doc.use(event);
@@ -572,7 +592,6 @@ export default function DHApplicationMixin(Base) {
             const action = attack?.id === actionId ? attack : actions?.find(a => a.id === actionId);
             await action.use(event);
         }
-
 
         /**
          * Toggle a ActiveEffect
@@ -604,7 +623,6 @@ export default function DHApplicationMixin(Base) {
             const descriptionElement = extensible?.querySelector('.invetory-description');
             if (t && !!descriptionElement) this.#prepareInventoryDescription(extensible, descriptionElement);
         }
-
     }
 
     return DHSheetV2;

--- a/module/applications/sheets/api/application-mixin.mjs
+++ b/module/applications/sheets/api/application-mixin.mjs
@@ -506,7 +506,12 @@ export default function DHApplicationMixin(Base) {
             if (doc) return doc.sheet.render({ force: true });
 
             // TODO: REDO this
-            const { actionId } = target.closest('[data-action-id]').dataset;
+            const actionNode = target.closest('[data-action-id]');
+            if (!actionNode) {
+                return ui.notifications.warn(game.i18n.localize('DAGGERHEART.UI.Notifications.featureIsMissing'));
+            }
+
+            const { actionId } = actionNode.dataset;
             const { actions, attack } = this.document.system;
             const action = attack?.id === actionId ? attack : actions?.find(a => a.id === actionId);
             new DHActionConfig(action).render({ force: true });

--- a/module/applications/sheets/api/base-item.mjs
+++ b/module/applications/sheets/api/base-item.mjs
@@ -290,6 +290,16 @@ export default class DHBaseItemSheet extends DHApplicationMixin(ItemSheetV2) {
 
         const item = await fromUuid(data.uuid);
         if (item?.type === 'feature') {
+            if (item.system.originId) {
+                const origin = await foundry.utils.fromUuid(item.system.originId);
+                return ui.notifications.warn(
+                    game.i18n.format('DAGGERHEART.UI.Notifications.featureAlreadyLinked', {
+                        name: item.name,
+                        origin: origin.name
+                    })
+                );
+            }
+
             await item.update({
                 system: {
                     originItemType: CONFIG.DH.ITEM.featureTypes[this.document.type].id,

--- a/module/applications/sheets/items/ancestry.mjs
+++ b/module/applications/sheets/items/ancestry.mjs
@@ -5,8 +5,7 @@ export default class AncestrySheet extends DHHeritageSheet {
     static DEFAULT_OPTIONS = {
         classes: ['ancestry'],
         actions: {
-            editFeature: AncestrySheet.#editFeature,
-            removeFeature: AncestrySheet.#removeFeature
+            editFeature: AncestrySheet.#editFeature
         },
         dragDrop: [{ dragSelector: null, dropSelector: '.tab.features .drop-section' }]
     };
@@ -37,21 +36,6 @@ export default class AncestrySheet extends DHHeritageSheet {
         feature.sheet.render(true);
     }
 
-    /**
-     * Remove a feature from the item.
-     * @type {ApplicationClickAction}
-     */
-    static async #removeFeature(event, button) {
-        event.stopPropagation();
-        const target = button.closest('.feature-item');
-        const feature = this.document.system[`${target.dataset.type}Feature`];
-
-        if (feature) await feature.update({ 'system.subType': null });
-        await this.document.update({
-            'system.features': this.document.system.features.filter(x => x && x.uuid !== feature.uuid).map(x => x.uuid)
-        });
-    }
-
     /* -------------------------------------------- */
     /*  Application Drag/Drop                       */
     /* -------------------------------------------- */
@@ -73,7 +57,14 @@ export default class AncestrySheet extends DHHeritageSheet {
                 return;
             }
 
-            await item.update({ 'system.subType': subType });
+            await item.update({
+                system: {
+                    subType: subType,
+                    originItemType: CONFIG.DH.ITEM.featureTypes[this.document.type].id,
+                    originId: this.document.uuid
+                }
+            });
+
             await this.document.update({
                 'system.features': [...this.document.system.features.map(x => x.uuid), item.uuid]
             });

--- a/module/applications/sheets/items/ancestry.mjs
+++ b/module/applications/sheets/items/ancestry.mjs
@@ -50,13 +50,17 @@ export default class AncestrySheet extends DHHeritageSheet {
 
         const item = await fromUuid(data.uuid);
         if (item?.type === 'feature') {
-            const subType = event.target.closest('.primary-feature') ? 'primary' : 'secondary';
-            if (item.system.subType && item.system.subType !== CONFIG.DH.ITEM.featureSubTypes[subType]) {
-                const error = subType === 'primary' ? 'featureNotPrimary' : 'featureNotSecondary';
-                ui.notifications.warn(game.i18n.localize(`DAGGERHEART.UI.Notifications.${error}`));
-                return;
+            if (item.system.originId) {
+                const origin = await foundry.utils.fromUuid(item.system.originId);
+                return ui.notifications.warn(
+                    game.i18n.format('DAGGERHEART.UI.Notifications.featureAlreadyLinked', {
+                        name: item.name,
+                        origin: origin.name
+                    })
+                );
             }
 
+            const subType = event.target.closest('.primary-feature') ? 'primary' : 'secondary';
             await item.update({
                 system: {
                     subType: subType,

--- a/module/applications/sheets/items/class.mjs
+++ b/module/applications/sheets/items/class.mjs
@@ -9,7 +9,7 @@ export default class ClassSheet extends DHBaseItemSheet {
         position: { width: 700 },
         actions: {
             removeItemFromCollection: ClassSheet.#removeItemFromCollection,
-            removeSuggestedItem: ClassSheet.#removeSuggestedItem,
+            removeSuggestedItem: ClassSheet.#removeSuggestedItem
         },
         tagifyConfigs: [
             {
@@ -93,7 +93,13 @@ export default class ClassSheet extends DHBaseItemSheet {
                     return;
                 }
 
-                await item.update({ 'system.subType': CONFIG.DH.ITEM.featureSubTypes.hope });
+                await item.update({
+                    system: {
+                        subType: CONFIG.DH.ITEM.featureSubTypes.hope,
+                        originItemType: CONFIG.DH.ITEM.featureTypes[this.document.type].id,
+                        originId: this.document.uuid
+                    }
+                });
                 await this.document.update({
                     'system.features': [...this.document.system.features.map(x => x.uuid), item.uuid]
                 });
@@ -103,7 +109,13 @@ export default class ClassSheet extends DHBaseItemSheet {
                     return;
                 }
 
-                await item.update({ 'system.subType': CONFIG.DH.ITEM.featureSubTypes.class });
+                await item.update({
+                    system: {
+                        subType: CONFIG.DH.ITEM.featureSubTypes.class,
+                        originItemType: CONFIG.DH.ITEM.featureTypes[this.document.type].id,
+                        originId: this.document.uuid
+                    }
+                });
                 await this.document.update({
                     'system.features': [...this.document.system.features.map(x => x.uuid), item.uuid]
                 });

--- a/module/applications/sheets/items/class.mjs
+++ b/module/applications/sheets/items/class.mjs
@@ -83,16 +83,38 @@ export default class ClassSheet extends DHBaseItemSheet {
         const item = await fromUuid(data.uuid);
         const target = event.target.closest('fieldset.drop-section');
         if (item.type === 'subclass') {
+            if (item.system.originId) {
+                const origin = await foundry.utils.fromUuid(item.system.originId);
+                return ui.notifications.warn(
+                    game.i18n.format('DAGGERHEART.UI.Notifications.featureAlreadyLinked', {
+                        name: item.name,
+                        origin: origin.name
+                    })
+                );
+            }
+
+            await item.update({
+                system: {
+                    originItemType: CONFIG.DH.ITEM.featureTypes[this.document.type].id,
+                    originId: this.document.uuid
+                }
+            });
+
             await this.document.update({
                 'system.subclasses': [...this.document.system.subclasses.map(x => x.uuid), item.uuid]
             });
         } else if (item.type === 'feature') {
-            if (target.classList.contains('hope-feature')) {
-                if (item.system.subType && item.system.subType !== CONFIG.DH.ITEM.featureSubTypes.hope) {
-                    ui.notifications.warn(game.i18n.localize('DAGGERHEART.UI.Notifications.featureNotHope'));
-                    return;
-                }
+            if (item.system.originId) {
+                const origin = await foundry.utils.fromUuid(item.system.originId);
+                return ui.notifications.warn(
+                    game.i18n.format('DAGGERHEART.UI.Notifications.featureAlreadyLinked', {
+                        name: item.name,
+                        origin: origin.name
+                    })
+                );
+            }
 
+            if (target.classList.contains('hope-feature')) {
                 await item.update({
                     system: {
                         subType: CONFIG.DH.ITEM.featureSubTypes.hope,
@@ -104,11 +126,6 @@ export default class ClassSheet extends DHBaseItemSheet {
                     'system.features': [...this.document.system.features.map(x => x.uuid), item.uuid]
                 });
             } else if (target.classList.contains('class-feature')) {
-                if (item.system.subType && item.system.subType !== CONFIG.DH.ITEM.featureSubTypes.class) {
-                    ui.notifications.warn(game.i18n.localize('DAGGERHEART.UI.Notifications.featureNotClass'));
-                    return;
-                }
-
                 await item.update({
                     system: {
                         subType: CONFIG.DH.ITEM.featureSubTypes.class,
@@ -151,18 +168,20 @@ export default class ClassSheet extends DHBaseItemSheet {
             }
         } else if (item.type === 'miscellaneous') {
             if (target.classList.contains('take-section')) {
-                if (this.document.system.inventory.take.length < 3)
+                if (this.document.system.inventory.take.length < 3) {
                     await this.document.update({
                         'system.inventory.take': [...this.document.system.inventory.take.map(x => x.uuid), item.uuid]
                     });
+                }
             } else if (target.classList.contains('choice-b-section')) {
-                if (this.document.system.inventory.choiceB.length < 2)
+                if (this.document.system.inventory.choiceB.length < 2) {
                     await this.document.update({
                         'system.inventory.choiceB': [
                             ...this.document.system.inventory.choiceB.map(x => x.uuid),
                             item.uuid
                         ]
                     });
+                }
             }
         }
     }
@@ -179,7 +198,19 @@ export default class ClassSheet extends DHBaseItemSheet {
     static async #removeItemFromCollection(_event, element) {
         const { uuid, target } = element.dataset;
         const prop = foundry.utils.getProperty(this.document.system, target);
-        await this.document.update({ [`system.${target}`]: prop.filter(i => i.uuid !== uuid) });
+        const item = await foundry.utils.fromUuid(uuid);
+
+        if (item) {
+            await item.update({
+                system: {
+                    originItemType: null,
+                    originId: null,
+                    subType: null
+                }
+            });
+        }
+
+        await this.document.update({ [`system.${target}`]: prop.filter(i => i && i.uuid !== uuid) });
     }
 
     /**

--- a/module/applications/sheets/items/subclass.mjs
+++ b/module/applications/sheets/items/subclass.mjs
@@ -68,7 +68,13 @@ export default class SubclassSheet extends DHBaseItemSheet {
                     return;
                 }
 
-                await item.update({ 'system.subType': CONFIG.DH.ITEM.featureSubTypes.foundation });
+                await item.update({
+                    system: {
+                        subType: CONFIG.DH.ITEM.featureSubTypes.foundation,
+                        originItemType: CONFIG.DH.ITEM.featureTypes[this.document.type].id,
+                        originId: this.document.uuid
+                    }
+                });
                 await this.document.update({
                     'system.features': [...this.document.system.features.map(x => x.uuid), item.uuid]
                 });
@@ -78,7 +84,13 @@ export default class SubclassSheet extends DHBaseItemSheet {
                     return;
                 }
 
-                await item.update({ 'system.subType': CONFIG.DH.ITEM.featureSubTypes.specialization });
+                await item.update({
+                    system: {
+                        subType: CONFIG.DH.ITEM.featureSubTypes.specialization,
+                        originItemType: CONFIG.DH.ITEM.featureTypes[this.document.type].id,
+                        originId: this.document.uuid
+                    }
+                });
                 await this.document.update({
                     'system.features': [...this.document.system.features.map(x => x.uuid), item.uuid]
                 });
@@ -88,7 +100,13 @@ export default class SubclassSheet extends DHBaseItemSheet {
                     return;
                 }
 
-                await item.update({ 'system.subType': CONFIG.DH.ITEM.featureSubTypes.mastery });
+                await item.update({
+                    system: {
+                        subType: CONFIG.DH.ITEM.featureSubTypes.mastery,
+                        originItemType: CONFIG.DH.ITEM.featureTypes[this.document.type].id,
+                        originId: this.document.uuid
+                    }
+                });
                 await this.document.update({
                     'system.features': [...this.document.system.features.map(x => x.uuid), item.uuid]
                 });

--- a/module/applications/sheets/items/subclass.mjs
+++ b/module/applications/sheets/items/subclass.mjs
@@ -62,12 +62,17 @@ export default class SubclassSheet extends DHBaseItemSheet {
         const item = await fromUuid(data.uuid);
         const target = event.target.closest('fieldset.drop-section');
         if (item.type === 'feature') {
-            if (target.dataset.type === 'foundation') {
-                if (item.system.subType && item.system.subType !== CONFIG.DH.ITEM.featureSubTypes.foundation) {
-                    ui.notifications.warn(game.i18n.localize('DAGGERHEART.UI.Notifications.featureNotFoundation'));
-                    return;
-                }
+            if (item.system.originId) {
+                const origin = await foundry.utils.fromUuid(item.system.originId);
+                return ui.notifications.warn(
+                    game.i18n.format('DAGGERHEART.UI.Notifications.featureAlreadyLinked', {
+                        name: item.name,
+                        origin: origin.name
+                    })
+                );
+            }
 
+            if (target.dataset.type === 'foundation') {
                 await item.update({
                     system: {
                         subType: CONFIG.DH.ITEM.featureSubTypes.foundation,
@@ -79,11 +84,6 @@ export default class SubclassSheet extends DHBaseItemSheet {
                     'system.features': [...this.document.system.features.map(x => x.uuid), item.uuid]
                 });
             } else if (target.dataset.type === 'specialization') {
-                if (item.system.subType && item.system.subType !== CONFIG.DH.ITEM.featureSubTypes.specialization) {
-                    ui.notifications.warn(game.i18n.localize('DAGGERHEART.UI.Notifications.featureNotSpecialization'));
-                    return;
-                }
-
                 await item.update({
                     system: {
                         subType: CONFIG.DH.ITEM.featureSubTypes.specialization,
@@ -95,11 +95,6 @@ export default class SubclassSheet extends DHBaseItemSheet {
                     'system.features': [...this.document.system.features.map(x => x.uuid), item.uuid]
                 });
             } else if (target.dataset.type === 'mastery') {
-                if (item.system.subType && item.system.subType !== CONFIG.DH.ITEM.featureSubTypes.mastery) {
-                    ui.notifications.warn(game.i18n.localize('DAGGERHEART.UI.Notifications.featureNotMastery'));
-                    return;
-                }
-
                 await item.update({
                     system: {
                         subType: CONFIG.DH.ITEM.featureSubTypes.mastery,

--- a/module/data/item/ancestry.mjs
+++ b/module/data/item/ancestry.mjs
@@ -20,18 +20,10 @@ export default class DHAncestry extends BaseDataItem {
     }
 
     get primaryFeature() {
-        return (
-            this.features.find(x => x?.system?.subType === CONFIG.DH.ITEM.featureSubTypes.primary) ??
-            (this.features.filter(x => !x).length > 0 ? {} : null)
-        );
+        return this.features.find(x => x?.system?.subType === CONFIG.DH.ITEM.featureSubTypes.primary) ?? null;
     }
 
     get secondaryFeature() {
-        return (
-            this.features.find(x => x?.system?.subType === CONFIG.DH.ITEM.featureSubTypes.secondary) ??
-            (this.features.filter(x => !x || x.system.subType === CONFIG.DH.ITEM.featureSubTypes.primary).length > 1
-                ? {}
-                : null)
-        );
+        return this.features.find(x => x?.system?.subType === CONFIG.DH.ITEM.featureSubTypes.secondary) ?? null;
     }
 }

--- a/module/data/item/base.mjs
+++ b/module/data/item/base.mjs
@@ -21,7 +21,8 @@ export default class BaseDataItem extends foundry.abstract.TypeDataModel {
             hasDescription: false,
             hasResource: false,
             isQuantifiable: false,
-            isInventoryItem: false
+            isInventoryItem: false,
+            possibleItemLink: false
         };
     }
 
@@ -68,6 +69,20 @@ export default class BaseDataItem extends foundry.abstract.TypeDataModel {
 
         if (this.metadata.isQuantifiable)
             schema.quantity = new fields.NumberField({ integer: true, initial: 1, min: 0, required: true });
+
+        if (this.metadata.possibleItemLink) {
+            schema.originItemType = new fields.StringField({
+                choices: CONFIG.DH.ITEM.featureTypes,
+                nullable: true,
+                initial: null
+            });
+            schema.originId = new fields.StringField({ nullable: true, initial: null });
+            schema.subType = new fields.StringField({
+                choices: CONFIG.DH.ITEM.featureSubTypes,
+                nullable: true,
+                initial: null
+            });
+        }
 
         return schema;
     }
@@ -137,22 +152,43 @@ export default class BaseDataItem extends foundry.abstract.TypeDataModel {
 
     async _preDelete() {
         if (this.originId) {
-            if (this.actor && this.actor.type === 'character') {
-                const items = this.actor.items.filter(item => item.system.originId === this.parent.id);
-                if (items.length > 0)
-                    await this.actor.deleteEmbeddedDocuments(
-                        'Item',
-                        items.map(x => x.id)
-                    );
-            } else {
-                const linkedItem = await foundry.utils.fromUuid(this.originId);
-                if (linkedItem) {
-                    await linkedItem.update({
-                        'system.features': linkedItem.system.features
-                            .filter(x => x.uuid !== this.parent.uuid)
-                            .map(x => x.uuid)
-                    });
+            if (this.parent.type === 'feature') {
+                if (this.actor && this.actor.type === 'character') {
+                    const items = this.actor.items.filter(item => item.system.originId === this.parent.id);
+                    if (items.length > 0)
+                        await this.actor.deleteEmbeddedDocuments(
+                            'Item',
+                            items.map(x => x.id)
+                        );
+                } else {
+                    const linkedItem = await foundry.utils.fromUuid(this.originId);
+                    if (linkedItem) {
+                        await linkedItem.update({
+                            'system.features': linkedItem.system.features
+                                .filter(x => x.uuid !== this.parent.uuid)
+                                .map(x => x.uuid)
+                        });
+                    }
                 }
+            } else if (this.parent.type === 'subclass') {
+                const linkedItem = await foundry.utils.fromUuid(this.originId);
+                await linkedItem.update({
+                    'system.subclasses': linkedItem.system.subclasses
+                        .filter(x => x.uuid !== this.parent.uuid)
+                        .map(x => x.uuid)
+                });
+            }
+        }
+
+        if (this.features?.length) {
+            for (var feature of this.features) {
+                await feature.update({
+                    system: {
+                        originItemType: null,
+                        originId: null,
+                        subType: null
+                    }
+                });
             }
         }
     }

--- a/module/data/item/class.mjs
+++ b/module/data/item/class.mjs
@@ -86,6 +86,18 @@ export default class DHClass extends BaseDataItem {
         }
     }
 
+    async _preDelete() {
+        for (var subclass of this.subclasses) {
+            await subclass.update({
+                system: {
+                    originItemType: null,
+                    originId: null,
+                    subType: null
+                }
+            });
+        }
+    }
+
     _onDelete(options, userId) {
         super._onDelete(options, userId);
 

--- a/module/data/item/feature.mjs
+++ b/module/data/item/feature.mjs
@@ -22,9 +22,8 @@ export default class DHFeature extends BaseDataItem {
                 nullable: true,
                 initial: null
             }),
-            subType: new fields.StringField({ choices: CONFIG.DH.ITEM.featureSubTypes, nullable: true, initial: null }),
             originId: new fields.StringField({ nullable: true, initial: null }),
-            identifier: new fields.StringField(),
+            subType: new fields.StringField({ choices: CONFIG.DH.ITEM.featureSubTypes, nullable: true, initial: null }),
             actions: new fields.ArrayField(new ActionField())
         };
     }

--- a/module/data/item/feature.mjs
+++ b/module/data/item/feature.mjs
@@ -8,7 +8,8 @@ export default class DHFeature extends BaseDataItem {
             label: 'TYPES.Item.feature',
             type: 'feature',
             hasDescription: true,
-            hasResource: true
+            hasResource: true,
+            possibleItemLink: true
         });
     }
 
@@ -17,13 +18,6 @@ export default class DHFeature extends BaseDataItem {
         const fields = foundry.data.fields;
         return {
             ...super.defineSchema(),
-            originItemType: new fields.StringField({
-                choices: CONFIG.DH.ITEM.featureTypes,
-                nullable: true,
-                initial: null
-            }),
-            originId: new fields.StringField({ nullable: true, initial: null }),
-            subType: new fields.StringField({ choices: CONFIG.DH.ITEM.featureSubTypes, nullable: true, initial: null }),
             actions: new fields.ArrayField(new ActionField())
         };
     }

--- a/module/data/item/subclass.mjs
+++ b/module/data/item/subclass.mjs
@@ -7,7 +7,8 @@ export default class DHSubclass extends BaseDataItem {
         return foundry.utils.mergeObject(super.metadata, {
             label: 'TYPES.Item.subclass',
             type: 'subclass',
-            hasDescription: true
+            hasDescription: true,
+            possibleItemLink: true
         });
     }
 

--- a/templates/sheets/global/partials/inventory-fieldset-items-V2.hbs
+++ b/templates/sheets/global/partials/inventory-fieldset-items-V2.hbs
@@ -26,14 +26,14 @@ Parameters:
   <legend>
     {{localize title}}
     {{#if canCreate}}
-    <a data-action="createDoc" data-document-class="{{ifThen (eq type 'effect') 'ActiveEffect' 'Item' }}"
-      data-type="{{ifThen (eq type 'effect') 'base' type}}"
-      {{#if inVault}}data-in-vault="{{inVault}}"{{/if}}
-      {{#if disabled}} data-disabled="{{disabled}}"{{/if}}
-      data-tooltip="{{localize 'DOCUMENT.Create' type=''}}"
-      >
-      <i class="fa-solid fa-plus icon-button"></i>
-    </a>
+      <a data-action="createDoc" data-document-class="{{ifThen (eq type 'effect') 'ActiveEffect' 'Item' }}"
+        data-type="{{ifThen (eq type 'effect') 'base' type}}"
+        {{#if inVault}}data-in-vault="{{inVault}}"{{/if}}
+        {{#if disabled}} data-disabled="{{disabled}}"{{/if}}
+        data-tooltip="{{localize 'DOCUMENT.Create' type=''}}"
+        >
+        <i class="fa-solid fa-plus icon-button"></i>
+      </a>
     {{/if }}
   </legend>
   {{#if (and cardView (eq type 'domainCard'))}}

--- a/templates/sheets/items/ancestry/features.hbs
+++ b/templates/sheets/items/ancestry/features.hbs
@@ -17,7 +17,7 @@
                     <img class="image" src="{{document.system.primaryFeature.img}}" />
                     <span>{{document.system.primaryFeature.name}}</span>
                     <div class="controls">
-                        <a data-action="removeFeature" data-type="primary"><i class="fa-solid fa-trash"></i></a>
+                        <a data-action="deleteFeature" data-item-uuid="{{document.system.primaryFeature.uuid}}"><i class="fa-solid fa-trash"></i></a>
                     </div>
                 </div> 
             {{/if}}
@@ -38,7 +38,7 @@
                     <img class="image" src="{{document.system.secondaryFeature.img}}" />
                     <span>{{document.system.secondaryFeature.name}}</span>
                     <div class="controls">
-                        <a data-action="removeFeature" data-type="secondary"><i class="fa-solid fa-trash"></i></a>
+                        <a data-action="deleteFeature" data-item-uuid="{{document.system.secondaryFeature.uuid}}"><i class="fa-solid fa-trash"></i></a>
                     </div>
                 </div> 
             {{/if}}

--- a/templates/sheets/items/class/settings.hbs
+++ b/templates/sheets/items/class/settings.hbs
@@ -90,7 +90,7 @@
                             <img class="image" src="{{this.img}}" />
                             <span>{{this.name}}</span>
                             <div class="controls">
-                                <i data-action="removeItemFromCollection" data-target="invetory.take" data-uuid="{{this.uuid}}" class="fa-solid fa-trash icon-button"></i>
+                                <i data-action="removeItemFromCollection" data-target="inventory.take" data-uuid="{{this.uuid}}" class="fa-solid fa-trash icon-button"></i>
                             </div>
                         </div>
                     {{/each}}
@@ -105,7 +105,7 @@
                             <img class="image" src="{{this.img}}" />
                             <span>{{this.name}}</span>
                             <div class="controls">
-                                <i data-action="removeItemFromCollection" data-target="invetory.choiceA" data-uuid="{{this.uuid}}" class="fa-solid fa-trash icon-button"></i>
+                                <i data-action="removeItemFromCollection" data-target="inventory.choiceA" data-uuid="{{this.uuid}}" class="fa-solid fa-trash icon-button"></i>
                             </div>
                         </div>
                     {{/each}}
@@ -120,7 +120,7 @@
                             <img class="image" src="{{this.img}}" />
                             <span>{{this.name}}</span>
                             <div class="controls">
-                                <i data-action="removeItemFromCollection" data-target="invetory.choiceB" data-uuid="{{this.uuid}}" class="fa-solid fa-trash icon-button"></i>
+                                <i data-action="removeItemFromCollection" data-target="inventory.choiceB" data-uuid="{{this.uuid}}" class="fa-solid fa-trash icon-button"></i>
                             </div>
                         </div>
                     {{/each}}


### PR DESCRIPTION
There was quite a few oddities regarding the deletion of Features/Subclasses before.

- We keep track of where a feature/subclass is using a `originId`.
- A feature/subclass that is slotted into something is not available to be put somewhere else. 1to1
<img width="801" height="109" alt="image" src="https://github.com/user-attachments/assets/a14e31b6-d373-474d-b288-cb5a35c99e3e" />

- If the 'owning' item is deleted, the link is removed.
- If the 'owned' item is deleted, the link is removed.

----
**Edit**: I don't think I like this -linking- solution. Should do it differently..