### PR TITLE
fix: statuses are Set not Array, change includes() to has() in placebles/token.mjs

### DIFF
--- a/module/canvas/placeables/token.mjs
+++ b/module/canvas/placeables/token.mjs
@@ -18,7 +18,7 @@ export default class DhTokenPlaceable extends foundry.canvas.placeables.Token {
                 x => x.statuses.size === 1 && x.name === game.i18n.localize(statusMap.get(x.statuses.first()).name)
             );
             for (var status of effect.statuses) {
-                if (!currentStatusActiveEffects.find(x => x.statuses.includes(status))) {
+                if (!currentStatusActiveEffects.find(x => x.statuses.has(status))) {
                     const statusData = statusMap.get(status);
                     acc.push({
                         name: game.i18n.localize(statusData.name),


### PR DESCRIPTION

## Description

It crash if I have a status on a token and I refresh Foundry. It's because it calls a include() function on a Set.


## Type of Change

Please check the relevant options:

- [x] Bug fix

## How Has This Been Tested?

- [x] Manual testing
- [x] Other:

## Screenshots (if applicable)

Include screenshots or GIFs to help explain your changes visually.
![Peek 2025-07-29 12-03](https://github.com/user-attachments/assets/b739d43f-2bb4-491c-b243-4b060ee118b0)
