### PR TITLE
[Feature] 645 - Rename Compendium Folder

### DIFF
--- a/system.json
+++ b/system.json
@@ -169,7 +169,7 @@
     ],
     "packFolders": [
         {
-            "name": "Daggerheart",
+            "name": "Daggerheart SRD",
             "sorting": "m",
             "color": "#08718c",
             "packs": ["adversaries", "environments", "journals"],


### PR DESCRIPTION
Closes #645 
Renamed main folder from Daggerheart to Daggerheart SRD.

Worth noting that the name will only be changed for newly created world, not in any existing testing worlds.