### PR TITLE
[Fix] Add various missing Attack icons to Adversaries

### DIFF
--- a/src/packs/adversaries/adversary_Conscript_99TqczuQipBmaB8i.json
+++ b/src/packs/adversaries/adversary_Conscript_99TqczuQipBmaB8i.json
@@ -60,6 +60,7 @@
     },
     "attack": {
       "name": "Spears",
+      "img": "icons/weapons/polearms/spear-flared-worn.webp",
       "range": "veryClose",
       "roll": {
         "bonus": 0,

--- a/src/packs/adversaries/adversary_Mortal_Hunter_mVV7a7KQAORoPMgZ.json
+++ b/src/packs/adversaries/adversary_Mortal_Hunter_mVV7a7KQAORoPMgZ.json
@@ -74,6 +74,7 @@
     "description": "<p>An undead figure wearing a heavy leather coat, with searching eyes and a casually cruel demeanor.</p>",
     "attack": {
       "name": "Tear at Flesh",
+      "img": "icons/skills/melee/strike-slashes-red.webp",
       "roll": {
         "bonus": 5,
         "type": "attack"

--- a/src/packs/adversaries/adversary_Spectral_Captain_65cSO3EQEh6ZH6Xk.json
+++ b/src/packs/adversaries/adversary_Spectral_Captain_65cSO3EQEh6ZH6Xk.json
@@ -74,6 +74,7 @@
     "motivesAndTactics": "Move through solid objects, rally troops, rehash old battles",
     "attack": {
       "name": "Longbow",
+      "img": "icons/weapons/bows/longbow-recurve-skull-brown.webp",
       "damage": {
         "parts": [
           {

--- a/src/packs/adversaries/adversary_Vault_Guardian_Sentinel_FVgYb28fhxlVcGwA.json
+++ b/src/packs/adversaries/adversary_Vault_Guardian_Sentinel_FVgYb28fhxlVcGwA.json
@@ -68,6 +68,7 @@
     "description": "<p>A dust-covered golden construct with boxy limbs and a huge mace for a hand.</p>",
     "attack": {
       "name": "Charged Mace",
+      "img": "icons/weapons/maces/shortmace-ornate-gold.webp",
       "range": "veryClose",
       "roll": {
         "bonus": 3,


### PR DESCRIPTION


## Description

Added missing attack icons to the following adversaries' respective attacks.

Conscript - Spears
Mortal Hunter - Tear at Flesh
Spectral Captain - Longbow
Vault Guardian Sentinel - Charged Mace

- Closes #643

## Type of Change

Please check the relevant options:

- [x] Bug fix
- [ ] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [x] Other (please describe): Content Update

## How Has This Been Tested?

Minimal testing for minimal cosmetic change only.

- [x] Manual testing
- [ ] Other:

## Screenshots (if applicable)

Conscript:
<img width="406" height="109" alt="image" src="https://github.com/user-attachments/assets/f4ee0412-9c5e-4fd6-807e-8306f00f1d2f" />

Mortal Hunter:
<img width="402" height="114" alt="image" src="https://github.com/user-attachments/assets/3e7358ce-4768-4a42-869b-d25e9e957f6e" />

Spectral Captain:
<img width="413" height="109" alt="image" src="https://github.com/user-attachments/assets/7a317eff-b2bb-4af9-9086-cd800bf16e07" />

Vault Guardian Sentinel:
<img width="405" height="104" alt="image" src="https://github.com/user-attachments/assets/a3ee8011-5afc-4319-8b4e-cf7a75a324ed" />

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [ ] New and existing tests pass locally with my changes

## Additional Comments

n/a
