### PR TITLE
[Fix] 1005 - RollTable ActionButtons

### DIFF
--- a/daggerheart.mjs
+++ b/daggerheart.mjs
@@ -8,7 +8,7 @@ import RegisterHandlebarsHelpers from './module/helpers/handlebarsHelper.mjs';
 import { enricherConfig, enricherRenderSetup } from './module/enrichers/_module.mjs';
 import { getCommandTarget, rollCommandToJSON } from './module/helpers/utils.mjs';
 import { NarrativeCountdowns } from './module/applications/ui/countdowns.mjs';
-import { DHRoll, DualityRoll, D20Roll, DamageRoll } from './module/dice/_module.mjs';
+import { BaseRoll, DHRoll, DualityRoll, D20Roll, DamageRoll } from './module/dice/_module.mjs';
 import { enrichedDualityRoll } from './module/enrichers/DualityRollEnricher.mjs';
 import { registerCountdownHooks } from './module/data/countdowns.mjs';
 import {
@@ -49,9 +49,7 @@ Hooks.once('init', () => {
         DamageRoll: DamageRoll
     };
 
-    CONFIG.Dice.rolls = [...CONFIG.Dice.rolls, DHRoll, DualityRoll, D20Roll, DamageRoll];
-    Roll.CHAT_TEMPLATE = 'systems/daggerheart/templates/ui/chat/foundryRoll.hbs';
-    Roll.TOOLTIP_TEMPLATE = 'systems/daggerheart/templates/ui/chat/foundryRollTooltip.hbs';
+    CONFIG.Dice.rolls = [BaseRoll, DHRoll, DualityRoll, D20Roll, DamageRoll];
     CONFIG.MeasuredTemplate.objectClass = placeables.DhMeasuredTemplate;
 
     const { DocumentSheetConfig } = foundry.applications.apps;

--- a/module/dice/_module.mjs
+++ b/module/dice/_module.mjs
@@ -1,3 +1,4 @@
+export { default as BaseRoll } from './baseRoll.mjs';
 export { default as D20Roll } from './d20Roll.mjs';
 export { default as DamageRoll } from './damageRoll.mjs';
 export { default as DHRoll } from './dhRoll.mjs';

--- a/module/dice/baseRoll.mjs
+++ b/module/dice/baseRoll.mjs
@@ -1,0 +1,7 @@
+export default class BaseRoll extends Roll {
+    /** @inheritdoc */
+    static CHAT_TEMPLATE = 'systems/daggerheart/templates/ui/chat/foundryRoll.hbs';
+
+    /** @inheritdoc */
+    static TOOLTIP_TEMPLATE = 'systems/daggerheart/templates/ui/chat/foundryRollTooltip.hbs';
+}

--- a/templates/ui/chat/foundryRoll.hbs
+++ b/templates/ui/chat/foundryRoll.hbs
@@ -8,7 +8,9 @@
         <h4 class="dice-total">{{total}}</h4>
     </div>
 </div>
-<div class="roll-buttons apply-buttons">
-    <button class="simple-roll-button">{{localize "DAGGERHEART.UI.Chat.damageRoll.dealDamage"}}</button>
-    <button class="simple-roll-button" data-type="healing">{{localize "DAGGERHEART.UI.Chat.healingRoll.applyHealing"}}</button>
-</div>
+{{#unless flags.core.RollTable}}
+    <div class="roll-buttons apply-buttons">
+        <button class="simple-roll-button">{{localize "DAGGERHEART.UI.Chat.damageRoll.dealDamage"}}</button>
+        <button class="simple-roll-button" data-type="healing">{{localize "DAGGERHEART.UI.Chat.healingRoll.applyHealing"}}</button>
+    </div>
+{{/unless}}


### PR DESCRIPTION
Fixes #1005 
RollTable ChatMessage - Removed the action buttons
Did it in a simple way, since otherwise we'd have to copy-paste 3 private methods from ChatMessage to change the renderData for the roll message.