### PR TITLE
[Fix] Creation/Levelup disable finish button

### DIFF
--- a/module/applications/characterCreation/characterCreation.mjs
+++ b/module/applications/characterCreation/characterCreation.mjs
@@ -494,7 +494,9 @@ export default class DhCharacterCreation extends HandlebarsApplicationMixin(Appl
         this.render();
     }
 
-    static async finish() {
+    static async finish(_, button) {
+        button.disabled = true;
+
         const primaryAncestryFeature = this.setup.primaryAncestry.system.primaryFeature;
         const secondaryAncestryFeature = this.setup.secondaryAncestry?.uuid
             ? this.setup.secondaryAncestry.system.secondaryFeature

--- a/module/applications/levelup/levelup.mjs
+++ b/module/applications/levelup/levelup.mjs
@@ -650,7 +650,9 @@ export default class DhlevelUp extends HandlebarsApplicationMixin(ApplicationV2)
         this.render();
     }
 
-    static async save() {
+    static async save(_, button) {
+        button.disabled = true;
+
         const levelupData = Object.keys(this.levelup.levels).reduce((acc, level) => {
             if (level >= this.levelup.startLevel) {
                 acc[level] = this.levelup.levels[level].toObject();

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
     "id": "daggerheart",
     "title": "Daggerheart",
     "description": "An unofficial implementation of the Daggerheart system",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "compatibility": {
         "minimum": "13",
         "verified": "13.347",


### PR DESCRIPTION
Set the finish buttons on levelup and creation to disable after first click. Decided to do it this way rather than debounce because I don't trust how laggy user computers/servers will be.