### PR TITLE
[Fix] 679 - Improved Beastform Tooltips

### DIFF
--- a/module/data/fields/action/beastformField.mjs
+++ b/module/data/fields/action/beastformField.mjs
@@ -4,7 +4,25 @@ export default class BeastformField extends fields.SchemaField {
     constructor(options = {}, context = {}) {
         const beastformFields = {
             tierAccess: new fields.SchemaField({
-                exact: new fields.NumberField({ integer: true, nullable: true, initial: null })
+                exact: new fields.NumberField({
+                    integer: true,
+                    nullable: true,
+                    initial: null,
+                    choices: () => {
+                        const settingsTiers = game.settings.get(
+                            CONFIG.DH.id,
+                            CONFIG.DH.SETTINGS.gameSettings.LevelTiers
+                        ).tiers;
+                        return Object.values(settingsTiers).reduce(
+                            (acc, tier) => {
+                                acc[tier.tier] = game.i18n.localize(tier.name);
+                                return acc;
+                            },
+                            { 1: game.i18n.localize('DAGGERHEART.GENERAL.Tiers.1') }
+                        );
+                    },
+                    hint: 'DAGGERHEART.ACTIONS.Config.beastform.exactHint'
+                })
             })
         };
         super(beastformFields, options, context);

--- a/module/data/item/beastform.mjs
+++ b/module/data/item/beastform.mjs
@@ -88,6 +88,26 @@ export default class DHBeastform extends BaseDataItem {
 
     /* -------------------------------------------- */
 
+    get beastformAttackData() {
+        const effect = this.parent.effects.find(x => x.type === 'beastform');
+        if (!effect) return null;
+
+        const traitBonus = effect.changes.find(x => x.key === `system.traits.${this.mainTrait}.value`)?.value ?? 0;
+        const evasionBonus = effect.changes.find(x => x.key === 'system.evasion')?.value ?? 0;
+
+        const damageDiceIndex = effect.changes.find(x => x.key === 'system.rules.attack.damage.diceIndex');
+        const damageDice = damageDiceIndex ? Object.keys(CONFIG.DH.GENERAL.diceTypes)[damageDiceIndex.value] : null;
+        const damageBonus = effect.changes.find(x => x.key === 'system.rules.attack.damage.bonus')?.value ?? 0;
+
+        return {
+            trait: game.i18n.localize(CONFIG.DH.ACTOR.abilities[this.mainTrait].label),
+            traitBonus: traitBonus ? Number(traitBonus).signedString() : '',
+            evasionBonus: evasionBonus ? Number(evasionBonus).signedString() : '',
+            damageDice: damageDice,
+            damageBonus: damageBonus ? `${Number(damageBonus).signedString()}` : ''
+        };
+    }
+
     async _preCreate() {
         if (!this.actor) return;
 

--- a/module/documents/tooltipManager.mjs
+++ b/module/documents/tooltipManager.mjs
@@ -161,7 +161,7 @@ export default class DhTooltipManager extends foundry.helpers.interaction.Toolti
                 for (const [index, itemValue] of pathValue.entries()) {
                     const itemIsAction = itemValue instanceof game.system.api.models.actions.actionsTypes.base;
                     const value = itemIsAction || !itemValue?.item ? itemValue : itemValue.item;
-                    const enrichedValue = await TextEditor.enrichHTML(value.description);
+                    const enrichedValue = await TextEditor.enrichHTML(value.system?.description ?? value.description);
                     if (itemIsAction) value.enrichedDescription = enrichedValue;
                     else foundry.utils.setProperty(item, `${basePath}.${index}.enrichedDescription`, enrichedValue);
                 }

--- a/styles/less/ux/tooltip/tooltip.less
+++ b/styles/less/ux/tooltip/tooltip.less
@@ -34,6 +34,10 @@
         text-align: start;
     }
 
+    .simple-info {
+        font-style: italic;
+    }
+
     .tooltip-sub-title {
         margin: 0;
         color: light-dark(@dark-blue, @beige);
@@ -44,6 +48,10 @@
         display: grid;
         grid-template-columns: 1fr 1fr;
         gap: 4px;
+
+        &.spaced {
+            margin-top: 8px;
+        }
 
         &.triple {
             grid-template-columns: 1fr 1fr 1fr;

--- a/templates/actionTypes/beastform.hbs
+++ b/templates/actionTypes/beastform.hbs
@@ -4,14 +4,6 @@
     </legend>
 
     <div class="action-category-data open">
-        <div class="hint-group">
-            <div class="form-fields">
-                <label>{{localize "DAGGERHEART.ACTIONS.Config.beastform.exact"}}</label>
-                <select name="beastform.tierAccess.exact" data-dtype="Number">
-                    {{selectOptions tierOptions selected=@root.source.beastform.tierAccess.exact  labelAttr="label" valueAttr="key" blank="" }}
-                </select>
-            </div>
-            <p class="hint">{{localize "DAGGERHEART.ACTIONS.Config.beastform.exactHint"}}</p>
-        </div>
+        {{formGroup fields.tierAccess.fields.exact value=beastform.tierAccess.exact labelAttr="label" valueAttr="key" localize=true blank=""}}
     </div>
 </fieldset>

--- a/templates/sheets-settings/action-settings/effect.hbs
+++ b/templates/sheets-settings/action-settings/effect.hbs
@@ -10,5 +10,5 @@
     {{#if fields.resource}}{{> 'systems/daggerheart/templates/actionTypes/resource.hbs' fields=fields.resource.fields source=source.resource}}{{/if}}
     {{#if fields.documentUUID}}{{> 'systems/daggerheart/templates/actionTypes/uuid.hbs' fields=fields.documentUUID source=source.documentUUID}}{{/if}}
     {{#if fields.effects}}{{> 'systems/daggerheart/templates/actionTypes/effect.hbs' fields=fields.effects.element.fields source=source.effects}}{{/if}}
-    {{#if fields.beastform}}{{> 'systems/daggerheart/templates/actionTypes/beastform.hbs' fields=fields.effects.element.fields source=source.beastform}}{{/if}}
+    {{#if fields.beastform}}{{> 'systems/daggerheart/templates/actionTypes/beastform.hbs' fields=fields.beastform.fields source=source.beastform}}{{/if}}
 </section>

--- a/templates/ui/tooltip/beastform.hbs
+++ b/templates/ui/tooltip/beastform.hbs
@@ -3,6 +3,29 @@
     <img class="tooltip-image" src="{{item.img}}" />
     <div class="tooltip-description">{{{description}}}</div>
 
+    <div class="simple-info">{{item.system.examples}}</div>
     {{> "systems/daggerheart/templates/ui/tooltip/parts/tooltipChips.hbs" chips=item.system.advantageOn label=(localize "DAGGERHEART.ITEMS.Beastform.FIELDS.advantageOn.label")}}
+
+    <div class="tooltip-information-section spaced">
+        {{#with item.system.beastformAttackData}}
+            <div class="tooltip-information">
+                <label>{{localize "Main Trait"}}</label>
+                <div>{{this.trait}}</div>
+            </div>
+            <div class="tooltip-information">
+                <label>{{localize "Trait Bonus"}}</label>
+                <div>{{this.traitBonus}}</div>
+            </div>
+            <div class="tooltip-information">
+                <label>{{localize "Evasion"}}</label>
+                <div>{{this.evasionBonus}}</div>
+            </div>
+            <div class="tooltip-information">
+                <label>{{localize "Damage"}}</label>
+                <div>{{concat this.damageDice ' ' this.damageBonus}} <i class="fa-solid fa-hand-fist"></i></div>
+            </div>
+        {{/with}}
+    </div>
+
     {{> "systems/daggerheart/templates/ui/tooltip/parts/tooltipTags.hbs" features=item.system.features label=(localize "DAGGERHEART.GENERAL.features")}}
 </div>


### PR DESCRIPTION
Improved tooltips with more data
<img width="392" height="762" alt="image" src="https://github.com/user-attachments/assets/6ee90c40-5045-49ad-bb41-5eb8bc1c3bd8" />
