### PR TITLE
[Fix] 924 - Damage Reduction Any

### DIFF
--- a/module/applications/dialogs/damageReductionDialog.mjs
+++ b/module/applications/dialogs/damageReductionDialog.mjs
@@ -39,7 +39,7 @@ export default class DamageReductionDialog extends HandlebarsApplicationMixin(Ap
         this.availableStressReductions = Object.keys(actor.system.rules.damageReduction.stressDamageReduction).reduce(
             (acc, key) => {
                 const dr = actor.system.rules.damageReduction.stressDamageReduction[key];
-                if (dr.enabled) {
+                if (dr.cost) {
                     if (acc === null) acc = {};
 
                     const damage = damageKeyToNumber(key);
@@ -260,7 +260,7 @@ export default class DamageReductionDialog extends HandlebarsApplicationMixin(Ap
             const reducedDamage = currentDamage !== this.damage ? getDamageLabel(currentDamage) : null;
             const currentDamageLabel = reducedDamage ?? getDamageLabel(this.damage);
 
-            if (stressReduction.from !== currentDamageLabel) return;
+            if (!stressReduction.any && stressReduction.from !== currentDamageLabel) return;
 
             stressReduction.selected = true;
             this.render();

--- a/module/data/fields/actorField.mjs
+++ b/module/data/fields/actorField.mjs
@@ -20,7 +20,6 @@ const resourceField = (max = 0, initial = 0, label, reverse = false, maxLabel) =
 
 const stressDamageReductionRule = localizationPath =>
     new fields.SchemaField({
-        enabled: new fields.BooleanField({ required: true, initial: false }),
         cost: new fields.NumberField({
             integer: true,
             label: `${localizationPath}.label`,

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -198,7 +198,7 @@ foundry.dice.terms.Die.prototype.selfCorrecting = function (modifier) {
 };
 
 export const getDamageKey = damage => {
-    return ['none', 'minor', 'major', 'severe'][damage];
+    return ['none', 'minor', 'major', 'severe', 'any'][damage];
 };
 
 export const getDamageLabel = damage => {
@@ -210,7 +210,8 @@ export const damageKeyToNumber = key => {
         none: 0,
         minor: 1,
         major: 2,
-        severe: 3
+        severe: 3,
+        any: 4
     }[key];
 };
 

--- a/src/packs/domains/domainCard_Get_Back_Up_BFWN2cObMdlk9uVz.json
+++ b/src/packs/domains/domainCard_Get_Back_Up_BFWN2cObMdlk9uVz.json
@@ -45,12 +45,6 @@
           "mode": 5,
           "value": "1",
           "priority": null
-        },
-        {
-          "key": "system.rules.damageReduction.stressDamageReduction.severe.enabled",
-          "mode": 5,
-          "value": "1",
-          "priority": null
         }
       ],
       "disabled": false,

--- a/src/packs/domains/domainCard_Shrug_It_Off_JwfhtgmmuRxg4zhI.json
+++ b/src/packs/domains/domainCard_Shrug_It_Off_JwfhtgmmuRxg4zhI.json
@@ -101,12 +101,6 @@
           "mode": 5,
           "value": "1",
           "priority": null
-        },
-        {
-          "key": "system.rules.damageReduction.stressDamageReduction.any.enabled",
-          "mode": 5,
-          "value": "1",
-          "priority": null
         }
       ],
       "disabled": false,


### PR DESCRIPTION
Fixes #924 
- Fixed damage reduction any not working
- Removed unneccessary `damageReduction.<>.enabled` flag. It's enough to just check if there is a cost available.