### PR TITLE
[Fix] 731 - FearTracker Decrease Button

### DIFF
--- a/styles/less/ui/resources/resources.less
+++ b/styles/less/ui/resources/resources.less
@@ -108,7 +108,7 @@
         box-shadow: unset;
         border-color: transparent;
         header,
-        .controls,
+        #resource-fear .controls,
         .window-resize-handle {
             opacity: 0;
         }


### PR DESCRIPTION
Closes #731 
The simple FearTrackers minus button was showing when disabled even if the element wasn't hovered. Fixed.