### PR TITLE
[Fix] Adversary Compendium Pass

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1434,11 +1434,11 @@
                 },
                 "protective": {
                     "name": "Protective",
-                    "description": "Add your character's Tier to your Armor Score",
+                    "description": "Add the item's Tier to your Armor Score",
                     "effects": {
                         "protective": {
                             "name": "Protective",
-                            "description": "Add your character's Tier to your Armor Score"
+                            "description": "Add the item's Tier to your Armor Score"
                         }
                     }
                 },

--- a/module/applications/sheets/actors/adversary.mjs
+++ b/module/applications/sheets/actors/adversary.mjs
@@ -1,3 +1,4 @@
+import { getDocFromElement } from '../../../helpers/utils.mjs';
 import DHBaseActorSheet from '../api/base-actor.mjs';
 
 /**@typedef {import('@client/applications/_types.mjs').ApplicationClickAction} ApplicationClickAction */
@@ -51,6 +52,15 @@ export default class AdversarySheet extends DHBaseActorSheet {
                 break;
         }
         return context;
+    }
+
+    /**@inheritdoc */
+    _attachPartListeners(partId, htmlElement, options) {
+        super._attachPartListeners(partId, htmlElement, options);
+
+        htmlElement.querySelectorAll('.inventory-item-resource').forEach(element => {
+            element.addEventListener('change', this.updateItemResource.bind(this));
+        });
     }
 
     /**
@@ -120,5 +130,19 @@ export default class AdversarySheet extends DHBaseActorSheet {
         };
 
         this.actor.diceRoll(config);
+    }
+
+    /* -------------------------------------------- */
+    /*  Application Listener Actions                */
+    /* -------------------------------------------- */
+
+    async updateItemResource(event) {
+        const item = await getDocFromElement(event.currentTarget);
+        if (!item) return;
+
+        const max = event.currentTarget.max ? Number(event.currentTarget.max) : null;
+        const value = max ? Math.min(Number(event.currentTarget.value), max) : event.currentTarget.value;
+        await item.update({ 'system.resource.value': value });
+        this.render();
     }
 }

--- a/src/packs/adversaries/adversary_Acid_Burrower_89yAh30vaNQOALlz.json
+++ b/src/packs/adversaries/adversary_Acid_Burrower_89yAh30vaNQOALlz.json
@@ -125,7 +125,7 @@
       "type": "attack",
       "description": "",
       "img": "icons/creatures/claws/claw-curved-jagged-yellow.webp",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/adversaries/adversary_Acid_Burrower_89yAh30vaNQOALlz.json
+++ b/src/packs/adversaries/adversary_Acid_Burrower_89yAh30vaNQOALlz.json
@@ -1,6 +1,6 @@
 {
   "name": "Acid Burrower",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -150,12 +150,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1754010222829,
-    "modifiedTime": 1754010222919,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462470,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "ownership": {
     "default": 0,
@@ -170,7 +170,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Adult_Flickerfly_G7jiltRjgvVhZewm.json
+++ b/src/packs/adversaries/adversary_Adult_Flickerfly_G7jiltRjgvVhZewm.json
@@ -104,7 +104,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Adult_Flickerfly_G7jiltRjgvVhZewm.json
+++ b/src/packs/adversaries/adversary_Adult_Flickerfly_G7jiltRjgvVhZewm.json
@@ -1,6 +1,6 @@
 {
   "name": "Adult Flickerfly",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "wTI7nZkPhKxl7Wwq",
   "system": {
@@ -112,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784219,
-    "modifiedTime": 1754236374441,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462665,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "G7jiltRjgvVhZewm",
   "sort": 3400000,
@@ -133,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Apprentice_Assassin_vNIbYQ4YSzNf0WPE.json
+++ b/src/packs/adversaries/adversary_Apprentice_Assassin_vNIbYQ4YSzNf0WPE.json
@@ -1,6 +1,6 @@
 {
   "name": "Apprentice Assassin",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -111,12 +111,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784220,
-    "modifiedTime": 1754236375474,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462932,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "vNIbYQ4YSzNf0WPE",
   "sort": 3500000,
@@ -132,7 +132,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Apprentice_Assassin_vNIbYQ4YSzNf0WPE.json
+++ b/src/packs/adversaries/adversary_Apprentice_Assassin_vNIbYQ4YSzNf0WPE.json
@@ -103,7 +103,8 @@
         ]
       },
       "img": "icons/weapons/daggers/dagger-bone-black.webp",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Arch_Necromancer_WPEOIGfclNJxWb87.json
+++ b/src/packs/adversaries/adversary_Arch_Necromancer_WPEOIGfclNJxWb87.json
@@ -115,7 +115,8 @@
         ]
       },
       "img": "icons/magic/unholy/beam-ringed-impact-purple.webp",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Arch_Necromancer_WPEOIGfclNJxWb87.json
+++ b/src/packs/adversaries/adversary_Arch_Necromancer_WPEOIGfclNJxWb87.json
@@ -1,6 +1,6 @@
 {
   "name": "Arch-Necromancer",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "7XHlANCPz18yvl5L",
   "system": {
@@ -123,12 +123,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784221,
-    "modifiedTime": 1754236374832,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462752,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "WPEOIGfclNJxWb87",
   "sort": 1200000,
@@ -144,7 +144,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Archer_Guard_JRhrrEg5UroURiAD.json
+++ b/src/packs/adversaries/adversary_Archer_Guard_JRhrrEg5UroURiAD.json
@@ -1,6 +1,6 @@
 {
   "name": "Archer Guard",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -117,12 +117,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784222,
-    "modifiedTime": 1754046151270,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462476,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "JRhrrEg5UroURiAD",
   "sort": 2900000,
@@ -138,7 +138,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Archer_Guard_JRhrrEg5UroURiAD.json
+++ b/src/packs/adversaries/adversary_Archer_Guard_JRhrrEg5UroURiAD.json
@@ -109,7 +109,8 @@
         ]
       },
       "img": "icons/weapons/bows/longbow-recurve-leather-brown.webp",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Archer_Squadron_0ts6CGd93lLqGZI5.json
+++ b/src/packs/adversaries/adversary_Archer_Squadron_0ts6CGd93lLqGZI5.json
@@ -1,6 +1,6 @@
 {
   "name": "Archer Squadron",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -112,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784223,
-    "modifiedTime": 1754236373813,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462516,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "0ts6CGd93lLqGZI5",
   "sort": 200000,
@@ -133,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Archer_Squadron_0ts6CGd93lLqGZI5.json
+++ b/src/packs/adversaries/adversary_Archer_Squadron_0ts6CGd93lLqGZI5.json
@@ -104,7 +104,8 @@
         "bonus": 0,
         "type": "attack"
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Assassin_Poisoner_h5RuhzGL17dW5FBT.json
+++ b/src/packs/adversaries/adversary_Assassin_Poisoner_h5RuhzGL17dW5FBT.json
@@ -110,7 +110,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Assassin_Poisoner_h5RuhzGL17dW5FBT.json
+++ b/src/packs/adversaries/adversary_Assassin_Poisoner_h5RuhzGL17dW5FBT.json
@@ -1,6 +1,6 @@
 {
   "name": "Assassin Poisoner",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -118,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784224,
-    "modifiedTime": 1754236375140,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462844,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "h5RuhzGL17dW5FBT",
   "sort": 2700000,
@@ -139,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Battle_Box_dgH3fW9FTYLaIDvS.json
+++ b/src/packs/adversaries/adversary_Battle_Box_dgH3fW9FTYLaIDvS.json
@@ -110,7 +110,8 @@
         ]
       },
       "range": "melee",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Battle_Box_dgH3fW9FTYLaIDvS.json
+++ b/src/packs/adversaries/adversary_Battle_Box_dgH3fW9FTYLaIDvS.json
@@ -1,6 +1,6 @@
 {
   "name": "Battle Box",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -109,7 +109,7 @@
           }
         ]
       },
-      "range": "",
+      "range": "melee",
       "type": "attack"
     }
   },
@@ -118,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784224,
-    "modifiedTime": 1754236375071,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755264708230,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "dgH3fW9FTYLaIDvS",
   "sort": 2600000,
@@ -139,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,
@@ -1146,7 +1146,7 @@
             },
             "name": "Mark Stress",
             "img": "icons/creatures/magical/construct-golem-stone-blue.webp",
-            "range": ""
+            "range": "self"
           }
         },
         "originItemType": null,
@@ -1166,12 +1166,12 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "13.347",
         "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
+        "systemVersion": "1.0.4",
         "createdTime": 1754074647690,
-        "modifiedTime": 1754142206511,
-        "lastModifiedBy": "MQSznptE5yLT7kj8"
+        "modifiedTime": 1755264742627,
+        "lastModifiedBy": "VZIeX2YDvX338Zvr"
       },
       "_key": "!actors.items!dgH3fW9FTYLaIDvS.ITzpRJr2jWK0Ksmp"
     },

--- a/src/packs/adversaries/adversary_Bear_71qKDLKO3CsrNkdy.json
+++ b/src/packs/adversaries/adversary_Bear_71qKDLKO3CsrNkdy.json
@@ -115,7 +115,8 @@
       },
       "img": "icons/creatures/claws/claw-straight-brown.webp",
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Bear_71qKDLKO3CsrNkdy.json
+++ b/src/packs/adversaries/adversary_Bear_71qKDLKO3CsrNkdy.json
@@ -1,6 +1,6 @@
 {
   "name": "Bear",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -40,11 +40,13 @@
     "experiences": {
       "5ASmWCwf7HMplPDT": {
         "name": "Ambusher",
-        "value": 3
+        "value": 3,
+        "description": ""
       },
       "rjs6ek5OZP8inYqu": {
         "name": "Keen Senses",
-        "value": 2
+        "value": 2,
+        "description": ""
       }
     },
     "bonuses": {
@@ -112,7 +114,8 @@
         ]
       },
       "img": "icons/creatures/claws/claw-straight-brown.webp",
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -120,12 +123,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784226,
-    "modifiedTime": 1754046151030,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462479,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "71qKDLKO3CsrNkdy",
   "sort": 1200000,
@@ -141,7 +144,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Bladed_Guard_B4LZcGuBAHzyVdzy.json
+++ b/src/packs/adversaries/adversary_Bladed_Guard_B4LZcGuBAHzyVdzy.json
@@ -110,7 +110,8 @@
         ]
       },
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Bladed_Guard_B4LZcGuBAHzyVdzy.json
+++ b/src/packs/adversaries/adversary_Bladed_Guard_B4LZcGuBAHzyVdzy.json
@@ -1,6 +1,6 @@
 {
   "name": "Bladed Guard",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -40,7 +40,8 @@
     "experiences": {
       "ptgh1mGd4XGIjaAO": {
         "name": "Local Knowledge",
-        "value": 3
+        "value": 3,
+        "description": ""
       }
     },
     "bonuses": {
@@ -108,7 +109,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -116,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784226,
-    "modifiedTime": 1754046151128,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462481,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "B4LZcGuBAHzyVdzy",
   "sort": 2000000,
@@ -137,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Brawny_Zombie_2UeZ0tEe7AzgSJNd.json
+++ b/src/packs/adversaries/adversary_Brawny_Zombie_2UeZ0tEe7AzgSJNd.json
@@ -1,6 +1,6 @@
 {
   "name": "Brawny Zombie",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -121,12 +121,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784231,
-    "modifiedTime": 1754046150943,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462487,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "2UeZ0tEe7AzgSJNd",
   "sort": 400000,
@@ -142,7 +142,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Brawny_Zombie_2UeZ0tEe7AzgSJNd.json
+++ b/src/packs/adversaries/adversary_Brawny_Zombie_2UeZ0tEe7AzgSJNd.json
@@ -113,7 +113,8 @@
         ]
       },
       "img": "icons/skills/melee/unarmed-punch-fist-yellow-red.webp",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Cave_Ogre_8Zkqk1jU09nKL2fy.json
+++ b/src/packs/adversaries/adversary_Cave_Ogre_8Zkqk1jU09nKL2fy.json
@@ -1,6 +1,6 @@
 {
   "name": "Cave Ogre",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -117,12 +117,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784233,
-    "modifiedTime": 1754046151057,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462491,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "8Zkqk1jU09nKL2fy",
   "sort": 1500000,
@@ -138,7 +138,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Cave_Ogre_8Zkqk1jU09nKL2fy.json
+++ b/src/packs/adversaries/adversary_Cave_Ogre_8Zkqk1jU09nKL2fy.json
@@ -109,7 +109,8 @@
       },
       "name": "Club",
       "img": "icons/weapons/clubs/club-banded-barbed-black.webp",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Chaos_Skull_jDmHqGvzg5wjgmxE.json
+++ b/src/packs/adversaries/adversary_Chaos_Skull_jDmHqGvzg5wjgmxE.json
@@ -104,7 +104,8 @@
         ]
       },
       "img": "icons/magic/light/beam-rays-magenta.webp",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Chaos_Skull_jDmHqGvzg5wjgmxE.json
+++ b/src/packs/adversaries/adversary_Chaos_Skull_jDmHqGvzg5wjgmxE.json
@@ -1,6 +1,6 @@
 {
   "name": "Chaos Skull",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -112,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784233,
-    "modifiedTime": 1754236375196,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462855,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "jDmHqGvzg5wjgmxE",
   "sort": 2800000,
@@ -133,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Conscript_99TqczuQipBmaB8i.json
+++ b/src/packs/adversaries/adversary_Conscript_99TqczuQipBmaB8i.json
@@ -1,6 +1,6 @@
 {
   "name": "Conscript",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -105,12 +105,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784234,
-    "modifiedTime": 1754236374185,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462618,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "99TqczuQipBmaB8i",
   "sort": 1200000,
@@ -126,7 +126,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Conscript_99TqczuQipBmaB8i.json
+++ b/src/packs/adversaries/adversary_Conscript_99TqczuQipBmaB8i.json
@@ -97,7 +97,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Construct_uOP5oT9QzXPlnf3p.json
+++ b/src/packs/adversaries/adversary_Construct_uOP5oT9QzXPlnf3p.json
@@ -1,6 +1,6 @@
 {
   "name": "Construct",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -103,7 +103,8 @@
       },
       "name": "Fist Slam",
       "img": "icons/skills/melee/unarmed-punch-fist-yellow-red.webp",
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -111,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784236,
-    "modifiedTime": 1754046151560,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462495,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "uOP5oT9QzXPlnf3p",
   "sort": 4900000,
@@ -132,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,
@@ -436,12 +437,12 @@
             },
             "effects": [],
             "target": {
-              "type": "any",
+              "type": "self",
               "amount": null
             },
             "name": "Mark Stress",
             "img": "icons/creatures/magical/construct-golem-stone-blue.webp",
-            "range": ""
+            "range": "self"
           }
         },
         "originItemType": null,
@@ -512,12 +513,12 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "13.347",
         "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
+        "systemVersion": "1.0.4",
         "createdTime": 1754013871234,
-        "modifiedTime": 1754143897693,
-        "lastModifiedBy": "MQSznptE5yLT7kj8"
+        "modifiedTime": 1755260161782,
+        "lastModifiedBy": "VZIeX2YDvX338Zvr"
       },
       "_key": "!actors.items!uOP5oT9QzXPlnf3p.EF6YIDjQ0liFubGA"
     },

--- a/src/packs/adversaries/adversary_Construct_uOP5oT9QzXPlnf3p.json
+++ b/src/packs/adversaries/adversary_Construct_uOP5oT9QzXPlnf3p.json
@@ -104,7 +104,8 @@
       "name": "Fist Slam",
       "img": "icons/skills/melee/unarmed-punch-fist-yellow-red.webp",
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Courtesan_ZxWaWPdzFIUPNC62.json
+++ b/src/packs/adversaries/adversary_Courtesan_ZxWaWPdzFIUPNC62.json
@@ -115,7 +115,8 @@
       },
       "img": "icons/weapons/daggers/dagger-straight-cracked.webp",
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Courtesan_ZxWaWPdzFIUPNC62.json
+++ b/src/packs/adversaries/adversary_Courtesan_ZxWaWPdzFIUPNC62.json
@@ -1,6 +1,6 @@
 {
   "name": "Courtesan",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -114,7 +114,8 @@
         ]
       },
       "img": "icons/weapons/daggers/dagger-straight-cracked.webp",
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -122,12 +123,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784237,
-    "modifiedTime": 1754236374964,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755264799637,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "ZxWaWPdzFIUPNC62",
   "sort": 2400000,
@@ -143,7 +144,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Courtier_CBBuEXAlLKFMJdjg.json
+++ b/src/packs/adversaries/adversary_Courtier_CBBuEXAlLKFMJdjg.json
@@ -110,7 +110,8 @@
       },
       "img": "icons/weapons/daggers/dagger-twin-green.webp",
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Courtier_CBBuEXAlLKFMJdjg.json
+++ b/src/packs/adversaries/adversary_Courtier_CBBuEXAlLKFMJdjg.json
@@ -1,6 +1,6 @@
 {
   "name": "Courtier",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -40,7 +40,8 @@
     "experiences": {
       "omqadwvxPY4xsd7K": {
         "name": "Socialite",
-        "value": 3
+        "value": 3,
+        "description": ""
       }
     },
     "bonuses": {
@@ -108,7 +109,8 @@
         ]
       },
       "img": "icons/weapons/daggers/dagger-twin-green.webp",
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -116,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784237,
-    "modifiedTime": 1754046151158,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462499,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "CBBuEXAlLKFMJdjg",
   "sort": 2200000,
@@ -137,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Cult_Adept_0NxCSugvKQ4W8OYZ.json
+++ b/src/packs/adversaries/adversary_Cult_Adept_0NxCSugvKQ4W8OYZ.json
@@ -1,6 +1,6 @@
 {
   "name": "Cult Adept",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -123,12 +123,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784239,
-    "modifiedTime": 1754236373793,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462512,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "0NxCSugvKQ4W8OYZ",
   "sort": 100000,
@@ -144,7 +144,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,
@@ -620,12 +620,7 @@
       "type": "feature",
       "system": {
         "description": "<p> Twice per scene, when a PC rolls a failure with Fear, clear a Stress.</p>",
-        "resource": {
-          "type": "simple",
-          "value": 0,
-          "max": "2",
-          "icon": ""
-        },
+        "resource": null,
         "actions": {
           "3tibqB97ooJesxf0": {
             "type": "healing",
@@ -637,8 +632,8 @@
             "cost": [],
             "uses": {
               "value": null,
-              "max": "",
-              "recovery": null
+              "max": "2",
+              "recovery": "scene"
             },
             "damage": {
               "parts": [
@@ -692,7 +687,7 @@
             },
             "name": "Clear Stress",
             "img": "icons/magic/unholy/silhouette-robe-evil-glow.webp",
-            "range": ""
+            "range": "self"
           }
         },
         "originItemType": null,
@@ -712,12 +707,12 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "13.347",
         "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
+        "systemVersion": "1.0.4",
         "createdTime": 1754076395683,
-        "modifiedTime": 1754142376642,
-        "lastModifiedBy": "MQSznptE5yLT7kj8"
+        "modifiedTime": 1755264866325,
+        "lastModifiedBy": "VZIeX2YDvX338Zvr"
       },
       "_key": "!actors.items!0NxCSugvKQ4W8OYZ.x6FbcrfOscb3er6P"
     }

--- a/src/packs/adversaries/adversary_Cult_Adept_0NxCSugvKQ4W8OYZ.json
+++ b/src/packs/adversaries/adversary_Cult_Adept_0NxCSugvKQ4W8OYZ.json
@@ -115,7 +115,8 @@
       },
       "range": "far",
       "img": "icons/weapons/staves/staff-ornate-purple.webp",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Cult_Fang_tyBOpLfigAhI9bU3.json
+++ b/src/packs/adversaries/adversary_Cult_Fang_tyBOpLfigAhI9bU3.json
@@ -104,7 +104,8 @@
         ]
       },
       "range": "melee",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Cult_Fang_tyBOpLfigAhI9bU3.json
+++ b/src/packs/adversaries/adversary_Cult_Fang_tyBOpLfigAhI9bU3.json
@@ -1,6 +1,6 @@
 {
   "name": "Cult Fang",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -103,7 +103,7 @@
           }
         ]
       },
-      "range": "",
+      "range": "melee",
       "type": "attack"
     }
   },
@@ -112,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784239,
-    "modifiedTime": 1754236375454,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755264898243,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "tyBOpLfigAhI9bU3",
   "sort": 3400000,
@@ -133,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Cult_Initiate_zx99sOGTXicP4SSD.json
+++ b/src/packs/adversaries/adversary_Cult_Initiate_zx99sOGTXicP4SSD.json
@@ -97,7 +97,8 @@
         ]
       },
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Cult_Initiate_zx99sOGTXicP4SSD.json
+++ b/src/packs/adversaries/adversary_Cult_Initiate_zx99sOGTXicP4SSD.json
@@ -1,6 +1,6 @@
 {
   "name": "Cult Initiate",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -96,7 +96,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -104,12 +105,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784240,
-    "modifiedTime": 1754236375538,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755264925295,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "zx99sOGTXicP4SSD",
   "sort": 3600000,
@@ -125,7 +126,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Deeproot_Defender_9x2xY9zwc3xzbXo5.json
+++ b/src/packs/adversaries/adversary_Deeproot_Defender_9x2xY9zwc3xzbXo5.json
@@ -1,6 +1,6 @@
 {
   "name": "Deeproot Defender",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -117,12 +117,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784246,
-    "modifiedTime": 1754046151094,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462506,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "9x2xY9zwc3xzbXo5",
   "sort": 1800000,
@@ -138,7 +138,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Deeproot_Defender_9x2xY9zwc3xzbXo5.json
+++ b/src/packs/adversaries/adversary_Deeproot_Defender_9x2xY9zwc3xzbXo5.json
@@ -109,7 +109,8 @@
         ]
       },
       "img": "icons/magic/nature/root-vines-grow-brown.webp",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Demon_of_Avarice_pnyjIGxxvurcWmTv.json
+++ b/src/packs/adversaries/adversary_Demon_of_Avarice_pnyjIGxxvurcWmTv.json
@@ -1,6 +1,6 @@
 {
   "name": "Demon of Avarice",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "wTI7nZkPhKxl7Wwq",
   "system": {
@@ -109,7 +109,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -117,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784247,
-    "modifiedTime": 1754236375381,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755265775161,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "pnyjIGxxvurcWmTv",
   "sort": 3400000,
@@ -138,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Demon_of_Avarice_pnyjIGxxvurcWmTv.json
+++ b/src/packs/adversaries/adversary_Demon_of_Avarice_pnyjIGxxvurcWmTv.json
@@ -110,7 +110,8 @@
         ]
       },
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Demon_of_Despair_kE4dfhqmIQpNd44e.json
+++ b/src/packs/adversaries/adversary_Demon_of_Despair_kE4dfhqmIQpNd44e.json
@@ -1,6 +1,6 @@
 {
   "name": "Demon of Despair",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "wTI7nZkPhKxl7Wwq",
   "system": {
@@ -109,7 +109,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "far"
     }
   },
   "flags": {},
@@ -117,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784248,
-    "modifiedTime": 1754236375236,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755266281854,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "kE4dfhqmIQpNd44e",
   "sort": 3400000,
@@ -138,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Demon_of_Despair_kE4dfhqmIQpNd44e.json
+++ b/src/packs/adversaries/adversary_Demon_of_Despair_kE4dfhqmIQpNd44e.json
@@ -110,7 +110,8 @@
         ]
       },
       "type": "attack",
-      "range": "far"
+      "range": "far",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Demon_of_Hubris_2VN3BftageoTTIzu.json
+++ b/src/packs/adversaries/adversary_Demon_of_Hubris_2VN3BftageoTTIzu.json
@@ -1,6 +1,6 @@
 {
   "name": "Demon of Hubris",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "wTI7nZkPhKxl7Wwq",
   "system": {
@@ -118,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784249,
-    "modifiedTime": 1754236373869,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462532,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "2VN3BftageoTTIzu",
   "sort": 3400000,
@@ -139,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Demon_of_Hubris_2VN3BftageoTTIzu.json
+++ b/src/packs/adversaries/adversary_Demon_of_Hubris_2VN3BftageoTTIzu.json
@@ -110,7 +110,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Demon_of_Jealousy_SxSOkM4bcVOFyjbo.json
+++ b/src/packs/adversaries/adversary_Demon_of_Jealousy_SxSOkM4bcVOFyjbo.json
@@ -1,6 +1,6 @@
 {
   "name": "Demon of Jealousy",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "wTI7nZkPhKxl7Wwq",
   "system": {
@@ -118,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784249,
-    "modifiedTime": 1754236374726,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462726,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "SxSOkM4bcVOFyjbo",
   "sort": 3400000,
@@ -139,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Demon_of_Jealousy_SxSOkM4bcVOFyjbo.json
+++ b/src/packs/adversaries/adversary_Demon_of_Jealousy_SxSOkM4bcVOFyjbo.json
@@ -110,7 +110,8 @@
         ]
       },
       "img": "icons/magic/symbols/rune-sigil-rough-white-teal.webp",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Demon_of_Wrath_5lphJAgzoqZI3VoG.json
+++ b/src/packs/adversaries/adversary_Demon_of_Wrath_5lphJAgzoqZI3VoG.json
@@ -1,6 +1,6 @@
 {
   "name": "Demon of Wrath",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "wTI7nZkPhKxl7Wwq",
   "system": {
@@ -118,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784252,
-    "modifiedTime": 1754236373976,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462568,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "5lphJAgzoqZI3VoG",
   "sort": 3400000,
@@ -139,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Demon_of_Wrath_5lphJAgzoqZI3VoG.json
+++ b/src/packs/adversaries/adversary_Demon_of_Wrath_5lphJAgzoqZI3VoG.json
@@ -110,7 +110,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Demonic_Hound_Pack_NoRZ1PqB8N5wcIw0.json
+++ b/src/packs/adversaries/adversary_Demonic_Hound_Pack_NoRZ1PqB8N5wcIw0.json
@@ -1,6 +1,6 @@
 {
   "name": "Demonic Hound Pack",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -109,7 +109,7 @@
         "bonus": 0,
         "type": "attack"
       },
-      "range": "",
+      "range": "melee",
       "type": "attack"
     }
   },
@@ -118,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784253,
-    "modifiedTime": 1754236374571,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755264935543,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "NoRZ1PqB8N5wcIw0",
   "sort": 1800000,
@@ -139,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Demonic_Hound_Pack_NoRZ1PqB8N5wcIw0.json
+++ b/src/packs/adversaries/adversary_Demonic_Hound_Pack_NoRZ1PqB8N5wcIw0.json
@@ -110,7 +110,8 @@
         "type": "attack"
       },
       "range": "melee",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Dire_Bat_tBWHW00epmMnkawe.json
+++ b/src/packs/adversaries/adversary_Dire_Bat_tBWHW00epmMnkawe.json
@@ -109,7 +109,8 @@
       },
       "img": "icons/creatures/claws/claw-hooked-curved.webp",
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Dire_Bat_tBWHW00epmMnkawe.json
+++ b/src/packs/adversaries/adversary_Dire_Bat_tBWHW00epmMnkawe.json
@@ -1,6 +1,6 @@
 {
   "name": "Dire Bat",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "wTI7nZkPhKxl7Wwq",
   "system": {
@@ -108,7 +108,8 @@
         ]
       },
       "img": "icons/creatures/claws/claw-hooked-curved.webp",
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -116,12 +117,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784253,
-    "modifiedTime": 1754236375442,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755266383523,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "tBWHW00epmMnkawe",
   "sort": 3400000,
@@ -137,7 +138,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,
@@ -280,12 +281,12 @@
             "compendiumSource": null,
             "duplicateSource": null,
             "exportSource": null,
-            "coreVersion": "13.346",
+            "coreVersion": "13.347",
             "systemId": "daggerheart",
             "systemVersion": "0.0.1",
             "createdTime": 1754126247394,
-            "modifiedTime": 1754126268904,
-            "lastModifiedBy": "MQSznptE5yLT7kj8"
+            "modifiedTime": 1755266380104,
+            "lastModifiedBy": "VZIeX2YDvX338Zvr"
           },
           "_key": "!actors.items.effects!tBWHW00epmMnkawe.gx22MpD8fWoi8klZ.qZfNiqw1iAIxeuYg"
         }

--- a/src/packs/adversaries/adversary_Dire_Wolf_wNzeuQLfLUMvgHlQ.json
+++ b/src/packs/adversaries/adversary_Dire_Wolf_wNzeuQLfLUMvgHlQ.json
@@ -1,6 +1,6 @@
 {
   "name": "Dire Wolf",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -40,7 +40,8 @@
     "experiences": {
       "JB2mFGRwgG2NIob8": {
         "name": "Keen Senses",
-        "value": 3
+        "value": 3,
+        "description": ""
       }
     },
     "bonuses": {
@@ -108,7 +109,8 @@
         ]
       },
       "img": "icons/creatures/claws/claw-straight-brown.webp",
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -116,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784257,
-    "modifiedTime": 1754046151583,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259591554,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "wNzeuQLfLUMvgHlQ",
   "sort": 5100000,
@@ -137,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Dire_Wolf_wNzeuQLfLUMvgHlQ.json
+++ b/src/packs/adversaries/adversary_Dire_Wolf_wNzeuQLfLUMvgHlQ.json
@@ -110,7 +110,8 @@
       },
       "img": "icons/creatures/claws/claw-straight-brown.webp",
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Dryad_wR7cFKrHvRzbzhBT.json
+++ b/src/packs/adversaries/adversary_Dryad_wR7cFKrHvRzbzhBT.json
@@ -1,6 +1,6 @@
 {
   "name": "Dryad",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "wTI7nZkPhKxl7Wwq",
   "system": {
@@ -118,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784258,
-    "modifiedTime": 1754236375484,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462937,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "wR7cFKrHvRzbzhBT",
   "sort": 3400000,
@@ -139,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,
@@ -537,7 +537,7 @@
             },
             "name": "Spend Fear",
             "img": "icons/magic/unholy/orb-hands-pink.webp",
-            "range": ""
+            "range": "self"
           }
         },
         "originItemType": null,
@@ -557,12 +557,12 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "13.347",
         "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
+        "systemVersion": "1.0.4",
         "createdTime": 1754127256705,
-        "modifiedTime": 1754127325813,
-        "lastModifiedBy": "MQSznptE5yLT7kj8"
+        "modifiedTime": 1755266428753,
+        "lastModifiedBy": "VZIeX2YDvX338Zvr"
       },
       "_key": "!actors.items!wR7cFKrHvRzbzhBT.z4JbqiHuxrWy6Cpu"
     }

--- a/src/packs/adversaries/adversary_Dryad_wR7cFKrHvRzbzhBT.json
+++ b/src/packs/adversaries/adversary_Dryad_wR7cFKrHvRzbzhBT.json
@@ -110,7 +110,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Electric_Eels_TLzY1nDw0Bu9Ud40.json
+++ b/src/packs/adversaries/adversary_Electric_Eels_TLzY1nDw0Bu9Ud40.json
@@ -1,6 +1,6 @@
 {
   "name": "Electric Eels",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -103,7 +103,7 @@
         "bonus": 0,
         "type": "attack"
       },
-      "range": "",
+      "range": "melee",
       "type": "attack"
     }
   },
@@ -112,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784258,
-    "modifiedTime": 1754236374738,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755264962798,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "TLzY1nDw0Bu9Ud40",
   "sort": 1900000,
@@ -133,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Electric_Eels_TLzY1nDw0Bu9Ud40.json
+++ b/src/packs/adversaries/adversary_Electric_Eels_TLzY1nDw0Bu9Ud40.json
@@ -104,7 +104,8 @@
         "type": "attack"
       },
       "range": "melee",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Elemental_Spark_P7h54ZePFPHpYwvB.json
+++ b/src/packs/adversaries/adversary_Elemental_Spark_P7h54ZePFPHpYwvB.json
@@ -1,6 +1,6 @@
 {
   "name": "Elemental Spark",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "wTI7nZkPhKxl7Wwq",
   "system": {
@@ -105,12 +105,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784259,
-    "modifiedTime": 1754236374651,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462705,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "P7h54ZePFPHpYwvB",
   "sort": 3400000,
@@ -126,7 +126,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Elemental_Spark_P7h54ZePFPHpYwvB.json
+++ b/src/packs/adversaries/adversary_Elemental_Spark_P7h54ZePFPHpYwvB.json
@@ -97,7 +97,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Elite_Soldier_bfhVWMBUh61b9J6n.json
+++ b/src/packs/adversaries/adversary_Elite_Soldier_bfhVWMBUh61b9J6n.json
@@ -89,7 +89,7 @@
       "systemPath": "actions",
       "type": "attack",
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/adversaries/adversary_Elite_Soldier_bfhVWMBUh61b9J6n.json
+++ b/src/packs/adversaries/adversary_Elite_Soldier_bfhVWMBUh61b9J6n.json
@@ -1,6 +1,6 @@
 {
   "name": "Elite Soldier",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -145,12 +145,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1754090776362,
-    "modifiedTime": 1754236375037,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462811,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "ownership": {
     "default": 0,
@@ -165,7 +165,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Failed_Experiment_ChwwVqowFw8hJQwT.json
+++ b/src/packs/adversaries/adversary_Failed_Experiment_ChwwVqowFw8hJQwT.json
@@ -1,6 +1,6 @@
 {
   "name": "Failed Experiment",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -109,7 +109,7 @@
         ]
       },
       "img": "icons/creatures/claws/claw-hooked-barbed.webp",
-      "range": "",
+      "range": "melee",
       "type": "attack"
     }
   },
@@ -118,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784262,
-    "modifiedTime": 1754236374339,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755265009751,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "ChwwVqowFw8hJQwT",
   "sort": 1500000,
@@ -139,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Failed_Experiment_ChwwVqowFw8hJQwT.json
+++ b/src/packs/adversaries/adversary_Failed_Experiment_ChwwVqowFw8hJQwT.json
@@ -110,7 +110,8 @@
       },
       "img": "icons/creatures/claws/claw-hooked-barbed.webp",
       "range": "melee",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Fallen_Shock_Troop_OsLG2BjaEdTZUJU9.json
+++ b/src/packs/adversaries/adversary_Fallen_Shock_Troop_OsLG2BjaEdTZUJU9.json
@@ -97,7 +97,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Fallen_Shock_Troop_OsLG2BjaEdTZUJU9.json
+++ b/src/packs/adversaries/adversary_Fallen_Shock_Troop_OsLG2BjaEdTZUJU9.json
@@ -1,6 +1,6 @@
 {
   "name": "Fallen Shock Troop",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "7XHlANCPz18yvl5L",
   "system": {
@@ -105,12 +105,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784264,
-    "modifiedTime": 1754236374634,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462703,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "OsLG2BjaEdTZUJU9",
   "sort": 900000,
@@ -126,7 +126,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Fallen_Sorcerer_PELRry1vqjBzSAlr.json
+++ b/src/packs/adversaries/adversary_Fallen_Sorcerer_PELRry1vqjBzSAlr.json
@@ -110,7 +110,8 @@
         ]
       },
       "img": "icons/weapons/staves/staff-animal-skull-bull.webp",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Fallen_Sorcerer_PELRry1vqjBzSAlr.json
+++ b/src/packs/adversaries/adversary_Fallen_Sorcerer_PELRry1vqjBzSAlr.json
@@ -1,6 +1,6 @@
 {
   "name": "Fallen Sorcerer",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "7XHlANCPz18yvl5L",
   "system": {
@@ -118,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784265,
-    "modifiedTime": 1754236374668,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462708,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "PELRry1vqjBzSAlr",
   "sort": 1000000,
@@ -139,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Fallen_Warlord__Realm_Breaker_hxZ0sgoFJubh5aj6.json
+++ b/src/packs/adversaries/adversary_Fallen_Warlord__Realm_Breaker_hxZ0sgoFJubh5aj6.json
@@ -3,7 +3,7 @@
   "name": "Fallen Warlord: Realm Breaker",
   "type": "adversary",
   "_id": "hxZ0sgoFJubh5aj6",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "system": {
     "description": "<p><em>A Fallen God, wreathed in rage and resentment, bearing millennia of experience in breaking heroes’ spirits.</em></p>",
     "resistance": {
@@ -164,7 +164,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,
@@ -740,12 +740,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753929378070,
-    "modifiedTime": 1754219468339,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462847,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_key": "!actors!hxZ0sgoFJubh5aj6"
 }

--- a/src/packs/adversaries/adversary_Fallen_Warlord__Undefeated_Champion_RXkZTwBRi4dJ3JE5.json
+++ b/src/packs/adversaries/adversary_Fallen_Warlord__Undefeated_Champion_RXkZTwBRi4dJ3JE5.json
@@ -153,7 +153,8 @@
           "bonus": 0,
           "dice": []
         }
-      }
+      },
+      "chatDisplay": false
     },
     "motivesAndTactics": "Dispatch merciless death, punish the defi ant, secure victory at any cost"
   },

--- a/src/packs/adversaries/adversary_Fallen_Warlord__Undefeated_Champion_RXkZTwBRi4dJ3JE5.json
+++ b/src/packs/adversaries/adversary_Fallen_Warlord__Undefeated_Champion_RXkZTwBRi4dJ3JE5.json
@@ -3,7 +3,7 @@
   "name": "Fallen Warlord: Undefeated Champion",
   "type": "adversary",
   "_id": "RXkZTwBRi4dJ3JE5",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "system": {
     "description": "<p><em>That which only the most feared have a chance to fear.</em></p>",
     "resistance": {
@@ -164,7 +164,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,
@@ -797,12 +797,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753929476879,
-    "modifiedTime": 1754219468339,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462720,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_key": "!actors!RXkZTwBRi4dJ3JE5"
 }

--- a/src/packs/adversaries/adversary_Giant_Beastmaster_8VZIgU12cB3cvlyH.json
+++ b/src/packs/adversaries/adversary_Giant_Beastmaster_8VZIgU12cB3cvlyH.json
@@ -110,7 +110,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Giant_Beastmaster_8VZIgU12cB3cvlyH.json
+++ b/src/packs/adversaries/adversary_Giant_Beastmaster_8VZIgU12cB3cvlyH.json
@@ -1,6 +1,6 @@
 {
   "name": "Giant Beastmaster",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -118,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784268,
-    "modifiedTime": 1754236374099,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462604,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "8VZIgU12cB3cvlyH",
   "sort": 800000,
@@ -139,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,
@@ -423,7 +423,31 @@
       "system": {
         "description": "<p>Twice per scene, summon a Bear, Dire Wolf, or similar Tier 1 animal adversary under the Beastmaster’s control. The adversary appears at Close range and is immediately spotlighted.</p>",
         "resource": null,
-        "actions": {},
+        "actions": {
+          "eSRUMqpQDPRG9leg": {
+            "type": "effect",
+            "_id": "eSRUMqpQDPRG9leg",
+            "systemPath": "actions",
+            "description": "<p>Twice per scene, summon a @UUID[Compendium.daggerheart.adversaries.Actor.71qKDLKO3CsrNkdy]{Bear}, @UUID[Compendium.daggerheart.adversaries.Actor.wNzeuQLfLUMvgHlQ]{Dire Wolf} or similar Tier 1 animal adversary under the Beastmaster’s control. The adversary appears at Close range and is immediately spotlighted.</p>",
+            "chatDisplay": true,
+            "actionType": "action",
+            "cost": [],
+            "uses": {
+              "value": null,
+              "max": "2",
+              "recovery": "scene",
+              "consumeOnSuccess": false
+            },
+            "effects": [],
+            "target": {
+              "type": "any",
+              "amount": null
+            },
+            "name": "Summon",
+            "img": "icons/creatures/mammals/ox-bull-horned-glowing-orange.webp",
+            "range": "close"
+          }
+        },
         "originItemType": null,
         "originId": null
       },
@@ -441,12 +465,12 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "13.347",
         "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
+        "systemVersion": "1.0.4",
         "createdTime": 1754078527859,
-        "modifiedTime": 1754078561245,
-        "lastModifiedBy": "MQSznptE5yLT7kj8"
+        "modifiedTime": 1755265167372,
+        "lastModifiedBy": "VZIeX2YDvX338Zvr"
       },
       "_key": "!actors.items!8VZIgU12cB3cvlyH.w1oHm0NoEavQgUzl"
     }

--- a/src/packs/adversaries/adversary_Giant_Brawler_YnObCleGjPT7yqEc.json
+++ b/src/packs/adversaries/adversary_Giant_Brawler_YnObCleGjPT7yqEc.json
@@ -110,7 +110,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Giant_Brawler_YnObCleGjPT7yqEc.json
+++ b/src/packs/adversaries/adversary_Giant_Brawler_YnObCleGjPT7yqEc.json
@@ -1,6 +1,6 @@
 {
   "name": "Giant Brawler",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -118,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784268,
-    "modifiedTime": 1754236374935,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462794,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "YnObCleGjPT7yqEc",
   "sort": 2300000,
@@ -139,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Giant_Eagle_OMQ0v6PE8s1mSU0K.json
+++ b/src/packs/adversaries/adversary_Giant_Eagle_OMQ0v6PE8s1mSU0K.json
@@ -1,10 +1,10 @@
 {
   "name": "Giant Eagle",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
-    "difficulty": 20,
+    "difficulty": 14,
     "damageThresholds": {
       "major": 8,
       "severe": 19
@@ -145,12 +145,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1754090770908,
-    "modifiedTime": 1754236374596,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755265221515,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "ownership": {
     "default": 0,
@@ -165,7 +165,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,
@@ -308,10 +308,11 @@
             "compendiumSource": null,
             "duplicateSource": null,
             "exportSource": null,
-            "coreVersion": "13.346",
+            "coreVersion": "13.347",
             "systemId": "daggerheart",
             "systemVersion": "0.0.1",
-            "lastModifiedBy": null
+            "lastModifiedBy": "VZIeX2YDvX338Zvr",
+            "modifiedTime": 1755265232810
           },
           "_key": "!actors.items.effects!OMQ0v6PE8s1mSU0K.wdNrstuoh4MFShYG.odAyKY0BSAkcO3Dd"
         }

--- a/src/packs/adversaries/adversary_Giant_Eagle_OMQ0v6PE8s1mSU0K.json
+++ b/src/packs/adversaries/adversary_Giant_Eagle_OMQ0v6PE8s1mSU0K.json
@@ -89,7 +89,7 @@
       "systemPath": "actions",
       "type": "attack",
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/adversaries/adversary_Giant_Mosquitoes_IIWV4ysJPFPnTP7W.json
+++ b/src/packs/adversaries/adversary_Giant_Mosquitoes_IIWV4ysJPFPnTP7W.json
@@ -1,6 +1,6 @@
 {
   "name": "Giant Mosquitoes",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -39,7 +39,8 @@
     "experiences": {
       "4SUFXKZh33mFvNt9": {
         "name": "Camouflage",
-        "value": 2
+        "value": 2,
+        "description": ""
       }
     },
     "bonuses": {
@@ -108,7 +109,7 @@
         "bonus": -2,
         "type": "attack"
       },
-      "range": "",
+      "range": "melee",
       "type": "attack"
     }
   },
@@ -117,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784269,
-    "modifiedTime": 1754046262389,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259619874,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "IIWV4ysJPFPnTP7W",
   "sort": 2800000,
@@ -138,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Giant_Mosquitoes_IIWV4ysJPFPnTP7W.json
+++ b/src/packs/adversaries/adversary_Giant_Mosquitoes_IIWV4ysJPFPnTP7W.json
@@ -110,7 +110,8 @@
         "type": "attack"
       },
       "range": "melee",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Giant_Rat_4PfLnaCrOcMdb4dK.json
+++ b/src/packs/adversaries/adversary_Giant_Rat_4PfLnaCrOcMdb4dK.json
@@ -103,7 +103,8 @@
         ]
       },
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Giant_Rat_4PfLnaCrOcMdb4dK.json
+++ b/src/packs/adversaries/adversary_Giant_Rat_4PfLnaCrOcMdb4dK.json
@@ -1,6 +1,6 @@
 {
   "name": "Giant Rat",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -23,7 +23,8 @@
     "experiences": {
       "G0iclPpoGwevQcTC": {
         "name": "Keen Senses",
-        "value": 3
+        "value": 3,
+        "description": ""
       }
     },
     "bonuses": {
@@ -101,7 +102,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -109,12 +111,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784270,
-    "modifiedTime": 1754236373924,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259636506,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "4PfLnaCrOcMdb4dK",
   "sort": 800000,
@@ -130,7 +132,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Giant_Recruit_5s8wSvpyC5rxY5aD.json
+++ b/src/packs/adversaries/adversary_Giant_Recruit_5s8wSvpyC5rxY5aD.json
@@ -1,6 +1,6 @@
 {
   "name": "Giant Recruit",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -105,12 +105,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784271,
-    "modifiedTime": 1754236373987,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462570,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "5s8wSvpyC5rxY5aD",
   "sort": 400000,
@@ -126,7 +126,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Giant_Recruit_5s8wSvpyC5rxY5aD.json
+++ b/src/packs/adversaries/adversary_Giant_Recruit_5s8wSvpyC5rxY5aD.json
@@ -97,7 +97,8 @@
         "bonus": 1,
         "type": "attack"
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Giant_Scorpion_fmfntuJ8mHRCAktP.json
+++ b/src/packs/adversaries/adversary_Giant_Scorpion_fmfntuJ8mHRCAktP.json
@@ -110,7 +110,8 @@
         ]
       },
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Giant_Scorpion_fmfntuJ8mHRCAktP.json
+++ b/src/packs/adversaries/adversary_Giant_Scorpion_fmfntuJ8mHRCAktP.json
@@ -1,6 +1,6 @@
 {
   "name": "Giant Scorpion",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -40,7 +40,8 @@
     "experiences": {
       "SZtO9UTincKiOlC4": {
         "name": "Camouflage",
-        "value": 2
+        "value": 2,
+        "description": ""
       }
     },
     "bonuses": {
@@ -108,7 +109,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -116,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784272,
-    "modifiedTime": 1754236375100,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259666128,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "fmfntuJ8mHRCAktP",
   "sort": 4200000,
@@ -137,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Glass_Snake_8KWVLWXFhlY2kYx0.json
+++ b/src/packs/adversaries/adversary_Glass_Snake_8KWVLWXFhlY2kYx0.json
@@ -1,6 +1,6 @@
 {
   "name": "Glass Snake",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -112,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784273,
-    "modifiedTime": 1754236374083,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462600,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "8KWVLWXFhlY2kYx0",
   "sort": 1400000,
@@ -133,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Glass_Snake_8KWVLWXFhlY2kYx0.json
+++ b/src/packs/adversaries/adversary_Glass_Snake_8KWVLWXFhlY2kYx0.json
@@ -104,7 +104,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Gorgon_8mJYMpbLTb8qIOrr.json
+++ b/src/packs/adversaries/adversary_Gorgon_8mJYMpbLTb8qIOrr.json
@@ -110,7 +110,8 @@
         ]
       },
       "img": "icons/weapons/bows/shortbow-recurve-yellow.webp",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Gorgon_8mJYMpbLTb8qIOrr.json
+++ b/src/packs/adversaries/adversary_Gorgon_8mJYMpbLTb8qIOrr.json
@@ -1,6 +1,6 @@
 {
   "name": "Gorgon",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -118,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784274,
-    "modifiedTime": 1754236374109,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462608,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "8mJYMpbLTb8qIOrr",
   "sort": 1000000,
@@ -139,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Greater_Earth_Elemental_dsfB3YhoL5SudvS2.json
+++ b/src/packs/adversaries/adversary_Greater_Earth_Elemental_dsfB3YhoL5SudvS2.json
@@ -1,6 +1,6 @@
 {
   "name": "Greater Earth Elemental",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "wTI7nZkPhKxl7Wwq",
   "system": {
@@ -112,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784275,
-    "modifiedTime": 1754236375088,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462829,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "dsfB3YhoL5SudvS2",
   "sort": 3400000,
@@ -133,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Greater_Earth_Elemental_dsfB3YhoL5SudvS2.json
+++ b/src/packs/adversaries/adversary_Greater_Earth_Elemental_dsfB3YhoL5SudvS2.json
@@ -104,7 +104,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Greater_Water_Elemental_xIICT6tEdnA7dKDV.json
+++ b/src/packs/adversaries/adversary_Greater_Water_Elemental_xIICT6tEdnA7dKDV.json
@@ -1,6 +1,6 @@
 {
   "name": "Greater Water Elemental",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "wTI7nZkPhKxl7Wwq",
   "system": {
@@ -112,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784278,
-    "modifiedTime": 1754236375512,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462945,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "xIICT6tEdnA7dKDV",
   "sort": 3400000,
@@ -133,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Greater_Water_Elemental_xIICT6tEdnA7dKDV.json
+++ b/src/packs/adversaries/adversary_Greater_Water_Elemental_xIICT6tEdnA7dKDV.json
@@ -104,7 +104,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Green_Ooze_SHXedd9zZPVfUgUa.json
+++ b/src/packs/adversaries/adversary_Green_Ooze_SHXedd9zZPVfUgUa.json
@@ -110,7 +110,8 @@
       },
       "img": "icons/creatures/slimes/slime-movement-dripping-pseudopods-green.webp",
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Green_Ooze_SHXedd9zZPVfUgUa.json
+++ b/src/packs/adversaries/adversary_Green_Ooze_SHXedd9zZPVfUgUa.json
@@ -1,6 +1,6 @@
 {
   "name": "Green Ooze",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -40,7 +40,8 @@
     "experiences": {
       "Ti0QFAMro3FpetoT": {
         "name": "Camouflage",
-        "value": 3
+        "value": 3,
+        "description": ""
       }
     },
     "bonuses": {
@@ -108,7 +109,8 @@
         ]
       },
       "img": "icons/creatures/slimes/slime-movement-dripping-pseudopods-green.webp",
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -116,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784278,
-    "modifiedTime": 1754236374705,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259726565,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "SHXedd9zZPVfUgUa",
   "sort": 3500000,
@@ -137,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Hallowed_Archer_kabueAo6BALApWqp.json
+++ b/src/packs/adversaries/adversary_Hallowed_Archer_kabueAo6BALApWqp.json
@@ -1,6 +1,6 @@
 {
   "name": "Hallowed Archer",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "7XHlANCPz18yvl5L",
   "system": {
@@ -112,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784279,
-    "modifiedTime": 1754236375250,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462863,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "kabueAo6BALApWqp",
   "sort": 1500000,
@@ -133,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Hallowed_Archer_kabueAo6BALApWqp.json
+++ b/src/packs/adversaries/adversary_Hallowed_Archer_kabueAo6BALApWqp.json
@@ -104,7 +104,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Hallowed_Soldier_VENwg7xEFcYObjmT.json
+++ b/src/packs/adversaries/adversary_Hallowed_Soldier_VENwg7xEFcYObjmT.json
@@ -1,6 +1,6 @@
 {
   "name": "Hallowed Soldier",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "7XHlANCPz18yvl5L",
   "system": {
@@ -96,7 +96,8 @@
         ]
       },
       "img": "icons/skills/melee/sword-shield-stylized-white.webp",
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -104,12 +105,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784279,
-    "modifiedTime": 1754236374772,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755266855456,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "VENwg7xEFcYObjmT",
   "sort": 1100000,
@@ -125,7 +126,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Hallowed_Soldier_VENwg7xEFcYObjmT.json
+++ b/src/packs/adversaries/adversary_Hallowed_Soldier_VENwg7xEFcYObjmT.json
@@ -97,7 +97,8 @@
       },
       "img": "icons/skills/melee/sword-shield-stylized-white.webp",
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Harrier_uRtghKE9mHlII4rs.json
+++ b/src/packs/adversaries/adversary_Harrier_uRtghKE9mHlII4rs.json
@@ -1,6 +1,6 @@
 {
   "name": "Harrier",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -117,12 +117,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784281,
-    "modifiedTime": 1754236375463,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462930,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "uRtghKE9mHlII4rs",
   "sort": 5000000,
@@ -138,7 +138,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Harrier_uRtghKE9mHlII4rs.json
+++ b/src/packs/adversaries/adversary_Harrier_uRtghKE9mHlII4rs.json
@@ -109,7 +109,8 @@
         ]
       },
       "img": "icons/weapons/polearms/spear-hooked-rounded.webp",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Head_Guard_mK3A5FTx6k8iPU3F.json
+++ b/src/packs/adversaries/adversary_Head_Guard_mK3A5FTx6k8iPU3F.json
@@ -1,6 +1,6 @@
 {
   "name": "Head Guard",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -40,11 +40,13 @@
     "experiences": {
       "3B8vav5pEdBrxWXw": {
         "name": "Commander",
-        "value": 2
+        "value": 2,
+        "description": ""
       },
       "DxLwVt9XFIUUhCAo": {
         "name": "Local Knowledge",
-        "value": 2
+        "value": 2,
+        "description": ""
       }
     },
     "bonuses": {
@@ -112,7 +114,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -120,12 +123,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784282,
-    "modifiedTime": 1754236375275,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259874457,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "mK3A5FTx6k8iPU3F",
   "sort": 4600000,
@@ -141,7 +144,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Head_Guard_mK3A5FTx6k8iPU3F.json
+++ b/src/packs/adversaries/adversary_Head_Guard_mK3A5FTx6k8iPU3F.json
@@ -115,7 +115,8 @@
         ]
       },
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Head_Vampire_i2UNbRvgyoSs07M6.json
+++ b/src/packs/adversaries/adversary_Head_Vampire_i2UNbRvgyoSs07M6.json
@@ -1,6 +1,6 @@
 {
   "name": "Head Vampire",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "wTI7nZkPhKxl7Wwq",
   "system": {
@@ -109,7 +109,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -117,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784283,
-    "modifiedTime": 1754236375168,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755266472641,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "i2UNbRvgyoSs07M6",
   "sort": 3400000,
@@ -138,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,
@@ -443,7 +444,7 @@
               "includeBase": false
             },
             "target": {
-              "type": "any",
+              "type": "self",
               "amount": null
             },
             "effects": [],
@@ -464,7 +465,7 @@
             },
             "name": "Clear HP",
             "img": "icons/creatures/abilities/fang-tooth-blood-red.webp",
-            "range": "melee"
+            "range": "self"
           }
         },
         "originItemType": null,
@@ -484,12 +485,12 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "13.347",
         "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
+        "systemVersion": "1.0.4",
         "createdTime": 1754128497673,
-        "modifiedTime": 1754128552831,
-        "lastModifiedBy": "MQSznptE5yLT7kj8"
+        "modifiedTime": 1755266523384,
+        "lastModifiedBy": "VZIeX2YDvX338Zvr"
       },
       "_key": "!actors.items!i2UNbRvgyoSs07M6.Oj6qkLG1N6uqQHcx"
     },

--- a/src/packs/adversaries/adversary_Head_Vampire_i2UNbRvgyoSs07M6.json
+++ b/src/packs/adversaries/adversary_Head_Vampire_i2UNbRvgyoSs07M6.json
@@ -110,7 +110,8 @@
         ]
       },
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_High_Seraph_r1mbfSSwKWdcFdAU.json
+++ b/src/packs/adversaries/adversary_High_Seraph_r1mbfSSwKWdcFdAU.json
@@ -1,6 +1,6 @@
 {
   "name": "High Seraph",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "7XHlANCPz18yvl5L",
   "system": {
@@ -118,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784283,
-    "modifiedTime": 1754236375397,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462909,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "r1mbfSSwKWdcFdAU",
   "sort": 1800000,
@@ -139,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_High_Seraph_r1mbfSSwKWdcFdAU.json
+++ b/src/packs/adversaries/adversary_High_Seraph_r1mbfSSwKWdcFdAU.json
@@ -110,7 +110,8 @@
         ]
       },
       "img": "icons/skills/melee/strike-blade-hooked-orange-blue.webp",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Huge_Green_Ooze_6hbqmxDXFOzZJDk4.json
+++ b/src/packs/adversaries/adversary_Huge_Green_Ooze_6hbqmxDXFOzZJDk4.json
@@ -1,6 +1,6 @@
 {
   "name": "Huge Green Ooze",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "wTI7nZkPhKxl7Wwq",
   "system": {
@@ -109,7 +109,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -117,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784284,
-    "modifiedTime": 1754236374016,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755266545039,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "6hbqmxDXFOzZJDk4",
   "sort": 3400000,
@@ -138,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Huge_Green_Ooze_6hbqmxDXFOzZJDk4.json
+++ b/src/packs/adversaries/adversary_Huge_Green_Ooze_6hbqmxDXFOzZJDk4.json
@@ -110,7 +110,8 @@
         ]
       },
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Hydra_MI126iMOOobQ1Obn.json
+++ b/src/packs/adversaries/adversary_Hydra_MI126iMOOobQ1Obn.json
@@ -104,7 +104,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Hydra_MI126iMOOobQ1Obn.json
+++ b/src/packs/adversaries/adversary_Hydra_MI126iMOOobQ1Obn.json
@@ -1,6 +1,6 @@
 {
   "name": "Hydra",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "wTI7nZkPhKxl7Wwq",
   "system": {
@@ -112,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784285,
-    "modifiedTime": 1754236374476,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462679,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "MI126iMOOobQ1Obn",
   "sort": 3400000,
@@ -133,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,
@@ -372,7 +372,7 @@
             },
             "name": "Spend Fear",
             "img": "icons/magic/life/cross-beam-green.webp",
-            "range": ""
+            "range": "self"
           }
         },
         "originItemType": null,
@@ -392,12 +392,12 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "13.347",
         "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
+        "systemVersion": "1.0.4",
         "createdTime": 1754129581504,
-        "modifiedTime": 1754129633128,
-        "lastModifiedBy": "MQSznptE5yLT7kj8"
+        "modifiedTime": 1755266587320,
+        "lastModifiedBy": "VZIeX2YDvX338Zvr"
       },
       "_key": "!actors.items!MI126iMOOobQ1Obn.b2KflqWoOxHMQf97"
     },

--- a/src/packs/adversaries/adversary_Jagged_Knife_Bandit_5Lh1T0zaT8Pkr2U2.json
+++ b/src/packs/adversaries/adversary_Jagged_Knife_Bandit_5Lh1T0zaT8Pkr2U2.json
@@ -110,7 +110,8 @@
       },
       "img": "icons/weapons/daggers/dagger-twin-green.webp",
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Jagged_Knife_Bandit_5Lh1T0zaT8Pkr2U2.json
+++ b/src/packs/adversaries/adversary_Jagged_Knife_Bandit_5Lh1T0zaT8Pkr2U2.json
@@ -1,6 +1,6 @@
 {
   "name": "Jagged Knife Bandit",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -39,7 +39,8 @@
     "experiences": {
       "ASrtgt4pTDvoXehG": {
         "name": "Thief",
-        "value": 2
+        "value": 2,
+        "description": ""
       }
     },
     "bonuses": {
@@ -108,7 +109,8 @@
         ]
       },
       "img": "icons/weapons/daggers/dagger-twin-green.webp",
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -116,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784290,
-    "modifiedTime": 1754236373947,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259904640,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "5Lh1T0zaT8Pkr2U2",
   "sort": 900000,
@@ -137,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Jagged_Knife_Hexer_MbBPIOxaxXYNApXz.json
+++ b/src/packs/adversaries/adversary_Jagged_Knife_Hexer_MbBPIOxaxXYNApXz.json
@@ -1,6 +1,6 @@
 {
   "name": "Jagged Knife Hexer",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -117,12 +117,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784291,
-    "modifiedTime": 1754236374521,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462688,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "MbBPIOxaxXYNApXz",
   "sort": 3000000,
@@ -138,7 +138,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Jagged_Knife_Hexer_MbBPIOxaxXYNApXz.json
+++ b/src/packs/adversaries/adversary_Jagged_Knife_Hexer_MbBPIOxaxXYNApXz.json
@@ -109,7 +109,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Jagged_Knife_Kneebreaker_CBKixLH3yhivZZuL.json
+++ b/src/packs/adversaries/adversary_Jagged_Knife_Kneebreaker_CBKixLH3yhivZZuL.json
@@ -115,7 +115,8 @@
         ]
       },
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Jagged_Knife_Kneebreaker_CBKixLH3yhivZZuL.json
+++ b/src/packs/adversaries/adversary_Jagged_Knife_Kneebreaker_CBKixLH3yhivZZuL.json
@@ -1,6 +1,6 @@
 {
   "name": "Jagged Knife Kneebreaker",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -40,11 +40,13 @@
     "experiences": {
       "VMCCn7A9eLU1PMz7": {
         "name": "Thief",
-        "value": 2
+        "value": 2,
+        "description": ""
       },
       "HXPw1dnHO0ckLOBS": {
         "name": "Unveiled Threats",
-        "value": 3
+        "value": 3,
+        "description": ""
       }
     },
     "bonuses": {
@@ -112,7 +114,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -120,12 +123,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784292,
-    "modifiedTime": 1754236374304,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259941370,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "CBKixLH3yhivZZuL",
   "sort": 2300000,
@@ -141,7 +144,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Jagged_Knife_Lackey_C0OMQqV7pN6t7ouR.json
+++ b/src/packs/adversaries/adversary_Jagged_Knife_Lackey_C0OMQqV7pN6t7ouR.json
@@ -95,7 +95,8 @@
         ]
       },
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     },
     "resources": {
       "hitPoints": {

--- a/src/packs/adversaries/adversary_Jagged_Knife_Lackey_C0OMQqV7pN6t7ouR.json
+++ b/src/packs/adversaries/adversary_Jagged_Knife_Lackey_C0OMQqV7pN6t7ouR.json
@@ -1,6 +1,6 @@
 {
   "name": "Jagged Knife Lackey",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -23,7 +23,8 @@
     "experiences": {
       "tNLKSFvNBTfjwujs": {
         "name": "Thief",
-        "value": 2
+        "value": 2,
+        "description": ""
       }
     },
     "bonuses": {
@@ -93,7 +94,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     },
     "resources": {
       "hitPoints": {
@@ -109,12 +111,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784293,
-    "modifiedTime": 1754236374283,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259961931,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "C0OMQqV7pN6t7ouR",
   "sort": 2100000,
@@ -130,7 +132,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Jagged_Knife_Lieutenant_aTljstqteGoLpCBq.json
+++ b/src/packs/adversaries/adversary_Jagged_Knife_Lieutenant_aTljstqteGoLpCBq.json
@@ -1,6 +1,6 @@
 {
   "name": "Jagged Knife Lieutenant",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -117,12 +117,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784294,
-    "modifiedTime": 1754236375013,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462803,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "aTljstqteGoLpCBq",
   "sort": 4000000,
@@ -138,7 +138,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Jagged_Knife_Lieutenant_aTljstqteGoLpCBq.json
+++ b/src/packs/adversaries/adversary_Jagged_Knife_Lieutenant_aTljstqteGoLpCBq.json
@@ -109,7 +109,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Jagged_Knife_Shadow_XF4tYTq9nPJAy2ox.json
+++ b/src/packs/adversaries/adversary_Jagged_Knife_Shadow_XF4tYTq9nPJAy2ox.json
@@ -1,6 +1,6 @@
 {
   "name": "Jagged Knife Shadow",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -40,7 +40,8 @@
     "experiences": {
       "ZUMG6p8iB73HY73o": {
         "name": "Intrusion",
-        "value": 3
+        "value": 3,
+        "description": ""
       }
     },
     "bonuses": {
@@ -108,7 +109,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -116,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784295,
-    "modifiedTime": 1754236374879,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755260040062,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "XF4tYTq9nPJAy2ox",
   "sort": 3700000,
@@ -137,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,
@@ -341,7 +343,36 @@
       "system": {
         "description": "<p>Become <em>Hidden</em> until after the Shadow’s next attack. Attacks made while Hidden from this feature have advantage.</p>",
         "resource": null,
-        "actions": {},
+        "actions": {
+          "s0X44RPg5hA8lVax": {
+            "type": "effect",
+            "_id": "s0X44RPg5hA8lVax",
+            "systemPath": "actions",
+            "description": "<p>Become <em>Hidden</em> until after the Shadow’s next attack. Attacks made while Hidden from this feature have advantage.</p>",
+            "chatDisplay": true,
+            "actionType": "action",
+            "cost": [],
+            "uses": {
+              "value": null,
+              "max": "",
+              "recovery": null,
+              "consumeOnSuccess": false
+            },
+            "effects": [
+              {
+                "_id": "w5VTwlHmUjl8XCQ4",
+                "onSave": false
+              }
+            ],
+            "target": {
+              "type": "self",
+              "amount": null
+            },
+            "name": "Use",
+            "img": "icons/magic/perception/silhouette-stealth-shadow.webp",
+            "range": "self"
+          }
+        },
         "originItemType": null,
         "subType": null,
         "originId": null
@@ -349,9 +380,11 @@
       "effects": [
         {
           "name": "Cloaked",
-          "type": "base",
-          "_id": "9fZkdsHfyTskJk7r",
           "img": "icons/magic/perception/silhouette-stealth-shadow.webp",
+          "origin": "Compendium.daggerheart.adversaries.Actor.XF4tYTq9nPJAy2ox.Item.ILIogeKbYioPutRw",
+          "transfer": false,
+          "_id": "w5VTwlHmUjl8XCQ4",
+          "type": "base",
           "system": {
             "rangeDependence": {
               "enabled": false,
@@ -360,8 +393,15 @@
               "range": "melee"
             }
           },
-          "changes": [],
-          "disabled": true,
+          "changes": [
+            {
+              "key": "system.advantageSources",
+              "mode": 2,
+              "value": "Attacks made while Hidden",
+              "priority": null
+            }
+          ],
+          "disabled": false,
           "duration": {
             "startTime": null,
             "combat": null,
@@ -372,9 +412,7 @@
             "startTurn": null
           },
           "description": "<p>Become <em>Hidden</em> until after the Shadow’s next attack. Attacks made while Hidden from this feature have advantage.</p>",
-          "origin": null,
           "tint": "#ffffff",
-          "transfer": true,
           "statuses": [
             "hidden"
           ],
@@ -384,14 +422,14 @@
             "compendiumSource": null,
             "duplicateSource": null,
             "exportSource": null,
-            "coreVersion": "13.346",
+            "coreVersion": "13.347",
             "systemId": "daggerheart",
-            "systemVersion": "0.0.1",
-            "createdTime": 1754049344935,
-            "modifiedTime": 1754049371699,
-            "lastModifiedBy": "MQSznptE5yLT7kj8"
+            "systemVersion": "1.0.4",
+            "createdTime": 1755263044332,
+            "modifiedTime": 1755263071114,
+            "lastModifiedBy": "VZIeX2YDvX338Zvr"
           },
-          "_key": "!actors.items.effects!XF4tYTq9nPJAy2ox.ILIogeKbYioPutRw.9fZkdsHfyTskJk7r"
+          "_key": "!actors.items.effects!XF4tYTq9nPJAy2ox.ILIogeKbYioPutRw.w5VTwlHmUjl8XCQ4"
         }
       ],
       "folder": null,
@@ -405,12 +443,12 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "13.347",
         "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
+        "systemVersion": "1.0.4",
         "createdTime": 1754049306353,
-        "modifiedTime": 1754049333765,
-        "lastModifiedBy": "MQSznptE5yLT7kj8"
+        "modifiedTime": 1755263044345,
+        "lastModifiedBy": "VZIeX2YDvX338Zvr"
       },
       "_key": "!actors.items!XF4tYTq9nPJAy2ox.ILIogeKbYioPutRw"
     }

--- a/src/packs/adversaries/adversary_Jagged_Knife_Shadow_XF4tYTq9nPJAy2ox.json
+++ b/src/packs/adversaries/adversary_Jagged_Knife_Shadow_XF4tYTq9nPJAy2ox.json
@@ -110,7 +110,8 @@
         ]
       },
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Jagged_Knife_Sniper_1zuyof1XuIfi3aMG.json
+++ b/src/packs/adversaries/adversary_Jagged_Knife_Sniper_1zuyof1XuIfi3aMG.json
@@ -1,6 +1,6 @@
 {
   "name": "Jagged Knife Sniper",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -117,12 +117,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784296,
-    "modifiedTime": 1754236373855,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462527,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "1zuyof1XuIfi3aMG",
   "sort": 300000,
@@ -138,7 +138,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Jagged_Knife_Sniper_1zuyof1XuIfi3aMG.json
+++ b/src/packs/adversaries/adversary_Jagged_Knife_Sniper_1zuyof1XuIfi3aMG.json
@@ -109,7 +109,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Juvenile_Flickerfly_MYXmTx2FHcIjdfYZ.json
+++ b/src/packs/adversaries/adversary_Juvenile_Flickerfly_MYXmTx2FHcIjdfYZ.json
@@ -1,6 +1,6 @@
 {
   "name": "Juvenile Flickerfly",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -112,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784297,
-    "modifiedTime": 1754236374492,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462684,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "MYXmTx2FHcIjdfYZ",
   "sort": 1700000,
@@ -133,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Juvenile_Flickerfly_MYXmTx2FHcIjdfYZ.json
+++ b/src/packs/adversaries/adversary_Juvenile_Flickerfly_MYXmTx2FHcIjdfYZ.json
@@ -104,7 +104,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Knight_of_the_Realm_7ai2opemrclQe3VF.json
+++ b/src/packs/adversaries/adversary_Knight_of_the_Realm_7ai2opemrclQe3VF.json
@@ -1,10 +1,10 @@
 {
   "name": "Knight of the Realm",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
-    "difficulty": 17,
+    "difficulty": 15,
     "damageThresholds": {
       "major": 13,
       "severe": 26
@@ -119,7 +119,7 @@
           }
         ]
       },
-      "range": "",
+      "range": "melee",
       "type": "attack"
     }
   },
@@ -128,12 +128,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784302,
-    "modifiedTime": 1754236374063,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755265352331,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "7ai2opemrclQe3VF",
   "sort": 700000,
@@ -149,7 +149,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,
@@ -292,12 +292,12 @@
             "compendiumSource": null,
             "duplicateSource": null,
             "exportSource": null,
-            "coreVersion": "13.346",
+            "coreVersion": "13.347",
             "systemId": "daggerheart",
             "systemVersion": "0.0.1",
             "createdTime": 1754080622148,
-            "modifiedTime": 1754080649583,
-            "lastModifiedBy": "MQSznptE5yLT7kj8"
+            "modifiedTime": 1755265361100,
+            "lastModifiedBy": "VZIeX2YDvX338Zvr"
           },
           "_key": "!actors.items.effects!7ai2opemrclQe3VF.5ag5tOemPJToOoUq.w8wLcSsTiTU3mS7e"
         }

--- a/src/packs/adversaries/adversary_Knight_of_the_Realm_7ai2opemrclQe3VF.json
+++ b/src/packs/adversaries/adversary_Knight_of_the_Realm_7ai2opemrclQe3VF.json
@@ -120,7 +120,8 @@
         ]
       },
       "range": "melee",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Kraken_4nqv3ZwJGjnmic8j.json
+++ b/src/packs/adversaries/adversary_Kraken_4nqv3ZwJGjnmic8j.json
@@ -110,7 +110,8 @@
         ]
       },
       "img": "icons/creatures/tentacles/tentacles-octopus-black-pink.webp",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Kraken_4nqv3ZwJGjnmic8j.json
+++ b/src/packs/adversaries/adversary_Kraken_4nqv3ZwJGjnmic8j.json
@@ -1,6 +1,6 @@
 {
   "name": "Kraken",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "7XHlANCPz18yvl5L",
   "system": {
@@ -118,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784303,
-    "modifiedTime": 1754236373932,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462553,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "4nqv3ZwJGjnmic8j",
   "sort": 600000,
@@ -139,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Masked_Thief_niBpVU7yeo5ccskE.json
+++ b/src/packs/adversaries/adversary_Masked_Thief_niBpVU7yeo5ccskE.json
@@ -110,7 +110,8 @@
         ]
       },
       "range": "melee",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Masked_Thief_niBpVU7yeo5ccskE.json
+++ b/src/packs/adversaries/adversary_Masked_Thief_niBpVU7yeo5ccskE.json
@@ -1,6 +1,6 @@
 {
   "name": "Masked Thief",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -109,7 +109,7 @@
           }
         ]
       },
-      "range": "",
+      "range": "melee",
       "type": "attack"
     }
   },
@@ -118,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784304,
-    "modifiedTime": 1754236375343,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755265377045,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "niBpVU7yeo5ccskE",
   "sort": 3000000,
@@ -139,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Master_Assassin_dNta0cUzr96xcFhf.json
+++ b/src/packs/adversaries/adversary_Master_Assassin_dNta0cUzr96xcFhf.json
@@ -115,7 +115,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Master_Assassin_dNta0cUzr96xcFhf.json
+++ b/src/packs/adversaries/adversary_Master_Assassin_dNta0cUzr96xcFhf.json
@@ -1,6 +1,6 @@
 {
   "name": "Master Assassin",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -123,12 +123,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784305,
-    "modifiedTime": 1754236375063,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462821,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "dNta0cUzr96xcFhf",
   "sort": 2500000,
@@ -144,7 +144,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Merchant_Al3w2CgjfdT3p9ma.json
+++ b/src/packs/adversaries/adversary_Merchant_Al3w2CgjfdT3p9ma.json
@@ -110,7 +110,8 @@
       },
       "img": "icons/weapons/clubs/club-baton-blue.webp",
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Merchant_Al3w2CgjfdT3p9ma.json
+++ b/src/packs/adversaries/adversary_Merchant_Al3w2CgjfdT3p9ma.json
@@ -1,6 +1,6 @@
 {
   "name": "Merchant",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -40,7 +40,8 @@
     "experiences": {
       "5cbm0DMiWxo6300c": {
         "name": "Shrewd Negotiator",
-        "value": 3
+        "value": 3,
+        "description": ""
       }
     },
     "bonuses": {
@@ -108,7 +109,8 @@
         ]
       },
       "img": "icons/weapons/clubs/club-baton-blue.webp",
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -116,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784305,
-    "modifiedTime": 1754236374230,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755263103972,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "Al3w2CgjfdT3p9ma",
   "sort": 1900000,
@@ -137,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Merchant_Baron_Vy02IhGhkJLuezu4.json
+++ b/src/packs/adversaries/adversary_Merchant_Baron_Vy02IhGhkJLuezu4.json
@@ -115,7 +115,8 @@
         ]
       },
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Merchant_Baron_Vy02IhGhkJLuezu4.json
+++ b/src/packs/adversaries/adversary_Merchant_Baron_Vy02IhGhkJLuezu4.json
@@ -1,6 +1,6 @@
 {
   "name": "Merchant Baron",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -114,7 +114,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -122,12 +123,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784306,
-    "modifiedTime": 1754236374821,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755265400782,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "Vy02IhGhkJLuezu4",
   "sort": 2100000,
@@ -143,7 +144,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Minor_Chaos_Elemental_sRn4bqerfARvhgSV.json
+++ b/src/packs/adversaries/adversary_Minor_Chaos_Elemental_sRn4bqerfARvhgSV.json
@@ -104,7 +104,8 @@
         ]
       },
       "range": "close",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Minor_Chaos_Elemental_sRn4bqerfARvhgSV.json
+++ b/src/packs/adversaries/adversary_Minor_Chaos_Elemental_sRn4bqerfARvhgSV.json
@@ -1,6 +1,6 @@
 {
   "name": "Minor Chaos Elemental",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -112,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784307,
-    "modifiedTime": 1754236375428,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462919,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "sRn4bqerfARvhgSV",
   "sort": 4800000,
@@ -133,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Minor_Demon_3tqCjDwJAQ7JKqMb.json
+++ b/src/packs/adversaries/adversary_Minor_Demon_3tqCjDwJAQ7JKqMb.json
@@ -103,7 +103,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Minor_Demon_3tqCjDwJAQ7JKqMb.json
+++ b/src/packs/adversaries/adversary_Minor_Demon_3tqCjDwJAQ7JKqMb.json
@@ -1,6 +1,6 @@
 {
   "name": "Minor Demon",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -111,12 +111,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784308,
-    "modifiedTime": 1754236373911,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462544,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "3tqCjDwJAQ7JKqMb",
   "sort": 700000,
@@ -132,7 +132,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Minor_Fire_Elemental_DscWkNVoHak6P4hh.json
+++ b/src/packs/adversaries/adversary_Minor_Fire_Elemental_DscWkNVoHak6P4hh.json
@@ -1,6 +1,6 @@
 {
   "name": "Minor Fire Elemental",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -112,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784308,
-    "modifiedTime": 1754236374357,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462650,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "DscWkNVoHak6P4hh",
   "sort": 2400000,
@@ -133,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Minor_Fire_Elemental_DscWkNVoHak6P4hh.json
+++ b/src/packs/adversaries/adversary_Minor_Fire_Elemental_DscWkNVoHak6P4hh.json
@@ -104,7 +104,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Minor_Treant_G62k4oSkhkoXEs2D.json
+++ b/src/packs/adversaries/adversary_Minor_Treant_G62k4oSkhkoXEs2D.json
@@ -97,7 +97,8 @@
         ]
       },
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Minor_Treant_G62k4oSkhkoXEs2D.json
+++ b/src/packs/adversaries/adversary_Minor_Treant_G62k4oSkhkoXEs2D.json
@@ -1,6 +1,6 @@
 {
   "name": "Minor Treant",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -96,7 +96,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -104,12 +105,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784309,
-    "modifiedTime": 1754236374420,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755263168654,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "G62k4oSkhkoXEs2D",
   "sort": 2600000,
@@ -125,7 +126,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Minotaur_Wrecker_rM9qCIYeWg9I0B4l.json
+++ b/src/packs/adversaries/adversary_Minotaur_Wrecker_rM9qCIYeWg9I0B4l.json
@@ -1,6 +1,6 @@
 {
   "name": "Minotaur Wrecker",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -112,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784310,
-    "modifiedTime": 1754236375407,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462912,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "rM9qCIYeWg9I0B4l",
   "sort": 3200000,
@@ -133,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Minotaur_Wrecker_rM9qCIYeWg9I0B4l.json
+++ b/src/packs/adversaries/adversary_Minotaur_Wrecker_rM9qCIYeWg9I0B4l.json
@@ -104,7 +104,8 @@
         ]
       },
       "img": "icons/weapons/axes/axe-double.webp",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Monarch_yx0vK2yfNVZKWUUi.json
+++ b/src/packs/adversaries/adversary_Monarch_yx0vK2yfNVZKWUUi.json
@@ -1,6 +1,6 @@
 {
   "name": "Monarch",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "wTI7nZkPhKxl7Wwq",
   "system": {
@@ -114,7 +114,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -122,12 +123,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784312,
-    "modifiedTime": 1754236375521,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755266608082,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "yx0vK2yfNVZKWUUi",
   "sort": 3400000,
@@ -143,7 +144,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Monarch_yx0vK2yfNVZKWUUi.json
+++ b/src/packs/adversaries/adversary_Monarch_yx0vK2yfNVZKWUUi.json
@@ -115,7 +115,8 @@
         ]
       },
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Mortal_Hunter_mVV7a7KQAORoPMgZ.json
+++ b/src/packs/adversaries/adversary_Mortal_Hunter_mVV7a7KQAORoPMgZ.json
@@ -1,6 +1,6 @@
 {
   "name": "Mortal Hunter",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -118,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784313,
-    "modifiedTime": 1754236375305,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462879,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "mVV7a7KQAORoPMgZ",
   "sort": 2900000,
@@ -139,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Mortal_Hunter_mVV7a7KQAORoPMgZ.json
+++ b/src/packs/adversaries/adversary_Mortal_Hunter_mVV7a7KQAORoPMgZ.json
@@ -110,7 +110,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Oak_Treant_XK78QUfY8c8Go8Uv.json
+++ b/src/packs/adversaries/adversary_Oak_Treant_XK78QUfY8c8Go8Uv.json
@@ -1,6 +1,6 @@
 {
   "name": "Oak Treant",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "wTI7nZkPhKxl7Wwq",
   "system": {
@@ -84,7 +84,9 @@
                 "enabled": false
               }
             },
-            "type": ["physical"],
+            "type": [
+              "physical"
+            ],
             "applyTo": "hitPoints",
             "resultBased": false,
             "valueAlt": {
@@ -109,12 +111,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.344",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784314,
-    "modifiedTime": 1753922784314,
-    "lastModifiedBy": "WafZqd6qLGpBRGTt"
+    "modifiedTime": 1755259462770,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "XK78QUfY8c8Go8Uv",
   "sort": 3400000,
@@ -130,7 +132,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Oak_Treant_XK78QUfY8c8Go8Uv.json
+++ b/src/packs/adversaries/adversary_Oak_Treant_XK78QUfY8c8Go8Uv.json
@@ -103,7 +103,8 @@
         ]
       },
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Oracle_of_Doom_befIqd5IYKg6eUz2.json
+++ b/src/packs/adversaries/adversary_Oracle_of_Doom_befIqd5IYKg6eUz2.json
@@ -1,6 +1,6 @@
 {
   "name": "Oracle of Doom",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "7XHlANCPz18yvl5L",
   "system": {
@@ -118,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784315,
-    "modifiedTime": 1754236375025,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462807,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "befIqd5IYKg6eUz2",
   "sort": 1400000,
@@ -139,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Oracle_of_Doom_befIqd5IYKg6eUz2.json
+++ b/src/packs/adversaries/adversary_Oracle_of_Doom_befIqd5IYKg6eUz2.json
@@ -110,7 +110,8 @@
         ]
       },
       "img": "icons/magic/symbols/rune-sigil-rough-white-teal.webp",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Outer_Realms_Abomination_A0SeeDzwjvqOsyof.json
+++ b/src/packs/adversaries/adversary_Outer_Realms_Abomination_A0SeeDzwjvqOsyof.json
@@ -1,6 +1,6 @@
 {
   "name": "Outer Realms Abomination",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "7XHlANCPz18yvl5L",
   "system": {
@@ -112,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784319,
-    "modifiedTime": 1754236374220,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462626,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "A0SeeDzwjvqOsyof",
   "sort": 700000,
@@ -133,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Outer_Realms_Abomination_A0SeeDzwjvqOsyof.json
+++ b/src/packs/adversaries/adversary_Outer_Realms_Abomination_A0SeeDzwjvqOsyof.json
@@ -104,7 +104,8 @@
         ]
       },
       "img": "icons/creatures/tentacles/tentacle-earth-green.webp",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Outer_Realms_Corrupter_ms6nuOl3NFkhPj1k.json
+++ b/src/packs/adversaries/adversary_Outer_Realms_Corrupter_ms6nuOl3NFkhPj1k.json
@@ -104,7 +104,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Outer_Realms_Corrupter_ms6nuOl3NFkhPj1k.json
+++ b/src/packs/adversaries/adversary_Outer_Realms_Corrupter_ms6nuOl3NFkhPj1k.json
@@ -1,6 +1,6 @@
 {
   "name": "Outer Realms Corrupter",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "7XHlANCPz18yvl5L",
   "system": {
@@ -112,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784320,
-    "modifiedTime": 1754236375331,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462889,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "ms6nuOl3NFkhPj1k",
   "sort": 1600000,
@@ -133,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Outer_Realms_Thrall_moJhHgKqTKPS2WYS.json
+++ b/src/packs/adversaries/adversary_Outer_Realms_Thrall_moJhHgKqTKPS2WYS.json
@@ -97,7 +97,8 @@
       },
       "img": "icons/creatures/claws/claw-talons-yellow-red.webp",
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Outer_Realms_Thrall_moJhHgKqTKPS2WYS.json
+++ b/src/packs/adversaries/adversary_Outer_Realms_Thrall_moJhHgKqTKPS2WYS.json
@@ -1,6 +1,6 @@
 {
   "name": "Outer Realms Thrall",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "7XHlANCPz18yvl5L",
   "system": {
@@ -96,7 +96,8 @@
         "type": "attack"
       },
       "img": "icons/creatures/claws/claw-talons-yellow-red.webp",
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -104,12 +105,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784321,
-    "modifiedTime": 1754236375320,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755266968806,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "moJhHgKqTKPS2WYS",
   "sort": 1700000,
@@ -125,7 +126,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Patchwork_Zombie_Hulk_EQTOAOUrkIvS2z88.json
+++ b/src/packs/adversaries/adversary_Patchwork_Zombie_Hulk_EQTOAOUrkIvS2z88.json
@@ -1,6 +1,6 @@
 {
   "name": "Patchwork Zombie Hulk",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -121,12 +121,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784322,
-    "modifiedTime": 1754236374380,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462653,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "EQTOAOUrkIvS2z88",
   "sort": 2500000,
@@ -142,7 +142,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,
@@ -397,7 +397,7 @@
             },
             "name": "Heal",
             "img": "icons/magic/death/skull-trio-badge-purple.webp",
-            "range": ""
+            "range": "self"
           }
         },
         "originItemType": null,
@@ -416,12 +416,12 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "13.347",
         "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
+        "systemVersion": "1.0.4",
         "createdTime": 1754051528475,
-        "modifiedTime": 1754144642466,
-        "lastModifiedBy": "MQSznptE5yLT7kj8"
+        "modifiedTime": 1755263257032,
+        "lastModifiedBy": "VZIeX2YDvX338Zvr"
       },
       "_key": "!actors.items!EQTOAOUrkIvS2z88.gw1Z2VazlRXYCiCK"
     },

--- a/src/packs/adversaries/adversary_Patchwork_Zombie_Hulk_EQTOAOUrkIvS2z88.json
+++ b/src/packs/adversaries/adversary_Patchwork_Zombie_Hulk_EQTOAOUrkIvS2z88.json
@@ -113,7 +113,8 @@
         ]
       },
       "img": "icons/commodities/biological/hand-clawed-blue.webp",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Perfected_Zombie_CP6iRfHdyFWniTHY.json
+++ b/src/packs/adversaries/adversary_Perfected_Zombie_CP6iRfHdyFWniTHY.json
@@ -1,6 +1,6 @@
 {
   "name": "Perfected Zombie",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "7XHlANCPz18yvl5L",
   "system": {
@@ -16,7 +16,7 @@
         "isReversed": true
       },
       "stress": {
-        "value": 1,
+        "value": 0,
         "max": 4,
         "isReversed": true
       }
@@ -112,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784323,
-    "modifiedTime": 1754236374324,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755267137806,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "CP6iRfHdyFWniTHY",
   "sort": 800000,
@@ -133,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Perfected_Zombie_CP6iRfHdyFWniTHY.json
+++ b/src/packs/adversaries/adversary_Perfected_Zombie_CP6iRfHdyFWniTHY.json
@@ -104,7 +104,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Petty_Noble_wycLpvebWdUqRhpP.json
+++ b/src/packs/adversaries/adversary_Petty_Noble_wycLpvebWdUqRhpP.json
@@ -1,6 +1,6 @@
 {
   "name": "Petty Noble",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -39,7 +39,8 @@
     "experiences": {
       "cATk1IILqCDA5pnb": {
         "name": "Aristocrat",
-        "value": 3
+        "value": 3,
+        "description": ""
       }
     },
     "bonuses": {
@@ -108,7 +109,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -116,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784324,
-    "modifiedTime": 1754236375504,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755263279700,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "wycLpvebWdUqRhpP",
   "sort": 5200000,
@@ -137,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Petty_Noble_wycLpvebWdUqRhpP.json
+++ b/src/packs/adversaries/adversary_Petty_Noble_wycLpvebWdUqRhpP.json
@@ -110,7 +110,8 @@
         ]
       },
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Pirate_Captain_OROJbjsqagVh7ECV.json
+++ b/src/packs/adversaries/adversary_Pirate_Captain_OROJbjsqagVh7ECV.json
@@ -1,6 +1,6 @@
 {
   "name": "Pirate Captain",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -40,11 +40,13 @@
     "experiences": {
       "ndSzzasQ0JcMPJ6W": {
         "name": "Commander",
-        "value": 2
+        "value": 2,
+        "description": ""
       },
       "N0jWLtKmD5Cy6CjY": {
         "name": "Sailor",
-        "value": 3
+        "value": 3,
+        "description": ""
       }
     },
     "bonuses": {
@@ -112,7 +114,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -120,12 +123,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784325,
-    "modifiedTime": 1754236374624,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755263303289,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "OROJbjsqagVh7ECV",
   "sort": 3200000,
@@ -141,7 +144,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Pirate_Captain_OROJbjsqagVh7ECV.json
+++ b/src/packs/adversaries/adversary_Pirate_Captain_OROJbjsqagVh7ECV.json
@@ -115,7 +115,8 @@
         ]
       },
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Pirate_Raiders_5YgEajn0wa4i85kC.json
+++ b/src/packs/adversaries/adversary_Pirate_Raiders_5YgEajn0wa4i85kC.json
@@ -110,7 +110,8 @@
         "type": "attack"
       },
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Pirate_Raiders_5YgEajn0wa4i85kC.json
+++ b/src/packs/adversaries/adversary_Pirate_Raiders_5YgEajn0wa4i85kC.json
@@ -1,6 +1,6 @@
 {
   "name": "Pirate Raiders",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -40,7 +40,8 @@
     "experiences": {
       "a2aFr2x2FEZp7dFx": {
         "name": "Sailor",
-        "value": 3
+        "value": 3,
+        "description": ""
       }
     },
     "bonuses": {
@@ -108,7 +109,8 @@
         "bonus": 1,
         "type": "attack"
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -116,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784326,
-    "modifiedTime": 1754236373965,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755263339105,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "5YgEajn0wa4i85kC",
   "sort": 1000000,
@@ -137,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Pirate_Tough_mhcVkVFrzIJ18FDm.json
+++ b/src/packs/adversaries/adversary_Pirate_Tough_mhcVkVFrzIJ18FDm.json
@@ -3,7 +3,7 @@
   "name": "Pirate Tough",
   "type": "adversary",
   "_id": "mhcVkVFrzIJ18FDm",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "system": {
     "description": "<p>A thickly muscled and tattooed pirate with melon-sized fists.</p>",
     "resistance": {
@@ -154,7 +154,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,
@@ -447,12 +447,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1754089855172,
-    "modifiedTime": 1754089915784,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462883,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_key": "!actors!mhcVkVFrzIJ18FDm"
 }

--- a/src/packs/adversaries/adversary_Red_Ooze_9rVlbJVrDNn1x7PS.json
+++ b/src/packs/adversaries/adversary_Red_Ooze_9rVlbJVrDNn1x7PS.json
@@ -110,7 +110,8 @@
       },
       "img": "icons/creatures/slimes/slime-movement-dripping-pseudopods-green.webp",
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Red_Ooze_9rVlbJVrDNn1x7PS.json
+++ b/src/packs/adversaries/adversary_Red_Ooze_9rVlbJVrDNn1x7PS.json
@@ -1,6 +1,6 @@
 {
   "name": "Red Ooze",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -40,7 +40,8 @@
     "experiences": {
       "0QeViWJm5MdiJ9GL": {
         "name": "Camouflage",
-        "value": 3
+        "value": 3,
+        "description": ""
       }
     },
     "bonuses": {
@@ -108,7 +109,8 @@
         ]
       },
       "img": "icons/creatures/slimes/slime-movement-dripping-pseudopods-green.webp",
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -116,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784338,
-    "modifiedTime": 1754236374205,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755263361677,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "9rVlbJVrDNn1x7PS",
   "sort": 1700000,
@@ -137,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Rotted_Zombie_gP3fWTLzSFnpA8EJ.json
+++ b/src/packs/adversaries/adversary_Rotted_Zombie_gP3fWTLzSFnpA8EJ.json
@@ -89,7 +89,8 @@
       },
       "img": "icons/creatures/abilities/mouth-teeth-sharp.webp",
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     },
     "resources": {
       "hitPoints": {

--- a/src/packs/adversaries/adversary_Rotted_Zombie_gP3fWTLzSFnpA8EJ.json
+++ b/src/packs/adversaries/adversary_Rotted_Zombie_gP3fWTLzSFnpA8EJ.json
@@ -1,6 +1,6 @@
 {
   "name": "Rotted Zombie",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -88,7 +88,8 @@
         ]
       },
       "img": "icons/creatures/abilities/mouth-teeth-sharp.webp",
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     },
     "resources": {
       "hitPoints": {
@@ -104,12 +105,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784339,
-    "modifiedTime": 1754236375111,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755263398665,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "gP3fWTLzSFnpA8EJ",
   "sort": 4300000,
@@ -125,7 +126,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Royal_Advisor_EtLJiTsilPPZvLUX.json
+++ b/src/packs/adversaries/adversary_Royal_Advisor_EtLJiTsilPPZvLUX.json
@@ -115,7 +115,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Royal_Advisor_EtLJiTsilPPZvLUX.json
+++ b/src/packs/adversaries/adversary_Royal_Advisor_EtLJiTsilPPZvLUX.json
@@ -1,6 +1,6 @@
 {
   "name": "Royal Advisor",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -123,12 +123,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784339,
-    "modifiedTime": 1754236374390,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462657,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "EtLJiTsilPPZvLUX",
   "sort": 1600000,
@@ -144,7 +144,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Secret_Keeper_sLAccjvCWfeedbpI.json
+++ b/src/packs/adversaries/adversary_Secret_Keeper_sLAccjvCWfeedbpI.json
@@ -1,6 +1,6 @@
 {
   "name": "Secret-Keeper",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -123,12 +123,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784341,
-    "modifiedTime": 1754236375419,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462915,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "sLAccjvCWfeedbpI",
   "sort": 3300000,
@@ -144,7 +144,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,
@@ -532,8 +532,8 @@
             ],
             "uses": {
               "value": null,
-              "max": "",
-              "recovery": null
+              "max": "1",
+              "recovery": "scene"
             },
             "effects": [],
             "target": {
@@ -562,12 +562,12 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "13.347",
         "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
+        "systemVersion": "1.0.4",
         "createdTime": 1754083283890,
-        "modifiedTime": 1754143114257,
-        "lastModifiedBy": "MQSznptE5yLT7kj8"
+        "modifiedTime": 1755265493498,
+        "lastModifiedBy": "VZIeX2YDvX338Zvr"
       },
       "_key": "!actors.items!sLAccjvCWfeedbpI.Q28NPuSMccjzykib"
     }

--- a/src/packs/adversaries/adversary_Secret_Keeper_sLAccjvCWfeedbpI.json
+++ b/src/packs/adversaries/adversary_Secret_Keeper_sLAccjvCWfeedbpI.json
@@ -115,7 +115,8 @@
         ]
       },
       "img": "icons/weapons/staves/staff-ornate-purple.webp",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Sellsword_bgreCaQ6ap2DVpCr.json
+++ b/src/packs/adversaries/adversary_Sellsword_bgreCaQ6ap2DVpCr.json
@@ -97,7 +97,8 @@
       },
       "img": "icons/weapons/swords/sword-guard.webp",
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Sellsword_bgreCaQ6ap2DVpCr.json
+++ b/src/packs/adversaries/adversary_Sellsword_bgreCaQ6ap2DVpCr.json
@@ -1,6 +1,6 @@
 {
   "name": "Sellsword",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -96,7 +96,8 @@
         "type": "attack"
       },
       "img": "icons/weapons/swords/sword-guard.webp",
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -104,12 +105,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784341,
-    "modifiedTime": 1754236375045,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755263436436,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "bgreCaQ6ap2DVpCr",
   "sort": 4100000,
@@ -125,7 +126,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Shambling_Zombie_2nXz4ilAY4xuhKLm.json
+++ b/src/packs/adversaries/adversary_Shambling_Zombie_2nXz4ilAY4xuhKLm.json
@@ -1,6 +1,6 @@
 {
   "name": "Shambling Zombie",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -103,7 +103,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -111,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784342,
-    "modifiedTime": 1754236373883,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755263464581,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "2nXz4ilAY4xuhKLm",
   "sort": 600000,
@@ -132,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Shambling_Zombie_2nXz4ilAY4xuhKLm.json
+++ b/src/packs/adversaries/adversary_Shambling_Zombie_2nXz4ilAY4xuhKLm.json
@@ -104,7 +104,8 @@
         ]
       },
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Shark_YmVAkdNsyuXWTtYp.json
+++ b/src/packs/adversaries/adversary_Shark_YmVAkdNsyuXWTtYp.json
@@ -1,6 +1,6 @@
 {
   "name": "Shark",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -112,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784342,
-    "modifiedTime": 1754236374913,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462790,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "YmVAkdNsyuXWTtYp",
   "sort": 2200000,
@@ -133,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Shark_YmVAkdNsyuXWTtYp.json
+++ b/src/packs/adversaries/adversary_Shark_YmVAkdNsyuXWTtYp.json
@@ -104,7 +104,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Siren_BK4jwyXSRx7IOQiO.json
+++ b/src/packs/adversaries/adversary_Siren_BK4jwyXSRx7IOQiO.json
@@ -110,7 +110,8 @@
       },
       "img": "icons/creatures/abilities/mouth-teeth-sharp.webp",
       "range": "melee",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Siren_BK4jwyXSRx7IOQiO.json
+++ b/src/packs/adversaries/adversary_Siren_BK4jwyXSRx7IOQiO.json
@@ -1,6 +1,6 @@
 {
   "name": "Siren",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -109,7 +109,7 @@
         ]
       },
       "img": "icons/creatures/abilities/mouth-teeth-sharp.webp",
-      "range": "",
+      "range": "melee",
       "type": "attack"
     }
   },
@@ -118,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784344,
-    "modifiedTime": 1754236374255,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755265520298,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "BK4jwyXSRx7IOQiO",
   "sort": 1400000,
@@ -139,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Skeleton_Archer_7X5q7a6ueeHs5oA9.json
+++ b/src/packs/adversaries/adversary_Skeleton_Archer_7X5q7a6ueeHs5oA9.json
@@ -104,7 +104,8 @@
         ]
       },
       "img": "icons/weapons/bows/shortbow-leather.webp",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Skeleton_Archer_7X5q7a6ueeHs5oA9.json
+++ b/src/packs/adversaries/adversary_Skeleton_Archer_7X5q7a6ueeHs5oA9.json
@@ -1,6 +1,6 @@
 {
   "name": "Skeleton Archer",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -112,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784345,
-    "modifiedTime": 1754236374038,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462590,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "7X5q7a6ueeHs5oA9",
   "sort": 1300000,
@@ -133,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Skeleton_Dredge_6l1a3Fazq8BoKIcc.json
+++ b/src/packs/adversaries/adversary_Skeleton_Dredge_6l1a3Fazq8BoKIcc.json
@@ -89,7 +89,8 @@
         ]
       },
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     },
     "resources": {
       "hitPoints": {

--- a/src/packs/adversaries/adversary_Skeleton_Dredge_6l1a3Fazq8BoKIcc.json
+++ b/src/packs/adversaries/adversary_Skeleton_Dredge_6l1a3Fazq8BoKIcc.json
@@ -1,6 +1,6 @@
 {
   "name": "Skeleton Dredge",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -88,7 +88,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     },
     "resources": {
       "hitPoints": {
@@ -104,12 +105,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784347,
-    "modifiedTime": 1754236374029,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755264328739,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "6l1a3Fazq8BoKIcc",
   "sort": 1100000,
@@ -125,7 +126,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Skeleton_Knight_Q9LaVTyXF9NF12C7.json
+++ b/src/packs/adversaries/adversary_Skeleton_Knight_Q9LaVTyXF9NF12C7.json
@@ -1,6 +1,6 @@
 {
   "name": "Skeleton Knight",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -103,7 +103,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -111,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784348,
-    "modifiedTime": 1754236374678,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755264339964,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "Q9LaVTyXF9NF12C7",
   "sort": 3300000,
@@ -132,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Skeleton_Knight_Q9LaVTyXF9NF12C7.json
+++ b/src/packs/adversaries/adversary_Skeleton_Knight_Q9LaVTyXF9NF12C7.json
@@ -104,7 +104,8 @@
         ]
       },
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Skeleton_Warrior_10YIQl0lvCJXZLfX.json
+++ b/src/packs/adversaries/adversary_Skeleton_Warrior_10YIQl0lvCJXZLfX.json
@@ -1,6 +1,6 @@
 {
   "name": "Skeleton Warrior",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -103,7 +103,8 @@
         ]
       },
       "img": "icons/weapons/swords/sword-guard-brass-worn.webp",
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -111,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784350,
-    "modifiedTime": 1754236373827,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755264406791,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "10YIQl0lvCJXZLfX",
   "sort": 100000,
@@ -132,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Skeleton_Warrior_10YIQl0lvCJXZLfX.json
+++ b/src/packs/adversaries/adversary_Skeleton_Warrior_10YIQl0lvCJXZLfX.json
@@ -104,7 +104,8 @@
       },
       "img": "icons/weapons/swords/sword-guard-brass-worn.webp",
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Spectral_Archer_5tCkhnBByUIN5UdG.json
+++ b/src/packs/adversaries/adversary_Spectral_Archer_5tCkhnBByUIN5UdG.json
@@ -110,7 +110,8 @@
         ]
       },
       "range": "far",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Spectral_Archer_5tCkhnBByUIN5UdG.json
+++ b/src/packs/adversaries/adversary_Spectral_Archer_5tCkhnBByUIN5UdG.json
@@ -1,6 +1,6 @@
 {
   "name": "Spectral Archer",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -118,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784351,
-    "modifiedTime": 1754236373994,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462572,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "5tCkhnBByUIN5UdG",
   "sort": 500000,
@@ -139,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Spectral_Captain_65cSO3EQEh6ZH6Xk.json
+++ b/src/packs/adversaries/adversary_Spectral_Captain_65cSO3EQEh6ZH6Xk.json
@@ -110,7 +110,8 @@
         "type": "attack"
       },
       "range": "far",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Spectral_Captain_65cSO3EQEh6ZH6Xk.json
+++ b/src/packs/adversaries/adversary_Spectral_Captain_65cSO3EQEh6ZH6Xk.json
@@ -1,6 +1,6 @@
 {
   "name": "Spectral Captain",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -118,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784352,
-    "modifiedTime": 1754236374005,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462575,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "65cSO3EQEh6ZH6Xk",
   "sort": 600000,
@@ -139,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Spectral_Guardian_UFVGl1osOsJTneLf.json
+++ b/src/packs/adversaries/adversary_Spectral_Guardian_UFVGl1osOsJTneLf.json
@@ -110,7 +110,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Spectral_Guardian_UFVGl1osOsJTneLf.json
+++ b/src/packs/adversaries/adversary_Spectral_Guardian_UFVGl1osOsJTneLf.json
@@ -1,6 +1,6 @@
 {
   "name": "Spectral Guardian",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -118,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784353,
-    "modifiedTime": 1754236374750,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462734,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "UFVGl1osOsJTneLf",
   "sort": 2000000,
@@ -139,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Spellblade_ldbWEL7uZs84vyrR.json
+++ b/src/packs/adversaries/adversary_Spellblade_ldbWEL7uZs84vyrR.json
@@ -111,7 +111,8 @@
         ]
       },
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Spellblade_ldbWEL7uZs84vyrR.json
+++ b/src/packs/adversaries/adversary_Spellblade_ldbWEL7uZs84vyrR.json
@@ -1,6 +1,6 @@
 {
   "name": "Spellblade",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -39,7 +39,8 @@
     "experiences": {
       "5K7W5e63iQNI0MdQ": {
         "name": "Magical Knowledge",
-        "value": 2
+        "value": 2,
+        "description": ""
       }
     },
     "bonuses": {
@@ -109,7 +110,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -117,12 +119,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784353,
-    "modifiedTime": 1754236375260,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755264447203,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "ldbWEL7uZs84vyrR",
   "sort": 4500000,
@@ -138,7 +140,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Spy_8zlynOhnVA59KpKT.json
+++ b/src/packs/adversaries/adversary_Spy_8zlynOhnVA59KpKT.json
@@ -110,7 +110,8 @@
       },
       "img": "icons/weapons/daggers/dagger-curved-purple.webp",
       "range": "melee",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Spy_8zlynOhnVA59KpKT.json
+++ b/src/packs/adversaries/adversary_Spy_8zlynOhnVA59KpKT.json
@@ -1,6 +1,6 @@
 {
   "name": "Spy",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -109,7 +109,7 @@
         ]
       },
       "img": "icons/weapons/daggers/dagger-curved-purple.webp",
-      "range": "",
+      "range": "melee",
       "type": "attack"
     }
   },
@@ -118,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784354,
-    "modifiedTime": 1754236374153,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755265655362,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "8zlynOhnVA59KpKT",
   "sort": 1100000,
@@ -139,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Stag_Knight_KGVwnLq85ywP9xvB.json
+++ b/src/packs/adversaries/adversary_Stag_Knight_KGVwnLq85ywP9xvB.json
@@ -1,6 +1,6 @@
 {
   "name": "Stag Knight",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "wTI7nZkPhKxl7Wwq",
   "system": {
@@ -109,7 +109,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -117,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784355,
-    "modifiedTime": 1754236374465,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755266627287,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "KGVwnLq85ywP9xvB",
   "sort": 3400000,
@@ -138,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Stag_Knight_KGVwnLq85ywP9xvB.json
+++ b/src/packs/adversaries/adversary_Stag_Knight_KGVwnLq85ywP9xvB.json
@@ -110,7 +110,8 @@
         ]
       },
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Stonewraith_3aAS2Qm3R6cgaYfE.json
+++ b/src/packs/adversaries/adversary_Stonewraith_3aAS2Qm3R6cgaYfE.json
@@ -110,7 +110,8 @@
         ]
       },
       "range": "melee",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Stonewraith_3aAS2Qm3R6cgaYfE.json
+++ b/src/packs/adversaries/adversary_Stonewraith_3aAS2Qm3R6cgaYfE.json
@@ -1,6 +1,6 @@
 {
   "name": "Stonewraith",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -109,7 +109,7 @@
           }
         ]
       },
-      "range": "",
+      "range": "melee",
       "type": "attack"
     }
   },
@@ -118,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784355,
-    "modifiedTime": 1754236373897,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755265669682,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "3aAS2Qm3R6cgaYfE",
   "sort": 300000,
@@ -139,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Swarm_of_Rats_qNgs3AbLyJrY19nt.json
+++ b/src/packs/adversaries/adversary_Swarm_of_Rats_qNgs3AbLyJrY19nt.json
@@ -1,6 +1,6 @@
 {
   "name": "Swarm of Rats",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -103,7 +103,8 @@
         "bonus": -3,
         "type": "attack"
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -111,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784356,
-    "modifiedTime": 1754236375390,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755264462044,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "qNgs3AbLyJrY19nt",
   "sort": 4700000,
@@ -132,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Swarm_of_Rats_qNgs3AbLyJrY19nt.json
+++ b/src/packs/adversaries/adversary_Swarm_of_Rats_qNgs3AbLyJrY19nt.json
@@ -104,7 +104,8 @@
         "type": "attack"
       },
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Sylvan_Soldier_VtFBt9XBE0WrGGxP.json
+++ b/src/packs/adversaries/adversary_Sylvan_Soldier_VtFBt9XBE0WrGGxP.json
@@ -110,7 +110,8 @@
         ]
       },
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Sylvan_Soldier_VtFBt9XBE0WrGGxP.json
+++ b/src/packs/adversaries/adversary_Sylvan_Soldier_VtFBt9XBE0WrGGxP.json
@@ -1,6 +1,6 @@
 {
   "name": "Sylvan Soldier",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -40,7 +40,8 @@
     "experiences": {
       "3HwCDcCvzVnicJKe": {
         "name": "Tracker",
-        "value": 2
+        "value": 2,
+        "description": ""
       }
     },
     "bonuses": {
@@ -108,7 +109,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -116,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784356,
-    "modifiedTime": 1754236374783,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755264471444,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "VtFBt9XBE0WrGGxP",
   "sort": 3600000,
@@ -137,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,
@@ -455,14 +457,14 @@
       "_id": "1dmKoSnV82sLc8xZ",
       "img": "icons/magic/nature/root-vine-leaves-green.webp",
       "system": {
-        "description": "<p>When the Soldier makes a successful attack, you can <strong>mark a Stress</strong> to become Hidden until the Soldier’s next attack or a PC succeeds on an Instinct Roll (14) to fi nd them.</p>",
+        "description": "<p>When the Soldier makes a successful attack, you can <strong>mark a Stress</strong> to become Hidden until the Soldier’s next attack or a PC succeeds on an Instinct Roll (14) to find them.</p>",
         "resource": null,
         "actions": {
           "l32BjO9J0jFvD0Zy": {
             "type": "effect",
             "_id": "l32BjO9J0jFvD0Zy",
             "systemPath": "actions",
-            "description": "<p>When the Soldier makes a successful attack, you can <strong>mark a Stress</strong> to become Hidden until the Soldier’s next attack or a PC succeeds on an Instinct Roll (14) to fi nd them.</p>",
+            "description": "<p>When the Soldier makes a successful attack, you can <strong>mark a Stress</strong> to become Hidden until the Soldier’s next attack or a PC succeeds on an Instinct Roll (14) to find them.</p>",
             "chatDisplay": true,
             "actionType": "action",
             "cost": [
@@ -557,12 +559,12 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "13.347",
         "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
+        "systemVersion": "1.0.4",
         "createdTime": 1754054512042,
-        "modifiedTime": 1754145055093,
-        "lastModifiedBy": "MQSznptE5yLT7kj8"
+        "modifiedTime": 1755261654355,
+        "lastModifiedBy": "VZIeX2YDvX338Zvr"
       },
       "_key": "!actors.items!VtFBt9XBE0WrGGxP.1dmKoSnV82sLc8xZ"
     }

--- a/src/packs/adversaries/adversary_Tangle_Bramble_Swarm_PKSXFuaIHUCoH63A.json
+++ b/src/packs/adversaries/adversary_Tangle_Bramble_Swarm_PKSXFuaIHUCoH63A.json
@@ -1,6 +1,6 @@
 {
   "name": "Tangle Bramble Swarm",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -150,12 +150,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1754054959791,
-    "modifiedTime": 1754055134138,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462711,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "ownership": {
     "default": 0,
@@ -170,7 +170,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Tangle_Bramble_XcAGOSmtCFLT1unN.json
+++ b/src/packs/adversaries/adversary_Tangle_Bramble_XcAGOSmtCFLT1unN.json
@@ -1,6 +1,6 @@
 {
   "name": "Tangle Bramble",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -146,12 +146,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1754055125822,
-    "modifiedTime": 1754055125822,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462779,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "ownership": {
     "default": 0,
@@ -166,7 +166,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Tiny_Green_Ooze_aLkLFuVoKz2NLoBK.json
+++ b/src/packs/adversaries/adversary_Tiny_Green_Ooze_aLkLFuVoKz2NLoBK.json
@@ -88,7 +88,8 @@
       },
       "img": "icons/creatures/slimes/slime-movement-dripping-pseudopods-green.webp",
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     },
     "damageThresholds": {
       "major": 4,

--- a/src/packs/adversaries/adversary_Tiny_Green_Ooze_aLkLFuVoKz2NLoBK.json
+++ b/src/packs/adversaries/adversary_Tiny_Green_Ooze_aLkLFuVoKz2NLoBK.json
@@ -1,6 +1,6 @@
 {
   "name": "Tiny Green Ooze",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -87,7 +87,8 @@
         ]
       },
       "img": "icons/creatures/slimes/slime-movement-dripping-pseudopods-green.webp",
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     },
     "damageThresholds": {
       "major": 4,
@@ -107,12 +108,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784359,
-    "modifiedTime": 1754236375002,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755264530216,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "aLkLFuVoKz2NLoBK",
   "sort": 3900000,
@@ -128,7 +129,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Tiny_Red_Ooze_1fkLQXVtmILqfJ44.json
+++ b/src/packs/adversaries/adversary_Tiny_Red_Ooze_1fkLQXVtmILqfJ44.json
@@ -1,6 +1,6 @@
 {
   "name": "Tiny Red Ooze",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -87,7 +87,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     },
     "resources": {
       "hitPoints": {
@@ -107,12 +108,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784359,
-    "modifiedTime": 1754236373842,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755264552312,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "1fkLQXVtmILqfJ44",
   "sort": 200000,
@@ -128,7 +129,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Tiny_Red_Ooze_1fkLQXVtmILqfJ44.json
+++ b/src/packs/adversaries/adversary_Tiny_Red_Ooze_1fkLQXVtmILqfJ44.json
@@ -88,7 +88,8 @@
         ]
       },
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     },
     "resources": {
       "hitPoints": {

--- a/src/packs/adversaries/adversary_Treant_Sapling_o63nS0k3wHu6EgKP.json
+++ b/src/packs/adversaries/adversary_Treant_Sapling_o63nS0k3wHu6EgKP.json
@@ -1,6 +1,6 @@
 {
   "name": "Treant Sapling",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "wTI7nZkPhKxl7Wwq",
   "system": {
@@ -104,12 +104,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784360,
-    "modifiedTime": 1754236375369,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462897,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "o63nS0k3wHu6EgKP",
   "sort": 3400000,
@@ -125,7 +125,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Treant_Sapling_o63nS0k3wHu6EgKP.json
+++ b/src/packs/adversaries/adversary_Treant_Sapling_o63nS0k3wHu6EgKP.json
@@ -96,7 +96,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Vampire_WWyUp6Mxl1S3KYUG.json
+++ b/src/packs/adversaries/adversary_Vampire_WWyUp6Mxl1S3KYUG.json
@@ -1,6 +1,6 @@
 {
   "name": "Vampire",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "wTI7nZkPhKxl7Wwq",
   "system": {
@@ -109,7 +109,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -117,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784364,
-    "modifiedTime": 1754236374850,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755266648769,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "WWyUp6Mxl1S3KYUG",
   "sort": 3400000,
@@ -138,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Vampire_WWyUp6Mxl1S3KYUG.json
+++ b/src/packs/adversaries/adversary_Vampire_WWyUp6Mxl1S3KYUG.json
@@ -110,7 +110,8 @@
         ]
       },
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Vault_Guardian_Gaoler_JqYraOqNmmhHk4Yy.json
+++ b/src/packs/adversaries/adversary_Vault_Guardian_Gaoler_JqYraOqNmmhHk4Yy.json
@@ -104,7 +104,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Vault_Guardian_Gaoler_JqYraOqNmmhHk4Yy.json
+++ b/src/packs/adversaries/adversary_Vault_Guardian_Gaoler_JqYraOqNmmhHk4Yy.json
@@ -1,6 +1,6 @@
 {
   "name": "Vault Guardian Gaoler",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "wTI7nZkPhKxl7Wwq",
   "system": {
@@ -112,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784367,
-    "modifiedTime": 1754236374457,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462674,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "JqYraOqNmmhHk4Yy",
   "sort": 3400000,
@@ -133,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Vault_Guardian_Sentinel_FVgYb28fhxlVcGwA.json
+++ b/src/packs/adversaries/adversary_Vault_Guardian_Sentinel_FVgYb28fhxlVcGwA.json
@@ -1,6 +1,6 @@
 {
   "name": "Vault Guardian Sentinel",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "wTI7nZkPhKxl7Wwq",
   "system": {
@@ -112,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784368,
-    "modifiedTime": 1754236374398,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462659,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "FVgYb28fhxlVcGwA",
   "sort": 3400000,
@@ -133,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Vault_Guardian_Sentinel_FVgYb28fhxlVcGwA.json
+++ b/src/packs/adversaries/adversary_Vault_Guardian_Sentinel_FVgYb28fhxlVcGwA.json
@@ -104,7 +104,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Vault_Guardian_Turret_c5hGdvY5UnSjlHws.json
+++ b/src/packs/adversaries/adversary_Vault_Guardian_Turret_c5hGdvY5UnSjlHws.json
@@ -1,6 +1,6 @@
 {
   "name": "Vault Guardian Turret",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "wTI7nZkPhKxl7Wwq",
   "system": {
@@ -112,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784368,
-    "modifiedTime": 1754236375053,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462816,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "c5hGdvY5UnSjlHws",
   "sort": 3400000,
@@ -133,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Vault_Guardian_Turret_c5hGdvY5UnSjlHws.json
+++ b/src/packs/adversaries/adversary_Vault_Guardian_Turret_c5hGdvY5UnSjlHws.json
@@ -104,7 +104,8 @@
         ]
       },
       "img": "icons/commodities/tech/metal-joint.webp",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Volcanic_Dragon__Ashen_Tyrant_pMuXGCSOQaxpi5tb.json
+++ b/src/packs/adversaries/adversary_Volcanic_Dragon__Ashen_Tyrant_pMuXGCSOQaxpi5tb.json
@@ -3,7 +3,7 @@
   "name": "Volcanic Dragon: Ashen Tyrant",
   "type": "adversary",
   "_id": "pMuXGCSOQaxpi5tb",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "system": {
     "description": "<p><em>No enemy has ever had the insolence to wound the dragon so. As the lava settles, it’s ground to ash like the dragon’s past foes.</em></p>",
     "resistance": {
@@ -21,7 +21,7 @@
     "tier": 4,
     "type": "solo",
     "notes": "",
-    "difficulty": 20,
+    "difficulty": 18,
     "hordeHp": 1,
     "damageThresholds": {
       "major": 29,
@@ -154,7 +154,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,
@@ -394,12 +394,12 @@
             "compendiumSource": null,
             "duplicateSource": null,
             "exportSource": null,
-            "coreVersion": "13.346",
+            "coreVersion": "13.347",
             "systemId": "daggerheart",
             "systemVersion": "0.0.1",
             "createdTime": 1754139762122,
-            "modifiedTime": 1754139779997,
-            "lastModifiedBy": "MQSznptE5yLT7kj8"
+            "modifiedTime": 1755267046098,
+            "lastModifiedBy": "VZIeX2YDvX338Zvr"
           },
           "_key": "!actors.items.effects!pMuXGCSOQaxpi5tb.jOojMjb779Kea1ZV.zCi90lgFAaA7yrJG"
         }
@@ -824,7 +824,7 @@
           "name": "Apocalyptic Thrasing",
           "img": "icons/creatures/abilities/mouth-teeth-fire-orange.webp",
           "origin": "Compendium.daggerheart.adversaries.Actor.pMuXGCSOQaxpi5tb.Item.uWiyaJPXcoW06pOM",
-          "transfer": true,
+          "transfer": false,
           "_id": "YUjdwrEZ4zn7WR9X",
           "type": "base",
           "system": {
@@ -849,7 +849,7 @@
           "description": "<p><em>Restrained</em> by the rubble until you break free with a successful Strength Roll.</p>",
           "tint": "#ffffff",
           "statuses": [
-            "restrain"
+            "restrained"
           ],
           "sort": 0,
           "flags": {},
@@ -857,12 +857,12 @@
             "compendiumSource": null,
             "duplicateSource": null,
             "exportSource": null,
-            "coreVersion": "13.346",
+            "coreVersion": "13.347",
             "systemId": "daggerheart",
             "systemVersion": "0.0.1",
             "createdTime": 1754140152911,
-            "modifiedTime": 1754140181136,
-            "lastModifiedBy": "MQSznptE5yLT7kj8"
+            "modifiedTime": 1755267090918,
+            "lastModifiedBy": "VZIeX2YDvX338Zvr"
           },
           "_key": "!actors.items.effects!pMuXGCSOQaxpi5tb.uWiyaJPXcoW06pOM.YUjdwrEZ4zn7WR9X"
         }
@@ -899,12 +899,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753929252617,
-    "modifiedTime": 1754219468339,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755267105169,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_key": "!actors!pMuXGCSOQaxpi5tb"
 }

--- a/src/packs/adversaries/adversary_Volcanic_Dragon__Molten_Scourge_eArAPuB38CNR0ZIM.json
+++ b/src/packs/adversaries/adversary_Volcanic_Dragon__Molten_Scourge_eArAPuB38CNR0ZIM.json
@@ -3,7 +3,7 @@
   "name": "Volcanic Dragon: Molten Scourge",
   "type": "adversary",
   "_id": "eArAPuB38CNR0ZIM",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "system": {
     "description": "<p><em>Enraged by their wounds, the dragon bursts into molten lava.</em></p>",
     "resistance": {
@@ -154,7 +154,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,
@@ -899,12 +899,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753929160832,
-    "modifiedTime": 1754219468339,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462833,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_key": "!actors!eArAPuB38CNR0ZIM"
 }

--- a/src/packs/adversaries/adversary_Volcanic_Dragon__Obsidian_Predator_ladm7wykhZczYzrQ.json
+++ b/src/packs/adversaries/adversary_Volcanic_Dragon__Obsidian_Predator_ladm7wykhZczYzrQ.json
@@ -3,7 +3,7 @@
   "name": "Volcanic Dragon: Obsidian Predator",
   "type": "adversary",
   "_id": "ladm7wykhZczYzrQ",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "system": {
     "description": "<p><em>A massive winged creature with obsidian scales and impossibly sharp claws.</em></p>",
     "resistance": {
@@ -154,7 +154,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,
@@ -330,12 +330,12 @@
             "compendiumSource": null,
             "duplicateSource": null,
             "exportSource": null,
-            "coreVersion": "13.346",
+            "coreVersion": "13.347",
             "systemId": "daggerheart",
             "systemVersion": "0.0.1",
             "createdTime": 1754141026641,
-            "modifiedTime": 1754141045045,
-            "lastModifiedBy": "MQSznptE5yLT7kj8"
+            "modifiedTime": 1755266990654,
+            "lastModifiedBy": "VZIeX2YDvX338Zvr"
           },
           "_key": "!actors.items.effects!ladm7wykhZczYzrQ.oN5za5NKi2qAXJ0e.8o8yG73ZfrZ3hb5i"
         }
@@ -804,12 +804,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753929001531,
-    "modifiedTime": 1754219468339,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462866,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_key": "!actors!ladm7wykhZczYzrQ"
 }

--- a/src/packs/adversaries/adversary_War_Wizard_noDdT0tsN6FXSmC8.json
+++ b/src/packs/adversaries/adversary_War_Wizard_noDdT0tsN6FXSmC8.json
@@ -115,7 +115,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_War_Wizard_noDdT0tsN6FXSmC8.json
+++ b/src/packs/adversaries/adversary_War_Wizard_noDdT0tsN6FXSmC8.json
@@ -1,6 +1,6 @@
 {
   "name": "War Wizard",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "OgzrmfH1ZbpljX7k",
   "system": {
@@ -123,12 +123,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784373,
-    "modifiedTime": 1754236375356,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462894,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "noDdT0tsN6FXSmC8",
   "sort": 3100000,
@@ -144,7 +144,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,
@@ -595,12 +595,7 @@
       "type": "feature",
       "system": {
         "description": "<p>When the Wizard takes damage from an attack within Close range, deal <strong>2d6</strong> magic damage to the attacker. This reaction can’t be used again until the Wizard refreshes it with their “Refresh Warding Sphere” action.</p>",
-        "resource": {
-          "type": "simple",
-          "value": 1,
-          "max": "1",
-          "icon": "fa-solid fa-hand-sparkles"
-        },
+        "resource": null,
         "actions": {
           "2fHrpaZW9toi6nin": {
             "type": "damage",
@@ -612,7 +607,7 @@
             "cost": [],
             "uses": {
               "value": null,
-              "max": "",
+              "max": "1",
               "recovery": null
             },
             "damage": {
@@ -673,12 +668,12 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "13.347",
         "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
+        "systemVersion": "1.0.4",
         "createdTime": 1754085493649,
-        "modifiedTime": 1754143416150,
-        "lastModifiedBy": "MQSznptE5yLT7kj8"
+        "modifiedTime": 1755265745660,
+        "lastModifiedBy": "VZIeX2YDvX338Zvr"
       },
       "_key": "!actors.items!noDdT0tsN6FXSmC8.9cPigHRcUfJC9gD8"
     }

--- a/src/packs/adversaries/adversary_Weaponmaster_ZNbQ2jg35LG4t9eH.json
+++ b/src/packs/adversaries/adversary_Weaponmaster_ZNbQ2jg35LG4t9eH.json
@@ -1,6 +1,6 @@
 {
   "name": "Weaponmaster",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -112,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784373,
-    "modifiedTime": 1754236374946,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462796,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "ZNbQ2jg35LG4t9eH",
   "sort": 3800000,
@@ -133,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,
@@ -406,7 +406,16 @@
                 "key": "fear",
                 "value": 1,
                 "keyIsID": false,
-                "step": null
+                "step": null,
+                "consumeOnSuccess": false
+              },
+              {
+                "scalable": false,
+                "key": "UsC0vtOBbf9Kut4v",
+                "value": 1,
+                "keyIsID": true,
+                "step": null,
+                "consumeOnSuccess": false
               }
             ],
             "uses": {
@@ -470,7 +479,7 @@
               "includeBase": false
             },
             "target": {
-              "type": "any",
+              "type": "self",
               "amount": null
             },
             "effects": [],
@@ -491,7 +500,7 @@
             },
             "name": "Spend Fear",
             "img": "icons/magic/life/cross-beam-green.webp",
-            "range": ""
+            "range": "self"
           }
         },
         "originItemType": null,
@@ -510,12 +519,12 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "13.347",
         "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
+        "systemVersion": "1.0.4",
         "createdTime": 1754055703816,
-        "modifiedTime": 1754145170728,
-        "lastModifiedBy": "MQSznptE5yLT7kj8"
+        "modifiedTime": 1755264604190,
+        "lastModifiedBy": "VZIeX2YDvX338Zvr"
       },
       "_key": "!actors.items!ZNbQ2jg35LG4t9eH.UsC0vtOBbf9Kut4v"
     },

--- a/src/packs/adversaries/adversary_Weaponmaster_ZNbQ2jg35LG4t9eH.json
+++ b/src/packs/adversaries/adversary_Weaponmaster_ZNbQ2jg35LG4t9eH.json
@@ -104,7 +104,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Young_Dryad_8yUj2Mzvnifhxegm.json
+++ b/src/packs/adversaries/adversary_Young_Dryad_8yUj2Mzvnifhxegm.json
@@ -110,7 +110,8 @@
         ]
       },
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Young_Dryad_8yUj2Mzvnifhxegm.json
+++ b/src/packs/adversaries/adversary_Young_Dryad_8yUj2Mzvnifhxegm.json
@@ -1,6 +1,6 @@
 {
   "name": "Young Dryad",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -39,7 +39,8 @@
     "experiences": {
       "lSUwWxW8jsQ2xho5": {
         "name": "Leadership",
-        "value": 3
+        "value": 3,
+        "description": ""
       }
     },
     "bonuses": {
@@ -108,7 +109,8 @@
           }
         ]
       },
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -116,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784374,
-    "modifiedTime": 1754236374121,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755264623824,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "8yUj2Mzvnifhxegm",
   "sort": 1600000,
@@ -137,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Young_Ice_Dragon_UGPiPLJsPvMTSKEF.json
+++ b/src/packs/adversaries/adversary_Young_Ice_Dragon_UGPiPLJsPvMTSKEF.json
@@ -1,6 +1,6 @@
 {
   "name": "Young Ice Dragon",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "wTI7nZkPhKxl7Wwq",
   "system": {
@@ -109,7 +109,8 @@
         ]
       },
       "img": "icons/creatures/claws/claw-scaled-red.webp",
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -117,12 +118,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784374,
-    "modifiedTime": 1754236374761,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755266725295,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "UGPiPLJsPvMTSKEF",
   "sort": 3400000,
@@ -138,7 +139,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Young_Ice_Dragon_UGPiPLJsPvMTSKEF.json
+++ b/src/packs/adversaries/adversary_Young_Ice_Dragon_UGPiPLJsPvMTSKEF.json
@@ -110,7 +110,8 @@
       },
       "img": "icons/creatures/claws/claw-scaled-red.webp",
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Zombie_Legion_YhJrP7rTBiRdX5Fp.json
+++ b/src/packs/adversaries/adversary_Zombie_Legion_YhJrP7rTBiRdX5Fp.json
@@ -104,7 +104,8 @@
       },
       "range": "close",
       "img": "icons/creatures/tentacles/tentacles-octopus-black-pink.webp",
-      "type": "attack"
+      "type": "attack",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Zombie_Legion_YhJrP7rTBiRdX5Fp.json
+++ b/src/packs/adversaries/adversary_Zombie_Legion_YhJrP7rTBiRdX5Fp.json
@@ -1,6 +1,6 @@
 {
   "name": "Zombie Legion",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "7XHlANCPz18yvl5L",
   "system": {
@@ -112,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
     "systemVersion": "0.0.1",
     "createdTime": 1753922784375,
-    "modifiedTime": 1754236374894,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755259462784,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "YhJrP7rTBiRdX5Fp",
   "sort": 1300000,
@@ -133,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/adversaries/adversary_Zombie_Pack_Nf0v43rtflV56V2T.json
+++ b/src/packs/adversaries/adversary_Zombie_Pack_Nf0v43rtflV56V2T.json
@@ -104,7 +104,8 @@
       },
       "img": "icons/creatures/abilities/mouth-teeth-sharp.webp",
       "type": "attack",
-      "range": "melee"
+      "range": "melee",
+      "chatDisplay": false
     }
   },
   "flags": {},

--- a/src/packs/adversaries/adversary_Zombie_Pack_Nf0v43rtflV56V2T.json
+++ b/src/packs/adversaries/adversary_Zombie_Pack_Nf0v43rtflV56V2T.json
@@ -1,6 +1,6 @@
 {
   "name": "Zombie Pack",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
   "type": "adversary",
   "folder": "sxvlEwi25uAoB2C5",
   "system": {
@@ -103,7 +103,8 @@
         "type": "attack"
       },
       "img": "icons/creatures/abilities/mouth-teeth-sharp.webp",
-      "type": "attack"
+      "type": "attack",
+      "range": "melee"
     }
   },
   "flags": {},
@@ -111,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753922784375,
-    "modifiedTime": 1754236374543,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755264639582,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_id": "Nf0v43rtflV56V2T",
   "sort": 3100000,
@@ -132,7 +133,7 @@
     "width": 1,
     "height": 1,
     "texture": {
-      "src": "icons/svg/mystery-man.svg",
+      "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
       "offsetX": 0,

--- a/src/packs/items/weapons/weapon_Advanced_Shortsword_p3nz5CaGUoyuGVg0.json
+++ b/src/packs/items/weapons/weapon_Advanced_Shortsword_p3nz5CaGUoyuGVg0.json
@@ -16,7 +16,7 @@
       {
         "value": "paired",
         "effectIds": [
-          "WSMhQAuJyjWet29Z"
+          "zQMaG3JcUWJR9k2L"
         ],
         "actionIds": []
       }
@@ -105,7 +105,7 @@
   "effects": [
     {
       "name": "Paired",
-      "description": "Add your character's Tier + 1 to primary weapon damage against targets within Melee range",
+      "description": "Add this Secondary Weapon's tier + 1 to your primary weapon against targets within Melee range",
       "img": "icons/skills/melee/weapons-crossed-swords-yellow-teal.webp",
       "changes": [
         {
@@ -114,9 +114,16 @@
           "value": "ITEM.@system.tier + 1"
         }
       ],
-      "_id": "WSMhQAuJyjWet29Z",
+      "system": {
+        "rangeDependence": {
+          "enabled": true,
+          "range": "melee",
+          "target": "hostile",
+          "type": "withinRange"
+        }
+      },
+      "_id": "zQMaG3JcUWJR9k2L",
       "type": "base",
-      "system": {},
       "disabled": false,
       "duration": {
         "startTime": null,
@@ -132,14 +139,14 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "13.347",
         "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1753794842150,
-        "modifiedTime": 1753794842150,
-        "lastModifiedBy": "FecEtPuoQh6MpjQ0"
+        "systemVersion": "1.0.4",
+        "createdTime": 1755268343094,
+        "modifiedTime": 1755268343094,
+        "lastModifiedBy": "VZIeX2YDvX338Zvr"
       },
-      "_key": "!items.effects!p3nz5CaGUoyuGVg0.WSMhQAuJyjWet29Z"
+      "_key": "!items.effects!p3nz5CaGUoyuGVg0.zQMaG3JcUWJR9k2L"
     }
   ],
   "sort": 0,
@@ -152,12 +159,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.0.4",
     "createdTime": 1753794821174,
-    "modifiedTime": 1753794842154,
-    "lastModifiedBy": "FecEtPuoQh6MpjQ0"
+    "modifiedTime": 1755268343096,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_key": "!items!p3nz5CaGUoyuGVg0"
 }

--- a/src/packs/items/weapons/weapon_Advanced_Small_Dagger_0thN0BpN05KT8Avx.json
+++ b/src/packs/items/weapons/weapon_Advanced_Small_Dagger_0thN0BpN05KT8Avx.json
@@ -16,7 +16,7 @@
       {
         "value": "paired",
         "effectIds": [
-          "MYgB3v3oQ5lIr3VE"
+          "6tJmTBsumbPmEwkY"
         ],
         "actionIds": []
       }
@@ -105,7 +105,7 @@
   "effects": [
     {
       "name": "Paired",
-      "description": "Add your character's Tier + 1 to primary weapon damage against targets within Melee range",
+      "description": "Add this Secondary Weapon's tier + 1 to your primary weapon against targets within Melee range",
       "img": "icons/skills/melee/weapons-crossed-swords-yellow-teal.webp",
       "changes": [
         {
@@ -122,7 +122,7 @@
           "type": "withinRange"
         }
       },
-      "_id": "MYgB3v3oQ5lIr3VE",
+      "_id": "6tJmTBsumbPmEwkY",
       "type": "base",
       "disabled": false,
       "duration": {
@@ -141,12 +141,12 @@
         "exportSource": null,
         "coreVersion": "13.347",
         "systemId": "daggerheart",
-        "systemVersion": "1.0.0",
-        "createdTime": 1754814673988,
-        "modifiedTime": 1754814673988,
-        "lastModifiedBy": "MQSznptE5yLT7kj8"
+        "systemVersion": "1.0.4",
+        "createdTime": 1755268350046,
+        "modifiedTime": 1755268350046,
+        "lastModifiedBy": "VZIeX2YDvX338Zvr"
       },
-      "_key": "!items.effects!0thN0BpN05KT8Avx.MYgB3v3oQ5lIr3VE"
+      "_key": "!items.effects!0thN0BpN05KT8Avx.6tJmTBsumbPmEwkY"
     }
   ],
   "sort": 0,
@@ -161,10 +161,10 @@
     "exportSource": null,
     "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "1.0.0",
+    "systemVersion": "1.0.4",
     "createdTime": 1753794938643,
-    "modifiedTime": 1754814673991,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755268350050,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_key": "!items!0thN0BpN05KT8Avx"
 }

--- a/src/packs/items/weapons/weapon_Improved_Shortsword_rSyBNRwemBVuTo3H.json
+++ b/src/packs/items/weapons/weapon_Improved_Shortsword_rSyBNRwemBVuTo3H.json
@@ -16,7 +16,7 @@
       {
         "value": "paired",
         "effectIds": [
-          "9iHHwd9BxkBsV9lY"
+          "UW2fqbhBqvnK1coG"
         ],
         "actionIds": []
       }
@@ -105,7 +105,7 @@
   "effects": [
     {
       "name": "Paired",
-      "description": "Add your character's Tier + 1 to primary weapon damage against targets within Melee range",
+      "description": "Add this Secondary Weapon's tier + 1 to your primary weapon against targets within Melee range",
       "img": "icons/skills/melee/weapons-crossed-swords-yellow-teal.webp",
       "changes": [
         {
@@ -122,7 +122,7 @@
           "type": "withinRange"
         }
       },
-      "_id": "9iHHwd9BxkBsV9lY",
+      "_id": "UW2fqbhBqvnK1coG",
       "type": "base",
       "disabled": false,
       "duration": {
@@ -141,12 +141,12 @@
         "exportSource": null,
         "coreVersion": "13.347",
         "systemId": "daggerheart",
-        "systemVersion": "1.0.0",
-        "createdTime": 1754814695260,
-        "modifiedTime": 1754814695260,
-        "lastModifiedBy": "MQSznptE5yLT7kj8"
+        "systemVersion": "1.0.4",
+        "createdTime": 1755268322552,
+        "modifiedTime": 1755268322552,
+        "lastModifiedBy": "VZIeX2YDvX338Zvr"
       },
-      "_key": "!items.effects!rSyBNRwemBVuTo3H.9iHHwd9BxkBsV9lY"
+      "_key": "!items.effects!rSyBNRwemBVuTo3H.UW2fqbhBqvnK1coG"
     }
   ],
   "sort": 0,
@@ -161,10 +161,10 @@
     "exportSource": null,
     "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "1.0.0",
+    "systemVersion": "1.0.4",
     "createdTime": 1753744566951,
-    "modifiedTime": 1754814695265,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755268322555,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_key": "!items!rSyBNRwemBVuTo3H"
 }

--- a/src/packs/items/weapons/weapon_Improved_Small_Dagger_nMuF8ZDZ2aXZVTg6.json
+++ b/src/packs/items/weapons/weapon_Improved_Small_Dagger_nMuF8ZDZ2aXZVTg6.json
@@ -16,7 +16,7 @@
       {
         "value": "paired",
         "effectIds": [
-          "JHIUGyZH5q83ODvd"
+          "PMXG4l85UkXRf41E"
         ],
         "actionIds": []
       }
@@ -105,7 +105,7 @@
   "effects": [
     {
       "name": "Paired",
-      "description": "Add your character's Tier + 1 to primary weapon damage against targets within Melee range",
+      "description": "Add this Secondary Weapon's tier + 1 to your primary weapon against targets within Melee range",
       "img": "icons/skills/melee/weapons-crossed-swords-yellow-teal.webp",
       "changes": [
         {
@@ -122,7 +122,7 @@
           "type": "withinRange"
         }
       },
-      "_id": "JHIUGyZH5q83ODvd",
+      "_id": "PMXG4l85UkXRf41E",
       "type": "base",
       "disabled": false,
       "duration": {
@@ -141,12 +141,12 @@
         "exportSource": null,
         "coreVersion": "13.347",
         "systemId": "daggerheart",
-        "systemVersion": "1.0.0",
-        "createdTime": 1754814703717,
-        "modifiedTime": 1754814703717,
-        "lastModifiedBy": "MQSznptE5yLT7kj8"
+        "systemVersion": "1.0.4",
+        "createdTime": 1755268329305,
+        "modifiedTime": 1755268329305,
+        "lastModifiedBy": "VZIeX2YDvX338Zvr"
       },
-      "_key": "!items.effects!nMuF8ZDZ2aXZVTg6.JHIUGyZH5q83ODvd"
+      "_key": "!items.effects!nMuF8ZDZ2aXZVTg6.PMXG4l85UkXRf41E"
     }
   ],
   "sort": 0,
@@ -161,10 +161,10 @@
     "exportSource": null,
     "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "1.0.0",
+    "systemVersion": "1.0.4",
     "createdTime": 1753794291887,
-    "modifiedTime": 1754814703719,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755268329308,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_key": "!items!nMuF8ZDZ2aXZVTg6"
 }

--- a/src/packs/items/weapons/weapon_Legendary_Shortsword_dEumq3BIZBk5xYTk.json
+++ b/src/packs/items/weapons/weapon_Legendary_Shortsword_dEumq3BIZBk5xYTk.json
@@ -16,7 +16,7 @@
       {
         "value": "paired",
         "effectIds": [
-          "VFt61c2Apfbli2dG"
+          "ebloMf4gItx38xkZ"
         ],
         "actionIds": []
       }
@@ -105,7 +105,7 @@
   "effects": [
     {
       "name": "Paired",
-      "description": "Add your character's Tier + 1 to primary weapon damage against targets within Melee range",
+      "description": "Add this Secondary Weapon's tier + 1 to your primary weapon against targets within Melee range",
       "img": "icons/skills/melee/weapons-crossed-swords-yellow-teal.webp",
       "changes": [
         {
@@ -122,7 +122,7 @@
           "type": "withinRange"
         }
       },
-      "_id": "VFt61c2Apfbli2dG",
+      "_id": "ebloMf4gItx38xkZ",
       "type": "base",
       "disabled": false,
       "duration": {
@@ -141,12 +141,12 @@
         "exportSource": null,
         "coreVersion": "13.347",
         "systemId": "daggerheart",
-        "systemVersion": "1.0.0",
-        "createdTime": 1754814544486,
-        "modifiedTime": 1754814544486,
-        "lastModifiedBy": "MQSznptE5yLT7kj8"
+        "systemVersion": "1.0.4",
+        "createdTime": 1755268362371,
+        "modifiedTime": 1755268362371,
+        "lastModifiedBy": "VZIeX2YDvX338Zvr"
       },
-      "_key": "!items.effects!dEumq3BIZBk5xYTk.VFt61c2Apfbli2dG"
+      "_key": "!items.effects!dEumq3BIZBk5xYTk.ebloMf4gItx38xkZ"
     }
   ],
   "sort": 0,
@@ -161,10 +161,10 @@
     "exportSource": null,
     "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "1.0.0",
+    "systemVersion": "1.0.4",
     "createdTime": 1753796913551,
-    "modifiedTime": 1754814544510,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755268362375,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_key": "!items!dEumq3BIZBk5xYTk"
 }

--- a/src/packs/items/weapons/weapon_Legendary_Small_Dagger_Px3Rh3kIvAqyISxJ.json
+++ b/src/packs/items/weapons/weapon_Legendary_Small_Dagger_Px3Rh3kIvAqyISxJ.json
@@ -16,7 +16,7 @@
       {
         "value": "paired",
         "effectIds": [
-          "rnVm0jSEtdWhKGCh"
+          "WAqE3sZFkTefglDq"
         ],
         "actionIds": []
       }
@@ -105,7 +105,7 @@
   "effects": [
     {
       "name": "Paired",
-      "description": "Add your character's Tier + 1 to primary weapon damage against targets within Melee range",
+      "description": "Add this Secondary Weapon's tier + 1 to your primary weapon against targets within Melee range",
       "img": "icons/skills/melee/weapons-crossed-swords-yellow-teal.webp",
       "changes": [
         {
@@ -122,7 +122,7 @@
           "type": "withinRange"
         }
       },
-      "_id": "rnVm0jSEtdWhKGCh",
+      "_id": "WAqE3sZFkTefglDq",
       "type": "base",
       "disabled": false,
       "duration": {
@@ -141,12 +141,12 @@
         "exportSource": null,
         "coreVersion": "13.347",
         "systemId": "daggerheart",
-        "systemVersion": "1.0.0",
-        "createdTime": 1754814562988,
-        "modifiedTime": 1754814562988,
-        "lastModifiedBy": "MQSznptE5yLT7kj8"
+        "systemVersion": "1.0.4",
+        "createdTime": 1755268370233,
+        "modifiedTime": 1755268370233,
+        "lastModifiedBy": "VZIeX2YDvX338Zvr"
       },
-      "_key": "!items.effects!Px3Rh3kIvAqyISxJ.rnVm0jSEtdWhKGCh"
+      "_key": "!items.effects!Px3Rh3kIvAqyISxJ.WAqE3sZFkTefglDq"
     }
   ],
   "sort": 0,
@@ -161,10 +161,10 @@
     "exportSource": null,
     "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "1.0.0",
+    "systemVersion": "1.0.4",
     "createdTime": 1753797057472,
-    "modifiedTime": 1754814562995,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755268370240,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_key": "!items!Px3Rh3kIvAqyISxJ"
 }

--- a/src/packs/items/weapons/weapon_Shortsword_cjGZpXCoshEqi1FI.json
+++ b/src/packs/items/weapons/weapon_Shortsword_cjGZpXCoshEqi1FI.json
@@ -16,7 +16,7 @@
       {
         "value": "paired",
         "effectIds": [
-          "5RpOUFs0kDhzwltM"
+          "djNtNpasgNDRP8Dd"
         ],
         "actionIds": []
       }
@@ -105,13 +105,14 @@
   "effects": [
     {
       "name": "Paired",
-      "description": "Add your character's Tier + 1 to primary weapon damage against targets within Melee range",
+      "description": "<p>Add this Secondary Weapon's tier + 1 to your primary weapon against targets within Melee range</p>",
       "img": "icons/skills/melee/weapons-crossed-swords-yellow-teal.webp",
       "changes": [
         {
           "key": "system.bonuses.damage.primaryWeapon.bonus",
           "mode": 2,
-          "value": "ITEM.@system.tier + 1"
+          "value": "ITEM.@system.tier + 1",
+          "priority": null
         }
       ],
       "system": {
@@ -122,12 +123,17 @@
           "type": "withinRange"
         }
       },
-      "_id": "5RpOUFs0kDhzwltM",
+      "_id": "djNtNpasgNDRP8Dd",
       "type": "base",
       "disabled": false,
       "duration": {
         "startTime": null,
-        "combat": null
+        "combat": null,
+        "seconds": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
       },
       "origin": null,
       "tint": "#ffffff",
@@ -141,12 +147,12 @@
         "exportSource": null,
         "coreVersion": "13.347",
         "systemId": "daggerheart",
-        "systemVersion": "1.0.0",
-        "createdTime": 1754814729443,
-        "modifiedTime": 1754814729443,
-        "lastModifiedBy": "MQSznptE5yLT7kj8"
+        "systemVersion": "1.0.4",
+        "createdTime": 1755268286534,
+        "modifiedTime": 1755268292662,
+        "lastModifiedBy": "VZIeX2YDvX338Zvr"
       },
-      "_key": "!items.effects!cjGZpXCoshEqi1FI.5RpOUFs0kDhzwltM"
+      "_key": "!items.effects!cjGZpXCoshEqi1FI.djNtNpasgNDRP8Dd"
     }
   ],
   "sort": 0,
@@ -161,10 +167,10 @@
     "exportSource": null,
     "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "1.0.0",
+    "systemVersion": "1.0.4",
     "createdTime": 1753741549716,
-    "modifiedTime": 1754814729447,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755268286538,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_key": "!items!cjGZpXCoshEqi1FI"
 }

--- a/src/packs/items/weapons/weapon_Small_Dagger_wKklDxs5nkzILNp4.json
+++ b/src/packs/items/weapons/weapon_Small_Dagger_wKklDxs5nkzILNp4.json
@@ -16,7 +16,7 @@
       {
         "value": "paired",
         "effectIds": [
-          "wK6ccFAirp9HYK5Q"
+          "HKh73AHxImdgxgTg"
         ],
         "actionIds": []
       }
@@ -105,7 +105,7 @@
   "effects": [
     {
       "name": "Paired",
-      "description": "Add your character's Tier + 1 to primary weapon damage against targets within Melee range",
+      "description": "Add this Secondary Weapon's tier + 1 to your primary weapon against targets within Melee range",
       "img": "icons/skills/melee/weapons-crossed-swords-yellow-teal.webp",
       "changes": [
         {
@@ -122,7 +122,7 @@
           "type": "withinRange"
         }
       },
-      "_id": "wK6ccFAirp9HYK5Q",
+      "_id": "HKh73AHxImdgxgTg",
       "type": "base",
       "disabled": false,
       "duration": {
@@ -141,12 +141,12 @@
         "exportSource": null,
         "coreVersion": "13.347",
         "systemId": "daggerheart",
-        "systemVersion": "1.0.0",
-        "createdTime": 1754814738851,
-        "modifiedTime": 1754814738851,
-        "lastModifiedBy": "MQSznptE5yLT7kj8"
+        "systemVersion": "1.0.4",
+        "createdTime": 1755268300195,
+        "modifiedTime": 1755268300195,
+        "lastModifiedBy": "VZIeX2YDvX338Zvr"
       },
-      "_key": "!items.effects!wKklDxs5nkzILNp4.wK6ccFAirp9HYK5Q"
+      "_key": "!items.effects!wKklDxs5nkzILNp4.HKh73AHxImdgxgTg"
     }
   ],
   "sort": 0,
@@ -161,10 +161,10 @@
     "exportSource": null,
     "coreVersion": "13.347",
     "systemId": "daggerheart",
-    "systemVersion": "1.0.0",
+    "systemVersion": "1.0.4",
     "createdTime": 1753744141625,
-    "modifiedTime": 1754814738854,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1755268300204,
+    "lastModifiedBy": "VZIeX2YDvX338Zvr"
   },
   "_key": "!items!wKklDxs5nkzILNp4"
 }

--- a/templates/sheets/actors/adversary/sidebar.hbs
+++ b/templates/sheets/actors/adversary/sidebar.hbs
@@ -49,8 +49,8 @@
             </div>
             <div class="status-number">
                 <div class='status-value armor-slots'>
-                    {{#if source.system.attack.roll.bonus}}
-                    <p>{{source.system.attack.roll.bonus}}</p>
+                    {{#if source.system.attack.roll.bonus includeZero=true}}
+                    <p>{{numberFormat source.system.attack.roll.bonus sign=true}}</p>
                     {{else}}
                     <p>-</p>
                     {{/if}}


### PR DESCRIPTION
Closes #906
Closes #927 
Closes #945 
- Fixed all ranges on Adversaries
- Fixed some faulty Difficulties on Adversaries
- Set all self targeting abilities I saw to target self.
- Changed so Adversaries show a +0 attack bonus when they have that instead of `-`
- Changed so Adversaries always show a signed number for their attack IE: `+2` instead of just `2`
- Updated all Adversary basic attacks to be `chatDisplay=false` so they don't send the initial message to chat on use.