### PR TITLE
[Fix] Adversary Attack Descriptions

### DIFF
--- a/src/packs/adversaries/adversary_Acid_Burrower_89yAh30vaNQOALlz.json
+++ b/src/packs/adversaries/adversary_Acid_Burrower_89yAh30vaNQOALlz.json
@@ -303,7 +303,7 @@
             "type": "attack",
             "_id": "4ppSeiTdbqnMzWAs",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to have the Burrower burst out of the ground. All creatures within Very Close range must succeed on an Agility Reaction Roll or be knocked over, making them Vulnerable until they next act.</p><p>@Template[type:emanation|range:vc]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -354,7 +354,7 @@
               "difficulty": null,
               "damageMod": "none"
             },
-            "name": "Use",
+            "name": "Roll Save",
             "img": "icons/magic/earth/barrier-stone-explosion-red.webp",
             "range": "veryClose"
           }
@@ -423,7 +423,8 @@
         "coreVersion": "13.346",
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
-        "lastModifiedBy": null
+        "lastModifiedBy": "MQSznptE5yLT7kj8",
+        "modifiedTime": 1754143640417
       },
       "_key": "!actors.items!89yAh30vaNQOALlz.ctXYwil2D1zfsekT"
     },
@@ -440,7 +441,7 @@
             "type": "attack",
             "_id": "yd10HwK6Wa3OEvv2",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Make an attack against all targets in front of the Burrower within Close range. Targets the Burrower succeeds against take <strong>2d6</strong> physical damage and must mark an Armor Slot without receiving its benefi ts (they can still use armor to reduce the damage). If they can’t mark an Armor Slot, they must mark an additional HP and you gain a Fear.</p><p>@Template[type:inFront|range:c]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -556,7 +557,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "lastModifiedBy": "MQSznptE5yLT7kj8",
-        "modifiedTime": 1754012083498
+        "modifiedTime": 1754143653876
       },
       "_key": "!actors.items!89yAh30vaNQOALlz.UpFsnlbZkyvM2Ftv"
     },
@@ -573,7 +574,7 @@
             "type": "damage",
             "_id": "XbtTzOBvlTaxOKTy",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Burrower takes Severe damage, all creatures within Close range are bathed in their acidic blood, taking <strong>1d10</strong> physical damage. This splash covers the ground within Very Close range with blood, and all creatures other than the Burrower who move through it take <strong>1d6</strong> physical damage.</p><p>@Template[type:emanation|range:c]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -627,7 +628,7 @@
             "type": "damage",
             "_id": "xpcp1ECTWF20kxve",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>This splash covers the ground within Very Close range with blood, and all creatures other than the Burrower who move through it take <strong>1d6</strong> physical damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -697,7 +698,8 @@
         "coreVersion": "13.346",
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
-        "lastModifiedBy": null
+        "lastModifiedBy": "MQSznptE5yLT7kj8",
+        "modifiedTime": 1754143695127
       },
       "_key": "!actors.items!89yAh30vaNQOALlz.aNIVT5LKhwLyjKpI"
     }

--- a/src/packs/adversaries/adversary_Apprentice_Assassin_vNIbYQ4YSzNf0WPE.json
+++ b/src/packs/adversaries/adversary_Apprentice_Assassin_vNIbYQ4YSzNf0WPE.json
@@ -262,7 +262,7 @@
             "type": "effect",
             "_id": "vgguNWz8vG8aoLXR",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to choose a target and spotlight all Apprentice Assassins within Close range of them. Those Minions move into Melee range of the target and make one shared attack roll. On a success, they deal 4 physical damage each. Combine this damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -310,7 +310,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754070539112,
-        "modifiedTime": 1754070582456,
+        "modifiedTime": 1754142025997,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!vNIbYQ4YSzNf0WPE.4wT7CmM1DJEPcraF"

--- a/src/packs/adversaries/adversary_Archer_Guard_JRhrrEg5UroURiAD.json
+++ b/src/packs/adversaries/adversary_Archer_Guard_JRhrrEg5UroURiAD.json
@@ -238,7 +238,7 @@
             "type": "attack",
             "_id": "84rwldOFvTPrrHJJ",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Make an attack against a target within Far range. On a success, <strong>mark a Stress</strong> to deal <strong>1d12+3</strong> physical damage. If the target marks HP from this attack, they have disadvantage on Agility Rolls until they clear at least 1 HP.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -385,7 +385,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754012548341,
-        "modifiedTime": 1754012705815,
+        "modifiedTime": 1754143709108,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!JRhrrEg5UroURiAD.DMtd1EXQPlPaoRmV"

--- a/src/packs/adversaries/adversary_Archer_Squadron_0ts6CGd93lLqGZI5.json
+++ b/src/packs/adversaries/adversary_Archer_Squadron_0ts6CGd93lLqGZI5.json
@@ -263,7 +263,7 @@
             "type": "attack",
             "_id": "uG7Hl2DqaT69aNs1",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to target a point within Far range. Make an attack with advantage against all targets within Close range of that point. Targets the Squadron succeeds against take <strong>1d10+4</strong> physical damage.</p><p>@Template[type:circle|range:c]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -360,7 +360,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754070661520,
-        "modifiedTime": 1754070745015,
+        "modifiedTime": 1754142041107,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!0ts6CGd93lLqGZI5.Wuf5y9tJ88BwzLv2"
@@ -376,7 +376,7 @@
             "type": "attack",
             "_id": "mH6mmJIMM1fwzePt",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to target a point within Far range. Until the next roll with Fear, a creature who moves within Close range of that point must make an Agility Reaction Roll. On a failure, they take <strong>2d6+3</strong> physical damage. On a success, they take half damage.</p><p>@Template[type:circle|range:c]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -465,7 +465,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754070760732,
-        "modifiedTime": 1754070860912,
+        "modifiedTime": 1754142058270,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!0ts6CGd93lLqGZI5.ayGHTtyjSuIR4BrV"

--- a/src/packs/adversaries/adversary_Assassin_Poisoner_h5RuhzGL17dW5FBT.json
+++ b/src/packs/adversaries/adversary_Assassin_Poisoner_h5RuhzGL17dW5FBT.json
@@ -236,7 +236,7 @@
             "type": "effect",
             "_id": "L83tU1TgmqoH9SSn",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Targets who mark HP from the Assassin’s attacks are Vulnerable until they clear a HP.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -328,7 +328,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754073069218,
-        "modifiedTime": 1754073116024,
+        "modifiedTime": 1754142079163,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!h5RuhzGL17dW5FBT.Fz2lnUEeBxsDpx0G"
@@ -429,7 +429,7 @@
             "type": "effect",
             "_id": "sp7RfJRQJsEUm09m",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Drop a smoke bomb that fills the air within Close range with smoke, Dizzying all targets in this area. Dizzied targets have disadvantage on their next action roll, then clear the condition.</p><p>@Template[type:emanation|range:c]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -519,7 +519,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754073225985,
-        "modifiedTime": 1754073324182,
+        "modifiedTime": 1754142105436,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!h5RuhzGL17dW5FBT.lAmiK8wVxjyHwKlp"

--- a/src/packs/adversaries/adversary_Battle_Box_dgH3fW9FTYLaIDvS.json
+++ b/src/packs/adversaries/adversary_Battle_Box_dgH3fW9FTYLaIDvS.json
@@ -269,7 +269,7 @@
             "type": "attack",
             "_id": "FX9jwg5ZNjAWnti3",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Mark a Stress and roll a <strong>d6</strong>. The Box uses the corresponding move:</p><ol><li><p><strong>Mana Beam</strong></p></li><li><p><strong>Fire Jets</strong></p></li><li><p><strong>Trample</strong></p></li><li><p><strong>Shocking Gas</strong></p></li><li><p><strong>Stunning Clap</strong></p></li><li><p><strong>Psionic Whine</strong></p></li></ol>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -341,7 +341,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754073845291,
-        "modifiedTime": 1754074092816,
+        "modifiedTime": 1754142121782,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!dgH3fW9FTYLaIDvS.ZqfLMjVkbUwDw4p6"
@@ -357,7 +357,7 @@
             "type": "attack",
             "_id": "Co09oXMw0yBjGaws",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>The Box fires a searing beam. Make an attack against a target within Far range. On a success, deal <strong>2d10+2</strong> magic damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -448,7 +448,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754074104758,
-        "modifiedTime": 1754074169215,
+        "modifiedTime": 1754142132743,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!dgH3fW9FTYLaIDvS.lqyN4CQop53BzarW"
@@ -464,7 +464,7 @@
             "type": "attack",
             "_id": "hRAKaOdzQXLYBNVV",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>The Box shoots into the air, spinning and releasing jets of flame. Make an attack against all targets within Close range. Targets the Box succeeds against take <strong>2d8</strong> physical damage.</p><p>@Template[type:emanation|range:c]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -555,7 +555,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754074175443,
-        "modifiedTime": 1754074254385,
+        "modifiedTime": 1754142142523,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!dgH3fW9FTYLaIDvS.IHQoqt39T772FVMs"
@@ -571,7 +571,7 @@
             "type": "attack",
             "_id": "IOgPMu12Xnn33TfG",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>The Box rockets around erratically. Make an attack against all PCs within Close range. Targets the Box succeeds against take <strong>1d6+5</strong> physical damage and are Vulnerable until their next roll with Hope.</p><p>@Template[type:emanation|range:c]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -714,7 +714,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754074260007,
-        "modifiedTime": 1754074361978,
+        "modifiedTime": 1754142151952,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!dgH3fW9FTYLaIDvS.XtnByqUr9AuYU9Ip"
@@ -730,7 +730,7 @@
             "type": "attack",
             "_id": "ky4OMl558J5wCbDp",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>The Box sprays out a silver gas sparking with lightning. All targets within Close range must succeed on a Finesse Reaction Roll or mark 3 Stress.</p><p>@Template[type:emanation|range:c]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -820,7 +820,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754074364206,
-        "modifiedTime": 1754081281415,
+        "modifiedTime": 1754142161096,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!dgH3fW9FTYLaIDvS.3bPURmuwQs06fThQ"
@@ -836,7 +836,7 @@
             "type": "attack",
             "_id": "LQtopkrtSlCQ5MAr",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>The Box leaps and their sides clap, creating a small sonic boom. All targets within Very Close range must succeed on a Strength Reaction Roll or become <em>Vulnerable</em> until the cube is defeated.</p><p>@Template[type:emanation|range:vc]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -879,7 +879,7 @@
               "difficulty": null,
               "damageMod": "none"
             },
-            "name": "Attack",
+            "name": "Roll Save",
             "img": "icons/magic/sonic/explosion-impact-shock-wave.webp",
             "range": "veryClose"
           }
@@ -952,7 +952,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754074454965,
-        "modifiedTime": 1754074555182,
+        "modifiedTime": 1754142182845,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!dgH3fW9FTYLaIDvS.ijIaKjroxq3xZd9Z"
@@ -968,7 +968,7 @@
             "type": "attack",
             "_id": "3R3pGOUj4rHaUzPK",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>The Box releases a cluster of mechanical bees whose buzz rattles mortal minds. All targets within Close range must succeed on a Presence Reaction Roll or take <strong>2d4+9</strong> direct magic damage.</p><p>@Template[type:emanation|range:c]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -1059,7 +1059,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754074558281,
-        "modifiedTime": 1754074641366,
+        "modifiedTime": 1754142197090,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!dgH3fW9FTYLaIDvS.JCue4ko61bjhedXv"
@@ -1075,7 +1075,7 @@
             "type": "healing",
             "_id": "3XOvKoYz4CqMNrU9",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Before rolling damage for the Box’s attack, you can <strong>mark a Stress</strong> to add a <strong>d6</strong> to the damage roll. Additionally, you gain a Fear.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -1168,7 +1168,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754074647690,
-        "modifiedTime": 1754074721984,
+        "modifiedTime": 1754142206511,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!dgH3fW9FTYLaIDvS.ITzpRJr2jWK0Ksmp"
@@ -1184,7 +1184,7 @@
             "type": "attack",
             "_id": "oCpv4zi9jtEpo0K1",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Box marks their last HP, the magic powering them ruptures in an explosion of force. All targets within Close range must succeed on an Instinct Reaction Roll or take <strong>2d8+1</strong> magic damage</p><p>@Template[type:emanation|range:c]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -1275,7 +1275,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754074737929,
-        "modifiedTime": 1754074811945,
+        "modifiedTime": 1754142216691,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!dgH3fW9FTYLaIDvS.YvfzPyJbbv2ia6Yp"

--- a/src/packs/adversaries/adversary_Bear_71qKDLKO3CsrNkdy.json
+++ b/src/packs/adversaries/adversary_Bear_71qKDLKO3CsrNkdy.json
@@ -275,7 +275,7 @@
             "type": "attack",
             "_id": "PXL3e51eBYZ4O2lb",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to make an attack against a target within Melee range. On a success, deal <strong>3d4+10</strong> physical damage and the target is <em>Restrained</em> until they break free with a successful Strength Roll.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -425,7 +425,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754012195973,
-        "modifiedTime": 1754012285100,
+        "modifiedTime": 1754143721840,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!71qKDLKO3CsrNkdy.zgR0MEqyobKp2yXr"
@@ -438,75 +438,7 @@
       "system": {
         "description": "<p>When the Bear makes a successful attack against a PC, you gain a Fear.</p>",
         "resource": null,
-        "actions": {
-          "HawHNALF7mdigX4X": {
-            "type": "healing",
-            "_id": "HawHNALF7mdigX4X",
-            "systemPath": "actions",
-            "description": "",
-            "chatDisplay": true,
-            "actionType": "action",
-            "cost": [],
-            "uses": {
-              "value": null,
-              "max": "",
-              "recovery": null
-            },
-            "damage": {
-              "parts": [
-                {
-                  "value": {
-                    "custom": {
-                      "enabled": true,
-                      "formula": "1"
-                    },
-                    "multiplier": "flat",
-                    "flatMultiplier": 1,
-                    "dice": "d6",
-                    "bonus": null
-                  },
-                  "applyTo": "fear",
-                  "base": false,
-                  "resultBased": false,
-                  "valueAlt": {
-                    "multiplier": "prof",
-                    "flatMultiplier": 1,
-                    "dice": "d6",
-                    "bonus": null,
-                    "custom": {
-                      "enabled": false
-                    }
-                  },
-                  "type": []
-                }
-              ],
-              "includeBase": false
-            },
-            "target": {
-              "type": "any",
-              "amount": null
-            },
-            "effects": [],
-            "roll": {
-              "type": null,
-              "trait": null,
-              "difficulty": null,
-              "bonus": null,
-              "advState": "neutral",
-              "diceRolling": {
-                "multiplier": "prof",
-                "flatMultiplier": 1,
-                "dice": "d6",
-                "compare": null,
-                "treshold": null
-              },
-              "useDefault": false
-            },
-            "name": "Gain Fear",
-            "img": "icons/magic/unholy/orb-hands-pink.webp",
-            "range": ""
-          }
-        },
+        "actions": {},
         "originItemType": null,
         "subType": null,
         "originId": null
@@ -527,7 +459,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754012330113,
-        "modifiedTime": 1754012418576,
+        "modifiedTime": 1754143729868,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!71qKDLKO3CsrNkdy.4hJbq9WCwJn78frt"

--- a/src/packs/adversaries/adversary_Bladed_Guard_B4LZcGuBAHzyVdzy.json
+++ b/src/packs/adversaries/adversary_Bladed_Guard_B4LZcGuBAHzyVdzy.json
@@ -237,7 +237,7 @@
             "type": "attack",
             "_id": "3lbeEeJdjzPn0MoG",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>A creature who tries to move within Very Close range of the Guard must succeed on an Agility Roll. If additional Bladed Guards are standing in a line alongside the first, and each is within Melee range of another guard in the line, the Difficulty increases by the total number of guards in that line.</p>",
             "chatDisplay": true,
             "actionType": "passive",
             "cost": [],
@@ -275,7 +275,7 @@
               "difficulty": null,
               "damageMod": "none"
             },
-            "name": "Use",
+            "name": "Block",
             "img": "icons/equipment/shield/shield-round-boss-wood-brown.webp",
             "range": "veryClose"
           }
@@ -300,7 +300,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754012824140,
-        "modifiedTime": 1754012926434,
+        "modifiedTime": 1754143793947,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!B4LZcGuBAHzyVdzy.qEn4baWgkjKtmILp"
@@ -318,7 +318,7 @@
             "type": "attack",
             "_id": "TK5R00afB1RIA6gp",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Make an attack against a target within Very Close range. On a success, <strong>mark a Stress</strong> to Restrain the target until they break free with a successful attack, Finesse Roll, or Strength Roll.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -433,7 +433,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754012944888,
-        "modifiedTime": 1754013114603,
+        "modifiedTime": 1754143803011,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!B4LZcGuBAHzyVdzy.9gizFt9ovKL05DXu"

--- a/src/packs/adversaries/adversary_Brawny_Zombie_2UeZ0tEe7AzgSJNd.json
+++ b/src/packs/adversaries/adversary_Brawny_Zombie_2UeZ0tEe7AzgSJNd.json
@@ -281,7 +281,7 @@
             "type": "attack",
             "_id": "qCcWw60cPZnEWbpG",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Make a standard attack with advantage against a target the Zombie has <em>Restrained</em>. On a success, the attack deals direct damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -371,7 +371,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754013355113,
-        "modifiedTime": 1754013446559,
+        "modifiedTime": 1754143817596,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!2UeZ0tEe7AzgSJNd.LP7xVLMTkJsmiIvl"
@@ -389,7 +389,7 @@
             "type": "damage",
             "_id": "xV1z3dk9c7jIkk7v",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Zombies makes a successful standard attack, you can <strong>mark a Stress</strong> to temporarily Restrain the target and force them to mark 2 Stress.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -518,7 +518,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754013473713,
-        "modifiedTime": 1754013614420,
+        "modifiedTime": 1754143824712,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!2UeZ0tEe7AzgSJNd.69reUZ5tv3splqyO"

--- a/src/packs/adversaries/adversary_Cave_Ogre_8Zkqk1jU09nKL2fy.json
+++ b/src/packs/adversaries/adversary_Cave_Ogre_8Zkqk1jU09nKL2fy.json
@@ -238,7 +238,7 @@
             "type": "effect",
             "_id": "UoZ6vXRXvWYjpJpZ",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>You must <strong>spend a Fear</strong> to spotlight the Ogre. While spotlighted, they can make their standard attack against all targets within range.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -285,7 +285,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754011303846,
-        "modifiedTime": 1754011580092,
+        "modifiedTime": 1754143837385,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!8Zkqk1jU09nKL2fy.ynuyMl1sMQYINfcQ"
@@ -337,7 +337,7 @@
             "type": "attack",
             "_id": "3p1qfHy5uHe4H2hB",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to pick up heavy objects and throw them at all targets in front of the Ogre within Far range. Make an attack against these targets. Targets the Ogre succeeds against take <strong>1d10+2</strong> physical damage. If they succeed against more than one target, you gain a Fear.</p><p>@Template[type:inFront|range:f]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -419,7 +419,7 @@
             "_id": "pmeromzI4eQOilbp",
             "systemPath": "actions",
             "description": "",
-            "chatDisplay": true,
+            "chatDisplay": false,
             "actionType": "action",
             "cost": [],
             "uses": {
@@ -502,7 +502,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754011680074,
-        "modifiedTime": 1754011917159,
+        "modifiedTime": 1754143860893,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!8Zkqk1jU09nKL2fy.zGvaBYJPOOnQVQEn"
@@ -520,7 +520,7 @@
             "type": "damage",
             "_id": "PtTu9bnCJKMySBSV",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Ogre marks 2 or more HP, they can rampage. Move the Ogre to a point within Close range and deal <strong>2d6+3</strong> direct physical damage to all targets in their path.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -590,7 +590,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754011925214,
-        "modifiedTime": 1754012026787,
+        "modifiedTime": 1754143873733,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!8Zkqk1jU09nKL2fy.Qxkddj6nQc4RDExW"

--- a/src/packs/adversaries/adversary_Chaos_Skull_jDmHqGvzg5wjgmxE.json
+++ b/src/packs/adversaries/adversary_Chaos_Skull_jDmHqGvzg5wjgmxE.json
@@ -348,7 +348,7 @@
             "type": "attack",
             "_id": "iF0PD1t3yovKMTfy",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to make an attack against all targets within Close range. Targets the Skull succeeds against take <strong>2d6+4</strong> magic damage.</p><p>@Template[type:emanation|range:c]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -447,7 +447,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754075150449,
-        "modifiedTime": 1754075227513,
+        "modifiedTime": 1754142237897,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!jDmHqGvzg5wjgmxE.Zn25zBr96y1hrmnr"
@@ -463,7 +463,7 @@
             "type": "attack",
             "_id": "872Fq88Hitwc6f3W",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to make an attack against a PC with a Spellcast trait within Very Close range. On a success, the target marks <strong>1d4</strong> Stress and the Skull clears that many Stress. Additionally, on a success, the Skull can immediately be spotlighted again.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -529,72 +529,6 @@
             "name": "Attack",
             "img": "icons/magic/control/sihouette-hold-beam-green.webp",
             "range": "veryClose"
-          },
-          "m71TUOhKkOLUj8FZ": {
-            "type": "healing",
-            "_id": "m71TUOhKkOLUj8FZ",
-            "systemPath": "actions",
-            "description": "",
-            "chatDisplay": true,
-            "actionType": "action",
-            "cost": [],
-            "uses": {
-              "value": null,
-              "max": "",
-              "recovery": null
-            },
-            "damage": {
-              "parts": [
-                {
-                  "value": {
-                    "custom": {
-                      "enabled": false
-                    },
-                    "flatMultiplier": 1,
-                    "dice": "d4",
-                    "bonus": null,
-                    "multiplier": "flat"
-                  },
-                  "applyTo": "stress",
-                  "base": false,
-                  "resultBased": false,
-                  "valueAlt": {
-                    "multiplier": "prof",
-                    "flatMultiplier": 1,
-                    "dice": "d6",
-                    "bonus": null,
-                    "custom": {
-                      "enabled": false
-                    }
-                  },
-                  "type": []
-                }
-              ],
-              "includeBase": false
-            },
-            "target": {
-              "type": "self",
-              "amount": null
-            },
-            "effects": [],
-            "roll": {
-              "type": null,
-              "trait": null,
-              "difficulty": null,
-              "bonus": null,
-              "advState": "neutral",
-              "diceRolling": {
-                "multiplier": "prof",
-                "flatMultiplier": 1,
-                "dice": "d6",
-                "compare": null,
-                "treshold": null
-              },
-              "useDefault": false
-            },
-            "name": "Clear Stress",
-            "img": "icons/magic/control/sihouette-hold-beam-green.webp",
-            "range": ""
           }
         },
         "originItemType": null,
@@ -618,7 +552,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754075230388,
-        "modifiedTime": 1754075325188,
+        "modifiedTime": 1754142272882,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!jDmHqGvzg5wjgmxE.urXRi4bdBfvl8U6K"

--- a/src/packs/adversaries/adversary_Conscript_99TqczuQipBmaB8i.json
+++ b/src/packs/adversaries/adversary_Conscript_99TqczuQipBmaB8i.json
@@ -255,7 +255,7 @@
             "type": "effect",
             "_id": "cbAvPSIhwBMBTI3D",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to choose a target and spotlight all Conscripts within Close range of them. Those Minions move into Melee range of the target and make one shared attack roll. On a success, they deal 6 physical damage each. Combine this damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -303,7 +303,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754075401268,
-        "modifiedTime": 1754075437940,
+        "modifiedTime": 1754142299386,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!99TqczuQipBmaB8i.MWfKUGzT1YBmLvpn"

--- a/src/packs/adversaries/adversary_Construct_uOP5oT9QzXPlnf3p.json
+++ b/src/packs/adversaries/adversary_Construct_uOP5oT9QzXPlnf3p.json
@@ -300,7 +300,7 @@
             "type": "attack",
             "_id": "OswphW4Z1B5oa4ts",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to make an attack against all targets in the Construct’s path when they move. Targets the Construct succeeds against take <strong>1d8</strong> physical damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -398,7 +398,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754013785248,
-        "modifiedTime": 1754013859298,
+        "modifiedTime": 1754143890173,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!uOP5oT9QzXPlnf3p.93m085bEaKFzvEWT"
@@ -416,7 +416,7 @@
             "type": "effect",
             "_id": "xYACTiZzApmCXXmf",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Before rolling damage for the Construct’s attack, you can <strong>mark a Stress</strong> to gain a +10 bonus to the damage roll. The Construct can then take the spotlight again.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -515,7 +515,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754013871234,
-        "modifiedTime": 1754013921817,
+        "modifiedTime": 1754143897693,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!uOP5oT9QzXPlnf3p.EF6YIDjQ0liFubGA"
@@ -533,7 +533,7 @@
             "type": "attack",
             "_id": "fkIWRdcGPgHgm6VC",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Construct marks their last HP, the magic powering them ruptures in an explosion of force. Make an attack with advantage against all targets within Very Close range. Targets the Construct succeeds against take <strong>1d12+2</strong> magic damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -623,7 +623,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754013980637,
-        "modifiedTime": 1754014038531,
+        "modifiedTime": 1754143905192,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!uOP5oT9QzXPlnf3p.UlGLuV1L33tDWkli"

--- a/src/packs/adversaries/adversary_Courtesan_ZxWaWPdzFIUPNC62.json
+++ b/src/packs/adversaries/adversary_Courtesan_ZxWaWPdzFIUPNC62.json
@@ -240,7 +240,7 @@
             "type": "damage",
             "_id": "dRtDCrAPLc1GYqBs",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When a PC within Close range makes a Presence Roll, you can <strong>mark a Stress</strong> to cast a gaze toward the aftermath. On the target’s failure, they must mark 2 Stress and are <em>Vulnerable</em> until the scene ends or they succeed on a social action against the Courtesan. On the target’s success, they must mark a Stress.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -370,7 +370,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754075457515,
-        "modifiedTime": 1754075591784,
+        "modifiedTime": 1754142315839,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!ZxWaWPdzFIUPNC62.rSMUPC5GhR982ifg"

--- a/src/packs/adversaries/adversary_Courtier_CBBuEXAlLKFMJdjg.json
+++ b/src/packs/adversaries/adversary_Courtier_CBBuEXAlLKFMJdjg.json
@@ -237,7 +237,7 @@
             "type": "attack",
             "_id": "Yi3rvjj0Umqt5Z8j",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to say something mocking and force a target within Close range to make a Presence Reaction Roll (14) to see if they can save face. On a failure, the target must mark 2 Stress and is Vulnerable until the scene ends.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -386,7 +386,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754014295058,
-        "modifiedTime": 1754014456928,
+        "modifiedTime": 1754143921727,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!CBBuEXAlLKFMJdjg.LYNaKEYcYMgvF4Rf"
@@ -404,7 +404,7 @@
             "type": "effect",
             "_id": "IwuFowlcXyjvfOxp",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> and target a PC. The Courtier convinces a crowd or prominent individual that the target is the cause of their current conflict or misfortune.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -451,7 +451,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754014473825,
-        "modifiedTime": 1754014546519,
+        "modifiedTime": 1754143929683,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!CBBuEXAlLKFMJdjg.Ux42ELBBuSYwm4yW"

--- a/src/packs/adversaries/adversary_Cult_Adept_0NxCSugvKQ4W8OYZ.json
+++ b/src/packs/adversaries/adversary_Cult_Adept_0NxCSugvKQ4W8OYZ.json
@@ -112,7 +112,8 @@
           }
         ]
       },
-      "range": "far"
+      "range": "far",
+      "img": "icons/weapons/staves/staff-ornate-purple.webp"
     }
   },
   "flags": {},
@@ -124,7 +125,7 @@
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784239,
-    "modifiedTime": 1754090770938,
+    "modifiedTime": 1754142403176,
     "lastModifiedBy": "MQSznptE5yLT7kj8"
   },
   "_id": "0NxCSugvKQ4W8OYZ",
@@ -240,7 +241,7 @@
             "type": "attack",
             "_id": "TQv3o9sRnlDNbPyu",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to make a standard attack against a target within range. On a success, the target must mark a Stress.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -364,7 +365,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754075842447,
-        "modifiedTime": 1754075990327,
+        "modifiedTime": 1754142328561,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!0NxCSugvKQ4W8OYZ.kCffzM8rX8NEr9d2"
@@ -380,7 +381,7 @@
             "type": "effect",
             "_id": "8yRj7EpEI4PlKNhl",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to wrap an ally within Close range in a shroud of Protection until the Adept marks their last HP. While Protected, the target has resistance to all damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -491,7 +492,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754075995517,
-        "modifiedTime": 1754076062027,
+        "modifiedTime": 1754142338486,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!0NxCSugvKQ4W8OYZ.IHWDn097sRgjlZXO"
@@ -507,7 +508,7 @@
             "type": "effect",
             "_id": "g4RDHrY0AEYXjH52",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> and choose a point within Far range. All targets within Close range of that point are <em>Restrained</em> in smoky chains until they break free with a successful Strength or Instinct Roll. A target Restrained by this feature must spend a Hope to make an action roll.</p><p>@Template[type:circle|range:c]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -607,7 +608,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754076110844,
-        "modifiedTime": 1754076347293,
+        "modifiedTime": 1754142351045,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!0NxCSugvKQ4W8OYZ.JpSrduK3vjd9h098"
@@ -617,13 +618,18 @@
       "type": "feature",
       "system": {
         "description": "<p> Twice per scene, when a PC rolls a failure with Fear, clear a Stress.</p>",
-        "resource": null,
+        "resource": {
+          "type": "simple",
+          "value": 0,
+          "max": "2",
+          "icon": ""
+        },
         "actions": {
           "3tibqB97ooJesxf0": {
             "type": "healing",
             "_id": "3tibqB97ooJesxf0",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Twice per scene, when a PC rolls a failure with Fear, clear a Stress.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -708,7 +714,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754076395683,
-        "modifiedTime": 1754076432247,
+        "modifiedTime": 1754142376642,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!0NxCSugvKQ4W8OYZ.x6FbcrfOscb3er6P"

--- a/src/packs/adversaries/adversary_Cult_Fang_tyBOpLfigAhI9bU3.json
+++ b/src/packs/adversaries/adversary_Cult_Fang_tyBOpLfigAhI9bU3.json
@@ -230,7 +230,7 @@
             "type": "effect",
             "_id": "hjuqvsMB7KNLNvjg",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>The Fang can climb and walk on vertical surfaces. <strong>Mark a Stress</strong> to move from one shadow to another within Far range.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -278,7 +278,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754076664932,
-        "modifiedTime": 1754076695392,
+        "modifiedTime": 1754142423230,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!tyBOpLfigAhI9bU3.vX5FHwLvFjuc4JC1"
@@ -294,7 +294,7 @@
             "type": "attack",
             "_id": "QjQ04SAwfjrxliNI",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to cause a target within Melee range to make an Instinct Reaction Roll. On a failure, the target must mark 2 Stress and is teleported with the Fang to a shadow within Far range, making them temporarily Vulnerable. On a success, the target must mark a Stress.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -371,7 +371,7 @@
               "difficulty": null,
               "damageMod": "none"
             },
-            "name": "Teleport",
+            "name": "Roll Save",
             "img": "icons/magic/unholy/barrier-fire-pink.webp",
             "range": "melee"
           }
@@ -444,7 +444,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754076697557,
-        "modifiedTime": 1754076794997,
+        "modifiedTime": 1754142442929,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!tyBOpLfigAhI9bU3.ohASSruBxcvuItIK"

--- a/src/packs/adversaries/adversary_Cult_Initiate_zx99sOGTXicP4SSD.json
+++ b/src/packs/adversaries/adversary_Cult_Initiate_zx99sOGTXicP4SSD.json
@@ -255,7 +255,7 @@
             "type": "effect",
             "_id": "EH1preaTWBD4rOvx",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to choose a target and spotlight all Cult Initiates within Close range of them. Those Minions move into Melee range of the target and make one shared attack roll. On a success, they deal 5 physical damage each. Combine this damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -303,7 +303,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754076871173,
-        "modifiedTime": 1754076911199,
+        "modifiedTime": 1754142459708,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!zx99sOGTXicP4SSD.WP6xQtYzouPEFr82"

--- a/src/packs/adversaries/adversary_Deeproot_Defender_9x2xY9zwc3xzbXo5.json
+++ b/src/packs/adversaries/adversary_Deeproot_Defender_9x2xY9zwc3xzbXo5.json
@@ -238,7 +238,7 @@
             "type": "damage",
             "_id": "55hCZsJQhJNcZ0lX",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Slam the ground, knocking all targets within Very Close range back to Far range. Each target knocked back this way must mark a Stress.</p><p>@Template[type:emanation|range:vc]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -307,7 +307,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754014765553,
-        "modifiedTime": 1754014836251,
+        "modifiedTime": 1754143942478,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!9x2xY9zwc3xzbXo5.0DSCzAFXy0hV4afJ"
@@ -325,7 +325,7 @@
             "type": "attack",
             "_id": "nQ3vXrrKBizZoaDt",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Make an attack against a target within Close range. On a success, <strong>spend a Fear</strong> to pull them into Melee range, deal <strong>1d6+2</strong> physical damage, and <em>Restrain</em> them until the Defender takes Severe damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -465,7 +465,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754014840148,
-        "modifiedTime": 1754014907017,
+        "modifiedTime": 1754143956037,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!9x2xY9zwc3xzbXo5.rreGFW5TbhUoZf2T"

--- a/src/packs/adversaries/adversary_Demonic_Hound_Pack_NoRZ1PqB8N5wcIw0.json
+++ b/src/packs/adversaries/adversary_Demonic_Hound_Pack_NoRZ1PqB8N5wcIw0.json
@@ -269,7 +269,7 @@
             "type": "damage",
             "_id": "XyLlX9RWSxciZ7oV",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to make all targets within Very Close range lose a Hope. If a target is not able to lose a Hope, they must instead mark 2 Stress.</p><p>@Template[type:emanation|range:vc]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -339,7 +339,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754077020106,
-        "modifiedTime": 1754077111451,
+        "modifiedTime": 1754142474768,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!NoRZ1PqB8N5wcIw0.WEbHwamS5ZBphiKq"

--- a/src/packs/adversaries/adversary_Dire_Wolf_wNzeuQLfLUMvgHlQ.json
+++ b/src/packs/adversaries/adversary_Dire_Wolf_wNzeuQLfLUMvgHlQ.json
@@ -237,7 +237,7 @@
             "type": "attack",
             "_id": "FFQvt3sMfuwXxIrf",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>If the Wolf makes a successful standard attack and another Dire Wolf is within Melee range of the target, deal <strong>1d6+5</strong> physical damage instead of their standard damage and you gain a Fear.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -325,7 +325,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754044226022,
-        "modifiedTime": 1754044331531,
+        "modifiedTime": 1754143967972,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!wNzeuQLfLUMvgHlQ.wQXEnMqrl2jo91oy"
@@ -343,7 +343,7 @@
             "type": "attack",
             "_id": "Tvizq1jEfG8FyfNc",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to make an attack against a target within Melee range. On a success, deal <strong>3d4+10</strong> direct physical damage and make them <em>Vulnerable</em> until they clear at least 1 HP.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -491,7 +491,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754044355011,
-        "modifiedTime": 1754044420728,
+        "modifiedTime": 1754143975342,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!wNzeuQLfLUMvgHlQ.85XrqDvLP30YOO43"

--- a/src/packs/adversaries/adversary_Electric_Eels_TLzY1nDw0Bu9Ud40.json
+++ b/src/packs/adversaries/adversary_Electric_Eels_TLzY1nDw0Bu9Ud40.json
@@ -263,7 +263,7 @@
             "type": "attack",
             "_id": "L4Rpg7fnFuxpD3im",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to make a standard attack against all targets within Very Close range. You gain a Fear for each target that marks HP.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -362,7 +362,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754077534109,
-        "modifiedTime": 1754077613127,
+        "modifiedTime": 1754142494905,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!TLzY1nDw0Bu9Ud40.u5NL1eUJeAkIEpgt"

--- a/src/packs/adversaries/adversary_Elite_Soldier_bfhVWMBUh61b9J6n.json
+++ b/src/packs/adversaries/adversary_Elite_Soldier_bfhVWMBUh61b9J6n.json
@@ -264,7 +264,7 @@
             "type": "attack",
             "_id": "XquYMA2xJZUKSmXQ",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to move into Melee range of an ally and make a standard attack against a target within Very Close range. On a success, deal <strong>2d10+2</strong> physical damage and the ally can clear a Stress.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -362,7 +362,8 @@
         "coreVersion": "13.346",
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
-        "lastModifiedBy": null
+        "lastModifiedBy": "MQSznptE5yLT7kj8",
+        "modifiedTime": 1754142511820
       },
       "_key": "!actors.items!bfhVWMBUh61b9J6n.ojiIZHBd0sMLxSUE"
     },
@@ -377,7 +378,7 @@
             "type": "effect",
             "_id": "dwpQNx63V6hL1mXZ",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Soldier is within Very Close range of a knight or other noble who would take damage, you can mark a Stress to move into Melee range of them and take the damage instead.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -424,7 +425,8 @@
         "coreVersion": "13.346",
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
-        "lastModifiedBy": null
+        "lastModifiedBy": "MQSznptE5yLT7kj8",
+        "modifiedTime": 1754142520242
       },
       "_key": "!actors.items!bfhVWMBUh61b9J6n.zcfyEY29yWqJtZbl"
     }

--- a/src/packs/adversaries/adversary_Failed_Experiment_ChwwVqowFw8hJQwT.json
+++ b/src/packs/adversaries/adversary_Failed_Experiment_ChwwVqowFw8hJQwT.json
@@ -354,7 +354,7 @@
             "type": "effect",
             "_id": "i3FANnO1t9AzJdTp",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to spotlight the Experiment as an additional GM move instead of spending Fear.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -402,7 +402,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754077960964,
-        "modifiedTime": 1754078015297,
+        "modifiedTime": 1754142534263,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!ChwwVqowFw8hJQwT.g0h3Zo6xqgfSlyxi"

--- a/src/packs/adversaries/adversary_Giant_Beastmaster_8VZIgU12cB3cvlyH.json
+++ b/src/packs/adversaries/adversary_Giant_Beastmaster_8VZIgU12cB3cvlyH.json
@@ -269,7 +269,7 @@
             "type": "attack",
             "_id": "ErwQgU4dwBcmZIBX",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Make a standard attack against a target. On a success, you can <strong>mark a Stress</strong> to pin them to a nearby surface. The pinned target is <em>Restrained</em> until they break free with a successful Finesse or Strength Roll.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -410,7 +410,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754078394872,
-        "modifiedTime": 1754078482791,
+        "modifiedTime": 1754142550948,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!8VZIgU12cB3cvlyH.6ZrDjgnWufJohkp1"

--- a/src/packs/adversaries/adversary_Giant_Brawler_YnObCleGjPT7yqEc.json
+++ b/src/packs/adversaries/adversary_Giant_Brawler_YnObCleGjPT7yqEc.json
@@ -236,7 +236,7 @@
             "type": "attack",
             "_id": "zns57MqnZ6M1d4r0",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to have the Brawler charge at an inanimate object within Close range they could feasibly smash (such as a wall, cart, or market stand) and destroy it. All targets within Very Close range of the object must succeed on an Agility Reaction Roll or take <strong>2d4+3</strong> physical damage from the shrapnel.</p><p>@Template[type:circle|range:vc]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -335,7 +335,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754078623104,
-        "modifiedTime": 1754081240943,
+        "modifiedTime": 1754142564481,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!YnObCleGjPT7yqEc.ro8AtBdgklyyuydK"
@@ -351,7 +351,7 @@
             "type": "attack",
             "_id": "D53yjFXoP5uFXe9M",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Brawler marks 2 or more HP from an attack within Very Close range, you can make a standard attack against the attacker. On a success, the Brawler deals <strong>2d6+15</strong> physical damage instead of their standard damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -442,7 +442,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754078720546,
-        "modifiedTime": 1754078783279,
+        "modifiedTime": 1754142579703,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!YnObCleGjPT7yqEc.kKBbEAffbHxmHo15"

--- a/src/packs/adversaries/adversary_Giant_Eagle_OMQ0v6PE8s1mSU0K.json
+++ b/src/packs/adversaries/adversary_Giant_Eagle_OMQ0v6PE8s1mSU0K.json
@@ -345,7 +345,7 @@
             "type": "attack",
             "_id": "KwsxjI3jBzmxgkPu",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to attack a target within Far range. On a success, deal <strong>2d10+2</strong> physical damage and knock the target over, making them <em>Vulnerable</em> until they next act.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -493,7 +493,8 @@
         "coreVersion": "13.346",
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
-        "lastModifiedBy": null
+        "lastModifiedBy": "MQSznptE5yLT7kj8",
+        "modifiedTime": 1754142603575
       },
       "_key": "!actors.items!OMQ0v6PE8s1mSU0K.MabIQE1Kjn60j08J"
     },
@@ -508,7 +509,7 @@
             "type": "attack",
             "_id": "NtgA9EQPF2Rdb9KK",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Make an attack against a target within Very Close range. On a success, deal <strong>2d4+3</strong> physical damage and the target must succeed on an Agility Reaction Roll or become temporarily Restrained within the Eagle’s massive talons. If the target is Restrained, the Eagle immediately lifts into the air to Very Far range above the battlefi eld while holding them.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -648,7 +649,8 @@
         "coreVersion": "13.346",
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
-        "lastModifiedBy": null
+        "lastModifiedBy": "MQSznptE5yLT7kj8",
+        "modifiedTime": 1754142613580
       },
       "_key": "!actors.items!OMQ0v6PE8s1mSU0K.NEOQ0E9AGSSIDm4v"
     },
@@ -663,7 +665,7 @@
             "type": "damage",
             "_id": "1tO018UgL0VG51ti",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>While flying, the Eagle can drop a Restrained target they are holding. When dropped, the target is no longer Restrained but starts falling. If their fall isn’t prevented during the PCs’ next action, the target takes <strong>2d20</strong> physical damage when they land.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -733,7 +735,8 @@
         "coreVersion": "13.346",
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
-        "lastModifiedBy": null
+        "lastModifiedBy": "MQSznptE5yLT7kj8",
+        "modifiedTime": 1754142622906
       },
       "_key": "!actors.items!OMQ0v6PE8s1mSU0K.jY0ynjYvbS6E3NgJ"
     }

--- a/src/packs/adversaries/adversary_Giant_Mosquitoes_IIWV4ysJPFPnTP7W.json
+++ b/src/packs/adversaries/adversary_Giant_Mosquitoes_IIWV4ysJPFPnTP7W.json
@@ -358,7 +358,7 @@
             "type": "effect",
             "_id": "7ee6IhkKYDehjLmg",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Mosquitoes’ attack causes a target to mark HP, you can <strong>mark a Stress</strong> to force the target to mark an additional HP.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -405,7 +405,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754046426987,
-        "modifiedTime": 1754046474428,
+        "modifiedTime": 1754143988475,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!IIWV4ysJPFPnTP7W.BTlMLjG65KQs0Jk2"

--- a/src/packs/adversaries/adversary_Giant_Rat_4PfLnaCrOcMdb4dK.json
+++ b/src/packs/adversaries/adversary_Giant_Rat_4PfLnaCrOcMdb4dK.json
@@ -263,7 +263,7 @@
             "type": "attack",
             "_id": "q8chow47nQLR9qeF",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to choose a target and spotlight all Giant Rats within Close range of them. Those Minions move into Melee range of the target and make one shared attack roll. On a success, they deal 1 physical damage each. Combine this damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -334,7 +334,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754046640194,
-        "modifiedTime": 1754046720495,
+        "modifiedTime": 1754144002636,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!4PfLnaCrOcMdb4dK.fsaBlCjTdq1jM23G"

--- a/src/packs/adversaries/adversary_Giant_Recruit_5s8wSvpyC5rxY5aD.json
+++ b/src/packs/adversaries/adversary_Giant_Recruit_5s8wSvpyC5rxY5aD.json
@@ -256,7 +256,7 @@
             "type": "effect",
             "_id": "DjbPQowW1OdBD9Zn",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to choose a target and spotlight all Giant Recruits within Close range of them. Those Minions move into Melee range of the target and make one shared attack roll. On a success, they deal 5 physical damage each. Combine this damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -304,7 +304,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754079291678,
-        "modifiedTime": 1754079327480,
+        "modifiedTime": 1754142639306,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!5s8wSvpyC5rxY5aD.FMgB28X1LammRInU"

--- a/src/packs/adversaries/adversary_Giant_Scorpion_fmfntuJ8mHRCAktP.json
+++ b/src/packs/adversaries/adversary_Giant_Scorpion_fmfntuJ8mHRCAktP.json
@@ -236,7 +236,7 @@
             "type": "attack",
             "_id": "PJbZ4ibLPle9BBRv",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to make a standard attack against two targets within Melee range.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -334,7 +334,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754046803174,
-        "modifiedTime": 1754046863892,
+        "modifiedTime": 1754144015161,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!fmfntuJ8mHRCAktP.4ct6XEXiTBFQKvXW"
@@ -348,22 +348,14 @@
         "description": "<p>Make an attack against a target within Very Close range. On a success, <strong>spend a Fear</strong> to deal <strong>1d4+4</strong> physical damage and Poison them until their next rest or they succeed on a Knowledge Roll (16). While Poisoned, the target must roll a <strong>d6</strong> before they make an action roll. On a result of 4 or lower, they must mark a Stress. </p>",
         "resource": null,
         "actions": {
-          "RvsClkuSWILB0nYa": {
-            "type": "damage",
-            "_id": "RvsClkuSWILB0nYa",
+          "ZkcplnqoMP7dH9F4": {
+            "type": "attack",
+            "_id": "ZkcplnqoMP7dH9F4",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Make an attack against a target within Very Close range. On a success, <strong>spend a Fear</strong> to deal <strong>1d4+4</strong> physical damage and Poison them until their next rest or they succeed on a Knowledge Roll (16). While Poisoned, the target must roll a <strong>d6</strong> before they make an action roll. On a result of 4 or lower, they must mark a Stress.</p>",
             "chatDisplay": true,
             "actionType": "action",
-            "cost": [
-              {
-                "scalable": false,
-                "key": "fear",
-                "value": 1,
-                "keyIsID": false,
-                "step": null
-              }
-            ],
+            "cost": [],
             "uses": {
               "value": null,
               "max": "",
@@ -382,7 +374,9 @@
                     "multiplier": "flat"
                   },
                   "applyTo": "hitPoints",
-                  "type": [],
+                  "type": [
+                    "physical"
+                  ],
                   "base": false,
                   "resultBased": false,
                   "valueAlt": {
@@ -400,17 +394,37 @@
             },
             "target": {
               "type": "any",
-              "amount": null
+              "amount": 1
             },
             "effects": [
               {
-                "_id": "cO2VDcRL8uDN7Uu6",
+                "_id": "oILkLJlGNZl7KI1R",
                 "onSave": false
               }
             ],
-            "name": "Spend Fear",
+            "roll": {
+              "type": "attack",
+              "trait": null,
+              "difficulty": null,
+              "bonus": null,
+              "advState": "neutral",
+              "diceRolling": {
+                "multiplier": "prof",
+                "flatMultiplier": 1,
+                "dice": "d6",
+                "compare": null,
+                "treshold": null
+              },
+              "useDefault": false
+            },
+            "save": {
+              "trait": null,
+              "difficulty": null,
+              "damageMod": "none"
+            },
+            "name": "Attack",
             "img": "icons/creatures/abilities/stinger-poison-scorpion-brown.webp",
-            "range": ""
+            "range": "veryClose"
           }
         },
         "originItemType": null,
@@ -419,11 +433,11 @@
       },
       "effects": [
         {
-          "name": "Poison",
+          "name": "Poisoned",
           "img": "icons/creatures/abilities/stinger-poison-scorpion-brown.webp",
           "origin": "Compendium.daggerheart.adversaries.Actor.fmfntuJ8mHRCAktP.Item.lANiDkxxth2sGacT",
           "transfer": false,
-          "_id": "cO2VDcRL8uDN7Uu6",
+          "_id": "oILkLJlGNZl7KI1R",
           "type": "base",
           "system": {
             "rangeDependence": {
@@ -444,7 +458,7 @@
             "startRound": null,
             "startTurn": null
           },
-          "description": "<p>You are <em>Poisoned</em> until your next rest or until you succeed on a Knowledge Roll (16). While Poisoned, you must roll a <strong>d6</strong> before you make an action roll. On a result of 4 or lower, you must mark a Stress. </p><p>[[/dr trait=knowledge difficulty=16]]</p>",
+          "description": "<p>You are <em>Poisoned</em> until your next rest or until you succeed on a Knowledge Roll (16). While Poisoned, you must roll a <strong>d6</strong> before you make an action roll. On a result of 4 or lower, you must mark a Stress.</p><p>[[/dr trait=knowledge difficulty=16]]</p>",
           "tint": "#ffffff",
           "statuses": [],
           "sort": 0,
@@ -456,11 +470,11 @@
             "coreVersion": "13.346",
             "systemId": "daggerheart",
             "systemVersion": "0.0.1",
-            "createdTime": 1754046921939,
-            "modifiedTime": 1754047011246,
+            "createdTime": 1754144091498,
+            "modifiedTime": 1754144099382,
             "lastModifiedBy": "MQSznptE5yLT7kj8"
           },
-          "_key": "!actors.items.effects!fmfntuJ8mHRCAktP.lANiDkxxth2sGacT.cO2VDcRL8uDN7Uu6"
+          "_key": "!actors.items.effects!fmfntuJ8mHRCAktP.lANiDkxxth2sGacT.oILkLJlGNZl7KI1R"
         }
       ],
       "folder": null,
@@ -478,7 +492,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754046868084,
-        "modifiedTime": 1754047035479,
+        "modifiedTime": 1754144091512,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!fmfntuJ8mHRCAktP.lANiDkxxth2sGacT"

--- a/src/packs/adversaries/adversary_Glass_Snake_8KWVLWXFhlY2kYx0.json
+++ b/src/packs/adversaries/adversary_Glass_Snake_8KWVLWXFhlY2kYx0.json
@@ -232,7 +232,7 @@
             "type": "damage",
             "_id": "H1nUSOudbtha1lnC",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>On a successful attack within Melee range against the Snake, the attacker must mark an Armor Slot without receiving its benefits (they can still use armor to reduce the damage). If they can’t mark an Armor Slot, they must mark an additional HP.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -301,7 +301,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754047117565,
-        "modifiedTime": 1754047173751,
+        "modifiedTime": 1754144118922,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!8KWVLWXFhlY2kYx0.Efa6t9Ow8b1DRyZV"
@@ -319,7 +319,7 @@
             "type": "attack",
             "_id": "2UzeQYL5HeyF3zwh",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to make an attack against all targets within Very Close range. Targets the Snake succeeds against take <strong>1d6+1</strong> physical damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -415,7 +415,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754047177610,
-        "modifiedTime": 1754047224249,
+        "modifiedTime": 1754144128032,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!8KWVLWXFhlY2kYx0.Ro9XCeXsTOT9SXyo"
@@ -433,7 +433,7 @@
             "type": "effect",
             "_id": "yx5fjMLLwSnvSbqs",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to introduce a <strong>d6</strong> Spitter Die.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -468,7 +468,7 @@
             "type": "attack",
             "_id": "Ds6KlQKZCOhh5OMT",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>All targets in front of the Snake within Far range must succeed on an Agility Reaction Roll or take <strong>1d4</strong> physical damage.</p><p>@Template[type:inFront|range:f]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -536,6 +536,52 @@
             "name": "Spit Attack",
             "img": "icons/magic/acid/projectile-needles-salvo-green.webp",
             "range": "far"
+          },
+          "xccwknU2xHUwQSdn": {
+            "type": "attack",
+            "_id": "xccwknU2xHUwQSdn",
+            "systemPath": "actions",
+            "description": "<p>When the Snake is in the spotlight, roll the spitter die. On a result of 5 or higher, do a spit Attack.</p>",
+            "chatDisplay": true,
+            "actionType": "action",
+            "cost": [],
+            "uses": {
+              "value": null,
+              "max": "",
+              "recovery": null
+            },
+            "damage": {
+              "parts": [],
+              "includeBase": false
+            },
+            "target": {
+              "type": "any",
+              "amount": null
+            },
+            "effects": [],
+            "roll": {
+              "type": "diceSet",
+              "trait": null,
+              "difficulty": null,
+              "bonus": null,
+              "advState": "neutral",
+              "diceRolling": {
+                "multiplier": "flat",
+                "flatMultiplier": 1,
+                "dice": "d6",
+                "compare": "aboveEqual",
+                "treshold": 5
+              },
+              "useDefault": false
+            },
+            "save": {
+              "trait": null,
+              "difficulty": null,
+              "damageMod": "none"
+            },
+            "name": "Roll d6",
+            "img": "icons/magic/acid/projectile-needles-salvo-green.webp",
+            "range": ""
           }
         },
         "originItemType": null,
@@ -603,7 +649,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754047231449,
-        "modifiedTime": 1754047430569,
+        "modifiedTime": 1754144287335,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!8KWVLWXFhlY2kYx0.LR5XHauNtWcl18CY"

--- a/src/packs/adversaries/adversary_Gorgon_8mJYMpbLTb8qIOrr.json
+++ b/src/packs/adversaries/adversary_Gorgon_8mJYMpbLTb8qIOrr.json
@@ -269,7 +269,7 @@
             "type": "effect",
             "_id": "fnTd5BjBAK46vRRk",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Gorgon makes a successful standard attack, the target Glows until the end of the scene and can’t become <em>Hidden</em>. Attack rolls made against a Glowing target have advantage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -359,7 +359,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754079448870,
-        "modifiedTime": 1754079525294,
+        "modifiedTime": 1754142654062,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!8mJYMpbLTb8qIOrr.NepVGKOo1lHYjA1F"
@@ -375,7 +375,7 @@
             "type": "attack",
             "_id": "ryfj8eiYYNGJPtBg",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Make an attack roll against a target within Melee range using the Gorgon’s protective snakes. On a success, mark a Stress to deal <strong>2d10+4</strong> physical damage and the target must mark a Stress.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -491,7 +491,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754079563580,
-        "modifiedTime": 1754079636868,
+        "modifiedTime": 1754142664204,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!8mJYMpbLTb8qIOrr.9SO2ov36lFH2YV0S"
@@ -507,7 +507,7 @@
             "type": "attack",
             "_id": "ySkX0wOpEFqtgeD9",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Gorgon takes damage from an attack within Close range, you can <strong>spend a Fear</strong> to force the attacker to make an Instinct Reaction Roll. On a failure, they begin to turn to stone, marking a HP and starting a Petrification Countdown (4). This countdown ticks down when the Gorgon is attacked. When it triggers, the target must make a death move. If the Gorgon is defeated, all petrification countdowns end.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -579,7 +579,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754079643285,
-        "modifiedTime": 1754079735211,
+        "modifiedTime": 1754142680813,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!8mJYMpbLTb8qIOrr.047o6OtNlUwLG1H1"

--- a/src/packs/adversaries/adversary_Green_Ooze_SHXedd9zZPVfUgUa.json
+++ b/src/packs/adversaries/adversary_Green_Ooze_SHXedd9zZPVfUgUa.json
@@ -275,7 +275,7 @@
             "type": "damage",
             "_id": "nU4xpjruOvskcmiA",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Ooze makes a successful attack, the target must mark an Armor Slot without receiving its benefits (they can still use armor to reduce the damage). If they can’t mark an Armor Slot, they must mark an additional HP.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -344,7 +344,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754047544158,
-        "modifiedTime": 1754047598393,
+        "modifiedTime": 1754144332281,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!SHXedd9zZPVfUgUa.gJWoUSTGwVsJwPmK"
@@ -362,7 +362,7 @@
             "type": "attack",
             "_id": "fSxq0AL6YwZs7OAH",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Make a standard attack against a target within Melee range. On a success, the Ooze envelops them and the target must mark 2 Stress. The target must mark an additional Stress when they make an action roll. If the Ooze takes Severe damage, the target is freed.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -527,7 +527,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754047601843,
-        "modifiedTime": 1754047680632,
+        "modifiedTime": 1754144340446,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!SHXedd9zZPVfUgUa.Sm9Sk4mSvcq6PkmR"
@@ -538,14 +538,14 @@
       "_id": "qNhrEK2YF8e3ljU6",
       "img": "icons/creatures/slimes/slime-movement-pseudopods-green.webp",
       "system": {
-        "description": "<p>When the Ooze has 3 or more HP marked, you can <strong>spend a Fear</strong> to split them into two Tiny Green Oozes (with no marked HP or Stress). Immediately spotlight both of them.</p>",
+        "description": "<p>When the Ooze has 3 or more HP marked, you can <strong>spend a Fear</strong> to split them into two @UUID[Compendium.daggerheart.adversaries.Actor.aLkLFuVoKz2NLoBK]{Tiny Green Oozes} (with no marked HP or Stress). Immediately spotlight both of them.</p>",
         "resource": null,
         "actions": {
           "s5mLw6DRGd76MLcC": {
             "type": "effect",
             "_id": "s5mLw6DRGd76MLcC",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Ooze has 3 or more HP marked, you can <strong>spend a Fear</strong> to split them into two @UUID[Compendium.daggerheart.adversaries.Actor.aLkLFuVoKz2NLoBK]{Tiny Green Oozes} (with no marked HP or Stress). Immediately spotlight both of them.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -592,7 +592,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754047707170,
-        "modifiedTime": 1754047746968,
+        "modifiedTime": 1754145255991,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!SHXedd9zZPVfUgUa.qNhrEK2YF8e3ljU6"

--- a/src/packs/adversaries/adversary_Harrier_uRtghKE9mHlII4rs.json
+++ b/src/packs/adversaries/adversary_Harrier_uRtghKE9mHlII4rs.json
@@ -271,7 +271,7 @@
             "type": "attack",
             "_id": "FiuiLUbNUL0YKq7w",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When a creature moves into Melee range to make an attack, you can <strong>mark a Stress</strong> before the attack roll to move anywhere within Close range and make an attack against that creature. On a success, deal <strong>1d10+2</strong> physical damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -369,7 +369,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754047898040,
-        "modifiedTime": 1754047992144,
+        "modifiedTime": 1754144359975,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!uRtghKE9mHlII4rs.v8TMp5ATyAjrmJJM"

--- a/src/packs/adversaries/adversary_Head_Guard_mK3A5FTx6k8iPU3F.json
+++ b/src/packs/adversaries/adversary_Head_Guard_mK3A5FTx6k8iPU3F.json
@@ -240,7 +240,7 @@
             "type": "attack",
             "_id": "lI0lnRb3xrUjqIYX",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend 2 Fear</strong> to spotlight the Head Guard and up to <strong>2d4</strong> allies within Far range.</p><p>@Template[type:emanation|range:f]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -311,7 +311,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754048051353,
-        "modifiedTime": 1754048138930,
+        "modifiedTime": 1754144371623,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!mK3A5FTx6k8iPU3F.SsgN2qSYpQLR43Cz"

--- a/src/packs/adversaries/adversary_Jagged_Knife_Bandit_5Lh1T0zaT8Pkr2U2.json
+++ b/src/packs/adversaries/adversary_Jagged_Knife_Bandit_5Lh1T0zaT8Pkr2U2.json
@@ -270,7 +270,7 @@
             "type": "damage",
             "_id": "X7xdCLY7ySMpaTHe",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Bandit succeeds on a standard attack from above a target, they deal <strong>1d10+1</strong> physical damage instead of their standard damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -340,7 +340,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754048351101,
-        "modifiedTime": 1754048394638,
+        "modifiedTime": 1754144389470,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!5Lh1T0zaT8Pkr2U2.V7haVmSLm6vTeffc"

--- a/src/packs/adversaries/adversary_Jagged_Knife_Hexer_MbBPIOxaxXYNApXz.json
+++ b/src/packs/adversaries/adversary_Jagged_Knife_Hexer_MbBPIOxaxXYNApXz.json
@@ -237,7 +237,7 @@
             "type": "effect",
             "_id": "yzjCJyfGzZrEd0G3",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Choose a target within Far range and temporarily Curse them. While the target is Cursed, you can <strong>mark a Stress</strong> when that target rolls with Hope to make the roll be with Fear instead.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -326,7 +326,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754048453602,
-        "modifiedTime": 1754048512335,
+        "modifiedTime": 1754144401991,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!MbBPIOxaxXYNApXz.Bl8L0RCGOgVUzuXo"
@@ -344,7 +344,7 @@
             "type": "attack",
             "_id": "HmvmqoMli6oC2y2a",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Make an attack against up to three targets within Very Close range. <strong>Mark a Stress</strong> to deal <strong>2d6+3</strong> magic damage to targets the Hexer succeeded against.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -434,7 +434,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754048558693,
-        "modifiedTime": 1754048626455,
+        "modifiedTime": 1754144410119,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!MbBPIOxaxXYNApXz.d8uVdKpTm9yw6TZS"

--- a/src/packs/adversaries/adversary_Jagged_Knife_Kneebreaker_CBKixLH3yhivZZuL.json
+++ b/src/packs/adversaries/adversary_Jagged_Knife_Kneebreaker_CBKixLH3yhivZZuL.json
@@ -274,7 +274,7 @@
             "type": "attack",
             "_id": "uMNSQzNPVPhHT34T",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Make an attack against a target within Melee range. On a success, the target takes no damage but is Restrained and <em>Vulnerable</em>. The target can break free, clearing both conditions, with a successful Strength Roll or is freed automatically if the Kneebreaker takes Major or greater damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -390,7 +390,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754048736567,
-        "modifiedTime": 1754048778059,
+        "modifiedTime": 1754144425310,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!CBKixLH3yhivZZuL.Sa4Nt0eoDjirBKGf"

--- a/src/packs/adversaries/adversary_Jagged_Knife_Lackey_C0OMQqV7pN6t7ouR.json
+++ b/src/packs/adversaries/adversary_Jagged_Knife_Lackey_C0OMQqV7pN6t7ouR.json
@@ -263,7 +263,7 @@
             "type": "effect",
             "_id": "aoQDb2m32NDxE6ZP",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to choose a target and spotlight all Jagged Knife Lackeys within Close range of them. Those Minions move into Melee range of the target and make one shared attack roll. On a success, they deal 2 physical damage each. Combine this damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -310,7 +310,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754048894188,
-        "modifiedTime": 1754048930970,
+        "modifiedTime": 1754144438393,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!C0OMQqV7pN6t7ouR.1k5TmQIAunM7Bv32"

--- a/src/packs/adversaries/adversary_Jagged_Knife_Lieutenant_aTljstqteGoLpCBq.json
+++ b/src/packs/adversaries/adversary_Jagged_Knife_Lieutenant_aTljstqteGoLpCBq.json
@@ -237,7 +237,7 @@
             "type": "effect",
             "_id": "IfMFU67g4sfhSYtm",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When you spotlight the Lieutenant, <strong>mark a Stress</strong> to also spotlight two allies within Close range.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -284,7 +284,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754048989987,
-        "modifiedTime": 1754049036837,
+        "modifiedTime": 1754144449897,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!aTljstqteGoLpCBq.LIAbel7pMzAHpgF3"
@@ -336,7 +336,7 @@
             "type": "attack",
             "_id": "fzVyO0DUwIVEUCtg",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to make an attack against a Vulnerable target within Close range. On a success, deal <strong>2d6+12</strong> physical damage and the target must mark a Stress.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -459,7 +459,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754049080786,
-        "modifiedTime": 1754049152990,
+        "modifiedTime": 1754144457672,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!aTljstqteGoLpCBq.qe94UdLZb0p3Gvxj"

--- a/src/packs/adversaries/adversary_Jagged_Knife_Shadow_XF4tYTq9nPJAy2ox.json
+++ b/src/packs/adversaries/adversary_Jagged_Knife_Shadow_XF4tYTq9nPJAy2ox.json
@@ -236,7 +236,7 @@
             "type": "attack",
             "_id": "6G5Dasl1pP8pfYkZ",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Shadow succeeds on a standard attack that has advantage, they deal 1d6+6 physical damage instead of their standard damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -326,7 +326,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754049227184,
-        "modifiedTime": 1754049294295,
+        "modifiedTime": 1754144471790,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!XF4tYTq9nPJAy2ox.dhycdSd4NYdPOYbP"

--- a/src/packs/adversaries/adversary_Jagged_Knife_Sniper_1zuyof1XuIfi3aMG.json
+++ b/src/packs/adversaries/adversary_Jagged_Knife_Sniper_1zuyof1XuIfi3aMG.json
@@ -237,7 +237,7 @@
             "type": "attack",
             "_id": "2eX7P0wSfbKKu8dJ",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>If the Sniper is <em>Hidden</em> when they make a successful standard attack against a target, they deal <strong>1d10+4</strong> physical damage instead of their standard damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -327,7 +327,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754049443033,
-        "modifiedTime": 1754049483638,
+        "modifiedTime": 1754144483728,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!1zuyof1XuIfi3aMG.adPXzpvLREjN3len"

--- a/src/packs/adversaries/adversary_Juvenile_Flickerfly_MYXmTx2FHcIjdfYZ.json
+++ b/src/packs/adversaries/adversary_Juvenile_Flickerfly_MYXmTx2FHcIjdfYZ.json
@@ -263,7 +263,7 @@
             "type": "attack",
             "_id": "RrKQktP8MI4YQR5k",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Before the Flickerfly makes an attack, roll a d6. On a result of 4 or higher, the target’s Evasion is halved against this attack.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -384,7 +384,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754080188281,
-        "modifiedTime": 1754080318705,
+        "modifiedTime": 1754142700531,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!MYXmTx2FHcIjdfYZ.PHHEvM6IDFFZ8LSl"
@@ -400,7 +400,7 @@
             "type": "attack",
             "_id": "0wL3ieMrXEb2gcxe",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to create a magically dazzling display that grapples the minds of nearby foes. All targets within Close range must make an Instinct Reaction Roll. For each target who failed, you gain a Fear and the Flickerfl y learns one of the target’s fears.</p><p>@Template[type:emanation|range:c]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -464,7 +464,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754080328898,
-        "modifiedTime": 1754081217532,
+        "modifiedTime": 1754142709272,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!MYXmTx2FHcIjdfYZ.Bt7MqMkPpPpzWksK"
@@ -480,7 +480,7 @@
             "type": "attack",
             "_id": "USEkCakSzYcZbBwY",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Countdown (Loop 1d6). When the Flickerfl y takes damage for the fi rst time, activate the countdown. When it triggers, the Flickerfly breathes hallucinatory gas on all targets in front of them up to Far range. Targets must succeed on an Instinct Reaction Roll or be tormented by fearful hallucinations. Targets whose fears are known to the Flickerfl y have disadvantage on this roll. Targets who fail must mark a Stress and lose a Hope.</p><p>@Template[type:inFront|range:f]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -595,7 +595,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754080402680,
-        "modifiedTime": 1754081225309,
+        "modifiedTime": 1754142717997,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!MYXmTx2FHcIjdfYZ.EjfM83eVCdcVGC3c"

--- a/src/packs/adversaries/adversary_Knight_of_the_Realm_7ai2opemrclQe3VF.json
+++ b/src/packs/adversaries/adversary_Knight_of_the_Realm_7ai2opemrclQe3VF.json
@@ -416,7 +416,7 @@
             "type": "attack",
             "_id": "Mb079uPkaZgpo9y3",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>If the Knight is mounted, move up to Far range and make a standard attack against a target. On a success, deal <strong>2d8+4</strong> physical damage and the target must mark a Stress.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -530,7 +530,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754080711147,
-        "modifiedTime": 1754080767205,
+        "modifiedTime": 1754142733317,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!7ai2opemrclQe3VF.djKDZawLnGF1zkbY"
@@ -546,7 +546,7 @@
             "type": "effect",
             "_id": "V5fLHHdTOita6u9f",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to spotlight <strong>[[/r 1d4+1]]</strong> allies. Attacks they make while spotlighted in this way deal half damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -594,7 +594,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754080771017,
-        "modifiedTime": 1754080864859,
+        "modifiedTime": 1754142743842,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!7ai2opemrclQe3VF.RoxNNIn0m9rHQDH8"

--- a/src/packs/adversaries/adversary_Masked_Thief_niBpVU7yeo5ccskE.json
+++ b/src/packs/adversaries/adversary_Masked_Thief_niBpVU7yeo5ccskE.json
@@ -236,7 +236,7 @@
             "type": "attack",
             "_id": "33xlM2ph77SSUfBs",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Make an attack against a target within Melee range. On a success, deal <strong>1d8+2</strong> physical damage and the Thief steals one item or consumable from the target’s inventory.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -325,7 +325,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754080943420,
-        "modifiedTime": 1754081019757,
+        "modifiedTime": 1754142758679,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!niBpVU7yeo5ccskE.Cgk36WXthA9LwOYb"
@@ -341,7 +341,7 @@
             "type": "attack",
             "_id": "sq0q1l2Go4GduR3B",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to reveal a snare trap set anywhere on the battlefi eld by the Thief. All targets within Very Close range of the trap must succeed on an Agility Reaction Roll (13) or be pulled off their feet and suspended upside down. A target is Restrained and Vulnerable until they break free, ending both conditions, with a successful Finesse or Strength Roll (13).</p><p>@Template[type:rect|range:c]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -458,7 +458,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754081025242,
-        "modifiedTime": 1754081140681,
+        "modifiedTime": 1754142767652,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!niBpVU7yeo5ccskE.tP2DD751nOLxFVps"

--- a/src/packs/adversaries/adversary_Master_Assassin_dNta0cUzr96xcFhf.json
+++ b/src/packs/adversaries/adversary_Master_Assassin_dNta0cUzr96xcFhf.json
@@ -274,7 +274,7 @@
             "type": "effect",
             "_id": "vKRDbD07bqR317Zv",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to spotlight a number of other Assassins equal to the Assassin’s unmarked Stress.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -322,7 +322,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754081423583,
-        "modifiedTime": 1754081462564,
+        "modifiedTime": 1754142790359,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!dNta0cUzr96xcFhf.za6Qr0CjI9Kb4I0U"
@@ -338,7 +338,7 @@
             "type": "effect",
             "_id": "tYkZ9BwjlOg61BhE",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Assassin successfully makes a standard attack against a <em>Vulnerable</em> target, you can <strong>spend a Fear</strong> to deal Severe damage instead of their standard damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -386,7 +386,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754081466397,
-        "modifiedTime": 1754081698475,
+        "modifiedTime": 1754142798924,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!dNta0cUzr96xcFhf.s0WcpK43WN2ptqNc"

--- a/src/packs/adversaries/adversary_Merchant_Al3w2CgjfdT3p9ma.json
+++ b/src/packs/adversaries/adversary_Merchant_Al3w2CgjfdT3p9ma.json
@@ -270,7 +270,7 @@
             "type": "damage",
             "_id": "sTHDvAggf1nUX4Ai",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When a PC rolls a 14 or lower on a Presence Roll made against the Merchant, they must mark a Stress.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -339,7 +339,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754049578056,
-        "modifiedTime": 1754049645666,
+        "modifiedTime": 1754144497139,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!Al3w2CgjfdT3p9ma.Ksdgov6mYg7Og2ys"

--- a/src/packs/adversaries/adversary_Merchant_Baron_Vy02IhGhkJLuezu4.json
+++ b/src/packs/adversaries/adversary_Merchant_Baron_Vy02IhGhkJLuezu4.json
@@ -240,7 +240,7 @@
             "type": "attack",
             "_id": "T7N9rDCaB5VOm6AY",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to offer a target a dangerous bargain for something they want or need. If used on a PC, they must make a Presence Reaction Roll (17). On a failure, they must mark 2 Stress or take the deal.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -330,7 +330,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754081872693,
-        "modifiedTime": 1754081940858,
+        "modifiedTime": 1754142812803,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!Vy02IhGhkJLuezu4.7dxToUpxOyISXXde"
@@ -346,7 +346,7 @@
             "type": "effect",
             "_id": "9NA6vgfsv0y2tX9v",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Once per scene, <strong>mark a Stress</strong> to summon 1d4+1 Tier 1 adversaries, who appear at Far range, to enforce the Baron’s will.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -394,7 +394,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754081946463,
-        "modifiedTime": 1754082024659,
+        "modifiedTime": 1754142821841,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!Vy02IhGhkJLuezu4.QnDvERcyaq3XLCjF"

--- a/src/packs/adversaries/adversary_Minor_Chaos_Elemental_sRn4bqerfARvhgSV.json
+++ b/src/packs/adversaries/adversary_Minor_Chaos_Elemental_sRn4bqerfARvhgSV.json
@@ -317,7 +317,7 @@
             "type": "damage",
             "_id": "g4CVwjDeJgTJ2oCw",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a HP</strong> to force all targets within Close range to mark a Stress and become <em>Vulnerable</em> until their next rest or they clear a HP.</p><p>@Template[type:emanation|range:c]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -446,7 +446,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754049738720,
-        "modifiedTime": 1754049853494,
+        "modifiedTime": 1754144510716,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!sRn4bqerfARvhgSV.oAxhAawgcK7DAdpa"
@@ -464,7 +464,7 @@
             "type": "damage",
             "_id": "QzuQIAtSrgz9Zd5V",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to transform the area within Very Close range into a different biome. All targets within this area take <strong>2d6+3</strong> direct magic damage.</p><p>@Template[type:emanation|range:vc]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -542,7 +542,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754049858342,
-        "modifiedTime": 1754049963046,
+        "modifiedTime": 1754144523565,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!sRn4bqerfARvhgSV.updQuIK8sybf4YmW"

--- a/src/packs/adversaries/adversary_Minor_Demon_3tqCjDwJAQ7JKqMb.json
+++ b/src/packs/adversaries/adversary_Minor_Demon_3tqCjDwJAQ7JKqMb.json
@@ -265,7 +265,7 @@
             "type": "damage",
             "_id": "XQ7QebA0iGvMti4A",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When a PC rolls a failure with Fear while within Close range of the Demon, they lose a Hope.</p><p>@Template[type:emanation|range:c]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -334,7 +334,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754050091351,
-        "modifiedTime": 1754050150499,
+        "modifiedTime": 1754144539341,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!3tqCjDwJAQ7JKqMb.kD9kO92V7t3IqZu8"
@@ -352,7 +352,7 @@
             "type": "attack",
             "_id": "nOzLQ0NJzeB3vKiV",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to rain down hellfire within Far range. All targets within the area must make an Agility Reaction Roll. Targets who fail take <strong>1d20+3</strong> magic damage. Targets who succeed take half damage.</p><p>@Template[type:emanation|range:f]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -450,7 +450,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754050154885,
-        "modifiedTime": 1754050246276,
+        "modifiedTime": 1754144548850,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!3tqCjDwJAQ7JKqMb.lA7vcvS7oGT9NTSy"
@@ -468,7 +468,7 @@
             "type": "effect",
             "_id": "vZq3iaJrMzLYbqQN",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Before rolling damage for the Demon’s attack, you can <strong>mark a Stress</strong> to gain a bonus to the damage roll equal to the Demon’s current number of marked HP.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -515,7 +515,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754050253435,
-        "modifiedTime": 1754050314370,
+        "modifiedTime": 1754144557513,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!3tqCjDwJAQ7JKqMb.bpLBGTW1DmXPgIcx"

--- a/src/packs/adversaries/adversary_Minor_Fire_Elemental_DscWkNVoHak6P4hh.json
+++ b/src/packs/adversaries/adversary_Minor_Fire_Elemental_DscWkNVoHak6P4hh.json
@@ -266,7 +266,7 @@
             "type": "attack",
             "_id": "x1VCkfcSYiPyg8fk",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to choose a point within Far range. The ground within Very Close range of that point immediately bursts into fl ames. All creatures within this area must make an Agility Reaction Roll. Targets who fail take <strong>2d8</strong> magic damage from the fl ames. Targets who succeed take half damage.</p><p>@Template[type:circle|range:vc]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -364,7 +364,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754050413593,
-        "modifiedTime": 1754050528586,
+        "modifiedTime": 1754144579484,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!DscWkNVoHak6P4hh.7AXE86WNd68OySkD"
@@ -382,7 +382,7 @@
             "type": "attack",
             "_id": "JQgqyW8H7fugR7F0",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to erupt in a fi ery explosion. Make an attack against all targets within Close range. Targets the Elemental succeeds against take <strong>1d8</strong> magic damage and are knocked back to Far range.</p><p>@Template[type:emanation|range:c]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -480,7 +480,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754050532131,
-        "modifiedTime": 1754050622414,
+        "modifiedTime": 1754144587890,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!DscWkNVoHak6P4hh.ESnu3I89BmUdBZEk"
@@ -503,7 +503,7 @@
             "type": "healing",
             "_id": "CTWSVVisdgJgF7pd",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Three times per scene, when the Elemental moves onto objects that are highly flammable, consume them to clear a HP or a Stress.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -570,7 +570,7 @@
             "type": "healing",
             "_id": "e0fG0xtj6hOUp66o",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Three times per scene, when the Elemental moves onto objects that are highly flammable, consume them to clear a HP or a Stress.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -654,7 +654,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754050626054,
-        "modifiedTime": 1754050713454,
+        "modifiedTime": 1754144608536,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!DscWkNVoHak6P4hh.3u6wvKPJAS2v5nWV"

--- a/src/packs/adversaries/adversary_Minor_Treant_G62k4oSkhkoXEs2D.json
+++ b/src/packs/adversaries/adversary_Minor_Treant_G62k4oSkhkoXEs2D.json
@@ -258,7 +258,7 @@
             "type": "effect",
             "_id": "xTMNAHcoErKuR6TZ",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to choose a target and spotlight all Minor Treants within Close range of them. Those Minions move into Melee range of the target and make one shared attack roll. On a success, they deal 4 physical damage each. Combine this damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -305,7 +305,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754050805777,
-        "modifiedTime": 1754050841338,
+        "modifiedTime": 1754144625197,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!G62k4oSkhkoXEs2D.K08WlZwGqzEo4idT"

--- a/src/packs/adversaries/adversary_Minotaur_Wrecker_rM9qCIYeWg9I0B4l.json
+++ b/src/packs/adversaries/adversary_Minotaur_Wrecker_rM9qCIYeWg9I0B4l.json
@@ -230,7 +230,7 @@
             "type": "effect",
             "_id": "oVGqHl82zSjnlym3",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>You must <strong>spend a Fear</strong> to spotlight the Minotaur. While spotlighted, they can make their standard attack against all targets within range.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -278,7 +278,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754082044045,
-        "modifiedTime": 1754082161500,
+        "modifiedTime": 1754142834839,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!rM9qCIYeWg9I0B4l.RxTetAI1hmmxzJTg"
@@ -294,7 +294,7 @@
             "type": "attack",
             "_id": "8fgkb7U2pxNyiHrB",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to charge through a group within Close range and make an attack against all targets in the Minotaur’s path. Targets the Minotaur succeeds against take <strong>2d6+8</strong> physical damage and are knocked back to Very Far range. If a target is knocked into a solid object or another creature, they take an extra <strong>1d6</strong> damage (combine the damage).</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -375,7 +375,7 @@
             "type": "damage",
             "_id": "fZ8jWUdMKBf5xSPO",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>If a target is knocked into a solid object or another creature, they take an extra <strong>1d6</strong> damage (combine the damage).</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -447,7 +447,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754082167407,
-        "modifiedTime": 1754082303567,
+        "modifiedTime": 1754142855890,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!rM9qCIYeWg9I0B4l.b2QvDYOq1nreI2uD"
@@ -463,7 +463,7 @@
             "type": "attack",
             "_id": "3yqz7Gj34KBWMjwt",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Make an attack against a target within Very Close range, moving the Minotaur into Melee range of them. On a success, deal <strong>2d8</strong> direct physical damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -552,7 +552,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754082306467,
-        "modifiedTime": 1754082351713,
+        "modifiedTime": 1754142873493,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!rM9qCIYeWg9I0B4l.WxbHcbaeb6L7g8qN"

--- a/src/packs/adversaries/adversary_Mortal_Hunter_mVV7a7KQAORoPMgZ.json
+++ b/src/packs/adversaries/adversary_Mortal_Hunter_mVV7a7KQAORoPMgZ.json
@@ -235,7 +235,7 @@
             "type": "damage",
             "_id": "9T1g3FH38cnCRG8k",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Hunter makes a successful attack, all PCs within Far range lose a Hope and you gain a Fear.</p><p>@Template[type:emanation|range:f]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -305,7 +305,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754082464443,
-        "modifiedTime": 1754082528689,
+        "modifiedTime": 1754142893376,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!mVV7a7KQAORoPMgZ.cID8rYBYealYs7mO"
@@ -321,7 +321,7 @@
             "type": "effect",
             "_id": "LUNsI29woLk4m2wo",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to curse a target within Very Close range with a necrotic Deathlock until the end of the scene. Attacks made by the Hunter against a Deathlocked target deal direct damage. The Hunter can only maintain one Deathlock at a time.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -419,7 +419,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754082532133,
-        "modifiedTime": 1754082586776,
+        "modifiedTime": 1754142902555,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!mVV7a7KQAORoPMgZ.r1T70u9n3bRfUTX5"
@@ -435,7 +435,7 @@
             "type": "attack",
             "_id": "wxOfNoEogH1EU0Jb",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to spotlight <strong>1d4</strong> allies. Attacks they make while spotlighted in this way deal half damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -507,7 +507,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754082607409,
-        "modifiedTime": 1754082662364,
+        "modifiedTime": 1754142911016,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!mVV7a7KQAORoPMgZ.5AQTqW1GDidHfU3a"
@@ -519,11 +519,33 @@
         "description": "<p>Countdown (Loop 1d6). When the Hunter is in the spotlight for the fi rst time, activate the countdown. When it triggers, move the Hunter in a straight line to a point within Far range and make an attack against all targets in their path. Targets the Hunter succeeds against take <strong>2d8+2</strong> physical damage.</p><p>@Template[type:ray|range:f]</p>",
         "resource": null,
         "actions": {
-          "145xZxtiQjao3XKe": {
-            "type": "attack",
-            "_id": "145xZxtiQjao3XKe",
+          "JGGTfZWI65nywjSu": {
+            "type": "effect",
+            "_id": "JGGTfZWI65nywjSu",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Countdown (Loop 1d6). When the Hunter is in the spotlight for the first time, activate the countdown.</p>",
+            "chatDisplay": true,
+            "actionType": "action",
+            "cost": [],
+            "uses": {
+              "value": null,
+              "max": "",
+              "recovery": null
+            },
+            "effects": [],
+            "target": {
+              "type": "any",
+              "amount": null
+            },
+            "name": "Countdown",
+            "img": "icons/magic/movement/trail-streak-zigzag-yellow.webp",
+            "range": ""
+          },
+          "VjiFxuzfAaq5N1jy": {
+            "type": "attack",
+            "_id": "VjiFxuzfAaq5N1jy",
+            "systemPath": "actions",
+            "description": "<p>When the countdown triggers, move the Hunter in a straight line to a point within Far range and make an attack against all targets in their path. Targets the Hunter succeeds against take <strong>2d8+2</strong> physical damage.</p><p>@Template[type:ray|range:f]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -614,7 +636,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754082669471,
-        "modifiedTime": 1754082750517,
+        "modifiedTime": 1754142979339,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!mVV7a7KQAORoPMgZ.IOCG3J20wUHvyvvh"

--- a/src/packs/adversaries/adversary_Patchwork_Zombie_Hulk_EQTOAOUrkIvS2z88.json
+++ b/src/packs/adversaries/adversary_Patchwork_Zombie_Hulk_EQTOAOUrkIvS2z88.json
@@ -309,7 +309,7 @@
             "type": "healing",
             "_id": "PfaFRZKFnHGg6mU4",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Zombie is within Very Close range of a corpse, they can incorporate it into themselves, clearing a HP and a Stress.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -418,7 +418,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754051528475,
-        "modifiedTime": 1754051573226,
+        "modifiedTime": 1754144642466,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!EQTOAOUrkIvS2z88.gw1Z2VazlRXYCiCK"
@@ -436,7 +436,7 @@
             "type": "attack",
             "_id": "2NYC0D7wkBNrUAKl",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to cause all PCs within Far range to make a Presence Reaction Roll (13). Targets who fail lose a Hope and you gain a Fear for each. Targets who succeed must mark a Stress.</p><p>@Template[type:emanation|range:f]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -533,7 +533,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754051580022,
-        "modifiedTime": 1754051676926,
+        "modifiedTime": 1754144651304,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!EQTOAOUrkIvS2z88.uTtQwNg46NAjgzuD"

--- a/src/packs/adversaries/adversary_Petty_Noble_wycLpvebWdUqRhpP.json
+++ b/src/packs/adversaries/adversary_Petty_Noble_wycLpvebWdUqRhpP.json
@@ -263,14 +263,14 @@
       "_id": "ebdAPBso5ROmdFNO",
       "img": "icons/environment/people/infantry-armored.webp",
       "system": {
-        "description": "<p>Once per scene, <strong>mark a Stress</strong> to summon <strong>1d4</strong> Bladed Guards, who appear at Far range to enforce the Noble’s will.</p>",
+        "description": "<p>Once per scene, <strong>mark a Stress</strong> to summon <strong>1d4</strong> @UUID[Compendium.daggerheart.adversaries.Actor.B4LZcGuBAHzyVdzy]{Bladed Guards}, who appear at Far range to enforce the Noble’s will.</p>",
         "resource": null,
         "actions": {
           "cUKwhq1imsTVru8D": {
             "type": "attack",
             "_id": "cUKwhq1imsTVru8D",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Once per scene, <strong>mark a Stress</strong> to summon <strong>1d4</strong> @UUID[Compendium.daggerheart.adversaries.Actor.B4LZcGuBAHzyVdzy]{Bladed Guards}, who appear at Far range to enforce the Noble’s will.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -341,7 +341,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754051802091,
-        "modifiedTime": 1754051889360,
+        "modifiedTime": 1754144696400,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!wycLpvebWdUqRhpP.ebdAPBso5ROmdFNO"
@@ -359,7 +359,7 @@
             "type": "effect",
             "_id": "dAHzRxf0iztyc1mI",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> and target a PC. The Noble proclaims that the target and their allies are exiled from the noble’s territory. While exiled, the target and their allies have disadvantage during social situations within the Noble’s domain.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -406,7 +406,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754051901804,
-        "modifiedTime": 1754052000961,
+        "modifiedTime": 1754144705317,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!wycLpvebWdUqRhpP.xN09fSsg33nURqpk"

--- a/src/packs/adversaries/adversary_Pirate_Captain_OROJbjsqagVh7ECV.json
+++ b/src/packs/adversaries/adversary_Pirate_Captain_OROJbjsqagVh7ECV.json
@@ -240,7 +240,7 @@
             "type": "damage",
             "_id": "xYphrI8GtMHHuT9a",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Captain marks 2 or fewer HP from an attack within Melee range, the attacker must mark a Stress.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -309,7 +309,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754052051501,
-        "modifiedTime": 1754052096031,
+        "modifiedTime": 1754144724207,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!OROJbjsqagVh7ECV.PsMA3x6giL8tixbf"
@@ -327,7 +327,7 @@
             "type": "effect",
             "_id": "NlgIp0KrmZoS27Xy",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Once per scene, <strong>mark a Stress</strong> to summon a Pirate Raiders Horde, which appears at Far range.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -374,7 +374,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754052100431,
-        "modifiedTime": 1754052144255,
+        "modifiedTime": 1754144730870,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!OROJbjsqagVh7ECV.WGEGO0DSOs5cF0EL"
@@ -392,7 +392,7 @@
             "type": "attack",
             "_id": "h2vM7jDTeFttVJKN",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to choose a target who has three or more Pirates within Melee range of them. The Captain leads the Pirates in hurling threats and promises of a watery grave. The target must make a Presence Reaction Roll. On a failure, the target marks <strong>1d4+1</strong> Stress. On a success, they must mark a Stress.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -488,7 +488,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754052150420,
-        "modifiedTime": 1754052237336,
+        "modifiedTime": 1754144738313,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!OROJbjsqagVh7ECV.brHnMc0TDiWVT4U6"

--- a/src/packs/adversaries/adversary_Pirate_Raiders_5YgEajn0wa4i85kC.json
+++ b/src/packs/adversaries/adversary_Pirate_Raiders_5YgEajn0wa4i85kC.json
@@ -270,7 +270,7 @@
             "type": "damage",
             "_id": "ejadA9jjMnVNVczS",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Raiders mark 2 or fewer HP from an attack within Melee range, the attacker must mark a Stress.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -339,7 +339,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754052352218,
-        "modifiedTime": 1754052393630,
+        "modifiedTime": 1754144754380,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!5YgEajn0wa4i85kC.N401rF937fLXMuMA"

--- a/src/packs/adversaries/adversary_Pirate_Tough_mhcVkVFrzIJ18FDm.json
+++ b/src/packs/adversaries/adversary_Pirate_Tough_mhcVkVFrzIJ18FDm.json
@@ -253,7 +253,7 @@
             "type": "damage",
             "_id": "xg3K78wfOhg8oCd3",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Tough marks 2 or fewer HP from an attack within Melee range, the attacker must mark a Stress.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -323,7 +323,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754089918298,
-        "modifiedTime": 1754089991383,
+        "modifiedTime": 1754144768141,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!mhcVkVFrzIJ18FDm.Zz5ITZOmPdtoLaUH"
@@ -339,7 +339,7 @@
             "type": "attack",
             "_id": "uJl1NJQ55yd9oCwz",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Make an attack against a target within Very Close range. On a success, <strong>mark a Stress</strong> to move into Melee range of the target, dealing <strong>3d4</strong> physical damage and knocking the target back to Close range.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -430,7 +430,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754090005821,
-        "modifiedTime": 1754090071032,
+        "modifiedTime": 1754144783385,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!mhcVkVFrzIJ18FDm.uzlxE1Cxm9GGmrNs"

--- a/src/packs/adversaries/adversary_Red_Ooze_9rVlbJVrDNn1x7PS.json
+++ b/src/packs/adversaries/adversary_Red_Ooze_9rVlbJVrDNn1x7PS.json
@@ -270,7 +270,7 @@
             "type": "attack",
             "_id": "b4g8XUIKLhxDlUPy",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Make an attack against a target within Very Close range. On a success, the target takes <strong>1d8</strong> magic damage and is Ignited until they’re extinguished with a successful Finesse Roll (14). While Ignited, the target takes <strong>1d4</strong> magic damage when they make an action roll.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -348,7 +348,7 @@
             "type": "damage",
             "_id": "6xYE9Zi8ce6bYjV8",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>While Ignited, the target takes <strong>1d4</strong> magic damage when they make an action roll.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -463,7 +463,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754052646207,
-        "modifiedTime": 1754052803213,
+        "modifiedTime": 1754144810550,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!9rVlbJVrDNn1x7PS.JU9uVwZSM0ItnZRq"
@@ -474,14 +474,14 @@
       "_id": "M9gAcPrgKfSg9Tjb",
       "img": "icons/creatures/slimes/slime-movement-splashing-red.webp",
       "system": {
-        "description": "<p>When the Ooze has 3 or more HP marked, you can <strong>spend a Fear</strong> to split them into two Tiny Red Oozes (with no marked HP or Stress). Immediately spotlight both of them.</p>",
+        "description": "<p>When the Ooze has 3 or more HP marked, you can <strong>spend a Fear</strong> to split them into two @UUID[Compendium.daggerheart.adversaries.Actor.1fkLQXVtmILqfJ44]{Tiny Red Oozes} (with no marked HP or Stress). Immediately spotlight both of them.</p>",
         "resource": null,
         "actions": {
           "dw6Juw8mriH7sg0e": {
             "type": "effect",
             "_id": "dw6Juw8mriH7sg0e",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Ooze has 3 or more HP marked, you can <strong>spend a Fear</strong> to split them into two @UUID[Compendium.daggerheart.adversaries.Actor.1fkLQXVtmILqfJ44]{Tiny Red Oozes} (with no marked HP or Stress). Immediately spotlight both of them.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -528,7 +528,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754052809157,
-        "modifiedTime": 1754052844133,
+        "modifiedTime": 1754144839066,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!9rVlbJVrDNn1x7PS.M9gAcPrgKfSg9Tjb"

--- a/src/packs/adversaries/adversary_Rotted_Zombie_gP3fWTLzSFnpA8EJ.json
+++ b/src/packs/adversaries/adversary_Rotted_Zombie_gP3fWTLzSFnpA8EJ.json
@@ -258,7 +258,7 @@
             "type": "effect",
             "_id": "DJBNtd3hWjwsjPwq",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to choose a target and spotlight all Rotted Zombies within Close range of them. Those Minions move into Melee range of the target and make one shared attack roll. On a success, they deal 2 physical damage each. Combine this damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -305,7 +305,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754053004648,
-        "modifiedTime": 1754053040875,
+        "modifiedTime": 1754144884372,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!gP3fWTLzSFnpA8EJ.R9vrwFNl5BD1YXJo"

--- a/src/packs/adversaries/adversary_Royal_Advisor_EtLJiTsilPPZvLUX.json
+++ b/src/packs/adversaries/adversary_Royal_Advisor_EtLJiTsilPPZvLUX.json
@@ -241,7 +241,7 @@
             "type": "damage",
             "_id": "gtM7UPq6xHgJHPPp",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>A PC who rolls less than 17 on an action roll targeting the Advisor must mark a Stress.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -311,7 +311,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754082801892,
-        "modifiedTime": 1754082844602,
+        "modifiedTime": 1754143000423,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!EtLJiTsilPPZvLUX.XFpF0FfTdqCjbHHF"
@@ -327,7 +327,7 @@
             "type": "effect",
             "_id": "JNFTnARlTAKermLx",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to influence an NPC within Melee range with whispered words. That target’s opinion on one matter shifts toward the Advisor’s preference unless it is in direct opposition to the target’s motives.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -375,7 +375,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754082871968,
-        "modifiedTime": 1754082966587,
+        "modifiedTime": 1754143009436,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!EtLJiTsilPPZvLUX.lG6vMc0zUbijpvCM"
@@ -391,7 +391,7 @@
             "type": "effect",
             "_id": "6oaHwUVWTmF362vI",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to convince a crowd or notable individual that one person or group is responsible for some problem facing the target. The target becomes hostile to the scapegoat until convinced of their innocence with a successful Presence Roll (17).</p><p>[[/dr trait=presence difficulty=17]]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -439,7 +439,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754082968228,
-        "modifiedTime": 1754083033696,
+        "modifiedTime": 1754143017351,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!EtLJiTsilPPZvLUX.iwNrNBbvm3RMgSw5"

--- a/src/packs/adversaries/adversary_Secret_Keeper_sLAccjvCWfeedbpI.json
+++ b/src/packs/adversaries/adversary_Secret_Keeper_sLAccjvCWfeedbpI.json
@@ -241,7 +241,7 @@
             "type": "attack",
             "_id": "e6DmGF9vOv27BJ6f",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend 2 Fear</strong> to spotlight <strong>1d4</strong> allies. Attacks they make while spotlighted in this way deal half damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -313,7 +313,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754083063489,
-        "modifiedTime": 1754083104394,
+        "modifiedTime": 1754143030405,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!sLAccjvCWfeedbpI.WLnguxRo9egh2hfX"
@@ -329,7 +329,7 @@
             "type": "healing",
             "_id": "MUdqLSRIpEEk1Ujc",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When you spotlight an ally within Far range, <strong>mark a Stress</strong> to gain a Fear.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -422,7 +422,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754083166776,
-        "modifiedTime": 1754083219597,
+        "modifiedTime": 1754143039212,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!sLAccjvCWfeedbpI.O5Nn1Slv8RJJpNeT"
@@ -433,7 +433,52 @@
       "system": {
         "description": "<p>Countdown (6). When the Secret-Keeper is in the spotlight for the first time, activate the countdown. When they mark HP, tick down this countdown by the number of HP marked. When it triggers, summon a @UUID[Compendium.daggerheart.adversaries.Actor.3tqCjDwJAQ7JKqMb]{Minor Demon} who appears at Close range.</p>",
         "resource": null,
-        "actions": {},
+        "actions": {
+          "PrShdg9N3MfeZaJc": {
+            "type": "effect",
+            "_id": "PrShdg9N3MfeZaJc",
+            "systemPath": "actions",
+            "description": "<p>Countdown (6). When the Secret-Keeper is in the spotlight for the first time, activate the countdown. When they mark HP, tick down this countdown by the number of HP marked.</p>",
+            "chatDisplay": true,
+            "actionType": "action",
+            "cost": [],
+            "uses": {
+              "value": null,
+              "max": "",
+              "recovery": null
+            },
+            "effects": [],
+            "target": {
+              "type": "any",
+              "amount": null
+            },
+            "name": "Countdown",
+            "img": "icons/magic/unholy/silhouette-light-fire-blue.webp",
+            "range": ""
+          },
+          "0rixG6jLRynAYNqA": {
+            "type": "effect",
+            "_id": "0rixG6jLRynAYNqA",
+            "systemPath": "actions",
+            "description": "<p>When the countdown triggers, summon a @UUID[Compendium.daggerheart.adversaries.Actor.3tqCjDwJAQ7JKqMb]{Minor Demon} who appears at Close range.</p>",
+            "chatDisplay": true,
+            "actionType": "action",
+            "cost": [],
+            "uses": {
+              "value": null,
+              "max": "",
+              "recovery": null
+            },
+            "effects": [],
+            "target": {
+              "type": "any",
+              "amount": null
+            },
+            "name": "Summon",
+            "img": "icons/magic/unholy/silhouette-light-fire-blue.webp",
+            "range": "close"
+          }
+        },
         "originItemType": null,
         "originId": null
       },
@@ -455,7 +500,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754083223957,
-        "modifiedTime": 1754083275897,
+        "modifiedTime": 1754143099523,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!sLAccjvCWfeedbpI.4L7aM9NDLbjvuwI3"
@@ -471,7 +516,7 @@
             "type": "effect",
             "_id": "JBuQUJhif2A7IlJd",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Once per scene, when the SecretKeeper marks 2 or more HP, you can <strong>mark a Stress</strong> to summon a @UUID[Compendium.daggerheart.adversaries.Actor.NoRZ1PqB8N5wcIw0]{Demonic Hound Pack}, which appears at Close range and is immediately spotlighted.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -519,7 +564,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754083283890,
-        "modifiedTime": 1754083364734,
+        "modifiedTime": 1754143114257,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!sLAccjvCWfeedbpI.Q28NPuSMccjzykib"

--- a/src/packs/adversaries/adversary_Sellsword_bgreCaQ6ap2DVpCr.json
+++ b/src/packs/adversaries/adversary_Sellsword_bgreCaQ6ap2DVpCr.json
@@ -258,7 +258,7 @@
             "type": "effect",
             "_id": "ghgFZskDiizJDjcn",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to choose a target and spotlight all Sellswords within Close range of them. Those Minions move into Melee range of the target and make one shared attack roll. On a success, they deal 3 physical damage each. Combine this damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -305,7 +305,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754053107600,
-        "modifiedTime": 1754053147721,
+        "modifiedTime": 1754144897730,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!bgreCaQ6ap2DVpCr.CQZQiEiRH70Br5Ge"

--- a/src/packs/adversaries/adversary_Shambling_Zombie_2nXz4ilAY4xuhKLm.json
+++ b/src/packs/adversaries/adversary_Shambling_Zombie_2nXz4ilAY4xuhKLm.json
@@ -258,14 +258,14 @@
       "_id": "iiOjamlZIuhpDC8W",
       "img": "icons/magic/death/skull-energy-light-purple.webp",
       "system": {
-        "description": "<p> Targets who mark HP from the Zombie’s attacks must also mark a Stress.</p>",
+        "description": "<p>Targets who mark HP from the Zombie’s attacks must also mark a Stress.</p>",
         "resource": null,
         "actions": {
           "JUw16Jag9uTfBmKZ": {
             "type": "damage",
             "_id": "JUw16Jag9uTfBmKZ",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Targets who mark HP from the Zombie’s attacks must also mark a Stress.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -309,7 +309,7 @@
               "amount": 1
             },
             "effects": [],
-            "name": "Stress Damage",
+            "name": "Mark Stress",
             "img": "icons/magic/death/skull-energy-light-purple.webp",
             "range": "melee"
           }
@@ -334,7 +334,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754053249379,
-        "modifiedTime": 1754053287602,
+        "modifiedTime": 1754144921344,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!2nXz4ilAY4xuhKLm.iiOjamlZIuhpDC8W"

--- a/src/packs/adversaries/adversary_Shark_YmVAkdNsyuXWTtYp.json
+++ b/src/packs/adversaries/adversary_Shark_YmVAkdNsyuXWTtYp.json
@@ -223,9 +223,62 @@
       "name": "Terrifying",
       "type": "feature",
       "system": {
-        "description": "<p>When the Shark makes a successful attack, all PCs within Far range lose a Hope and you gain a Fear.</p>",
+        "description": "<p>When the Shark makes a successful attack, all PCs within Far range lose a Hope and you gain a Fear.</p><p>@Template[type:emanation|range:f]</p>",
         "resource": null,
-        "actions": {},
+        "actions": {
+          "NoEb6qR3ktIu9kRJ": {
+            "type": "damage",
+            "_id": "NoEb6qR3ktIu9kRJ",
+            "systemPath": "actions",
+            "description": "<p>When the Shark makes a successful attack, all PCs within Far range lose a Hope and you gain a Fear.</p><p>@Template[type:emanation|range:f]</p>",
+            "chatDisplay": true,
+            "actionType": "action",
+            "cost": [],
+            "uses": {
+              "value": null,
+              "max": "",
+              "recovery": null
+            },
+            "damage": {
+              "parts": [
+                {
+                  "value": {
+                    "custom": {
+                      "enabled": true,
+                      "formula": "1"
+                    },
+                    "multiplier": "flat",
+                    "flatMultiplier": 1,
+                    "dice": "d6",
+                    "bonus": null
+                  },
+                  "applyTo": "hope",
+                  "type": [],
+                  "base": false,
+                  "resultBased": false,
+                  "valueAlt": {
+                    "multiplier": "prof",
+                    "flatMultiplier": 1,
+                    "dice": "d6",
+                    "bonus": null,
+                    "custom": {
+                      "enabled": false
+                    }
+                  }
+                }
+              ],
+              "includeBase": false
+            },
+            "target": {
+              "type": "any",
+              "amount": null
+            },
+            "effects": [],
+            "name": "Lose Hope",
+            "img": "icons/magic/death/skull-energy-light-purple.webp",
+            "range": ""
+          }
+        },
         "originItemType": null,
         "originId": null
       },
@@ -247,7 +300,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754083474532,
-        "modifiedTime": 1754083489071,
+        "modifiedTime": 1754143155459,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!YmVAkdNsyuXWTtYp.w46d3D2gXUIJh2GH"
@@ -263,7 +316,7 @@
             "type": "attack",
             "_id": "a0gC7uWycUB2NgKS",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Shark makes a successful attack, the target must mark an Armor Slot without receiving its benefits (they can still use armor to reduce the damage). If they can’t mark an Armor Slot, they must mark an additional HP.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -379,7 +432,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754083491482,
-        "modifiedTime": 1754083557003,
+        "modifiedTime": 1754143165634,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!YmVAkdNsyuXWTtYp.zT4AOW20LPlDoncy"
@@ -395,7 +448,7 @@
             "type": "effect",
             "_id": "sE9KRd9siZeYHPhb",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When a creature within Close range of the Shark marks HP from another creature’s attack, you can <strong>mark a Stress</strong> to immediately spotlight the Shark, moving them into Melee range of the target and making a standard attack.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -443,7 +496,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754083562494,
-        "modifiedTime": 1754083655609,
+        "modifiedTime": 1754143174466,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!YmVAkdNsyuXWTtYp.LBKPfi8XktBAwbrt"

--- a/src/packs/adversaries/adversary_Siren_BK4jwyXSRx7IOQiO.json
+++ b/src/packs/adversaries/adversary_Siren_BK4jwyXSRx7IOQiO.json
@@ -236,7 +236,7 @@
             "type": "attack",
             "_id": "FxWbdt0hRNv2k9Pm",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>If the Siren makes a standard attack against a target Entranced by their song, the attack deals <strong>2d10+1</strong> damage instead of their standard damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -327,7 +327,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754083726966,
-        "modifiedTime": 1754083784344,
+        "modifiedTime": 1754143194449,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!BK4jwyXSRx7IOQiO.Zc3PFPTgKRX03Fx6"
@@ -343,7 +343,7 @@
             "type": "attack",
             "_id": "FY8K8Nsg0TKAWok8",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to sing a song that affects all targets within Close range. Targets must succeed on an Instinct Reaction Roll or become Entranced until they mark 2 Stress. Other Sirens within Close range of the target can <strong>mark a Stress</strong> to each add a +1 bonus to the Difficulty of the reaction roll. While Entranced, a target can’t act and is <em>Vulnerable</em>.</p><p>@Template[type:emanation|range:c]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -467,7 +467,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754083791012,
-        "modifiedTime": 1754083933087,
+        "modifiedTime": 1754143204465,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!BK4jwyXSRx7IOQiO.Ks3HpB4W1l5FqR7p"

--- a/src/packs/adversaries/adversary_Skeleton_Archer_7X5q7a6ueeHs5oA9.json
+++ b/src/packs/adversaries/adversary_Skeleton_Archer_7X5q7a6ueeHs5oA9.json
@@ -266,7 +266,7 @@
             "type": "attack",
             "_id": "nKmxl3D7g4p7Zcub",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Make an attack against a Vulnerable target within Far range. On a success, <strong>mark a Stress</strong> to deal <strong>3d4+8</strong> physical damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -356,7 +356,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754053364547,
-        "modifiedTime": 1754053413477,
+        "modifiedTime": 1754144936679,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!7X5q7a6ueeHs5oA9.4w20xpEo6L1fgro3"

--- a/src/packs/adversaries/adversary_Skeleton_Dredge_6l1a3Fazq8BoKIcc.json
+++ b/src/packs/adversaries/adversary_Skeleton_Dredge_6l1a3Fazq8BoKIcc.json
@@ -258,7 +258,7 @@
             "type": "effect",
             "_id": "Sz55uB8xkoNytLwJ",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to choose a target and spotlight all Dredges within Close range of them. Those Minions move into Melee range of the target and make one shared attack roll. On a success, they deal 1 physical damage each. Combine this damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -305,7 +305,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754053501054,
-        "modifiedTime": 1754053534908,
+        "modifiedTime": 1754144949457,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!6l1a3Fazq8BoKIcc.wl9KKEpVWDBu62hU"

--- a/src/packs/adversaries/adversary_Skeleton_Knight_Q9LaVTyXF9NF12C7.json
+++ b/src/packs/adversaries/adversary_Skeleton_Knight_Q9LaVTyXF9NF12C7.json
@@ -231,7 +231,7 @@
             "type": "damage",
             "_id": "9EiPNrGzwLtuf9g0",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Knight makes a successful attack, all PCs within Close range lose a Hope and you gain a Fear.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -300,7 +300,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754053581860,
-        "modifiedTime": 1754053647447,
+        "modifiedTime": 1754144961490,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!Q9LaVTyXF9NF12C7.OZKEz4eK9h7zCbuf"
@@ -318,7 +318,7 @@
             "type": "attack",
             "_id": "vMv4monku9LOSxUZ",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to make an attack against all targets within Very Close range. Targets the Knight succeeds against take <strong>1d8+2</strong> physical damage and must mark a Stress.</p><p>@Template[type:emanation|range:vc]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -441,7 +441,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754053666861,
-        "modifiedTime": 1754053803001,
+        "modifiedTime": 1754144968936,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!Q9LaVTyXF9NF12C7.WdVLwy9RNkVlZnCL"
@@ -459,7 +459,7 @@
             "type": "attack",
             "_id": "NtGhAVVOJF6ZGBRv",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Knight is defeated, they make an attack against a target within Very Close range (prioritizing the creature who killed them). On a success, the target takes <strong>1d4+8</strong> physical damage and loses <strong>1d4</strong> Hope.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -549,7 +549,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754053741722,
-        "modifiedTime": 1754053792513,
+        "modifiedTime": 1754144976680,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!Q9LaVTyXF9NF12C7.STesKV2KB61PlwCh"

--- a/src/packs/adversaries/adversary_Skeleton_Warrior_10YIQl0lvCJXZLfX.json
+++ b/src/packs/adversaries/adversary_Skeleton_Warrior_10YIQl0lvCJXZLfX.json
@@ -317,7 +317,7 @@
             "type": "attack",
             "_id": "QnuFrptj8oARaA3i",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Warrior is defeated, you can spotlight them and roll a <strong>d6</strong>. On a result of 6, if there are other adversaries on the battlefi eld, the Warrior re-forms with no marked HP.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -380,7 +380,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754053904083,
-        "modifiedTime": 1754053962878,
+        "modifiedTime": 1754144989858,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!10YIQl0lvCJXZLfX.hYl31ThCmZdc0MFa"

--- a/src/packs/adversaries/adversary_Spectral_Archer_5tCkhnBByUIN5UdG.json
+++ b/src/packs/adversaries/adversary_Spectral_Archer_5tCkhnBByUIN5UdG.json
@@ -236,7 +236,7 @@
             "type": "effect",
             "_id": "kkKfo1gwetxB3tFQ",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to move up to Close range through solid objects.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -336,7 +336,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754083956529,
-        "modifiedTime": 1754083997927,
+        "modifiedTime": 1754143224652,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!5tCkhnBByUIN5UdG.qvJRjKrdr6MG05iJ"
@@ -352,7 +352,7 @@
             "type": "attack",
             "_id": "KahJnM94QQfy6oMK",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to make an attack within Far range against a PC who is within Very Close range of at least two other PCs. On a success, the target takes <strong>2d8+12</strong> physical damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -443,7 +443,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754084041991,
-        "modifiedTime": 1754084157885,
+        "modifiedTime": 1754143246296,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!5tCkhnBByUIN5UdG.0h4IVmCgWXyQngAw"

--- a/src/packs/adversaries/adversary_Spectral_Captain_65cSO3EQEh6ZH6Xk.json
+++ b/src/packs/adversaries/adversary_Spectral_Captain_65cSO3EQEh6ZH6Xk.json
@@ -235,7 +235,7 @@
             "type": "effect",
             "_id": "k7RuXErgCsEBmhmk",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to move up to Close range through solid objects.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -335,7 +335,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754084228113,
-        "modifiedTime": 1754084284677,
+        "modifiedTime": 1754143262316,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!65cSO3EQEh6ZH6Xk.JU93RyfAB5XhZ6FN"
@@ -351,7 +351,7 @@
             "type": "effect",
             "_id": "eHmbN4aPLUuEoDQt",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend 2 Fear</strong> to return up to [[/r 1d4+1]] defeated Spectral allies to the battle at the points where they first appeared (with no marked HP or Stress).</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -399,7 +399,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754084289554,
-        "modifiedTime": 1754084346643,
+        "modifiedTime": 1754143273976,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!65cSO3EQEh6ZH6Xk.7YVe4DfEWMNLXNvu"
@@ -415,7 +415,7 @@
             "type": "effect",
             "_id": "aRg1bcPGUn69GPyB",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Captain’s Spectral allies are forced to make a reaction roll, you can <strong>mark a Stress</strong> to give those allies a +2 bonus to the roll.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -463,7 +463,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754084350199,
-        "modifiedTime": 1754084392491,
+        "modifiedTime": 1754143281444,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!65cSO3EQEh6ZH6Xk.X0vtV30ACVVZ6NfF"

--- a/src/packs/adversaries/adversary_Spectral_Guardian_UFVGl1osOsJTneLf.json
+++ b/src/packs/adversaries/adversary_Spectral_Guardian_UFVGl1osOsJTneLf.json
@@ -236,7 +236,7 @@
             "type": "effect",
             "_id": "X1JlwWqyYHjahbpA",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to move up to Close range through solid objects.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -336,7 +336,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754084531966,
-        "modifiedTime": 1754084602322,
+        "modifiedTime": 1754143300180,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!UFVGl1osOsJTneLf.x3g1lM5S1W7DAKIc"
@@ -352,7 +352,7 @@
             "type": "attack",
             "_id": "AdfULyYsj9YPcCj6",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to make an attack against a target within Very Close range. On a success, deal <strong>2d10+6</strong> physical damage and the target must mark a Stress.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -476,7 +476,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754084605936,
-        "modifiedTime": 1754084661003,
+        "modifiedTime": 1754143308994,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!UFVGl1osOsJTneLf.L48tQmj5O3s2pjBn"

--- a/src/packs/adversaries/adversary_Spellblade_ldbWEL7uZs84vyrR.json
+++ b/src/packs/adversaries/adversary_Spellblade_ldbWEL7uZs84vyrR.json
@@ -271,7 +271,7 @@
             "type": "attack",
             "_id": "K4VnxigKTiu7hhZx",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> and target a group within Far range. All targets must succeed on an Agility Reaction Roll or take <strong>1d8+2</strong> magic damage. You gain a Fear for each target who marked HP from this attack.</p><p>@Template[type:emanation|range:f]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -369,7 +369,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754054061492,
-        "modifiedTime": 1754054159859,
+        "modifiedTime": 1754145003754,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!ldbWEL7uZs84vyrR.a76dNCrcoZOH1RRT"
@@ -387,7 +387,7 @@
             "type": "effect",
             "_id": "N42NPEu7fcVDXEvl",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend 2 Fear</strong> to spotlight up to fi ve allies within Far range.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -434,7 +434,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754054175855,
-        "modifiedTime": 1754054211540,
+        "modifiedTime": 1754145012244,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!ldbWEL7uZs84vyrR.piyJhdHzztabmZ8I"

--- a/src/packs/adversaries/adversary_Spy_8zlynOhnVA59KpKT.json
+++ b/src/packs/adversaries/adversary_Spy_8zlynOhnVA59KpKT.json
@@ -236,7 +236,7 @@
             "type": "effect",
             "_id": "iq5KzP5hgA4377fO",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to describe how the Spy knows a secret about a PC in the scene.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -284,7 +284,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754084722024,
-        "modifiedTime": 1754084779191,
+        "modifiedTime": 1754143322352,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!8zlynOhnVA59KpKT.csCWQuSqic5ckHeO"
@@ -300,7 +300,7 @@
             "type": "effect",
             "_id": "Ml8nt7SPNFc2iQno",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When a PC or group is discussing something sensitive, you can <strong>mark a Stress</strong> to reveal that the Spy is present in the scene, observing them. If the Spy escapes the scene to report their findings, you gain <strong>1d4</strong> Fear.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -330,7 +330,7 @@
             "type": "healing",
             "_id": "qCA2hTMIYGW0FhGy",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>If the Spy escapes the scene to report their findings, you gain <strong>1d4</strong> Fear.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -414,7 +414,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754084782425,
-        "modifiedTime": 1754084860717,
+        "modifiedTime": 1754143342129,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!8zlynOhnVA59KpKT.UvgVDn0YjISLdKE4"

--- a/src/packs/adversaries/adversary_Stonewraith_3aAS2Qm3R6cgaYfE.json
+++ b/src/packs/adversaries/adversary_Stonewraith_3aAS2Qm3R6cgaYfE.json
@@ -269,7 +269,7 @@
             "type": "attack",
             "_id": "E8C2Nd4mwcGTXoXb",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>While <em>Hidden</em>, <strong>mark a Stress</strong> to leap into Melee range with a target within Very Close range. The target must succeed on an Agility or Instinct Reaction Roll (15) or take <strong>2d8</strong> physical damage and become temporarily Restrained.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -418,7 +418,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754084946110,
-        "modifiedTime": 1754085052359,
+        "modifiedTime": 1754143356249,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!3aAS2Qm3R6cgaYfE.tQgxiSS48TJ3X1Dl"
@@ -434,7 +434,7 @@
             "type": "attack",
             "_id": "4UGEEuK9XY8leCBV",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to roar while within a cave and cause a cave-in. All targets within Close range must succeed on an Agility Reaction Roll (14) or take <strong>2d10</strong> physical damage. The rubble can be cleared with a Progress Countdown (8).</p><p>@Template[type:emanation|range:c]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -533,7 +533,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754085059319,
-        "modifiedTime": 1754085157724,
+        "modifiedTime": 1754143365810,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!3aAS2Qm3R6cgaYfE.9Z0i0uURfBMVIapJ"

--- a/src/packs/adversaries/adversary_Sylvan_Soldier_VtFBt9XBE0WrGGxP.json
+++ b/src/packs/adversaries/adversary_Sylvan_Soldier_VtFBt9XBE0WrGGxP.json
@@ -236,7 +236,7 @@
             "type": "attack",
             "_id": "dmlz83o2JOAoGiuK",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>If the Soldier makes a standard attack and another Sylvan Soldier is within Melee range of the target, deal <strong>1d8+5</strong> physical damage instead of their standard damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -326,7 +326,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754054372208,
-        "modifiedTime": 1754054415661,
+        "modifiedTime": 1754145037925,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!VtFBt9XBE0WrGGxP.uo5DbPuQQ018Pyfd"
@@ -344,7 +344,7 @@
             "type": "attack",
             "_id": "UyL02IaAO3m8LgWI",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to pull down a tree within Close range. A creature hit by the tree must succeed on an Agility Reaction Roll (15) or take <strong>1d10</strong> physical damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -442,7 +442,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754054421332,
-        "modifiedTime": 1754054505735,
+        "modifiedTime": 1754145046401,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!VtFBt9XBE0WrGGxP.phtxvgptyvT3WoeK"
@@ -460,7 +460,7 @@
             "type": "effect",
             "_id": "l32BjO9J0jFvD0Zy",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Soldier makes a successful attack, you can <strong>mark a Stress</strong> to become Hidden until the Soldier’s next attack or a PC succeeds on an Instinct Roll (14) to fi nd them.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -559,7 +559,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754054512042,
-        "modifiedTime": 1754054562730,
+        "modifiedTime": 1754145055093,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!VtFBt9XBE0WrGGxP.1dmKoSnV82sLc8xZ"

--- a/src/packs/adversaries/adversary_Tangle_Bramble_Swarm_PKSXFuaIHUCoH63A.json
+++ b/src/packs/adversaries/adversary_Tangle_Bramble_Swarm_PKSXFuaIHUCoH63A.json
@@ -303,7 +303,7 @@
             "type": "damage",
             "_id": "CiA4K6py0eW6eihU",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to deal <strong>2d6+8</strong> direct physical damage to a target with 3 or more bramble tokens.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -380,7 +380,8 @@
         "coreVersion": "13.346",
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
-        "lastModifiedBy": null
+        "lastModifiedBy": "MQSznptE5yLT7kj8",
+        "modifiedTime": 1754145096824
       },
       "_key": "!actors.items!PKSXFuaIHUCoH63A.2HlelvCZA00izcQa"
     },
@@ -397,7 +398,7 @@
             "type": "effect",
             "_id": "Cdw2XxA5NhAQhQse",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Swarm succeeds on an attack, give the target a bramble token. If a target has any bramble tokens, they are Restrained. If a target has 3 or more bramble tokens, they are also Vulnerable. All bramble tokens can be removed by succeeding on a Finesse Roll (12 + the number of bramble tokens) or dealing Major or greater damage to the Swarm. If bramble tokens are removed from a target using a Finesse Roll, a number of Tangle Bramble Minions spawn within Melee range equal to the number of tokens removed.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -485,7 +486,8 @@
         "coreVersion": "13.346",
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
-        "lastModifiedBy": null
+        "lastModifiedBy": "MQSznptE5yLT7kj8",
+        "modifiedTime": 1754145109151
       },
       "_key": "!actors.items!PKSXFuaIHUCoH63A.JRSGc3ozDnKCAvCj"
     }

--- a/src/packs/adversaries/adversary_Tangle_Bramble_XcAGOSmtCFLT1unN.json
+++ b/src/packs/adversaries/adversary_Tangle_Bramble_XcAGOSmtCFLT1unN.json
@@ -299,7 +299,7 @@
             "type": "effect",
             "_id": "ZC5pKIb9N82vgMWu",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to choose a target and spotlight all Tangle Brambles within Close range of them. Those Minions move into Melee range of the target and make one shared attack roll. On a success, they deal 2 physical damage each. Combine this damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -345,7 +345,8 @@
         "coreVersion": "13.346",
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
-        "lastModifiedBy": null
+        "lastModifiedBy": "MQSznptE5yLT7kj8",
+        "modifiedTime": 1754145071567
       },
       "_key": "!actors.items!XcAGOSmtCFLT1unN.WiobzuyvJ46zfsOv"
     },
@@ -355,7 +356,7 @@
       "_id": "KBMf7oBfFSHoafKN",
       "img": "icons/magic/nature/root-vines-knot-brown.webp",
       "system": {
-        "description": "<p>When an attack from the Bramble causes a target to mark HP and there are three or more Tangle Bramble Minions within Close range, you can combine the Minions into a Tangle Bramble Swarm Horde. The Horde’s HP is equal to the number of Minions combined.</p>",
+        "description": "<p>When an attack from the Bramble causes a target to mark HP and there are three or more Tangle Bramble Minions within Close range, you can combine the Minions into a @UUID[Compendium.daggerheart.adversaries.Actor.PKSXFuaIHUCoH63A]{Tangle Bramble Swarm Horde}. The Horde’s HP is equal to the number of Minions combined.</p>",
         "resource": null,
         "actions": {},
         "originItemType": null,
@@ -377,7 +378,8 @@
         "coreVersion": "13.346",
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
-        "lastModifiedBy": null
+        "lastModifiedBy": "MQSznptE5yLT7kj8",
+        "modifiedTime": 1754145296974
       },
       "_key": "!actors.items!XcAGOSmtCFLT1unN.KBMf7oBfFSHoafKN"
     }

--- a/src/packs/adversaries/adversary_Tiny_Green_Ooze_aLkLFuVoKz2NLoBK.json
+++ b/src/packs/adversaries/adversary_Tiny_Green_Ooze_aLkLFuVoKz2NLoBK.json
@@ -227,7 +227,7 @@
             "type": "damage",
             "_id": "HfK0u0c7NRppuF1Q",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Ooze makes a successful attack, the target must mark an Armor Slot without receiving its benefi ts (they can still use armor to reduce the damage). If they can’t mark an Armor Slot, they must mark an additional HP.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -296,7 +296,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754055148507,
-        "modifiedTime": 1754055187632,
+        "modifiedTime": 1754145130460,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!aLkLFuVoKz2NLoBK.WpOh5kHHx7lcTvEY"

--- a/src/packs/adversaries/adversary_Tiny_Red_Ooze_1fkLQXVtmILqfJ44.json
+++ b/src/packs/adversaries/adversary_Tiny_Red_Ooze_1fkLQXVtmILqfJ44.json
@@ -227,7 +227,7 @@
             "type": "damage",
             "_id": "cHaEnBwinVKmoS9s",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When a creature within Melee range deals damage to the Ooze, they take <strong>1d6</strong> direct magic damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -297,7 +297,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754055288007,
-        "modifiedTime": 1754055327095,
+        "modifiedTime": 1754145142986,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!1fkLQXVtmILqfJ44.zsUMP2qNmNpVHwk0"

--- a/src/packs/adversaries/adversary_War_Wizard_noDdT0tsN6FXSmC8.json
+++ b/src/packs/adversaries/adversary_War_Wizard_noDdT0tsN6FXSmC8.json
@@ -241,7 +241,7 @@
             "type": "effect",
             "_id": "39zC1I5DYozI47lP",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Before or after making a standard attack, you can <strong>mark a Stress</strong> to teleport to a location within Far range.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -289,7 +289,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754085243264,
-        "modifiedTime": 1754085284707,
+        "modifiedTime": 1754143380458,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!noDdT0tsN6FXSmC8.PUUz48dsObawcSgp"
@@ -305,7 +305,7 @@
             "type": "effect",
             "_id": "FCuksmAGRC4061zm",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to refresh the Wizard’s “Warding Sphere” reaction.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -353,7 +353,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754085287538,
-        "modifiedTime": 1754085324562,
+        "modifiedTime": 1754143388156,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!noDdT0tsN6FXSmC8.dI2MGjC7NFAru1Gd"
@@ -369,7 +369,7 @@
             "type": "attack",
             "_id": "vnMq4NuQO6GYxWhM",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> and choose a point within Far range. A Very Close area around that point erupts into impassable terrain. All targets within that area must make an Agility Reaction Roll (14). Targets who fail take <strong>2d10</strong> physical damage and are thrown out of the area. Targets who succeed take half damage and aren’t moved.</p><p>@Template[type:circle|range:vc]</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -468,7 +468,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754085334993,
-        "modifiedTime": 1754085423257,
+        "modifiedTime": 1754143396761,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!noDdT0tsN6FXSmC8.PnQ0m0FLnpht7oE4"
@@ -484,7 +484,7 @@
             "type": "attack",
             "_id": "DFHR8LtvjZjHP6BL",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to unleash a precise hail of magical blasts. All targets in the scene must make an Agility Reaction Roll. Targets who fail take <strong>2d12</strong> magic damage. Targets who succeed take half damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -583,7 +583,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754085427830,
-        "modifiedTime": 1754085490170,
+        "modifiedTime": 1754143405896,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!noDdT0tsN6FXSmC8.s2luvEVxJLZmOrdh"
@@ -604,7 +604,7 @@
             "type": "damage",
             "_id": "2fHrpaZW9toi6nin",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Wizard takes damage from an attack within Close range, deal <strong>2d6</strong> magic damage to the attacker. This reaction can’t be used again until the Wizard refreshes it with their “Refresh Warding Sphere” action.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -675,7 +675,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754085493649,
-        "modifiedTime": 1754085606011,
+        "modifiedTime": 1754143416150,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!noDdT0tsN6FXSmC8.9cPigHRcUfJC9gD8"

--- a/src/packs/adversaries/adversary_Weaponmaster_ZNbQ2jg35LG4t9eH.json
+++ b/src/packs/adversaries/adversary_Weaponmaster_ZNbQ2jg35LG4t9eH.json
@@ -232,7 +232,7 @@
             "type": "attack",
             "_id": "mlPgZJNL2TjykjUb",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Make a standard attack against a target. On a success, <strong>mark a Stress</strong> to Taunt the target until their next successful attack. The next time the Taunted target attacks, they have disadvantage against targets other than the Weaponmaster.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [],
@@ -372,7 +372,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754055391558,
-        "modifiedTime": 1754055694529,
+        "modifiedTime": 1754145156618,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!ZNbQ2jg35LG4t9eH.tyGgOqQzDSIypoMz"
@@ -395,7 +395,7 @@
             "type": "healing",
             "_id": "WQ067ZFiG2QMBo2n",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>Once per scene, spend a Fear to clear 2 HP and 2 Stress.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -512,7 +512,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754055703816,
-        "modifiedTime": 1754055795306,
+        "modifiedTime": 1754145170728,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!ZNbQ2jg35LG4t9eH.UsC0vtOBbf9Kut4v"

--- a/src/packs/adversaries/adversary_Young_Dryad_8yUj2Mzvnifhxegm.json
+++ b/src/packs/adversaries/adversary_Young_Dryad_8yUj2Mzvnifhxegm.json
@@ -236,7 +236,7 @@
             "type": "attack",
             "_id": "0VOUNQKNjwlLhnRW",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Mark a Stress</strong> to spotlight <strong>1d4</strong> allies within range of a target they can attack without moving. On a success, their attacks deal half damage.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -307,7 +307,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754055838842,
-        "modifiedTime": 1754055987216,
+        "modifiedTime": 1754145187760,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!8yUj2Mzvnifhxegm.lXhVuh31S2N4NVPG"
@@ -325,7 +325,7 @@
             "type": "effect",
             "_id": "cXOjhfMgKh2yD1mc",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p><strong>Spend a Fear</strong> to form a cage around a target within Very Close range and Restrain them until they’re freed with a successful Strength Roll. When a creature makes an action roll against the cage, they must mark a Stress.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -424,7 +424,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754055992231,
-        "modifiedTime": 1754056038239,
+        "modifiedTime": 1754145198821,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!8yUj2Mzvnifhxegm.i8NoUGUTNY2C5NhC"

--- a/src/packs/adversaries/adversary_Zombie_Pack_Nf0v43rtflV56V2T.json
+++ b/src/packs/adversaries/adversary_Zombie_Pack_Nf0v43rtflV56V2T.json
@@ -265,7 +265,7 @@
             "type": "effect",
             "_id": "0Im5AEgp8gJaVJHh",
             "systemPath": "actions",
-            "description": "",
+            "description": "<p>When the Zombies mark HP from an attack within Melee range, you can <strong>mark a Stress</strong> to make a standard attack against the attacker.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -312,7 +312,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754056184398,
-        "modifiedTime": 1754056281089,
+        "modifiedTime": 1754145211964,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!actors.items!Nf0v43rtflV56V2T.jQmltra0ovHE33Nx"

--- a/src/packs/domains/domainCard_Inspirational_Words_cWu1o82ZF7GvnbXc.json
+++ b/src/packs/domains/domainCard_Inspirational_Words_cWu1o82ZF7GvnbXc.json
@@ -9,7 +9,6 @@
     "recallCost": 1,
     "level": 1,
     "type": "ability",
-
     "resource": {
       "type": "simple",
       "value": 0,
@@ -244,7 +243,6 @@
         "range": ""
       }
     }
-
   },
   "flags": {},
   "_stats": {
@@ -255,9 +253,7 @@
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784473,
-
     "modifiedTime": 1754101191119,
-
     "lastModifiedBy": "Q9NoTaEarn3VMS6Z"
   },
   "_id": "cWu1o82ZF7GvnbXc",


### PR DESCRIPTION
Actions on Tier 1-3 didn't have the descriptions added to them (they were only on Features), fixed.