### PR TITLE
[Fix] 846 Effect Item ModelData

### DIFF
--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -341,7 +341,7 @@ export const itemAbleRollParse = (value, actor, item) => {
     const model = isItemTarget ? item : actor;
 
     try {
-        return Roll.replaceFormulaData(slicedValue, model?.getRollData?.() ?? model);
+        return Roll.replaceFormulaData(slicedValue, isItemTarget || !model?.getRollData ? model : model.getRollData());
     } catch (_) {
         return '';
     }


### PR DESCRIPTION
Fixed so effects supposed to use item data use the model directly, since items have no rolldata