### PR TITLE
[PR][Feature] Improves ForeignDocumentUUIDArrayField for can use documents to update it.

### DIFF
--- a/module/data/fields/foreignDocumentUUIDField.mjs
+++ b/module/data/fields/foreignDocumentUUIDField.mjs
@@ -38,4 +38,13 @@ export default class ForeignDocumentUUIDField extends foundry.data.fields.Docume
     toObject(value) {
         return value?.uuid ?? value;
     }
+
+    /** @override */
+    _cast(value) {
+        if (typeof value === 'string') return value;
+        if (value instanceof foundry.abstract.Document) return value.uuid;
+        throw new Error(
+            `The value provided to a ForeignDocumentUUIDField must be a ${foundry.abstract.Document.name} instance or a UUID string.`
+        );
+    }
 }

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -177,7 +177,7 @@ Roll.replaceFormulaData = function (formula, data = {}, { missing, warn = false 
     return nativeReplaceFormulaData(formula, data, { missing, warn });
 };
 
-foundry.dice.terms.Die.MODIFIERS.sc = 'selfCorrecting';
+foundry.utils.setProperty(foundry, 'dice.terms.Die.MODIFIERS.sc', 'selfCorrecting');
 
 /**
  * Return the configured value as result if 1 is rolled


### PR DESCRIPTION
## Description

ForeignDocumentUUIDFields now accept document instances at update time.

The way of how selfCorrecting modifier is set is change so that it doesn't break IntelliSense in VScode.

- Fixes #389

## Type of Change

Please check the relevant options:

- [ ] Bug fix
- [X] New feature
- [X] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

