### PR TITLE
Update sidebar.less Armor Slots label padding, for translations

### DIFF
--- a/styles/less/sheets/actors/character/sidebar.less
+++ b/styles/less/sheets/actors/character/sidebar.less
@@ -239,7 +239,7 @@
                 height: 30px;
 
                 .status-label {
-                    padding: 2px 10px;
+                    padding: 2px 2px;
                     position: relative;
                     top: 30px;
                     height: 22px;


### PR DESCRIPTION
Equalizes the vertical and horizontal cutoff padding on the Armor Slots status label, to allow for more (much needed) room for the upcoming French translation (and others in the future).

Doesn't change anything for the display in English.

<img width="351" height="91" alt="image" src="https://github.com/user-attachments/assets/36b1d685-09dd-4e61-a16d-aa6f6bcf6c0a" />

<img width="368" height="85" alt="image" src="https://github.com/user-attachments/assets/7737b2dd-8e73-46d0-bd7f-5a7614b16a74" />


## How Has This Been Tested?

- [ X ] Manual testing
- [ ] Other: