### PR TITLE
Change the critical damage max calculation

### DIFF
--- a/module/dice/damageRoll.mjs
+++ b/module/dice/damageRoll.mjs
@@ -137,12 +137,7 @@ export default class DamageRoll extends DHRoll {
         }
 
         if (config.isCritical && part.applyTo === CONFIG.DH.GENERAL.healingTypes.hitPoints.id) {
-            let total = 0;
-            part.roll.terms.forEach(term => {
-                if (term._faces) {
-                  total += term._faces * term._number;
-                }
-            });
+            const total = part.roll.dice.reduce((acc, term) => acc + term._faces*term._number, 0);
             if (total > 0) {
                 part.roll.terms.push(...this.formatModifier(total));
             }

--- a/module/dice/damageRoll.mjs
+++ b/module/dice/damageRoll.mjs
@@ -137,9 +137,15 @@ export default class DamageRoll extends DHRoll {
         }
 
         if (config.isCritical && part.applyTo === CONFIG.DH.GENERAL.healingTypes.hitPoints.id) {
-            const tmpRoll = Roll.fromTerms(part.roll.terms)._evaluateSync({ maximize: true }),
-                criticalBonus = tmpRoll.total - this.constructor.calculateTotalModifiers(tmpRoll);
-            part.roll.terms.push(...this.formatModifier(criticalBonus));
+            let total = 0;
+            part.roll.terms.forEach(term => {
+                if (term._faces) {
+                  total += term._faces * term._number;
+                }
+            });
+            if (total > 0) {
+                part.roll.terms.push(...this.formatModifier(total));
+            }
         }
 
         /* To Remove When Reaction System */

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "rollup": "^4.40.0"
   },
   "scripts": {
-    "start": "concurrently \"rollup -c --watch\" \"node /home/foundry/foundryvtt/resources/app/main.js --dataPath=/home/foundry/foundrydata/  --noupnp\"  \"gulp\"",
+    "start": "concurrently \"rollup -c --watch\" \"node ../../../../FoundryDev/main.js --dataPath=../../../  --noupnp\"  \"gulp\"",
     "start-test": "node ./resources/app/main.js --dataPath=./ && rollup -c --watch && gulp",
     "build": "npm run rollup && npm run gulp",
     "rollup": "rollup -c",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "rollup": "^4.40.0"
   },
   "scripts": {
-    "start": "concurrently \"rollup -c --watch\" \"node ../../../../FoundryDev/main.js --dataPath=../../../  --noupnp\"  \"gulp\"",
+    "start": "concurrently \"rollup -c --watch\" \"node /home/foundry/foundryvtt/resources/app/main.js --dataPath=/home/foundry/foundrydata/  --noupnp\"  \"gulp\"",
     "start-test": "node ./resources/app/main.js --dataPath=./ && rollup -c --watch && gulp",
     "build": "npm run rollup && npm run gulp",
     "rollup": "rollup -c",


### PR DESCRIPTION
## Description

Alternate attempt at calculating max damage portion of critical roll.

- Fixes #889
 
## Type of Change

Please check the relevant options:

- [ x] Bug fix

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [ x] Manual testing

Add any other context or questions here.

When testing this, cover the following:
* different tier characters
* abilities that add to the damage, e.g. sneak attack
* check the modifiers are correct, e.g. weapon dam is 1d8 + 1, crit should appear as 1d8 + 1 + 8 (plus other bonuses).
