### PR TITLE
[Feature] ActiveEffect Improvements

### DIFF
--- a/module/applications/hud/tokenHUD.mjs
+++ b/module/applications/hud/tokenHUD.mjs
@@ -66,12 +66,9 @@ export default class DHTokenHUD extends foundry.applications.hud.TokenHUD {
                 if (!status) continue;
                 if (status._id) {
                     if (status._id !== effect.id) continue;
-                } else {
-                    if (effect.statuses.size !== 1) continue;
                 }
                 status.isActive = true;
                 if (effect.getFlag('core', 'overlay')) status.isOverlay = true;
-                break;
             }
         }
 

--- a/module/applications/sheets-configs/activeEffectConfig.mjs
+++ b/module/applications/sheets-configs/activeEffectConfig.mjs
@@ -99,7 +99,17 @@ export default class DhActiveEffectConfig extends foundry.applications.sheets.Ac
     async _preparePartContext(partId, context) {
         const partContext = await super._preparePartContext(partId, context);
         switch (partId) {
-            case 'changes':
+            case 'details':
+                const useGeneric = game.settings.get(
+                    CONFIG.DH.id,
+                    CONFIG.DH.SETTINGS.gameSettings.appearance
+                ).showGenericStatusEffects;
+                if (!useGeneric) {
+                    partContext.statuses = Object.values(CONFIG.DH.GENERAL.conditions).map(status => ({
+                        value: status.id,
+                        label: game.i18n.localize(status.name)
+                    }));
+                }
                 break;
         }
 

--- a/module/documents/activeEffect.mjs
+++ b/module/documents/activeEffect.mjs
@@ -41,6 +41,14 @@ export default class DhActiveEffect extends ActiveEffect {
         });
     }
 
+    get localizedStatuses() {
+        const statusMap = new Map(foundry.CONFIG.statusEffects.map(status => [status.id, status.name]));
+        return this.statuses.map(x => ({
+            key: x,
+            name: game.i18n.localize(statusMap.get(x))
+        }));
+    }
+
     async _preCreate(data, options, user) {
         const update = {};
         if (!data.img) {

--- a/module/documents/activeEffect.mjs
+++ b/module/documents/activeEffect.mjs
@@ -42,20 +42,11 @@ export default class DhActiveEffect extends ActiveEffect {
     }
 
     get localizedStatuses() {
-        const { statusMap, isStatusActiveEffect } = this.isStatusActiveEffect;
-        if (!isStatusActiveEffect) return [];
-
+        const statusMap = new Map(foundry.CONFIG.statusEffects.map(status => [status.id, status.name]));
         return this.statuses.map(x => ({
             key: x,
-            name: game.i18n.localize(statusMap.get(x).name)
+            name: game.i18n.localize(statusMap.get(x))
         }));
-    }
-
-    get isStatusActiveEffect() {
-        const statusMap = new Map(foundry.CONFIG.statusEffects.map(status => [status.id, status]));
-        const isStatusActiveEffect =
-            this.statuses.size === 1 && this.name === game.i18n.localize(statusMap.get(this.statuses.first()).name);
-        return { statusMap, isStatusActiveEffect };
     }
 
     async _preCreate(data, options, user) {
@@ -69,34 +60,6 @@ export default class DhActiveEffect extends ActiveEffect {
         }
 
         await super._preCreate(data, options, user);
-    }
-
-    _onCreate(data, options, userId) {
-        super._onCreate(data, options, userId);
-
-        if (game.user.id === userId) {
-            this.addStatusActiveEffects(data.statuses);
-        }
-    }
-
-    _onUpdate(changed, options, userId) {
-        super._onUpdate(changed, options, userId);
-
-        if ('disabled' in changed) {
-            if (changed.disabled) {
-                this.removeStatusActiveEffects(this.statuses);
-            } else {
-                this.addStatusActiveEffects(this.statuses);
-            }
-        }
-    }
-
-    _onDelete(data, userId) {
-        super._onDelete(data, userId);
-
-        if (game.user.id === userId) {
-            this.removeStatusActiveEffects(this.statuses);
-        }
     }
 
     static applyField(model, change, field) {
@@ -117,54 +80,6 @@ export default class DhActiveEffect extends ActiveEffect {
         }
 
         return result;
-    }
-
-    async addStatusActiveEffects(statuses) {
-        if (this.parent.type !== 'character') return;
-
-        const { statusMap, isStatusActiveEffect } = this.isStatusActiveEffect;
-        if (isStatusActiveEffect) return;
-
-        const statusesToAdd = statuses.reduce((acc, status) => {
-            const statusData = statusMap.get(status);
-            const statusName = game.i18n.localize(statusData.name);
-            const alreadyExists = this.parent.effects.find(
-                effect => effect.statuses.size === 1 && effect.statuses.first() === status && effect.name === statusName
-            );
-            if (!alreadyExists) {
-                acc.push({
-                    name: statusName,
-                    description: game.i18n.localize(statusData.description),
-                    img: statusData.icon,
-                    statuses: [status]
-                });
-            }
-
-            return acc;
-        }, []);
-
-        await this.parent.createEmbeddedDocuments('ActiveEffect', statusesToAdd);
-    }
-
-    async removeStatusActiveEffects(statuses) {
-        if (this.parent.type !== 'character') return;
-
-        const { statusMap, isStatusActiveEffect } = this.isStatusActiveEffect;
-        if (isStatusActiveEffect) return;
-
-        const statusesToRemove = statuses.reduce((acc, status) => {
-            const statusName = game.i18n.localize(statusMap.get(status).name);
-            const existingEffect = this.parent.effects.find(
-                effect => effect.statuses.size === 1 && effect.statuses.first() === status && effect.name === statusName
-            );
-            if (existingEffect) {
-                acc.push(existingEffect.id);
-            }
-
-            return acc;
-        }, []);
-
-        await this.parent.deleteEmbeddedDocuments('ActiveEffect', statusesToRemove);
     }
 
     async toChat(origin) {

--- a/module/documents/activeEffect.mjs
+++ b/module/documents/activeEffect.mjs
@@ -42,11 +42,20 @@ export default class DhActiveEffect extends ActiveEffect {
     }
 
     get localizedStatuses() {
-        const statusMap = new Map(foundry.CONFIG.statusEffects.map(status => [status.id, status.name]));
+        const { statusMap, isStatusActiveEffect } = this.isStatusActiveEffect;
+        if (!isStatusActiveEffect) return [];
+
         return this.statuses.map(x => ({
             key: x,
-            name: game.i18n.localize(statusMap.get(x))
+            name: game.i18n.localize(statusMap.get(x).name)
         }));
+    }
+
+    get isStatusActiveEffect() {
+        const statusMap = new Map(foundry.CONFIG.statusEffects.map(status => [status.id, status]));
+        const isStatusActiveEffect =
+            this.statuses.size === 1 && this.name === game.i18n.localize(statusMap.get(this.statuses.first()).name);
+        return { statusMap, isStatusActiveEffect };
     }
 
     async _preCreate(data, options, user) {
@@ -60,6 +69,34 @@ export default class DhActiveEffect extends ActiveEffect {
         }
 
         await super._preCreate(data, options, user);
+    }
+
+    _onCreate(data, options, userId) {
+        super._onCreate(data, options, userId);
+
+        if (game.user.id === userId) {
+            this.addStatusActiveEffects(data.statuses);
+        }
+    }
+
+    _onUpdate(changed, options, userId) {
+        super._onUpdate(changed, options, userId);
+
+        if ('disabled' in changed) {
+            if (changed.disabled) {
+                this.removeStatusActiveEffects(this.statuses);
+            } else {
+                this.addStatusActiveEffects(this.statuses);
+            }
+        }
+    }
+
+    _onDelete(data, userId) {
+        super._onDelete(data, userId);
+
+        if (game.user.id === userId) {
+            this.removeStatusActiveEffects(this.statuses);
+        }
     }
 
     static applyField(model, change, field) {
@@ -80,6 +117,54 @@ export default class DhActiveEffect extends ActiveEffect {
         }
 
         return result;
+    }
+
+    async addStatusActiveEffects(statuses) {
+        if (this.parent.type !== 'character') return;
+
+        const { statusMap, isStatusActiveEffect } = this.isStatusActiveEffect;
+        if (isStatusActiveEffect) return;
+
+        const statusesToAdd = statuses.reduce((acc, status) => {
+            const statusData = statusMap.get(status);
+            const statusName = game.i18n.localize(statusData.name);
+            const alreadyExists = this.parent.effects.find(
+                effect => effect.statuses.size === 1 && effect.statuses.first() === status && effect.name === statusName
+            );
+            if (!alreadyExists) {
+                acc.push({
+                    name: statusName,
+                    description: game.i18n.localize(statusData.description),
+                    img: statusData.icon,
+                    statuses: [status]
+                });
+            }
+
+            return acc;
+        }, []);
+
+        await this.parent.createEmbeddedDocuments('ActiveEffect', statusesToAdd);
+    }
+
+    async removeStatusActiveEffects(statuses) {
+        if (this.parent.type !== 'character') return;
+
+        const { statusMap, isStatusActiveEffect } = this.isStatusActiveEffect;
+        if (isStatusActiveEffect) return;
+
+        const statusesToRemove = statuses.reduce((acc, status) => {
+            const statusName = game.i18n.localize(statusMap.get(status).name);
+            const existingEffect = this.parent.effects.find(
+                effect => effect.statuses.size === 1 && effect.statuses.first() === status && effect.name === statusName
+            );
+            if (existingEffect) {
+                acc.push(existingEffect.id);
+            }
+
+            return acc;
+        }, []);
+
+        await this.parent.deleteEmbeddedDocuments('ActiveEffect', statusesToRemove);
     }
 
     async toChat(origin) {

--- a/templates/sheets/global/partials/inventory-item-V2.hbs
+++ b/templates/sheets/global/partials/inventory-item-V2.hbs
@@ -156,8 +156,8 @@ Parameters:
           {{localize 'DAGGERHEART.EFFECTS.Duration.passive'}}
           {{/if}}
         </div>
-        {{#each item.statuses as |status|}}
-        <div class="tag">{{localize (concat 'DAGGERHEART.CONFIG.Condition.' status '.name')}}</div>
+        {{#each item.localizedStatuses as |status|}}
+          <div class="tag">{{status.name}}</div>
         {{/each}}
       </div>
       {{else if (not hideLabels)}}


### PR DESCRIPTION
- Fixed so genericStatuses aren't shown in activeEffectConfig if the system setting is turned off. 
- Fixed localization of genericStatuses in Inventory-ItemV2, they weren't before.
- Effects with statuses on them will show them on the token - they will also be shown as active in the Token HUD.

