### PR TITLE
Stress is a isReversed resource, so need to supply different values t…

### DIFF
--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -227,13 +227,13 @@ export const registerRollDiceHooks = () => {
         if (!actor) return;
         if (config.roll.isCritical || config.roll.result.duality === 1)
             updates.push({ key: 'hope', value: 1, total: -1, enabled: true });
-        if (config.roll.isCritical) updates.push({ key: 'stress', value: -1, total: 1, enabled: true });
+        if (config.roll.isCritical) updates.push({ key: 'stress', value: 1, total: -1, enabled: true });
         if (config.roll.result.duality === -1) updates.push({ key: 'fear', value: 1, total: -1, enabled: true });
 
         if (config.rerolledRoll) {
             if (config.rerolledRoll.isCritical || config.rerolledRoll.result.duality === 1)
                 updates.push({ key: 'hope', value: -1, total: 1, enabled: true });
-            if (config.rerolledRoll.isCritical) updates.push({ key: 'stress', value: 1, total: -1, enabled: true });
+            if (config.rerolledRoll.isCritical) updates.push({ key: 'stress', value: -1, total: 1, enabled: true });
             if (config.rerolledRoll.result.duality === -1)
                 updates.push({ key: 'fear', value: -1, total: 1, enabled: true });
         }


### PR DESCRIPTION
## Description

Reversed the values supplied to clear a stress (or to restore on reroll).

- Fixes #930

## Type of Change

Please check the relevant options:

- [ x] Bug fix

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [ x] Manual testing

An example of testing: 

- Create a Rogue with Rain of Blades. 
- Mark a Stress to have > 0 stress. 
- Cast Rain of Blades until you get a Crit (you may need to add Hope). 
- See the Stress reduce.

Alternatively a similar approach with just weapon attacks also works.