### PR TITLE
[PR]Add setup script for development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+FOUNDRY_MAIN_PATH=/path/to/foundry/resources/app/main.js
+FOUNDRY_DATA_PATH=/path/to/foundry/data

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.env
 node_modules
 /packs
 Build

--- a/README.md
+++ b/README.md
@@ -24,24 +24,41 @@ You can find the documentation here: https://github.com/Foundryborne/daggerheart
 
 ## Development Setup
 
-- Open a terminal in the directory with the repo `cd <path>/<to>/<repo>`
-- NOTE: The repo should be placed in the system files are or somewhere else and a link (if on linux) is placed in the system directory
-- NOTE: Linux link can be made using `ln -snf <path to development folder> daggerheart` inside the system folder
-- Install npm `npm install`
-- Update package.json to match your profile
+1. **Navigate to the repo directory:**
 
-```
-"start": "concurrently \"rollup -c --watch\" \"node C:/FoundryDev/resources/app/main.js --dataPath=C:/FoundryDevFiles  --noupnp\"  \"gulp\"",
-"start-test": "node C:/FoundryDev/resources/app/main.js --dataPath=C:/FoundryDevFiles && rollup -c --watch && gulp",
+    ```bash
+    cd <path>/<to>/<repo>
+    ```
 
-```
+2. **Install dependencies:**
 
-- Replace `C:/FoundryDev/resources/app/main.js` with `<your>/<path>/<to>/<foundry>/<main.js>`
-- The main is likely in `<Foundry Install Location>/resouces/app/main.js`
-- Replace `--dataPath=C:/FoundryDevFiles` with `<your>/<path>/<to>/<foundry>/<data>`
+    ```bash
+    npm install
+    ```
 
-Now you should be able to build the app using `npm start`
-[Foundry VTT Website][1]
+3. **Configure your Foundry paths:**
+
+    ```bash
+    npm run setup:dev -- --foundry-path="/path/to/foundry/main.js" --data-path="/path/to/data"
+    ```
+
+4. **Start developing:**
+    ```bash
+    npm start
+    ```
+
+### Available Scripts
+
+- `npm start` - Start development with file watching and Foundry launching
+- `npm run build` - One-time build
+- `npm run setup:dev -- --foundry-path="<path>" --data-path="<path>"` - Configure development environment
+
+### Notes
+
+- The repo should be placed in your Foundry `Data/systems/` directory or symlinked there
+- Linux symlink can be made using `ln -snf <path to development folder> daggerheart` inside the systems folder
+- Your `.env` file is ignored by git, so each developer can have their own configuration
+  [Foundry VTT Website][1]
 
 [1]: https://foundryvtt.com/
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "rollup": "^4.40.0"
   },
   "scripts": {
-    "start": "concurrently \"rollup -c --watch\" \"node ../../../../FoundryDev/main.js --dataPath=../../../  --noupnp\"  \"gulp\"",
+    "start": "node ./tools/run-start.mjs",
     "start-test": "node ./resources/app/main.js --dataPath=./ && rollup -c --watch && gulp",
     "build": "npm run rollup && npm run gulp",
     "rollup": "rollup -c",
@@ -16,7 +16,8 @@
     "pushLDBtoYML": "node ./tools/pushLDBtoYML.mjs",
     "pullYMLtoLDB": "node ./tools/pullYMLtoLDB.mjs",
     "pullYMLtoLDBBuild": "node ./tools/pullYMLtoLDBBuild.mjs",
-    "createSymlink": "node ./tools/create-symlink.mjs"
+    "createSymlink": "node ./tools/create-symlink.mjs",
+    "setup:dev": "node ./tools/dev-setup.mjs"
   },
   "devDependencies": {
     "@foundryvtt/foundryvtt-cli": "^1.0.2",

--- a/tools/dev-setup.mjs
+++ b/tools/dev-setup.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+import fs from 'fs';
+
+const args = process.argv.slice(2);
+const foundryPath = args.find(arg => arg.startsWith('--foundry-path='))?.split('=')[1];
+const dataPath = args.find(arg => arg.startsWith('--data-path='))?.split('=')[1];
+
+if (!foundryPath || !dataPath) {
+    console.log('Usage: npm run setup:dev -- --foundry-path="/path/to/foundry/main.js" --data-path="/path/to/data"');
+    process.exit(1);
+}
+
+const envContent = `FOUNDRY_MAIN_PATH=${foundryPath}
+FOUNDRY_DATA_PATH=${dataPath}
+`;
+
+fs.writeFileSync('.env', envContent);
+console.log(`✅ Development environment configured: ${foundryPath}, ${dataPath}`);

--- a/tools/run-start.mjs
+++ b/tools/run-start.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+import { spawn } from 'child_process';
+import fs from 'fs';
+
+// Load .env file if it exists
+if (fs.existsSync('.env')) {
+    const envFile = fs.readFileSync('.env', 'utf8');
+    envFile.split('\n').forEach(line => {
+        const [key, value] = line.split('=');
+        if (key && value) {
+            process.env[key] = value;
+        }
+    });
+}
+
+// Set defaults if not in environment
+const foundryPath = process.env.FOUNDRY_MAIN_PATH || '../../../../FoundryDev/main.js';
+const dataPath = process.env.FOUNDRY_DATA_PATH || '../../../';
+
+// Run the original command with proper environment
+const args = ['rollup -c --watch', `node "${foundryPath}" --dataPath="${dataPath}" --noupnp`, 'gulp'];
+
+spawn('npx', ['concurrently', ...args.map(arg => `"${arg}"`)], {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+    shell: true
+});


### PR DESCRIPTION
## Description

This PR introduces a configurable development environment setup that eliminates the need for developers to manually edit hardcoded paths in `package.json`. Instead of requiring each contributor to modify the repository files with their local Foundry installation paths, the system now uses environment variables with current values as fallbacks.

**Key improvements:**
- Developers can set up their environment with a single command: `npm run setup:dev -- --foundry-path="<path>" --data-path="<path>"`
- Environment variables are stored in a `.env` file (gitignored) for per-developer configuration

## Type of Change

- [x] New feature
- [x] Configuration change
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual testing
  - Tested without `.env` file (fallback to original hardcoded paths)
  - Tested with `.env` file (uses configured environment variables)
  - Verified build processes (rollup, gulp) work correctly in both scenarios
  - Tested cross-platform compatibility with proper path quoting

## Screenshots (if applicable)

N/A - This is a development workflow improvement

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [x] New and existing tests pass locally with my changes
