### PR TITLE
Set the Variant Rules settings to GM Only

### DIFF
--- a/module/systemRegistration/settings.mjs
+++ b/module/systemRegistration/settings.mjs
@@ -86,7 +86,7 @@ const registerMenus = () => {
         hint: game.i18n.localize('DAGGERHEART.SETTINGS.Menu.variantRules.hint'),
         icon: CONFIG.DH.SETTINGS.menu.VariantRules.Icon,
         type: DhVariantRuleSettings,
-        restricted: false
+        restricted: true
     });
 };
 


### PR DESCRIPTION
## Description

Restricts the Variant Rules settings to the GM Only.

- Fixes #620

## Type of Change

Please check the relevant options:

- [ x] Bug fix

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [ x] Manual testing

Tested as GM.
Tested as Player.

## Screenshots (if applicable)
