### PR TITLE
[Fix] CostSelection In Rollmessage

### DIFF
--- a/templates/dialogs/dice-roll/rollSelection.hbs
+++ b/templates/dialogs/dice-roll/rollSelection.hbs
@@ -136,10 +136,11 @@
                     {{#if (eq @root.rollType 'DualityRoll')}}<span class="formula-label">{{localize "DAGGERHEART.GENERAL.situationalBonus"}}</span>{{/if}}
                     <input type="text" value="{{extraFormula}}" name="extraFormula" placeholder="{{#if (eq @root.rollType 'DualityRoll')}}Ex: 1d6 + 5{{else}}Situational Bonus{{/if}}">
                 </fieldset>
-                {{#if (or costs uses)}}
-                    {{> 'systems/daggerheart/templates/dialogs/dice-roll/costSelection.hbs'}}
-                {{/if}}
             {{/unless}}
+
+            {{#if (or costs uses)}}
+                {{> 'systems/daggerheart/templates/dialogs/dice-roll/costSelection.hbs'}}
+            {{/if}}
 
             <span class="formula-label"><b>{{localize "DAGGERHEART.GENERAL.formula"}}:</b> {{@root.formula}}</span>
                 


### PR DESCRIPTION
Fixed so CostSelection is always in the RollSelection. Previously it was excluded in "lite" messages.