### PR TITLE
Feature/443 adversary action roll type

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1381,6 +1381,7 @@
             "imagePath": "Image Path",
             "inactiveEffects": "Inactive Effects",
             "inventory": "Inventory",
+            "itemResource": "Item Resource",
             "level": "Level",
             "levelUp": "Level Up",
             "loadout": "Loadout",

--- a/lang/en.json
+++ b/lang/en.json
@@ -716,7 +716,7 @@
                     "name": "Hope",
                     "abbreviation": "HO"
                 },
-                "armorStack": {
+                "armorSlot": {
                     "name": "Armor Slot",
                     "abbreviation": "AS"
                 },

--- a/module/applications/dialogs/damageReductionDialog.mjs
+++ b/module/applications/dialogs/damageReductionDialog.mjs
@@ -225,7 +225,7 @@ export default class DamageReductionDialog extends HandlebarsApplicationMixin(Ap
         await super.close({});
     }
 
-    static async armorStackQuery({ actorId, damage, type }) {
+    static async armorSlotQuery({ actorId, damage, type }) {
         return new Promise(async (resolve, reject) => {
             const actor = await fromUuid(actorId);
             if (!actor || !actor?.isOwner) reject();

--- a/module/applications/sheets-configs/action-config.mjs
+++ b/module/applications/sheets-configs/action-config.mjs
@@ -112,7 +112,7 @@ export default class DHActionConfig extends DaggerheartSheet(ApplicationV2) {
         context.disableOption = this.disableOption.bind(this);
         context.isNPC = this.action.actor?.isNPC;
         context.baseSaveDifficulty = this.action.actor?.baseSaveDifficulty;
-        context.baseAttackBonus = this.action.actor?.system.attack?.damage.parts[0].value.bonus;
+        context.baseAttackBonus = this.action.actor?.system.attack?.roll.bonus;
         context.hasRoll = this.action.hasRoll;
 
         const settingsTiers = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.LevelTiers).tiers;

--- a/module/applications/sheets-configs/action-config.mjs
+++ b/module/applications/sheets-configs/action-config.mjs
@@ -108,9 +108,11 @@ export default class DHActionConfig extends DaggerheartSheet(ApplicationV2) {
             context.hasBaseDamage = !!this.action.parent.attack;
         context.getEffectDetails = this.getEffectDetails.bind(this);
         context.costOptions = this.getCostOptions();
+        context.getRollTypeOptions = this.getRollTypeOptions();
         context.disableOption = this.disableOption.bind(this);
         context.isNPC = this.action.actor?.isNPC;
         context.baseSaveDifficulty = this.action.actor?.baseSaveDifficulty;
+        context.baseAttackBonus = this.action.actor?.system.attack?.damage.parts[0].value.bonus;
         context.hasRoll = this.action.hasRoll;
 
         const settingsTiers = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.LevelTiers).tiers;
@@ -137,6 +139,15 @@ export default class DHActionConfig extends DaggerheartSheet(ApplicationV2) {
         }
 
         return options;
+    }
+
+    getRollTypeOptions() {
+        const types = foundry.utils.deepClone(CONFIG.DH.GENERAL.rollTypes);
+        if(!this.action.actor) return types;
+        Object.values(types).forEach(t => {
+            if(this.action.actor.type !== 'character' && t.playerOnly) delete types[t.id];
+        })
+        return types;
     }
 
     disableOption(index, costOptions, choices) {

--- a/module/applications/sheets-configs/action-config.mjs
+++ b/module/applications/sheets-configs/action-config.mjs
@@ -133,8 +133,8 @@ export default class DHActionConfig extends DaggerheartSheet(ApplicationV2) {
         const resource = this.action.parent.resource;
         if (resource) {
             options[this.action.parent.parent.id] = {
-                label: this.action.parent.parent.name,
-                group: 'TYPES.Actor.character'
+                label: "DAGGERHEART.GENERAL.itemResource",
+                group: 'Global'
             };
         }
 

--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -260,7 +260,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
                 icon: 'fa-solid fa-arrow-up',
                 condition: target => {
                     const doc = getDocFromElementSync(target);
-                    return doc && system.inVault;
+                    return doc && doc.system.inVault;
                 },
                 callback: async target => {
                     const doc = await getDocFromElement(target);

--- a/module/config/generalConfig.mjs
+++ b/module/config/generalConfig.mjs
@@ -85,10 +85,10 @@ export const healingTypes = {
         label: 'DAGGERHEART.CONFIG.HealingType.hope.name',
         abbreviation: 'DAGGERHEART.CONFIG.HealingType.hope.abbreviation'
     },
-    armorStack: {
-        id: 'armorStack',
-        label: 'DAGGERHEART.CONFIG.HealingType.armorStack.name',
-        abbreviation: 'DAGGERHEART.CONFIG.HealingType.armorStack.abbreviation'
+    armorSlot: {
+        id: 'armorSlot',
+        label: 'DAGGERHEART.CONFIG.HealingType.armorSlot.name',
+        abbreviation: 'DAGGERHEART.CONFIG.HealingType.armorSlot.abbreviation'
     },
     fear: {
         id: 'fear',
@@ -199,7 +199,7 @@ export const defaultRestOptions = {
                     actionType: 'action',
                     chatDisplay: false,
                     healing: {
-                        applyTo: healingTypes.armorStack.id,
+                        applyTo: healingTypes.armorSlot.id,
                         value: {
                             custom: {
                                 enabled: true,
@@ -287,7 +287,7 @@ export const defaultRestOptions = {
                     actionType: 'action',
                     chatDisplay: false,
                     healing: {
-                        applyTo: healingTypes.armorStack.id,
+                        applyTo: healingTypes.armorSlot.id,
                         value: {
                             custom: {
                                 enabled: true,
@@ -425,8 +425,8 @@ export const refreshTypes = {
 };
 
 export const abilityCosts = {
-    hp: {
-        id: 'hp',
+    hitPoints: {
+        id: 'hitPoints',
         label: 'DAGGERHEART.CONFIG.HealingType.hitPoints.name',
         group: 'Global'
     },

--- a/module/config/generalConfig.mjs
+++ b/module/config/generalConfig.mjs
@@ -473,11 +473,13 @@ export const rollTypes = {
     },
     spellcast: {
         id: 'spellcast',
-        label: 'DAGGERHEART.CONFIG.RollTypes.spellcast.name'
+        label: 'DAGGERHEART.CONFIG.RollTypes.spellcast.name',
+        playerOnly: true
     },
     trait: {
         id: 'trait',
-        label: 'DAGGERHEART.CONFIG.RollTypes.trait.name'
+        label: 'DAGGERHEART.CONFIG.RollTypes.trait.name',
+        playerOnly: true
     },
     diceSet: {
         id: 'diceSet',

--- a/module/config/itemConfig.mjs
+++ b/module/config/itemConfig.mjs
@@ -604,7 +604,7 @@ export const weaponFeatures = {
                 img: 'icons/skills/melee/hand-grip-sword-strike-orange.webp',
                 cost: [
                     {
-                        type: 'armorStack',
+                        type: 'armorSlot',
                         value: 1
                     }
                 ],

--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -203,6 +203,7 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
 
     async consume(config) {
         const usefulResources = foundry.utils.deepClone(this.actor.system.resources);
+        
         for (var cost of config.costs) {
             if (cost.keyIsID) {
                 usefulResources[cost.key] = {
@@ -223,13 +224,10 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
                     keyIsID: resource.keyIsID
                 };
             });
-
+        console.log(resources)
         await this.actor.modifyResource(resources);
-        if (config.uses?.enabled) {
-            const newActions = foundry.utils.getProperty(this.item.system, this.systemPath).map(x => x.toObject());
-            newActions[this.index].uses.value++;
-            await this.item.update({ [`system.${this.systemPath}`]: newActions });
-        }
+        if (config.uses?.enabled)
+            this.update({ 'uses.value': this.uses.value + 1 });
     }
     /* */
 

--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -299,17 +299,16 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
     /* SAVE */
     async rollSave(actor, event, message) {
         if (!actor) return;
-        return actor
-            .diceRoll({
-                event,
-                title: 'Roll Save',
-                roll: {
-                    trait: this.save.trait,
-                    difficulty: this.save.difficulty ?? this.actor?.baseSaveDifficulty,
-                    type: 'reaction'
-                },
-                data: actor.getRollData()
-            });
+        return actor.diceRoll({
+            event,
+            title: 'Roll Save',
+            roll: {
+                trait: this.save.trait,
+                difficulty: this.save.difficulty ?? this.actor?.baseSaveDifficulty,
+                type: 'reaction'
+            },
+            data: actor.getRollData()
+        });
     }
 
     updateSaveMessage(result, message, targetId) {
@@ -322,7 +321,7 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
         else updateMsg();
     }
 
-    static rollSaveQuery({ actionId, actorId,  event, message }) {
+    static rollSaveQuery({ actionId, actorId, event, message }) {
         return new Promise(async (resolve, reject) => {
             const actor = await fromUuid(actorId),
                 action = await fromUuid(actionId);

--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -37,7 +37,11 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
 
         this.extraSchemas.forEach(s => {
             let clsField;
-            if ((clsField = this.getActionField(s))) schemaFields[s] = new clsField();
+            if ((clsField = this.getActionField(s))) schemaFields[s] = new clsField(
+                {
+                    type: this
+                }
+            );
         });
 
         return schemaFields;

--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -185,13 +185,11 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
 
     prepareRoll() {
         const roll = {
-            modifiers: this.modifiers,
-            trait: this.roll?.trait,
+            baseModifiers: this.roll.getModifier(),
             label: 'Attack',
             type: this.actionType,
             difficulty: this.roll?.difficulty,
             formula: this.roll.getFormula(),
-            bonus: this.roll.bonus,
             advantage: CONFIG.DH.ACTIONS.advantageState[this.roll.advState].value
         };
         if (this.roll?.type === 'diceSet') roll.lite = true;
@@ -237,7 +235,7 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
 
     /* ROLL */
     get hasRoll() {
-        return !!this.roll?.type || !!this.roll?.bonus;
+        return !!this.roll?.type;
     }
 
     get modifiers() {

--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -37,11 +37,7 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
 
         this.extraSchemas.forEach(s => {
             let clsField;
-            if ((clsField = this.getActionField(s))) schemaFields[s] = new clsField(
-                {
-                    type: this
-                }
-            );
+            if ((clsField = this.getActionField(s))) schemaFields[s] = new clsField();
         });
 
         return schemaFields;

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -563,6 +563,12 @@ export default class DhCharacter extends BaseDataActor {
         this.resources.hope.value = Math.min(baseHope, this.resources.hope.max);
         this.attack.roll.trait = this.rules.attack.roll.trait ?? this.attack.roll.trait;
 
+        this.resources.armor = {
+            value: this.armor.system.marks.value,
+            max: this.armorScore,
+            isReversed: true
+        };
+
         this.attack.damage.parts[0].value.custom.formula = `@prof${this.basicAttackDamageDice}${this.rules.attack.damage.bonus ? ` + ${this.rules.attack.damage.bonus}` : ''}`;
     }
 

--- a/module/data/fields/action/costField.mjs
+++ b/module/data/fields/action/costField.mjs
@@ -54,8 +54,8 @@ export default class CostField extends fields.ArrayField {
                 !resources[c.key]
                     ? a
                     : a && resources[c.key].isReversed
-                        ? resources[c.key].value + (c.total ?? c.value) <= resources[c.key].max
-                        : resources[c.key]?.value >= (c.total ?? c.value),
+                      ? resources[c.key].value + (c.total ?? c.value) <= resources[c.key].max
+                      : resources[c.key]?.value >= (c.total ?? c.value),
             true
         );
     }
@@ -67,8 +67,7 @@ export default class CostField extends fields.ArrayField {
             if (itemResource.keyIsID) {
                 itemResources[itemResource.key] = {
                     value: this.parent.resource.value ?? 0,
-                    max: CostField.formatMax.call(this, this.parent?.resource?.max),
-                    isReversed: true
+                    max: CostField.formatMax.call(this, this.parent?.resource?.max)
                 };
             }
         }
@@ -86,10 +85,10 @@ export default class CostField extends fields.ArrayField {
 
     static formatMax(max) {
         max ??= 0;
-        if(isNaN(max)) {
+        if (isNaN(max)) {
             const roll = Roll.replaceFormulaData(max, this.getRollData());
             max = roll.total;
         }
-        return max;
+        return Number(max);
     }
 }

--- a/module/data/fields/action/costField.mjs
+++ b/module/data/fields/action/costField.mjs
@@ -51,9 +51,11 @@ export default class CostField extends fields.ArrayField {
         const resources = CostField.getResources.call(this, realCosts);
         return realCosts.reduce(
             (a, c) =>
-                a && resources[c.key].isReversed
-                    ? resources[c.key].value + (c.total ?? c.value) <= resources[c.key].max
-                    : resources[c.key]?.value >= (c.total ?? c.value),
+                !resources[c.key]
+                    ? a
+                    : a && resources[c.key].isReversed
+                        ? resources[c.key].value + (c.total ?? c.value) <= resources[c.key].max
+                        : resources[c.key]?.value >= (c.total ?? c.value),
             true
         );
     }
@@ -61,10 +63,12 @@ export default class CostField extends fields.ArrayField {
     static getResources(costs) {
         const actorResources = this.actor.system.resources;
         const itemResources = {};
-        for (var itemResource of costs) {
+        for (let itemResource of costs) {
             if (itemResource.keyIsID) {
                 itemResources[itemResource.key] = {
-                    value: this.parent.resource.value ?? 0
+                    value: this.parent.resource.value ?? 0,
+                    max: CostField.formatMax.call(this, this.parent?.resource?.max),
+                    isReversed: true
                 };
             }
         }
@@ -78,5 +82,14 @@ export default class CostField extends fields.ArrayField {
     static getRealCosts(costs) {
         const realCosts = costs?.length ? costs.filter(c => c.enabled) : [];
         return realCosts;
+    }
+
+    static formatMax(max) {
+        max ??= 0;
+        if(isNaN(max)) {
+            const roll = Roll.replaceFormulaData(max, this.getRollData());
+            max = roll.total;
+        }
+        return max;
     }
 }

--- a/module/data/fields/action/costField.mjs
+++ b/module/data/fields/action/costField.mjs
@@ -26,11 +26,19 @@ export default class CostField extends fields.ArrayField {
     }
 
     static calcCosts(costs) {
+        console.log(costs, CostField.getResources.call(this, costs))
+        const resources = CostField.getResources.call(this, costs);
         return costs.map(c => {
             c.scale = c.scale ?? 1;
             c.step = c.step ?? 1;
-            c.total = c.value * c.scale * c.step;
+            c.total = c.value + ((c.scale - 1) * c.step);
             c.enabled = c.hasOwnProperty('enabled') ? c.enabled : true;
+            c.max = c.key === 'fear'
+                        ? game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Resources.Fear)
+                        : resources[c.key].isReversed
+                            ? resources[c.key].max
+                            : resources[c.key].value
+            if(c.scalable) c.maxStep = Math.floor(c.max / c.step);
             return c;
         });
     }

--- a/module/data/fields/action/rollField.mjs
+++ b/module/data/fields/action/rollField.mjs
@@ -4,7 +4,7 @@ export class DHActionRollData extends foundry.abstract.DataModel {
     /** @override */
     static defineSchema() {
         return {
-            type: new fields.StringField({ nullable: true, initial: null, choices: CONFIG.DH.GENERAL.rollTypes }),
+            type: new fields.StringField({ nullable: true, initial: null, choices: this.getRollTypes() }),
             trait: new fields.StringField({ nullable: true, initial: null, choices: CONFIG.DH.ACTOR.abilities }),
             difficulty: new fields.NumberField({ nullable: true, initial: null, integer: true, min: 0 }),
             bonus: new fields.NumberField({ nullable: true, initial: null, integer: true }),
@@ -45,6 +45,15 @@ export class DHActionRollData extends foundry.abstract.DataModel {
         };
     }
 
+    static getRollTypes() {
+        console.log(this.parent, this._source)
+        return CONFIG.DH.GENERAL.rollTypes;
+    }
+
+    _configure() {
+        console.log(this)
+    }
+
     getFormula() {
         if (!this.type) return;
         let formula = '';
@@ -71,5 +80,6 @@ export class DHActionRollData extends foundry.abstract.DataModel {
 export default class RollField extends fields.EmbeddedDataField {
     constructor(options, context = {}) {
         super(DHActionRollData, options, context);
+        console.log(this)
     }
 }

--- a/module/data/fields/action/rollField.mjs
+++ b/module/data/fields/action/rollField.mjs
@@ -66,6 +66,43 @@ export class DHActionRollData extends foundry.abstract.DataModel {
         }
         return formula;
     }
+
+    getModifier() {
+        const modifiers = [];
+        if(!this.parent?.actor) return modifiers;
+        switch (this.parent.actor.type) {
+            case 'character':
+                const trait = this.useDefault || !this.trait ? this.parent.item.system.attack.roll.trait : this.trait;
+                if(this.type === CONFIG.DH.GENERAL.rollTypes.attack.id || this.type === CONFIG.DH.GENERAL.rollTypes.trait.id)
+                    modifiers.push(
+                        {
+                            label: `DAGGERHEART.CONFIG.Traits.${trait}.name`,
+                            value: this.parent.actor.system.traits[trait].value
+                        }
+                    )
+                else if(this.type === CONFIG.DH.GENERAL.rollTypes.spellcast.id)
+                    modifiers.push(
+                        {
+                            label: `DAGGERHEART.CONFIG.RollTypes.spellcast.name`,
+                            value: this.parent.actor.system.spellcastModifier
+                        }
+                    )
+                break;
+            case 'companion':
+            case 'adversary':
+                if(this.type === CONFIG.DH.GENERAL.rollTypes.attack.id)
+                    modifiers.push(
+                        {
+                            label: 'Bonus to Hit',
+                            value: this.bonus ?? this.parent.actor.system.attack.roll.bonus
+                        }
+                    )
+                break;
+            default:
+                break;
+        }
+        return modifiers;
+    }
 }
 
 export default class RollField extends fields.EmbeddedDataField {

--- a/module/data/fields/action/rollField.mjs
+++ b/module/data/fields/action/rollField.mjs
@@ -72,7 +72,7 @@ export class DHActionRollData extends foundry.abstract.DataModel {
         if(!this.parent?.actor) return modifiers;
         switch (this.parent.actor.type) {
             case 'character':
-                const trait = this.useDefault || !this.trait ? this.parent.item.system.attack.roll.trait : this.trait;
+                const trait = this.useDefault || !this.trait ? (this.parent.item.system.attack.roll.trait ?? 'agility') : this.trait;
                 if(this.type === CONFIG.DH.GENERAL.rollTypes.attack.id || this.type === CONFIG.DH.GENERAL.rollTypes.trait.id)
                     modifiers.push(
                         {

--- a/module/data/fields/action/rollField.mjs
+++ b/module/data/fields/action/rollField.mjs
@@ -4,7 +4,7 @@ export class DHActionRollData extends foundry.abstract.DataModel {
     /** @override */
     static defineSchema() {
         return {
-            type: new fields.StringField({ nullable: true, initial: null, choices: this.getRollTypes() }),
+            type: new fields.StringField({ nullable: true, initial: null, choices: CONFIG.DH.GENERAL.rollTypes }),
             trait: new fields.StringField({ nullable: true, initial: null, choices: CONFIG.DH.ACTOR.abilities }),
             difficulty: new fields.NumberField({ nullable: true, initial: null, integer: true, min: 0 }),
             bonus: new fields.NumberField({ nullable: true, initial: null, integer: true }),
@@ -45,15 +45,6 @@ export class DHActionRollData extends foundry.abstract.DataModel {
         };
     }
 
-    static getRollTypes() {
-        console.log(this.parent, this._source)
-        return CONFIG.DH.GENERAL.rollTypes;
-    }
-
-    _configure() {
-        console.log(this)
-    }
-
     getFormula() {
         if (!this.type) return;
         let formula = '';
@@ -80,6 +71,5 @@ export class DHActionRollData extends foundry.abstract.DataModel {
 export default class RollField extends fields.EmbeddedDataField {
     constructor(options, context = {}) {
         super(DHActionRollData, options, context);
-        console.log(this)
     }
 }

--- a/module/data/item/base.mjs
+++ b/module/data/item/base.mjs
@@ -10,6 +10,7 @@
 
 import { addLinkedItemsDiff, updateLinkedItemApps } from '../../helpers/utils.mjs';
 import { ActionsField } from '../fields/actionField.mjs';
+import FormulaField from '../fields/formulaField.mjs';
 
 const fields = foundry.data.fields;
 
@@ -48,7 +49,7 @@ export default class BaseDataItem extends foundry.abstract.TypeDataModel {
                         initial: CONFIG.DH.ITEM.itemResourceTypes.simple
                     }),
                     value: new fields.NumberField({ integer: true, min: 0, initial: 0 }),
-                    max: new fields.StringField({ nullable: true, initial: null }),
+                    max: new FormulaField({ nullable: true, initial: null, deterministic: true }),
                     icon: new fields.StringField(),
                     recovery: new fields.StringField({
                         choices: CONFIG.DH.GENERAL.refreshTypes,

--- a/module/dice/d20Roll.mjs
+++ b/module/dice/d20Roll.mjs
@@ -124,13 +124,7 @@ export default class D20Roll extends DHRoll {
     }
 
     applyBaseBonus() {
-        const modifiers = [];
-
-        if (this.options.roll.bonus)
-            modifiers.push({
-                label: 'Bonus to Hit',
-                value: this.options.roll.bonus
-            });
+        const modifiers = foundry.utils.deepClone(this.options.roll.baseModifiers) ?? [];
 
         modifiers.push(...this.getBonus(`roll.${this.options.type}`, `${this.options.type?.capitalize()} Bonus`));
         modifiers.push(

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -481,7 +481,7 @@ export default class DhpActor extends Actor {
                 this.system.armor &&
                 this.#canReduceDamage(hpDamage.value, hpDamage.damageTypes)
             ) {
-                const armorStackResult = await this.owner.query('armorStack', {
+                const armorSlotResult = await this.owner.query('armorSlot', {
                         actorId: this.uuid,
                         damage: hpDamage.value,
                         type: [...hpDamage.damageTypes]
@@ -490,11 +490,11 @@ export default class DhpActor extends Actor {
                         timeout: 30000
                     }
                 );
-                if (armorStackResult) {
-                    const { modifiedDamage, armorSpent, stressSpent } = armorStackResult;
+                if (armorSlotResult) {
+                    const { modifiedDamage, armorSpent, stressSpent } = armorSlotResult;
                     updates.find(u => u.key === 'hitPoints').value = modifiedDamage;
                     updates.push(
-                        ...(armorSpent ? [{ value: armorSpent, key: 'armorStack' }] : []),
+                        ...(armorSpent ? [{ value: armorSpent, key: 'armor' }] : []),
                         ...(stressSpent ? [{ value: stressSpent, key: 'stress' }] : [])
                     );
                 }
@@ -569,6 +569,7 @@ export default class DhpActor extends Actor {
             armor: { target: this.system.armor, resources: {} },
             items: {}
         };
+        
         resources.forEach(r => {
             if (r.keyIsID) {
                 updates.items[r.key] = {
@@ -584,7 +585,7 @@ export default class DhpActor extends Actor {
                             game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Resources.Fear) + r.value
                         );
                         break;
-                    case 'armorStack':
+                    case 'armor':
                         updates.armor.resources['system.marks.value'] = Math.max(
                             Math.min(this.system.armor.system.marks.value + r.value, this.system.armorScore),
                             0

--- a/module/helpers/handlebarsHelper.mjs
+++ b/module/helpers/handlebarsHelper.mjs
@@ -7,6 +7,7 @@ export default class RegisterHandlebarsHelpers {
             includes: this.includes,
             times: this.times,
             damageFormula: this.damageFormula,
+            formulaValue: this.formulaValue,
             damageSymbols: this.damageSymbols,
             rollParsed: this.rollParsed,
             hasProperty: foundry.utils.hasProperty,
@@ -37,6 +38,15 @@ export default class RegisterHandlebarsHelpers {
         ].filter(x => x);
 
         return instances.join(traitTotal > 0 ? ' + ' : ' - ');
+    }
+
+    static formulaValue(formula, item) {
+        if(isNaN(formula)) {
+            const data = item.getRollData.bind(item)(),
+                roll = new Roll(Roll.replaceFormulaData(formula, data)).evaluateSync();
+            formula = roll.total;
+        }
+        return formula;
     }
 
     static damageSymbols(damageParts) {

--- a/module/systemRegistration/socket.mjs
+++ b/module/systemRegistration/socket.mjs
@@ -77,7 +77,7 @@ export const registerSocketHooks = () => {
 };
 
 export const registerUserQueries = () => {
-    CONFIG.queries.armorStack = DamageReductionDialog.armorStackQuery;
+    CONFIG.queries.armorSlot = DamageReductionDialog.armorSlotQuery;
     CONFIG.queries.reactionRoll = game.system.api.models.actions.actionsTypes.base.rollSaveQuery;
 }
 

--- a/templates/actionTypes/cost.hbs
+++ b/templates/actionTypes/cost.hbs
@@ -6,7 +6,7 @@
     {{#each source as |cost index|}}
         <div class="nest-inputs">
             {{formField ../fields.scalable label="Scalable" value=cost.scalable name=(concat "cost." index ".scalable") classes="checkbox"}}
-            {{formField ../fields.key choices=(@root.disableOption index @root.costOptions ../source) label="Resource" value=cost.key name=(concat "cost." index ".key") localize=true}}
+            {{formField ../fields.key choices=(@root.disableOption index @root.costOptions ../source) label="Resource" value=cost.key name=(concat "cost." index ".key") localize=true blank=false}}
             {{formField ../fields.value label="Amount" value=cost.value name=(concat "cost." index ".value")}}
             {{formField ../fields.step label="Step" value=cost.step name=(concat "cost." index ".step") disabled=(not cost.scalable)}}
             <a class="btn" data-tooltip="{{localize "CONTROLS.CommonDelete"}}" data-action="removeElement" data-index="{{index}}"><i class="fas fa-trash"></i></a>

--- a/templates/actionTypes/roll.hbs
+++ b/templates/actionTypes/roll.hbs
@@ -26,26 +26,4 @@
             {{formField fields.advState label= "Advantage State" name="roll.advState" value=source.advState localize=true disabled=(not source.type)}}
         </div>
     {{/if}}
-
-    {{!-- {{#if @root.isNPC}}
-        {{formField fields.bonus label="Bonus" name="roll.bonus" value=source.bonus}}
-        {{formField fields.advState label= "Advantage State" name="roll.advState" value=source.advState localize=true}}
-    {{else}}
-        {{formField fields.type label="Type" name="roll.type" value=source.type localize=true}}
-        {{#if (eq source.type "diceSet")}}
-            <div class="nest-inputs">
-                {{formField fields.diceRolling.fields.multiplier name="roll.diceRolling.multiplier" value=source.diceRolling.multiplier localize=true}}
-                {{#if (eq source.diceRolling.multiplier 'flat')}}{{formField fields.diceRolling.fields.flatMultiplier value=source.diceRolling.flatMultiplier name="roll.diceRolling.flatMultiplier" localize=true }}{{/if}}
-                {{formField fields.diceRolling.fields.dice name="roll.diceRolling.dice" value=source.diceRolling.dice localize=true}}
-                {{formField fields.diceRolling.fields.compare name="roll.diceRolling.compare" value=source.diceRolling.compare localize=true blank=""}}
-                {{formField fields.diceRolling.fields.treshold name="roll.diceRolling.treshold" value=source.diceRolling.treshold localize=true}}
-            </div>
-        {{else}}
-            <div class="nest-inputs">
-                {{#unless (eq source.type 'spellcast')}}{{formField fields.trait label="Trait" name="roll.trait" value=source.trait localize=true disabled=(not source.type)}}{{/unless}}
-                {{formField fields.difficulty label="Difficulty" name="roll.difficulty" value=source.difficulty disabled=(not source.type)}}
-                {{formField fields.advState label= "Advantage State" name="roll.advState" value=source.advState localize=true}}
-            </div>
-        {{/if}}
-    {{/if}} --}}
 </fieldset>

--- a/templates/actionTypes/roll.hbs
+++ b/templates/actionTypes/roll.hbs
@@ -3,7 +3,31 @@
         Roll
         {{#if @root.hasBaseDamage}}{{formInput fields.useDefault name="roll.useDefault" value=source.useDefault dataset=(object tooltip="Use default Item values" tooltipDirection="UP")}}{{/if}}
     </legend>
-    {{#if @root.isNPC}}
+    
+    {{formField fields.type label="Type" name="roll.type" value=source.type localize=true choices=@root.getRollTypeOptions}}
+    {{#if (eq source.type "diceSet")}}
+        <div class="nest-inputs">
+            {{formField fields.diceRolling.fields.multiplier name="roll.diceRolling.multiplier" value=source.diceRolling.multiplier localize=true}}
+            {{#if (eq source.diceRolling.multiplier 'flat')}}{{formField fields.diceRolling.fields.flatMultiplier value=source.diceRolling.flatMultiplier name="roll.diceRolling.flatMultiplier" localize=true }}{{/if}}
+            {{formField fields.diceRolling.fields.dice name="roll.diceRolling.dice" value=source.diceRolling.dice localize=true}}
+            {{formField fields.diceRolling.fields.compare name="roll.diceRolling.compare" value=source.diceRolling.compare localize=true blank=""}}
+            {{formField fields.diceRolling.fields.treshold name="roll.diceRolling.treshold" value=source.diceRolling.treshold localize=true}}
+        </div>
+    {{else}}
+        <div class="nest-inputs">
+            {{#unless (eq source.type 'spellcast')}}
+                {{#if @root.isNPC}}
+                    {{formField fields.bonus label="Bonus" name="roll.bonus" value=source.bonus placeholder=@root.baseAttackBonus disabled=(not source.type)}}
+                {{else}}
+                    {{formField fields.trait label="Trait" name="roll.trait" value=source.trait localize=true disabled=(not source.type)}}
+                {{/if}}
+            {{/unless}}
+            {{formField fields.difficulty label="Difficulty" name="roll.difficulty" value=source.difficulty disabled=(not source.type)}}
+            {{formField fields.advState label= "Advantage State" name="roll.advState" value=source.advState localize=true disabled=(not source.type)}}
+        </div>
+    {{/if}}
+
+    {{!-- {{#if @root.isNPC}}
         {{formField fields.bonus label="Bonus" name="roll.bonus" value=source.bonus}}
         {{formField fields.advState label= "Advantage State" name="roll.advState" value=source.advState localize=true}}
     {{else}}
@@ -18,10 +42,10 @@
             </div>
         {{else}}
             <div class="nest-inputs">
-                {{formField fields.trait label="Trait" name="roll.trait" value=source.trait localize=true disabled=(not source.type)}}
+                {{#unless (eq source.type 'spellcast')}}{{formField fields.trait label="Trait" name="roll.trait" value=source.trait localize=true disabled=(not source.type)}}{{/unless}}
                 {{formField fields.difficulty label="Difficulty" name="roll.difficulty" value=source.difficulty disabled=(not source.type)}}
                 {{formField fields.advState label= "Advantage State" name="roll.advState" value=source.advState localize=true}}
             </div>
         {{/if}}
-    {{/if}}
+    {{/if}} --}}
 </fieldset>

--- a/templates/dialogs/dice-roll/costSelection.hbs
+++ b/templates/dialogs/dice-roll/costSelection.hbs
@@ -20,10 +20,10 @@
                     <label>{{label}}</label>
                 </div>
             </div>
-            {{#if scalable}}
-                <input type="range" value="{{scale}}" min="1" max="10" step="{{step}}" name="costs.{{index}}.scale">
+            {{#if (and scalable (gt maxStep 1))}}
+                <input type="range" value="{{scale}}" min="1" max="{{maxStep}}" step="1" name="costs.{{index}}.scale">
             {{/if}}
-            <label class="modifier-label">{{total}}/10</label>
+            <label class="modifier-label">{{total}}/{{max}}</label>
         </li>
         {{/each}}
     </ul>

--- a/templates/dialogs/dice-roll/costSelection.hbs
+++ b/templates/dialogs/dice-roll/costSelection.hbs
@@ -8,8 +8,8 @@
                         <input name="uses.enabled" type="checkbox"{{#if uses.enabled}} checked{{/if}}>
                         <label for="uses.enabled">Uses</label>
                     </div>
-                </div>
-                <label class="modifier-label">{{uses.value}}/{{uses.max}}</label>
+                </div>{{log @root}}
+                <label class="modifier-label">{{uses.value}}/{{formulaValue uses.max @root.rollConfig.data}}</label>
             </li>
         {{/if}}
         {{#each costs as | cost index |}}

--- a/templates/ui/tooltip/action.hbs
+++ b/templates/ui/tooltip/action.hbs
@@ -2,7 +2,6 @@
     <h2 class="tooltip-title">{{item.name}}</h2>
     <img class="tooltip-image" src="{{item.img}}" />
     <div class="tooltip-description">{{{description}}}</div>
-
     {{#if item.uses.max}}
         <h4 class="tooltip-sub-title">{{localize "DAGGERHEART.GENERAL.uses"}}</h4>
         <div class="tooltip-information-section triple spaced">
@@ -12,7 +11,7 @@
             </div>
             <div class="tooltip-information">
                 <label>{{localize "DAGGERHEART.GENERAL.max"}}</label>
-                <div>{{item.uses.max}}</div>
+                <div>{{formulaValue item.uses.max item}}</div>
             </div>
             <div class="tooltip-information">
                 <label>{{localize "DAGGERHEART.GENERAL.recovery"}}</label>


### PR DESCRIPTION
## Description

- Adversary can now set their Action Roll type as none, Attack or DiceSet
- Adversary attack bonus is equal to their base attack bonus by default
- Item Resource & Action uses max property is now a FormulaField
- Added max for resources in Roll Dialog


- Closes https://github.com/Foundryborne/daggerheart/issues/443

## Type of Change

Please check the relevant options:

- [x] Bug fix
- [x] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [ ] Manual testing
- [ ] Other:

## Screenshots (if applicable)

Include screenshots or GIFs to help explain your changes visually.

## Checklist

- [ ] My code follows the project style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [ ] New and existing tests pass locally with my changes

## Additional Comments

Add any other context or questions here.

---

> Thank you for your contribution! 🎉
