### PR TITLE
Fix : we want to equip weapon if beatform is inactive.

### DIFF
--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -640,7 +640,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
                 await item.update({ 'system.equipped': true });
                 break;
             case 'weapon':
-                if (this.document.effects.find(x => x.type === 'beastform')) {
+                if (this.document.effects.find(x => !x.disabled && x.type === 'beastform')) {
                     return ui.notifications.warn(
                         game.i18n.localize('DAGGERHEART.UI.Notifications.beastformEquipWeapon')
                     );


### PR DESCRIPTION
## Description

a character cannot equip anymore its magical weapon, it was because beatform effect is considering active even if it is disabled.

- [x] Bug fix

## How Has This Been Tested?

- [x] Manual testing

## Screenshots (if applicable)

![Peek 2025-08-02 01-08](https://github.com/user-attachments/assets/c0b1c355-d14e-4716-ae47-666a2629644e)
