### PR TITLE
[Fix] Character Creation ActiveEffects

### DIFF
--- a/module/data/item/domainCard.mjs
+++ b/module/data/item/domainCard.mjs
@@ -46,12 +46,13 @@ export default class DHDomainCard extends BaseDataItem {
         if (allowed === false) return;
 
         if (this.actor?.type === 'character') {
-            if (!this.actor.system.class.value) {
+            const actorClasses = this.actor.items.filter(x => x.type === 'class');
+            if (!actorClasses.length) {
                 ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.noClassSelected'));
                 return false;
             }
 
-            if (!this.actor.system.domains.find(x => x === this.domain)) {
+            if (!actorClasses.some(c => c.system.domains.find(x => x === this.domain))) {
                 ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.lacksDomain'));
                 return false;
             }

--- a/module/documents/activeEffect.mjs
+++ b/module/documents/activeEffect.mjs
@@ -158,16 +158,19 @@ export default class DhActiveEffect extends foundry.documents.ActiveEffect {
                         x.type === 'subclass' &&
                         x.system.isMulticlass === (this.parent.system.identifier === 'multiclass')
                 );
-                const featureState = subclass.system.featureState;
-                const featureType = subclass
-                    ? (subclass.system.features.find(x => x.item?.uuid === this.parent.uuid)?.type ?? null)
-                    : null;
 
-                if (
-                    (featureType === CONFIG.DH.ITEM.featureSubTypes.specialization && featureState < 2) ||
-                    (featureType === CONFIG.DH.ITEM.featureSubTypes.mastery && featureState < 3)
-                ) {
-                    this.transfer = false;
+                if (subclass) {
+                    const featureState = subclass.system.featureState;
+                    const featureType = subclass
+                        ? (subclass.system.features.find(x => x.item?.uuid === this.parent.uuid)?.type ?? null)
+                        : null;
+
+                    if (
+                        (featureType === CONFIG.DH.ITEM.featureSubTypes.specialization && featureState < 2) ||
+                        (featureType === CONFIG.DH.ITEM.featureSubTypes.mastery && featureState < 3)
+                    ) {
+                        this.transfer = false;
+                    }
                 }
             }
         }

--- a/module/documents/chatMessage.mjs
+++ b/module/documents/chatMessage.mjs
@@ -40,6 +40,8 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
         elements.forEach(e => {
             const uuid = e.dataset.permId,
                 document = fromUuidSync(uuid);
+            if (!document) return;
+
             e.setAttribute('data-view-perm', document.testUserPermission(game.user, 'OBSERVER'));
             e.setAttribute('data-use-perm', document.testUserPermission(game.user, 'OWNER'));
         });

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -355,3 +355,17 @@ export function createScrollText(actor, optionsData) {
         });
     }
 }
+
+export async function createEmbeddedItemWithEffects(actor, baseData, update) {
+    const data = baseData.uuid.startsWith('Compendium') ? await foundry.utils.fromUuid(baseData.uuid) : baseData;
+    const [doc] = await actor.createEmbeddedDocuments('Item', [
+        {
+            ...(update ?? data),
+            id: data.id,
+            uuid: data.uuid,
+            effects: data.effects?.map(effect => effect.toObject())
+        }
+    ]);
+
+    return doc;
+}

--- a/src/packs/domains/domainCard_Untouchable_9QElncQUDSakuSdR.json
+++ b/src/packs/domains/domainCard_Untouchable_9QElncQUDSakuSdR.json
@@ -42,7 +42,7 @@
         {
           "key": "system.evasion",
           "mode": 2,
-          "value": "@system.traits.agility.value / 2",
+          "value": "ceil(@system.traits.agility.value / 2)",
           "priority": null
         }
       ],
@@ -71,7 +71,7 @@
         "systemId": "daggerheart",
         "systemVersion": "0.0.1",
         "createdTime": 1754247027320,
-        "modifiedTime": 1754247067643,
+        "modifiedTime": 1754403424797,
         "lastModifiedBy": "MQSznptE5yLT7kj8"
       },
       "_key": "!items.effects!9QElncQUDSakuSdR.H8hazlQe4Wj4JFO6"


### PR DESCRIPTION
Closes #602 
Closes #588 
- ActiveEffects were getting lost when using the CharacterCreation because of compendium data being different. Fixed.
- Fixed Untouchable card evasion not being rounded.