### PR TITLE
confirm character creation if equipment not selected

### DIFF
--- a/module/applications/characterCreation/characterCreation.mjs
+++ b/module/applications/characterCreation/characterCreation.mjs
@@ -212,8 +212,8 @@ export default class DhCharacterCreation extends HandlebarsApplicationMixin(Appl
             v.active = this.tabGroups[v.group]
                 ? this.tabGroups[v.group] === v.id
                 : this.tabGroups.primary !== 'equipment'
-                  ? v.active
-                  : false;
+                    ? v.active
+                    : false;
             v.cssClass = v.active ? 'active' : '';
 
             switch (v.id) {
@@ -324,9 +324,9 @@ export default class DhCharacterCreation extends HandlebarsApplicationMixin(Appl
 
                 context.suggestedTraits = this.setup.class.system
                     ? Object.keys(this.setup.class.system.characterGuide.suggestedTraits).map(traitKey => {
-                          const trait = this.setup.class.system.characterGuide.suggestedTraits[traitKey];
-                          return `${game.i18n.localize(`DAGGERHEART.CONFIG.Traits.${traitKey}.short`)} ${trait > 0 ? `+${trait}` : trait}`;
-                      })
+                        const trait = this.setup.class.system.characterGuide.suggestedTraits[traitKey];
+                        return `${game.i18n.localize(`DAGGERHEART.CONFIG.Traits.${traitKey}.short`)} ${trait > 0 ? `+${trait}` : trait}`;
+                    })
                     : [];
                 context.traits = {
                     values: Object.keys(this.setup.traits).map(traitKey => {
@@ -571,6 +571,15 @@ export default class DhCharacterCreation extends HandlebarsApplicationMixin(Appl
     }
 
     static async finish() {
+        const isEquipmentFinished = this._getTabs(this.constructor.TABS).equipment.finished;
+        if (!isEquipmentFinished) {
+            const confirm = await foundry.applications.api.DialogV2.confirm({
+                window: { title: 'Equipment not selected' },
+                content: `<p>You have not selected equipment.</p><p>Are you sure you want to continue?</p></p>`
+            });
+            if (!confirm) return;
+        }
+
         const primaryAncestryFeature = this.setup.primaryAncestry.system.primaryFeature;
         const secondaryAncestryFeature = this.setup.secondaryAncestry?.uuid
             ? this.setup.secondaryAncestry.system.secondaryFeature


### PR DESCRIPTION
## Description

Adds a dialog prompt if user has not selected equipment at character creation.
if "yes" they continue character creation
if "no" dialog closes and user can continue character creation

- Fixes #691
- Closes #691

## Type of Change

Please check the relevant options:

- [ ] Bug fix
- [x] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [ ] Manual testing
- [ ] Other:

## Screenshots (if applicable)
<img width="923" height="572" alt="Screenshot 2025-08-11 at 17 45 27" src="https://github.com/user-attachments/assets/89f113f2-8397-447f-a34c-64feecf216c8" />


## Checklist

- [ ] My code follows the project style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [ ] New and existing tests pass locally with my changes

## Additional Comments

Add any other context or questions here.

---

> Thank you for your contribution! 🎉
