### PR TITLE
[Bug] Downtime Actions Fixes

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1243,6 +1243,9 @@
                 "attack": {
                     "damage": {
                         "value": { "label": "Base Attack: Damage" }
+                    },
+                    "roll": {
+                        "trait": { "label": "Base Attack: Trait" }
                     }
                 }
             },
@@ -1593,6 +1596,10 @@
                         "hint": "test"
                     }
                 }
+            },
+            "ResetSettings": {
+                "resetConfirmationTitle": "Reset Settings",
+                "resetConfirmationText": "Are you sure you want to reset the {settings}?"
             }
         },
         "UI": {

--- a/module/applications/settings/homebrewSettings.mjs
+++ b/module/applications/settings/homebrewSettings.mjs
@@ -136,10 +136,14 @@ export default class DhHomebrewSettings extends HandlebarsApplicationMixin(Appli
                     ...move,
                     name: game.i18n.localize(move.name),
                     description: game.i18n.localize(move.description),
-                    actions: move.actions.map(action => ({
-                        ...action,
-                        name: game.i18n.localize(action.name)
-                    }))
+                    actions: Object.keys(move.actions).reduce((acc, key) => {
+                        const action = move.actions[key];
+                        acc[key] = {
+                            ...action,
+                            name: game.i18n.localize(action.name)
+                        };
+                        return acc;
+                    }, {})
                 };
 
                 return acc;
@@ -165,8 +169,18 @@ export default class DhHomebrewSettings extends HandlebarsApplicationMixin(Appli
     }
 
     static async reset() {
+        const confirmed = await foundry.applications.api.DialogV2.confirm({
+            window: {
+                title: game.i18n.format('DAGGERHEART.SETTINGS.ResetSettings.resetConfirmationTitle')
+            },
+            content: game.i18n.format('DAGGERHEART.SETTINGS.ResetSettings.resetConfirmationText', {
+                settings: game.i18n.localize('DAGGERHEART.SETTINGS.Menu.homebrew.name')
+            })
+        });
+        if (!confirmed) return;
+
         const resetSettings = new DhHomebrew();
-        let localizedSettings = this.localizeObject(resetSettings);
+        let localizedSettings = this.localizeObject(resetSettings.toObject());
         this.settings.updateSource(localizedSettings);
         this.render();
     }

--- a/module/applications/settings/homebrewSettings.mjs
+++ b/module/applications/settings/homebrewSettings.mjs
@@ -136,7 +136,7 @@ export default class DhHomebrewSettings extends HandlebarsApplicationMixin(Appli
                     ...move,
                     name: game.i18n.localize(move.name),
                     description: game.i18n.localize(move.description),
-                    actions: Object.keys(move.actions).reduce((acc, key) => {
+                    actions: move.actions.reduce((acc, key) => {
                         const action = move.actions[key];
                         acc[key] = {
                             ...action,

--- a/module/applications/sheets/items/beastform.mjs
+++ b/module/applications/sheets/items/beastform.mjs
@@ -81,6 +81,7 @@ export default class BeastformSheet extends DHBaseItemSheet {
             case 'effects':
                 context.effects.actives = context.effects.actives.map(effect => {
                     const data = effect.toObject();
+                    data.uuid = effect.uuid;
                     data.id = effect.id;
                     if (effect.type === 'beastform') data.mandatory = true;
 

--- a/module/config/generalConfig.mjs
+++ b/module/config/generalConfig.mjs
@@ -141,6 +141,7 @@ export const defaultRestOptions = {
             actions: {
                 tendToWounds: {
                     type: 'healing',
+                    systemPath: 'restMoves.shortRest.moves.tendToWounds.actions',
                     name: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.shortRest.tendToWounds.name'),
                     img: 'icons/magic/life/cross-worn-green.webp',
                     actionType: 'action',
@@ -166,6 +167,7 @@ export const defaultRestOptions = {
             actions: {
                 clearStress: {
                     type: 'healing',
+                    systemPath: 'restMoves.shortRest.moves.clearStress.actions',
                     name: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.shortRest.clearStress.name'),
                     img: 'icons/magic/perception/eye-ringed-green.webp',
                     actionType: 'action',
@@ -191,6 +193,7 @@ export const defaultRestOptions = {
             actions: {
                 repairArmor: {
                     type: 'healing',
+                    systemPath: 'restMoves.shortRest.moves.repairArmor.actions',
                     name: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.shortRest.repairArmor.name'),
                     img: 'icons/skills/trades/smithing-anvil-silver-red.webp',
                     actionType: 'action',
@@ -226,6 +229,7 @@ export const defaultRestOptions = {
             actions: {
                 tendToWounds: {
                     type: 'healing',
+                    systemPath: 'restMoves.longRest.moves.tendToWounds.actions',
                     name: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.longRest.tendToWounds.name'),
                     img: 'icons/magic/life/cross-worn-green.webp',
                     actionType: 'action',
@@ -251,6 +255,7 @@ export const defaultRestOptions = {
             actions: {
                 clearStress: {
                     type: 'healing',
+                    systemPath: 'restMoves.longRest.moves.clearStress.actions',
                     name: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.longRest.clearStress.name'),
                     img: 'icons/magic/perception/eye-ringed-green.webp',
                     actionType: 'action',
@@ -276,6 +281,7 @@ export const defaultRestOptions = {
             actions: {
                 repairArmor: {
                     type: 'healing',
+                    systemPath: 'restMoves.longRest.moves.repairArmor.actions',
                     name: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.longRest.repairArmor.name'),
                     img: 'icons/skills/trades/smithing-anvil-silver-red.webp',
                     actionType: 'action',

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -204,7 +204,7 @@ export default class DhCharacter extends BaseDataActor {
                         })
                     })
                 }),
-                maxLoadout : new fields.NumberField({
+                maxLoadout: new fields.NumberField({
                     integer: true,
                     initial: 0,
                     label: 'DAGGERHEART.GENERAL.Bonuses.maxLoadout.label'
@@ -248,6 +248,13 @@ export default class DhCharacter extends BaseDataActor {
                             required: true,
                             initial: '@profd4',
                             label: 'DAGGERHEART.GENERAL.Rules.attack.damage.value.label'
+                        })
+                    }),
+                    roll: new fields.SchemaField({
+                        trait: new fields.StringField({
+                            required: true,
+                            initial: CONFIG.DH.ACTOR.abilities.strength.id,
+                            label: 'DAGGERHEART.GENERAL.Rules.attack.roll.trait.label'
                         })
                     })
                 }),
@@ -329,13 +336,15 @@ export default class DhCharacter extends BaseDataActor {
 
     get loadoutSlot() {
         const loadoutCount = this.domainCards.loadout?.length ?? 0,
-            max = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Homebrew).maxLoadout + this.bonuses.maxLoadout;
+            max =
+                game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Homebrew).maxLoadout +
+                this.bonuses.maxLoadout;
 
         return {
             current: loadoutCount,
             available: Math.max(max - loadoutCount, 0),
             max
-        }
+        };
     }
 
     get armor() {

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -253,7 +253,9 @@ export default class DhCharacter extends BaseDataActor {
                     roll: new fields.SchemaField({
                         trait: new fields.StringField({
                             required: true,
-                            initial: CONFIG.DH.ACTOR.abilities.strength.id,
+                            choices: CONFIG.DH.ACTOR.abilities,
+                            nullable: true,
+                            initial: null,
                             label: 'DAGGERHEART.GENERAL.Rules.attack.roll.trait.label'
                         })
                     })
@@ -544,6 +546,7 @@ export default class DhCharacter extends BaseDataActor {
     prepareDerivedData() {
         const baseHope = this.resources.hope.value + (this.companion?.system?.resources?.hope ?? 0);
         this.resources.hope.value = Math.min(baseHope, this.resources.hope.max);
+        this.attack.roll.trait = this.rules.attack.roll.trait ?? this.attack.roll.trait;
     }
 
     getRollData() {

--- a/module/data/fields/actionField.mjs
+++ b/module/data/fields/actionField.mjs
@@ -215,7 +215,10 @@ export function ActionMixin(Base) {
                 await this.parent.updateSource({ [path]: updates }, options);
                 result = this.parent;
             } else {
-                result = await this.item.update({ [path]: updates }, options);
+                /* Fix me - For some reason updating the "healing" section in particular doesn't work without this */
+                await this.item.update({ [path]: updates }, options);
+                await this.item.updateSource({ [path]: updates }, options);
+                result = this.item;
             }
 
             return this.inCollection

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -63,6 +63,19 @@ export default class DHWeapon extends AttachableItem {
                         ]
                     }
                 }
+            }),
+            rules: new fields.SchemaField({
+                attack: new fields.SchemaField({
+                    roll: new fields.SchemaField({
+                        trait: new fields.StringField({
+                            required: true,
+                            choices: CONFIG.DH.ACTOR.abilities,
+                            nullable: true,
+                            initial: null,
+                            label: 'DAGGERHEART.GENERAL.Rules.attack.roll.trait.label'
+                        })
+                    })
+                })
             })
         };
     }
@@ -75,6 +88,10 @@ export default class DHWeapon extends AttachableItem {
         return this.actions.filter(
             action => !this.weaponFeatures.some(feature => feature.actionIds.includes(action.id))
         );
+    }
+
+    prepareDerivedData() {
+        this.attack.roll.trait = this.rules.attack.roll.trait ?? this.attack.roll.trait;
     }
 
     async _preUpdate(changes, options, user) {

--- a/module/documents/activeEffect.mjs
+++ b/module/documents/activeEffect.mjs
@@ -55,7 +55,8 @@ export default class DhActiveEffect extends ActiveEffect {
     }
 
     static applyField(model, change, field) {
-        change.value = this.effectSafeEval(itemAbleRollParse(change.value, model, change.effect.parent));
+        const evalValue = this.effectSafeEval(itemAbleRollParse(change.value, model, change.effect.parent));
+        change.value = evalValue ?? change.value;
         super.applyField(model, change, field);
     }
 


### PR DESCRIPTION
- Reseting HomebrewSettings failed because of the changed Action structure. Fixed.
- The default rest actions had lost their SystemPath, so they failed to update. Restored them 
- Added a temp fix to a problem where you couldn't edit the healing section of an action in the config.