### PR TITLE
[Fix] GetDocFromElement Async

### DIFF
--- a/module/applications/sheets-configs/environment-settings.mjs
+++ b/module/applications/sheets-configs/environment-settings.mjs
@@ -75,7 +75,7 @@ export default class DHEnvironmentSettings extends DHBaseActorSettings {
      * @returns
      */
     static async #deleteAdversary(_event, target) {
-        const doc = getDocFromElement(target);
+        const doc = await getDocFromElement(target);
         const { category } = target.dataset;
         const path = `system.potentialAdversaries.${category}.adversaries`;
 

--- a/module/applications/sheets/api/base-item.mjs
+++ b/module/applications/sheets/api/base-item.mjs
@@ -117,7 +117,7 @@ export default class DHBaseItemSheet extends DHApplicationMixin(ItemSheetV2) {
             name: 'CONTROLS.CommonDelete',
             icon: '<i class="fa-solid fa-trash"></i>',
             callback: async target => {
-                const feature = getDocFromElement(target);
+                const feature = await getDocFromElement(target);
                 if (!feature) return;
                 const confirmed = await foundry.applications.api.DialogV2.confirm({
                     window: {
@@ -168,7 +168,7 @@ export default class DHBaseItemSheet extends DHApplicationMixin(ItemSheetV2) {
      */
     static async #deleteFeature(_, element) {
         const target = element.closest('[data-item-uuid]');
-        const feature = getDocFromElement(target);
+        const feature = await getDocFromElement(target);
         if (!feature) return ui.notifications.warn(game.i18n.localize('DAGGERHEART.UI.Notifications.featureIsMissing'));
         await this.document.update({
             'system.features': this.document.system.features

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -235,9 +235,25 @@ export const updateActorTokens = async (actor, update) => {
  * @param {HTMLElement} element - The DOM element to start the search from.
  * @returns {foundry.abstract.Document|null} The resolved document, or null if not found or invalid.
  */
-export function getDocFromElement(element) {
+export async function getDocFromElement(element) {
     const target = element.closest('[data-item-uuid]');
-    return foundry.utils.fromUuidSync(target.dataset.itemUuid) ?? null;
+    return (await foundry.utils.fromUuid(target.dataset.itemUuid)) ?? null;
+}
+
+/**
+ * Retrieves a Foundry document associated with the nearest ancestor element
+ * that has a `data-item-uuid` attribute.
+ * @param {HTMLElement} element - The DOM element to start the search from.
+ * @returns {foundry.abstract.Document|null} The resolved document, or null if not found, invalid
+ * or in embedded compendium collection.
+ */
+export function getDocFromElementSync(element) {
+    const target = element.closest('[data-item-uuid]');
+    try {
+        return foundry.utils.fromUuidSync(target.dataset.itemUuid) ?? null;
+    } catch (_) {
+        return null;
+    }
 }
 
 /**


### PR DESCRIPTION
GetDocFromElement was erroring out when used in compendiums as it can't be used async for embedded collections on compendiums. Fixed by making it async.

- GetDocFromElement is now async to work with compendiums.
- Added GetDocFromElementSync for use in contextMenu condition cases.
- Updated current uses to be async and await when needed.

