### PR TITLE
renamed Misc Items to Loot to match SRD and Rulebook name

### DIFF
--- a/system.json
+++ b/system.json
@@ -119,10 +119,10 @@
             "flags": {}
         },
         {
-            "name": "miscellaneous",
-            "label": "Miscellaneous",
+            "name": "Loot",
+            "label": "Loot",
             "system": "daggerheart",
-            "path": "packs/items/miscellaneous.db",
+            "path": "packs/items/loot.db",
             "type": "Item",
             "private": false,
             "flags": {}


### PR DESCRIPTION
## Description

the Misc items should be named Loot instead, as that is the name used for the list in both the SRD and the core rulebook.

## Type of Change


- [x] Bug fix
- [ ] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x] Manual testing
- [ ] Other:

## Checklist

- [ ] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [ ] New and existing tests pass locally with my changes

## Additional Comments

Add any other context or questions here.

---

> Thank you for your contribution! 🎉
