### PR TITLE
[Fix] 852 - Custom Downtimes Lack Tooltip

### DIFF
--- a/module/documents/tooltipManager.mjs
+++ b/module/documents/tooltipManager.mjs
@@ -49,11 +49,11 @@ export default class DhTooltipManager extends foundry.helpers.interaction.Toolti
             const longRest = element.dataset.tooltip?.startsWith('#longRest#');
             if (shortRest || longRest) {
                 const key = element.dataset.tooltip.slice(shortRest ? 11 : 10);
-                const downtimeOptions = shortRest
-                    ? CONFIG.DH.GENERAL.defaultRestOptions.shortRest()
-                    : CONFIG.DH.GENERAL.defaultRestOptions.longRest();
 
-                const move = downtimeOptions[key];
+                const moves = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Homebrew).restMoves[
+                    element.dataset.restType
+                ].moves;
+                const move = moves[key];
                 const description = await TextEditor.enrichHTML(move.description);
                 html = await foundry.applications.handlebars.renderTemplate(
                     `systems/daggerheart/templates/ui/tooltip/downtime.hbs`,

--- a/templates/dialogs/downtime/activities.hbs
+++ b/templates/dialogs/downtime/activities.hbs
@@ -3,7 +3,7 @@
 
     <div class="activities-container">   
         {{#each moves as |move key|}}
-            <a class="activity-container" data-action="selectMove" data-category="{{../category}}" data-move="{{key}}" data-tooltip="{{concat "#" ../category "#" key}}">
+            <a class="activity-container" data-action="selectMove" data-category="{{../category}}" data-move="{{key}}" data-tooltip="{{concat "#" ../category "#" key}}" data-rest-type="{{../category}}">
                 <div class="activity-inner-container">
                     <i class="{{#if move.selected}}fa-solid{{else}}fa-regular{{/if}} fa-circle activity-marker"></i>
                     <div class="activity-select-section">


### PR DESCRIPTION
Closes #852 
Fixed so custom downtime moves will display their descriptions in the tooltip.