### PR TITLE
[Feature] 1031 - Action Names In Chat

### DIFF
--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -163,7 +163,7 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
         const hasRoll = this.getUseHasRoll(byPass);
         return {
             event,
-            title: `${this.item.name}: ${game.i18n.localize(this.name)}`,
+            title: game.i18n.localize(this.name),
             source: {
                 item: this.item._id,
                 action: this._id,


### PR DESCRIPTION
Fixes #1031 
Fixed so that actions don't print the actor name in chat along with its own name