### PR TITLE
[Fix] Add icon to Minor Chaos Elemental's Attack (Warp Blast)

### DIFF
--- a/src/packs/adversaries/adversary_Minor_Chaos_Elemental_sRn4bqerfARvhgSV.json
+++ b/src/packs/adversaries/adversary_Minor_Chaos_Elemental_sRn4bqerfARvhgSV.json
@@ -68,6 +68,7 @@
     "description": "<p>A coruscating mass of uncontrollable magic.</p>",
     "attack": {
       "name": "Warp Blast",
+      "img": "icons/magic/light/beam-rays-magenta.webp",
       "roll": {
         "bonus": 3,
         "type": "attack"


### PR DESCRIPTION

## Description

Added path to an appropriate icon to represent the Minor Chaos Elemental's attack, Warp Blast.

Used "icons/magic/light/beam-rays-magenta.webp" as the icon is appropriate and matches that used by Chaos Skull's Energy Blast attack.

- Closes #642 

## Type of Change

Please check the relevant options:

- [x] Bug fix
- [ ] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [x] Other (please describe): Content Update

## How Has This Been Tested?

Minimal change has been minimally tested - this is a cosmetic update only.

- [x] Manual testing
- [ ] Other:

## Screenshots (if applicable)

.<img width="406" height="134" alt="image" src="https://github.com/user-attachments/assets/a623d672-95bd-4221-a9a7-9b9a63f9721d" />

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [ ] New and existing tests pass locally with my changes

## Additional Comments

n/a
