### PR TITLE
[Fix] Tooltip Information

### DIFF
--- a/styles/less/ux/tooltip/tooltip.less
+++ b/styles/less/ux/tooltip/tooltip.less
@@ -3,6 +3,7 @@
     flex-direction: column;
     align-items: center;
     gap: 4px;
+    border-width: 0;
 
     .tooltip-title-container {
         width: 100%;
@@ -30,6 +31,7 @@
 
     .tooltip-description {
         font-style: italic;
+        text-align: start;
     }
 
     .tooltip-sub-title {
@@ -45,12 +47,6 @@
 
         &.triple {
             grid-template-columns: 1fr 1fr 1fr;
-        }
-
-        &.border {
-            border: 1px solid light-dark(@dark-blue, @golden);
-            border-radius: 6px;
-            padding: 2px;
         }
 
         .tooltip-information {

--- a/templates/ui/tooltip/adversary.hbs
+++ b/templates/ui/tooltip/adversary.hbs
@@ -59,6 +59,4 @@
             <div>{{item.system.motivesAndTactics}}</div>
         </div>
     </div>
-
-    {{> "systems/daggerheart/templates/ui/tooltip/parts/tooltipTags.hbs" features=item.system.features }}
 </div>

--- a/templates/ui/tooltip/armor.hbs
+++ b/templates/ui/tooltip/armor.hbs
@@ -18,20 +18,4 @@
             <div>{{item.system.baseThresholds.severe}}</div>
         </div>
     </div>
-
-    {{#if (gt item.system.armorFeatures.length 0)}}<h4 class="tooltip-sub-title">{{localize "DAGGERHEART.GENERAL.features"}}</h4>{{/if}}
-    <div class="tooltip-tags">
-        {{#each item.system.armorFeatures}}
-            {{#with (lookup ../config.ITEM.armorFeatures this.value) as | feature | }}
-                <div class="tooltip-tag">
-                    <div class="tooltip-tag-label-container">
-                        <div class="tooltip-tag-label">{{localize feature.label}}</div>
-                    </div>
-                    <div class="tooltip-tag-description">{{{localize feature.description}}}</div>
-                </div>
-            {{/with}}
-        {{/each}}
-    </div>
-
-    {{> "systems/daggerheart/templates/ui/tooltip/parts/tooltipTags.hbs" features=item.system.customActions isAction=true label=(localize "DAGGERHEART.GENERAL.Action.plural")}}
 </div>

--- a/templates/ui/tooltip/beastform.hbs
+++ b/templates/ui/tooltip/beastform.hbs
@@ -2,7 +2,4 @@
     <h2 class="tooltip-title">{{item.name}}</h2>
     <img class="tooltip-image" src="{{item.img}}" />
     <div class="tooltip-description">{{{description}}}</div>
-
-    {{> "systems/daggerheart/templates/ui/tooltip/parts/tooltipChips.hbs" chips=item.system.advantageOn label=(localize "DAGGERHEART.ITEMS.Beastform.FIELDS.advantageOn.label")}}
-    {{> "systems/daggerheart/templates/ui/tooltip/parts/tooltipTags.hbs" features=item.system.features label=(localize "DAGGERHEART.GENERAL.features")}}
 </div>

--- a/templates/ui/tooltip/consumable.hbs
+++ b/templates/ui/tooltip/consumable.hbs
@@ -9,6 +9,4 @@
             <div>{{item.system.quantity}}</div>
         </div>
     </div>
-
-    {{> "systems/daggerheart/templates/ui/tooltip/parts/tooltipTags.hbs" features=item.system.actions isAction=true label=(localize "DAGGERHEART.GENERAL.Action.plural") }}
 </div>

--- a/templates/ui/tooltip/domainCard.hbs
+++ b/templates/ui/tooltip/domainCard.hbs
@@ -26,6 +26,4 @@
             <div>{{item.system.recallCost}}</div>
         </div>
     </div>
-
-    {{> "systems/daggerheart/templates/ui/tooltip/parts/tooltipTags.hbs" features=item.system.actions isAction=true label=(localize "DAGGERHEART.GENERAL.Action.plural") }}
 </div>

--- a/templates/ui/tooltip/feature.hbs
+++ b/templates/ui/tooltip/feature.hbs
@@ -2,7 +2,4 @@
     <h2 class="tooltip-title">{{item.name}}</h2>
     <img class="tooltip-image" src="{{item.img}}" />
     <div class="tooltip-description">{{{description}}}</div>
-
-    {{> "systems/daggerheart/templates/ui/tooltip/parts/tooltipTags.hbs" features=item.system.actions isAction=true label=(localize "DAGGERHEART.GENERAL.Action.plural") }}
-    {{> "systems/daggerheart/templates/ui/tooltip/parts/tooltipTags.hbs" features=item.effects label=(localize "DAGGERHEART.GENERAL.Effect.plural") }}
 </div>

--- a/templates/ui/tooltip/weapon.hbs
+++ b/templates/ui/tooltip/weapon.hbs
@@ -37,20 +37,4 @@
             <div>{{{damageSymbols item.system.attack.damage.parts}}}</div>
         </div>
     </div>
-
-    {{#if (gt item.system.weaponFeatures.length 0)}}<h4 class="tooltip-sub-title">{{localize "DAGGERHEART.GENERAL.features"}}</h4>{{/if}}
-    <div class="tooltip-tags">
-        {{#each item.system.weaponFeatures}}
-            {{#with (lookup ../config.ITEM.weaponFeatures this.value) as | feature | }}
-                <div class="tooltip-tag">
-                    <div class="tooltip-tag-label-container">
-                        <div class="tooltip-tag-label">{{localize feature.label}}</div>
-                    </div>
-                    <div class="tooltip-tag-description">{{{localize feature.description}}}</div>
-                </div>
-            {{/with}}
-        {{/each}}
-    </div>
-    
-    {{> "systems/daggerheart/templates/ui/tooltip/parts/tooltipTags.hbs" features=item.system.customActions isAction=true label=(localize "DAGGERHEART.GENERAL.Action.plural") }}
 </div>


### PR DESCRIPTION
- Tooltips were previously repeating information by showing actions etc, since that information is already in the Feature description.
- Also removed the golden borders. Better without here.

Before
<img width="399" height="465" alt="image" src="https://github.com/user-attachments/assets/da64ce8c-f960-4366-8395-f6972af4077d" />

After
<img width="389" height="376" alt="image" src="https://github.com/user-attachments/assets/59fd79d6-f93a-4d29-92ce-90ff3ef9bf95" />
