### PR TITLE
Feat: add massive and powerful feature on weapon

### DIFF
--- a/module/config/itemConfig.mjs
+++ b/module/config/itemConfig.mjs
@@ -946,14 +946,9 @@ export const weaponFeatures = {
                         value: '-1'
                     },
                     {
-                        key: 'system.bonuses.damage.primaryWeapon.extraDice',
+                        key: 'system.bonuses.damage.primaryWeapon.addDiceAndDiscardLowest',
                         mode: 2,
-                        value: '1'
-                    },
-                    {
-                        key: 'system.rules.weapon.dropLowestDamageDice',
-                        mode: 5,
-                        value: '1'
+                        value: true
                     }
                 ]
             }
@@ -1048,31 +1043,16 @@ export const weaponFeatures = {
     powerful: {
         label: 'DAGGERHEART.CONFIG.WeaponFeature.powerful.name',
         description: 'DAGGERHEART.CONFIG.WeaponFeature.powerful.description',
-        actions: [
+        effects: [
             {
-                type: 'effect',
-                actionType: 'action',
-                chatDisplay: true,
                 name: 'DAGGERHEART.CONFIG.WeaponFeature.powerful.name',
                 description: 'DAGGERHEART.CONFIG.WeaponFeature.powerful.description',
                 img: 'icons/magic/control/buff-flight-wings-runes-red-yellow.webp',
-                effects: [
+                changes: [
                     {
-                        name: 'DAGGERHEART.CONFIG.WeaponFeature.powerful.name',
-                        description: 'DAGGERHEART.CONFIG.WeaponFeature.powerful.description',
-                        img: 'icons/magic/control/buff-flight-wings-runes-red-yellow.webp',
-                        changes: [
-                            {
-                                key: 'system.bonuses.damage.primaryWeapon.extraDice',
-                                mode: 2,
-                                value: '1'
-                            },
-                            {
-                                key: 'system.rules.weapon.dropLowestDamageDice',
-                                mode: 5,
-                                value: '1'
-                            }
-                        ]
+                        key: 'system.bonuses.damage.primaryWeapon.addDiceAndDiscardLowest',
+                        mode: 2,
+                        value: true
                     }
                 ]
             }

--- a/module/dice/damageRoll.mjs
+++ b/module/dice/damageRoll.mjs
@@ -132,6 +132,16 @@ export default class DamageRoll extends DHRoll {
                 criticalBonus = tmpRoll.total - this.constructor.calculateTotalModifiers(tmpRoll);
             part.roll.terms.push(...this.formatModifier(criticalBonus));
         }
+
+        if ( config.data.bonuses.damage.primaryWeapon?.addDiceAndDiscardLowest) {
+            const index = part.roll.terms.findIndex(t => t instanceof foundry.dice.terms.Die);
+            if (index !== -1) {
+                const diceTerm = part.roll.terms[index];
+                diceTerm.modifiers = ['k' + diceTerm.number];
+                diceTerm.number += 1;
+            }
+        }
+
         return (part.roll._formula = this.constructor.getFormula(part.roll.terms));
     }
 }


### PR DESCRIPTION
## Description

I rework as clean as possible the effect "massive" and "powerfull".

I think adding a dice then remove it is not a good approach for two reason :
- Foundry give us a native way to manage this
- Critical roll will check the final number of dice to apply max dice value to damage

It's for this reason that I place it directly in damageRoll.

I remove also the action on "Poweful" weapon because it's not an other action, it's now directly embedded in the default action.

## Type of Change

Please check the relevant options:

- [x] New feature
- [x] Code cleanup/refactor

## How Has This Been Tested?

- [x] Manual testing
- [ ] Other:

## Screenshots (if applicable)

![Peek 2025-07-29 03-32](https://github.com/user-attachments/assets/e9abc833-f0db-41db-8abd-98e1ae9094fa)


## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [ ] New and existing tests pass locally with my changes
