### PR TITLE
[Fix] ItemLink Fix

### DIFF
--- a/daggerheart.mjs
+++ b/daggerheart.mjs
@@ -13,6 +13,7 @@ import { enrichedDualityRoll } from './module/enrichers/DualityRollEnricher.mjs'
 import { registerCountdownHooks } from './module/data/countdowns.mjs';
 import {
     handlebarsRegistration,
+    runMigrations,
     settingsRegistration,
     socketRegistration
 } from './module/systemRegistration/_module.mjs';
@@ -168,6 +169,8 @@ Hooks.on('ready', async () => {
             game.user.setFlag(CONFIG.DH.id, CONFIG.DH.FLAGS.userFlags.welcomeMessage, true);
         }
     }
+
+    runMigrations();
 });
 
 Hooks.once('dicesoniceready', () => {});

--- a/lang/en.json
+++ b/lang/en.json
@@ -193,7 +193,9 @@
                 "companionLevelup": {
                     "confirmTitle": "Companion Levelup",
                     "confirmText": "Would you like to level up your companion {name} by {levelChange} levels at this time? (You can do it manually later)"
-                }
+                },
+                "InvalidOldCharacterImportTitle": "Old Character Import",
+                "InvalidOldCharacterImportText": "Character data exported prior to system version 1.1 will not generate a complete character. Do you wish to continue?"
             },
             "Companion": {
                 "FIELDS": {

--- a/module/applications/sheets/api/application-mixin.mjs
+++ b/module/applications/sheets/api/application-mixin.mjs
@@ -591,7 +591,6 @@ export default function DHApplicationMixin(Base) {
             if (featureOnCharacter) {
                 systemData = {
                     originItemType: this.document.type,
-                    originId: this.document.id,
                     identifier: this.document.system.isMulticlass ? 'multiclass' : null
                 };
             }

--- a/module/applications/sheets/api/base-item.mjs
+++ b/module/applications/sheets/api/base-item.mjs
@@ -149,12 +149,12 @@ export default class DHBaseItemSheet extends DHApplicationMixin(ItemSheetV2) {
         const { type } = target.dataset;
         const cls = foundry.documents.Item.implementation;
 
+        const multiclass = this.document.system.isMulticlass ? 'multiclass' : null;
         let systemData = {};
         if (this.document.parent?.type === 'character') {
             systemData = {
                 originItemType: this.document.type,
-                originId: this.document.id,
-                identifier: this.document.system.isMulticlass ? 'multiclass' : null
+                identifier: multiclass ?? type
             };
         }
 
@@ -275,14 +275,15 @@ export default class DHBaseItemSheet extends DHApplicationMixin(ItemSheetV2) {
 
             if (this.document.parent?.type === 'character') {
                 const itemData = item.toObject();
+                const multiclass = this.document.system.isMulticlass ? 'multiclass' : null;
                 item = await cls.create(
                     {
                         ...itemData,
+                        _stats: { compendiumSource: this.document.uuid },
                         system: {
                             ...itemData.system,
                             originItemType: this.document.type,
-                            originId: this.document.id,
-                            identifier: this.document.system.isMulticlass ? 'multiclass' : null
+                            identifier: multiclass ?? target.dataset.type
                         }
                     },
                     { parent: this.document.parent }

--- a/module/config/settingsConfig.mjs
+++ b/module/config/settingsConfig.mjs
@@ -26,5 +26,6 @@ export const gameSettings = {
         Fear: 'ResourcesFear'
     },
     LevelTiers: 'LevelTiers',
-    Countdowns: 'Countdowns'
+    Countdowns: 'Countdowns',
+    LastMigrationVersion: 'LastMigrationVersion'
 };

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -444,16 +444,12 @@ export default class DhCharacter extends BaseDataActor {
             } else if (item.system.originItemType === CONFIG.DH.ITEM.featureTypes.subclass.id) {
                 if (this.class.subclass) {
                     const subclassState = this.class.subclass.system.featureState;
-                    const subclass =
-                        item.system.identifier === 'multiclass' ? this.multiclass.subclass : this.class.subclass;
-                    const featureType = subclass
-                        ? (subclass.system.features.find(x => x.item?.uuid === item.uuid)?.type ?? null)
-                        : null;
 
                     if (
-                        featureType === CONFIG.DH.ITEM.featureSubTypes.foundation ||
-                        (featureType === CONFIG.DH.ITEM.featureSubTypes.specialization && subclassState >= 2) ||
-                        (featureType === CONFIG.DH.ITEM.featureSubTypes.mastery && subclassState >= 3)
+                        item.system.identifier === CONFIG.DH.ITEM.featureSubTypes.foundation ||
+                        (item.system.identifier === CONFIG.DH.ITEM.featureSubTypes.specialization &&
+                            subclassState >= 2) ||
+                        (item.system.identifier === CONFIG.DH.ITEM.featureSubTypes.mastery && subclassState >= 3)
                     ) {
                         subclassFeatures.push(item);
                     }

--- a/module/data/item/base.mjs
+++ b/module/data/item/base.mjs
@@ -144,48 +144,28 @@ export default class BaseDataItem extends foundry.abstract.TypeDataModel {
         }
 
         if (this.actor && this.actor.type === 'character' && this.features) {
-            const featureUpdates = {};
+            const features = [];
             for (let f of this.features) {
                 const fBase = f.item ?? f;
                 const feature = fBase.system ? fBase : await foundry.utils.fromUuid(fBase.uuid);
-                const createData = foundry.utils.mergeObject(
-                    feature.toObject(),
-                    {
-                        system: {
-                            originItemType: this.parent.type,
-                            originId: data._id,
-                            identifier: this.isMulticlass ? 'multiclass' : null
-                        }
-                    },
-                    { inplace: false }
+                const multiclass = this.isMulticlass ? 'multiclass' : null;
+                features.push(
+                    foundry.utils.mergeObject(
+                        feature.toObject(),
+                        {
+                            _stats: { compendiumSource: fBase.uuid },
+                            system: {
+                                originItemType: this.parent.type,
+                                identifier: multiclass ?? (f.item ? f.type : null)
+                            }
+                        },
+                        { inplace: false }
+                    )
                 );
-                const [doc] = await this.actor.createEmbeddedDocuments('Item', [createData]);
-
-                if (!featureUpdates.features)
-                    featureUpdates.features = this.features.map(x => (x.item ? { ...x, item: x.item.uuid } : x.uuid));
-
-                if (f.item) {
-                    const existingFeature = featureUpdates.features.find(x => x.item === f.item.uuid);
-                    existingFeature.item = doc.uuid;
-                } else {
-                    const replaceIndex = featureUpdates.features.findIndex(x => x === f.uuid);
-                    featureUpdates.features.splice(replaceIndex, 1, doc.uuid);
-                }
             }
 
-            await this.updateSource(featureUpdates);
+            await this.actor.createEmbeddedDocuments('Item', features);
         }
-    }
-
-    async _preDelete() {
-        if (!this.actor || this.actor.type !== 'character') return;
-
-        const items = this.actor.items.filter(item => item.system.originId === this.parent.id);
-        if (items.length > 0)
-            await this.actor.deleteEmbeddedDocuments(
-                'Item',
-                items.map(x => x.id)
-            );
     }
 
     async _preUpdate(changed, options, userId) {

--- a/module/data/item/feature.mjs
+++ b/module/data/item/feature.mjs
@@ -1,5 +1,4 @@
 import BaseDataItem from './base.mjs';
-import { ActionField, ActionsField } from '../fields/actionField.mjs';
 
 export default class DHFeature extends BaseDataItem {
     /** @inheritDoc */
@@ -30,24 +29,7 @@ export default class DHFeature extends BaseDataItem {
                 nullable: true,
                 initial: null
             }),
-            originId: new fields.StringField({ nullable: true, initial: null }),
             identifier: new fields.StringField()
         };
-    }
-
-    get spellcastingModifier() {
-        let traitValue = 0;
-        if (this.actor && this.originId && ['class', 'subclass'].includes(this.originItemType)) {
-            if (this.originItemType === 'subclass') {
-                traitValue =
-                    this.actor.system.traits[this.actor.items.get(this.originId).system.spellcastingTrait]?.value ?? 0;
-            } else {
-                const { value: multiclass, subclass } = this.actor.system.multiclass;
-                const selectedSubclass = multiclass?.id === this.originId ? subclass : this.actor.system.class.subclass;
-                traitValue = this.actor.system.traits[selectedSubclass.system.spellcastingTrait]?.value ?? 0;
-            }
-        }
-
-        return traitValue;
     }
 }

--- a/module/data/item/feature.mjs
+++ b/module/data/item/feature.mjs
@@ -12,6 +12,20 @@ export default class DHFeature extends BaseDataItem {
         });
     }
 
+    // /** @inheritDoc */
+    // _initializeSource(data, options={}) {
+    //     const { originItemType, isMulticlass } = data;
+    //     const base = (originItemType && this.parent?.parent?.type === 'character') ? this.parent.parent.items._source.find(x => x.type === originItemType && Boolean(isMulticlass) === x.system.isMulticlass) : null;
+    //     if(base) {
+    //         const feature = base.system.features.find(x => x.item && x.item === this.parent.uuid);
+    //         if(feature && data.identifier !== 'multiclass') {
+    //             data.identifier = feature.type;
+    //         }
+    //     }
+
+    //     return super._initializeSource(data, options);
+    // }
+
     /* -------------------------------------------- */
 
     /**@override */

--- a/module/data/item/feature.mjs
+++ b/module/data/item/feature.mjs
@@ -12,20 +12,6 @@ export default class DHFeature extends BaseDataItem {
         });
     }
 
-    // /** @inheritDoc */
-    // _initializeSource(data, options={}) {
-    //     const { originItemType, isMulticlass } = data;
-    //     const base = (originItemType && this.parent?.parent?.type === 'character') ? this.parent.parent.items._source.find(x => x.type === originItemType && Boolean(isMulticlass) === x.system.isMulticlass) : null;
-    //     if(base) {
-    //         const feature = base.system.features.find(x => x.item && x.item === this.parent.uuid);
-    //         if(feature && data.identifier !== 'multiclass') {
-    //             data.identifier = feature.type;
-    //         }
-    //     }
-
-    //     return super._initializeSource(data, options);
-    // }
-
     /* -------------------------------------------- */
 
     /**@override */

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -420,3 +420,14 @@ export async function createEmbeddedItemsWithEffects(actor, baseData) {
 export const slugify = name => {
     return name.toLowerCase().replaceAll(' ', '-').replaceAll('.', '');
 };
+
+export const versionCompare = (current, target) => {
+    const currentSplit = current.split('.').map(x => Number.parseInt(x));
+    const targetSplit = target.split('.').map(x => Number.parseInt(x));
+    for (var i = 0; i < currentSplit.length; i++) {
+        if (currentSplit[i] < targetSplit[i]) return true;
+        if (currentSplit[i] > targetSplit[i]) return false;
+    }
+
+    return false;
+};

--- a/module/systemRegistration/_module.mjs
+++ b/module/systemRegistration/_module.mjs
@@ -1,3 +1,4 @@
 export { preloadHandlebarsTemplates as handlebarsRegistration } from './handlebars.mjs';
 export * as settingsRegistration from './settings.mjs';
 export * as socketRegistration from './socket.mjs';
+export { runMigrations } from './migrations.mjs';

--- a/module/systemRegistration/migrations.mjs
+++ b/module/systemRegistration/migrations.mjs
@@ -2,7 +2,7 @@ export async function runMigrations() {
     let lastMigrationVersion = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.LastMigrationVersion);
     if (!lastMigrationVersion) lastMigrationVersion = '1.0.6';
 
-    if (versionCompare(lastMigrationVersion, '1.0.7')) {
+    if (versionCompare(lastMigrationVersion, '1.1.0')) {
         const compendiumActors = [];
         for (let pack of game.packs) {
             const documents = await pack.getDocuments();
@@ -32,7 +32,7 @@ export async function runMigrations() {
             actor.updateEmbeddedDocuments('Item', items);
         });
 
-        lastMigrationVersion = '1.0.7';
+        lastMigrationVersion = '1.1.0';
     }
 
     await game.settings.set(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.LastMigrationVersion, lastMigrationVersion);

--- a/module/systemRegistration/migrations.mjs
+++ b/module/systemRegistration/migrations.mjs
@@ -1,0 +1,50 @@
+export async function runMigrations() {
+    let lastMigrationVersion = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.LastMigrationVersion);
+    if (!lastMigrationVersion) lastMigrationVersion = '1.0.6';
+
+    if (versionCompare(lastMigrationVersion, '1.0.7')) {
+        const compendiumActors = [];
+        for (let pack of game.packs) {
+            const documents = await pack.getDocuments();
+            compendiumActors.push(...documents.filter(x => x.type === 'character'));
+        }
+
+        [...compendiumActors, ...game.actors].forEach(actor => {
+            const items = actor.items.reduce((acc, item) => {
+                if (item.type === 'feature') {
+                    const { originItemType, isMulticlass, identifier } = item.system;
+                    const base = originItemType
+                        ? actor.items.find(
+                              x => x.type === originItemType && Boolean(isMulticlass) === Boolean(x.system.isMulticlass)
+                          )
+                        : null;
+                    if (base) {
+                        const feature = base.system.features.find(x => x.item && x.item.uuid === item.uuid);
+                        if (feature && identifier !== 'multiclass') {
+                            acc.push({ _id: item.id, system: { identifier: feature.type } });
+                        }
+                    }
+                }
+
+                return acc;
+            }, []);
+
+            actor.updateEmbeddedDocuments('Item', items);
+        });
+
+        lastMigrationVersion = '1.0.7';
+    }
+
+    await game.settings.set(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.LastMigrationVersion, lastMigrationVersion);
+}
+
+const versionCompare = (current, target) => {
+    const currentSplit = current.split('.').map(x => Number.parseInt(x));
+    const targetSplit = target.split('.').map(x => Number.parseInt(x));
+    for (var i = 0; i < currentSplit.length; i++) {
+        if (currentSplit[i] < targetSplit[i]) return true;
+        if (currentSplit[i] > targetSplit[i]) return false;
+    }
+
+    return false;
+};

--- a/module/systemRegistration/migrations.mjs
+++ b/module/systemRegistration/migrations.mjs
@@ -1,3 +1,5 @@
+import { versionCompare } from '../helpers/utils.mjs';
+
 export async function runMigrations() {
     let lastMigrationVersion = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.LastMigrationVersion);
     if (!lastMigrationVersion) lastMigrationVersion = '1.0.6';
@@ -37,14 +39,3 @@ export async function runMigrations() {
 
     await game.settings.set(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.LastMigrationVersion, lastMigrationVersion);
 }
-
-const versionCompare = (current, target) => {
-    const currentSplit = current.split('.').map(x => Number.parseInt(x));
-    const targetSplit = target.split('.').map(x => Number.parseInt(x));
-    for (var i = 0; i < currentSplit.length; i++) {
-        if (currentSplit[i] < targetSplit[i]) return true;
-        if (currentSplit[i] > targetSplit[i]) return false;
-    }
-
-    return false;
-};

--- a/module/systemRegistration/settings.mjs
+++ b/module/systemRegistration/settings.mjs
@@ -91,6 +91,12 @@ const registerMenus = () => {
 };
 
 const registerNonConfigSettings = () => {
+    game.settings.register(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.LastMigrationVersion, {
+        scope: 'world',
+        config: false,
+        type: String
+    });
+
     game.settings.register(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.LevelTiers, {
         scope: 'world',
         config: false,

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
     "id": "daggerheart",
     "title": "Daggerheart",
     "description": "An unofficial implementation of the Daggerheart system",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "compatibility": {
         "minimum": "13",
         "verified": "13.347",

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
     "id": "daggerheart",
     "title": "Daggerheart",
     "description": "An unofficial implementation of the Daggerheart system",
-    "version": "1.0.7",
+    "version": "1.1.0",
     "compatibility": {
         "minimum": "13",
         "verified": "13.347",


### PR DESCRIPTION
Fix #1021 
Fix #1004 

- Changed so that features created on a Character are standalone compared to before. Holding all the info needed for functions.

Previously we relinked things, so that the Ancestry/Class etc on a character had the features on it pointing to the copied features existing in the Character Item Collection. This caused a lot of issues however,
Now all items with links on them on the Character simply keep their original links.

-------
I introduced one-time migrations based on a new `lastMigrationVersion` game setting. I couldn't come up with any other way to to be able to update the way I needed to.