### PR TITLE
[BUG] - domain card menu not working in loadout screen

### DIFF
--- a/templates/sheets/global/partials/domain-card-item.hbs
+++ b/templates/sheets/global/partials/domain-card-item.hbs
@@ -1,4 +1,4 @@
-<li class="card-item" data-item-uuid="{{item.uuid}}">
+<li class="card-item" data-item-uuid="{{item.uuid}}" data-type="domainCard">
     <img src="{{item.img}}" data-action="useItem" class="card-img" />
     <div class="card-label">
         <div


### PR DESCRIPTION
Fixes #594

## Type of Change

Please check the relevant options:

- [X] Bug fix
- [ ] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [X] Manual testing
- [ ] Other:

## Additional Comments

The functioning of the div menu should be reviewed so that it is visible even when the mouse is not over the card-item element but has a context menu activated.

