### PR TITLE
[Fix] 595 - Experience Deleting Improvements

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -188,7 +188,8 @@
                 "manualMulticlassSubclass": {
                     "title": "Multiclass Subclass",
                     "text": "Do you want to add this subclass as your multiclass subclass?"
-                }
+                },
+                "cannotRemoveCoreExperience": "You are using Levelup Auto. You cannot remove an experience given to you by the rule progression."
             },
             "Companion": {
                 "FIELDS": {
@@ -2115,6 +2116,10 @@
                     "resourceScrollTexts": {
                         "label": "Show Resource Change Scrolltexts",
                         "hint": "When a character is damaged, uses armor etc, a scrolling text will briefly appear by the token to signify this."
+                    },
+                    "playerCanEditSheet": {
+                        "label": "Players Can Manually Edit Character Settings",
+                        "hint": "Players are allowed to access the manual Character Settings and change their statistics beyond the rules."
                     }
                 }
             },

--- a/module/applications/characterCreation/characterCreation.mjs
+++ b/module/applications/characterCreation/characterCreation.mjs
@@ -20,8 +20,8 @@ export default class DhCharacterCreation extends HandlebarsApplicationMixin(Appl
             class: this.character.system.class?.value ?? {},
             subclass: this.character.system.class?.subclass ?? {},
             experiences: {
-                [foundry.utils.randomID()]: { name: '', value: 2 },
-                [foundry.utils.randomID()]: { name: '', value: 2 }
+                [foundry.utils.randomID()]: { name: '', value: 2, core: true },
+                [foundry.utils.randomID()]: { name: '', value: 2, core: true }
             },
             domainCards: {
                 [foundry.utils.randomID()]: {},
@@ -588,12 +588,21 @@ export default class DhCharacterCreation extends HandlebarsApplicationMixin(Appl
             this.setup.class.system.inventory.take.filter(x => x)
         );
 
-        await this.character.update({
-            system: {
-                traits: this.setup.traits,
-                experiences: this.setup.experiences
-            }
-        });
+        await this.character.update(
+            {
+                system: {
+                    traits: this.setup.traits,
+                    experiences: {
+                        ...this.setup.experiences,
+                        ...Object.keys(this.character.system.experiences).reduce((acc, key) => {
+                            acc[`-=${key}`] = null;
+                            return acc;
+                        }, {})
+                    }
+                }
+            },
+            { overwrite: true }
+        );
 
         this.close();
     }

--- a/module/applications/levelup/characterLevelup.mjs
+++ b/module/applications/levelup/characterLevelup.mjs
@@ -289,7 +289,7 @@ export default class DhCharacterLevelUp extends LevelUpBase {
                                         const experience = Object.keys(this.actor.system.experiences).find(
                                             x => x === data
                                         );
-                                        return this.actor.system.experiences[experience]?.description ?? '';
+                                        return this.actor.system.experiences[experience]?.name ?? '';
                                     });
                                     advancement[choiceKey].push({ data: data, value: checkbox.value });
                                     break;

--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -178,6 +178,13 @@ export default class CharacterSheet extends DHBaseActorSheet {
     async _preparePartContext(partId, context, options) {
         context = await super._preparePartContext(partId, context, options);
         switch (partId) {
+            case 'header':
+                const { playerCanEditSheet, levelupAuto } = game.settings.get(
+                    CONFIG.DH.id,
+                    CONFIG.DH.SETTINGS.gameSettings.Automation
+                );
+                context.showSettings = game.user.isGM || !levelupAuto || (levelupAuto && playerCanEditSheet);
+                break;
             case 'loadout':
                 await this._prepareLoadoutContext(context, options);
                 break;
@@ -188,6 +195,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
                 await this._prepareBiographyContext(context, options);
                 break;
         }
+
         return context;
     }
 

--- a/module/applications/sheets/api/base-actor.mjs
+++ b/module/applications/sheets/api/base-actor.mjs
@@ -175,7 +175,6 @@ export default class DHBaseActorSheet extends DHApplicationMixin(ActorSheetV2) {
 
         const newValue = (action.uses.value ?? 0) + (increase ? 1 : -1);
         await action.update({ 'uses.value': Math.min(Math.max(newValue, 0), action.uses.max ?? 0) });
-        this.render();
     }
 
     /* -------------------------------------------- */

--- a/module/data/settings/Automation.mjs
+++ b/module/data/settings/Automation.mjs
@@ -45,6 +45,11 @@ export default class DhAutomation extends foundry.abstract.DataModel {
                 required: true,
                 initial: true,
                 label: 'DAGGERHEART.SETTINGS.Automation.FIELDS.resourceScrollTexts.label'
+            }),
+            playerCanEditSheet: new fields.BooleanField({
+                required: true,
+                initial: false,
+                label: 'DAGGERHEART.SETTINGS.Automation.FIELDS.playerCanEditSheet.label'
             })
         };
     }

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -202,7 +202,8 @@ export default class DhpActor extends Actor {
                     await this.update({
                         [`system.experiences.${experienceKey}`]: {
                             name: experience.name,
-                            value: experience.modifier
+                            value: experience.modifier,
+                            core: true
                         }
                     });
 
@@ -210,7 +211,8 @@ export default class DhpActor extends Actor {
                         await this.system.companion.update({
                             [`system.experiences.${experienceKey}`]: {
                                 name: '',
-                                value: experience.modifier
+                                value: experience.modifier,
+                                core: true
                             }
                         });
                     }
@@ -559,8 +561,8 @@ export default class DhpActor extends Actor {
 
         updates.forEach(
             u =>
-            (u.value =
-                u.key === 'fear' || this.system?.resources?.[u.key]?.isReversed === false ? u.value * -1 : u.value)
+                (u.value =
+                    u.key === 'fear' || this.system?.resources?.[u.key]?.isReversed === false ? u.value * -1 : u.value)
         );
 
         await this.modifyResource(updates);
@@ -606,9 +608,9 @@ export default class DhpActor extends Actor {
 
         updates.forEach(
             u =>
-            (u.value = !(u.key === 'fear' || this.system?.resources?.[u.key]?.isReversed === false)
-                ? u.value * -1
-                : u.value)
+                (u.value = !(u.key === 'fear' || this.system?.resources?.[u.key]?.isReversed === false)
+                    ? u.value * -1
+                    : u.value)
         );
 
         await this.modifyResource(updates);

--- a/styles/less/dialog/level-up/selections-container.less
+++ b/styles/less/dialog/level-up/selections-container.less
@@ -143,7 +143,8 @@
             padding: 0 12px;
         }
 
-        .levelup-trait-increases {
+        .levelup-trait-increases,
+        .levelup-experience-increases {
             width: 100%;
         }
 

--- a/styles/less/global/elements.less
+++ b/styles/less/global/elements.less
@@ -495,7 +495,6 @@
             border-radius: 6px;
 
             button {
-                padding: 6px 6px 6px 10px;
                 border-radius: 3px 0px 0px 3px;
                 color: light-dark(@dark-blue, @dark-blue);
                 white-space: nowrap;
@@ -506,7 +505,7 @@
                     color: light-dark(@dark-blue, @golden);
                 }
 
-                &:last-child {
+                &:not(:first-child) {
                     padding: 6px;
                     background: light-dark(@dark-blue-10, @golden-secondary);
                     border-radius: 0px 3px 3px 0px;

--- a/styles/less/sheets-settings/adversary-settings/experiences.less
+++ b/styles/less/sheets-settings/adversary-settings/experiences.less
@@ -26,12 +26,19 @@
                 align-items: center;
                 gap: 5px;
 
-                &.no-controls {
-                    grid-template-columns: 3fr 1fr;
-                }
+                span {
+                    display: flex;
+                    justify-content: center;
 
-                a {
-                    text-align: center;
+                    a {
+                        text-align: center;
+
+                        &.disabled {
+                            i {
+                                opacity: 0.4;
+                            }
+                        }
+                    }
                 }
             }
 

--- a/system.json
+++ b/system.json
@@ -5,7 +5,7 @@
     "version": "0.0.1",
     "compatibility": {
         "minimum": "13",
-        "verified": "13.346",
+        "verified": "13.347",
         "maximum": "13"
     },
     "authors": [

--- a/templates/settings/automation-settings.hbs
+++ b/templates/settings/automation-settings.hbs
@@ -12,6 +12,7 @@
     {{formGroup settingFields.schema.fields.hordeDamage value=settingFields._source.hordeDamage localize=true}}
     {{formGroup settingFields.schema.fields.effects.fields.rangeDependent value=settingFields._source.effects.rangeDependent localize=true}}
     {{formGroup settingFields.schema.fields.levelupAuto value=settingFields._source.levelupAuto localize=true}}
+    {{formGroup settingFields.schema.fields.playerCanEditSheet value=settingFields._source.playerCanEditSheet localize=true}}
     {{formGroup settingFields.schema.fields.damageReductionRulesDefault value=settingFields._source.damageReductionRulesDefault localize=true}}
     {{formGroup settingFields.schema.fields.resourceScrollTexts value=settingFields._source.resourceScrollTexts localize=true}}
     

--- a/templates/sheets-settings/character-settings/experiences.hbs
+++ b/templates/sheets-settings/character-settings/experiences.hbs
@@ -12,10 +12,15 @@
         <ul class="experience-list">
             {{#each document._source.system.experiences as |experience key|}}
                 <li class="experience-item">
-                    <div class="experience-inner-item {{#if @root.levelupAuto}}no-controls{{/if}}">
+                    <div class="experience-inner-item">
                         <input class="name" type="text" name="system.experiences.{{key}}.name" value="{{experience.name}}" />
                         <input class="modifier" type="text" name="system.experiences.{{key}}.value" value="{{experience.value}}" data-dtype="Number" />
-                        {{#unless @root.levelupAuto}}<a data-action="removeExperience" data-experience="{{key}}" data-tooltip="{{localize 'CONTROLS.CommonDelete'}}"><i class="fa-solid fa-trash"></i></a>{{/unless}}
+
+                        <span data-tooltip="{{#if experience.core}}{{localize 'DAGGERHEART.ACTORS.Character.cannotRemoveCoreExperience'}}{{else}}{{localize 'CONTROLS.CommonDelete'}}{{/if}}">
+                            <a data-action="removeExperience" data-experience="{{key}}" class="{{#if experience.core}}disabled{{/if}}">
+                                <i class="fa-solid fa-trash"></i>
+                            </a>
+                        </span>
                     </div>
                     <textarea name="system.experiences.{{key}}.description">{{experience.description}}</textarea>
                 </li>

--- a/templates/sheets/actors/character/header.hbs
+++ b/templates/sheets/actors/character/header.hbs
@@ -1,4 +1,4 @@
-4<header class="character-header-sheet">
+<header class="character-header-sheet">
     <line-div></line-div>
     <div class="name-row">
         <h1 class='actor-name'>
@@ -126,7 +126,9 @@
         {{/each}}
     </div>
 
-    {{#> 'systems/daggerheart/templates/sheets/global/tabs/tab-navigation.hbs'}}
-        <button type="button" data-action="openSettings" data-tooltip-text="{{localize "DAGGERHEART.UI.Tooltip.openSheetSettings"}}"><i class="fa-solid fa-wrench"></i></button>
+    {{#> 'systems/daggerheart/templates/sheets/global/tabs/tab-navigation.hbs' showSettings=showSettings }}
+        {{#if ../showSettings}}
+            <button type="button" data-action="openSettings" data-tooltip-text="{{localize "DAGGERHEART.UI.Tooltip.openSheetSettings"}}"><i class="fa-solid fa-wrench"></i></button>
+        {{/if}}
     {{/'systems/daggerheart/templates/sheets/global/tabs/tab-navigation.hbs'}}
 </header>


### PR DESCRIPTION
Closes #595 

- The Character Settings button in the sheet is now hidden unless you are GM or not using `Levelup Auto` setting.
- There is now a setting for `Players Can Manually Edit Character Settings`. If you -are- in `Levelup Auto` setting with it enabled, you can still access the button.
- Delete buttons are now visible in the Character Settings sheet when using `Levelup Auto`. You are not allowed to delete any `core` experiences, IE, your first 2 + any given by levelup.