### PR TITLE
display only class subclasses on character creation

### DIFF
--- a/module/applications/characterCreation/characterCreation.mjs
+++ b/module/applications/characterCreation/characterCreation.mjs
@@ -511,6 +511,10 @@ export default class DhCharacterCreation extends HandlebarsApplicationMixin(Appl
                 'system.domain': { key: 'system.domain', value: this.setup.class?.system.domains ?? null }
             };
 
+        if (type === 'subclasses') {
+            presets.items = this.setup.class?.system.subclasses ?? null;
+        }
+
         return (this.itemBrowser = await new ItemBrowser({ presets }).render({ force: true }));
     }
 

--- a/module/applications/ui/itemBrowser.mjs
+++ b/module/applications/ui/itemBrowser.mjs
@@ -90,7 +90,7 @@ export class ItemBrowser extends HandlebarsApplicationMixin(ApplicationV2) {
     async _preFirstRender(context, options) {
         if(context.presets?.render?.noFolder || context.presets?.render?.lite)
             options.position.width = 600;
-        
+
         await super._preFirstRender(context, options);
     }
 
@@ -110,13 +110,13 @@ export class ItemBrowser extends HandlebarsApplicationMixin(ApplicationV2) {
         this._createSearchFilter();
         this._createFilterInputs();
         this._createDragProcess();
-        
+
         if(context.presets?.render?.lite)
             this.element.classList.add('lite');
-        
+
         if(context.presets?.render?.noFolder)
             this.element.classList.add('no-folder');
-        
+
         if(context.presets?.render?.noFilter)
             this.element.classList.add('no-filter');
 
@@ -181,6 +181,11 @@ export class ItemBrowser extends HandlebarsApplicationMixin(ApplicationV2) {
             const comp = game.packs.get(`${compendium}.${key}`);
             if (!comp) return;
             items = items.concat(await comp.getDocuments({ type__in: folderData.type }));
+        }
+
+        if (this.presets.items?.length > 0) {
+            const ids = this.presets.items.map(i => i._id);
+            items = items.filter(i => ids.includes(i._id));
         }
 
         this.items = ItemBrowser.sortBy(items, 'name');
@@ -320,7 +325,7 @@ export class ItemBrowser extends HandlebarsApplicationMixin(ApplicationV2) {
         for (const li of this.element.querySelectorAll('.item-container')) {
             const itemUUID = li.dataset.itemUuid,
                 item = this.items.find(i => i.uuid === itemUUID);
-            
+
             if(!item) continue;
 
             const matchesMenu =
@@ -335,11 +340,11 @@ export class ItemBrowser extends HandlebarsApplicationMixin(ApplicationV2) {
             li.hidden = !(search.has(item.id) && matchesMenu);
         }
     }
-    
+
     /**
      * Foundry evaluateFilter doesn't allow you to match if filter values are included into item data
-     * @param {*} obj 
-     * @param {*} filter 
+     * @param {*} obj
+     * @param {*} filter
      */
     static evaluateFilter(obj, filter) {
         let docValue = foundry.utils.getProperty(obj, filter.field);
@@ -386,7 +391,7 @@ export class ItemBrowser extends HandlebarsApplicationMixin(ApplicationV2) {
 
         target.closest(".item-list-header").querySelectorAll('[data-sort-key]').forEach(b => b.dataset.sortType = "");
         target.dataset.sortType = type;
-        
+
         const newOrder = [...itemList].reverse().sort((a, b) => {
             const aProp = a.querySelector(`[data-item-key="${key}"]`),
                 bProp = b.querySelector(`[data-item-key="${key}"]`)
@@ -396,7 +401,7 @@ export class ItemBrowser extends HandlebarsApplicationMixin(ApplicationV2) {
                 return aProp.innerText > bProp.innerText ? 1 : -1;
             }
         });
-        
+
         itemListContainer.replaceChildren(...newOrder);
     }
 


### PR DESCRIPTION
## Description

Fixes #715

This PR fixes the issue where all subclasses are displayed in the compendium browser by allowing a fixed set of items as part of the presets passed to the ItemBrowser.

## Type of Change

Please check the relevant options:

- [x] Bug fix
- [ ] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x] Manual testing
- [ ] Other:

## Screenshots (if applicable)

<img width="1138" height="422" alt="Screenshot 2025-08-10 at 11 12 38" src="https://github.com/user-attachments/assets/24ed8fb8-3692-4d4f-b120-61b2605881a9" />

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix or feature works
- [x] New and existing tests pass locally with my changes

## Additional Comments

Feel free to suggest a better way if you think adding this option for the presets in ItemBrowser is not the best option. My initial thought was to use a filter, just like some other types of items do, but subclasses do not have a reference to the class they belong to, that reference is in the class, so unless such a reference is added, filters can't be used for this specifically.

Some spaces were automatically removed by prettier.
