### PR TITLE
Partial fix for #671

### DIFF
--- a/daggerheart.mjs
+++ b/daggerheart.mjs
@@ -209,8 +209,10 @@ Hooks.on('chatMessage', (_, message) => {
         const difficulty = rollCommand.difficulty;
 
         const target = getCommandTarget({ allowNull: true });
+        const titleType = reaction ? 'DAGGERHEART.UI.Chat.dualityRoll.abilityReactionCheckTitle'
+                                   : 'DAGGERHEART.UI.Chat.dualityRoll.abilityCheckTitle';
         const title = traitValue
-            ? game.i18n.format('DAGGERHEART.UI.Chat.dualityRoll.abilityCheckTitle', {
+            ? game.i18n.format(titleType, {
                   ability: game.i18n.localize(SYSTEM.ACTOR.abilities[traitValue].label)
               })
             : game.i18n.localize('DAGGERHEART.GENERAL.duality');

--- a/lang/en.json
+++ b/lang/en.json
@@ -2265,7 +2265,8 @@
                     "title": "Domain Card"
                 },
                 "dualityRoll": {
-                    "abilityCheckTitle": "{ability} Check"
+                    "abilityCheckTitle": "{ability} Check",
+                    "abilityReactionCheckTitle": "{ability} Reaction Check"
                 },
                 "featureTitle": "Class Feature",
                 "healingRoll": {

--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -337,7 +337,7 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
         if (!actor) return;
         const title = actor.isNPC
             ? game.i18n.localize('DAGGERHEART.GENERAL.reactionRoll')
-            : game.i18n.format('DAGGERHEART.UI.Chat.dualityRoll.abilityCheckTitle', {
+            : game.i18n.format('DAGGERHEART.UI.Chat.dualityRoll.abilityReactionCheckTitle', {
                   ability: game.i18n.localize(abilities[this.save.trait]?.label)
               });
         return actor.diceRoll({

--- a/templates/ui/chat/parts/roll-part.hbs
+++ b/templates/ui/chat/parts/roll-part.hbs
@@ -6,8 +6,12 @@
                 {{#if roll.isCritical}}
                     <span>{{localize "DAGGERHEART.GENERAL.criticalShort"}}</span>
                 {{else}}
-                    {{#if roll.result}}
-                        <span>{{localize "DAGGERHEART.GENERAL.withThing" thing=roll.result.label}}</span>
+                    {{#if (eq roll.type "reaction")}}
+                        {{!-- Display no hope/fear as per rules --}}
+                    {{else}}
+                        {{#if roll.result}}
+                            <span>{{localize "DAGGERHEART.GENERAL.withThing" thing=roll.result.label}}</span>
+                        {{/if}}
                     {{/if}}
                 {{/if}}
             </span>


### PR DESCRIPTION
## Description

Partial fix for #671. This reduces the potential confusion for Reaction Roll results and matches the rules more closely. See the screenshots below for more details.

- Fixes #671 

## Type of Change

Please check the relevant options:

- [x ] Bug fix

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [ x] Manual testing

## Screenshots (if applicable)

<img width="304" height="238" alt="Screenshot_20250811_183045" src="https://github.com/user-attachments/assets/0f0f1e44-7394-4944-83f4-614eb709b355" />

**Note the "Agility Reaction Check" title, and the result has no "with Hope", as per the rules.**

<img width="294" height="227" alt="Screenshot_20250811_183251" src="https://github.com/user-attachments/assets/b5c88f72-2879-42a6-815d-66196eab5f5e" />

**Note the "Agility Reaction Check" title, and the result has no "with Fear", as per the rules.**

The above 2 images were successful rolls against the Difficulty.

<img width="295" height="223" alt="Screenshot_20250811_183429" src="https://github.com/user-attachments/assets/397631c9-733b-4a97-b8e7-95d82c05ab44" />

**A failed Agility reaction roll.**

<img width="300" height="553" alt="Screenshot_20250811_183858" src="https://github.com/user-attachments/assets/23f8328f-10a8-4527-9474-39507cd55337" />

**An Agility reaction roll that is a critical. Note that the "Critical" wording in the result remains, as per the rules, crits give extra benefits than a normal success (but no Hope, no clear a Stress).**

PROBLEM:
<img width="586" height="511" alt="Screenshot_20250811_184444" src="https://github.com/user-attachments/assets/d2c7e8d4-8f15-47b4-884f-22e131e0457a" />
<img width="308" height="205" alt="Screenshot_20250811_184513" src="https://github.com/user-attachments/assets/6d48d172-183c-4609-8550-af7f9eeb019b" />

If I do a reaction roll by clicking an attribute on a character sheet, you get the DR dialog and have to hit the reaction icon to change its mode.  However the details in the chat don't get changed properly, because (I think) the title details are built before it knows it's a reaction. I have not worked out how to fix this.


## Checklist

- [ x] My code follows the project style guidelines
- [ x] I have performed a self-review of my code
