### PR TITLE
fix language display and attribute roll bug

### DIFF
--- a/module/applications/settings/appearanceSettings.mjs
+++ b/module/applications/settings/appearanceSettings.mjs
@@ -43,7 +43,7 @@ export default class DHAppearanceSettings extends HandlebarsApplicationMixin(App
                 { id: 'hope', label: 'DAGGERHEART.GENERAL.hope' },
                 { id: 'fear', label: 'DAGGERHEART.GENERAL.fear' },
                 { id: 'advantage', label: 'DAGGERHEART.GENERAL.Advantage.full' },
-                { id: 'disadvantage', label: 'DAGGERHEART.GENERAL.Advantage.full' }
+                { id: 'disadvantage', label: 'DAGGERHEART.GENERAL.Disadvantage.full' }
             ],
             initial: 'hope'
         }

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -53,12 +53,14 @@ export const getCommandTarget = () => {
 };
 
 export const setDiceSoNiceForDualityRoll = async (rollResult, advantageState, hopeFaces, fearFaces, advantageFaces) => {
-    const diceSoNicePresets = await getDiceSoNicePresets(hopeFaces, fearFaces, advantageFaces, advantageFaces);
-    rollResult.dice[0].options = diceSoNicePresets.hope;
-    rollResult.dice[1].options = diceSoNicePresets.fear;
-    if (rollResult.dice[2] && advantageState) {
-        rollResult.dice[2].options =
-            advantageState === 1 ? diceSoNicePresets.advantage : diceSoNicePresets.disadvantage;
+    if (game.modules.get('dice-so-nice')?.active) {
+        const diceSoNicePresets = await getDiceSoNicePresets(hopeFaces, fearFaces, advantageFaces, advantageFaces);
+        rollResult.dice[0].options = diceSoNicePresets.hope;
+        rollResult.dice[1].options = diceSoNicePresets.fear;
+        if (rollResult.dice[2] && advantageState) {
+            rollResult.dice[2].options =
+                advantageState === 1 ? diceSoNicePresets.advantage : diceSoNicePresets.disadvantage;
+        }
     }
 };
 


### PR DESCRIPTION
## Description

The appearance change setting had the disadvatage tab read as advanated. Fixed the label to read disadvantage for that tab. 
When rolling duality dice with Dice so Nice not enabled, it would get an error. Now checks if the Dice So Nice module is enabled before attempting to apply custom colors. 

- Fixes #431
- Closes #431

## Type of Change

Please check the relevant options:

- [x] Bug fix
- [ ] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x] Manual testing
- [ ] Other:

## Screenshots (if applicable)

Include screenshots or GIFs to help explain your changes visually.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [ ] New and existing tests pass locally with my changes

## Additional Comments

Add any other context or questions here.

---

> Thank you for your contribution! 🎉
