### PR TITLE
[Fix] 1053 - Defeated Status Bug

### DIFF
--- a/module/data/actor/base.mjs
+++ b/module/data/actor/base.mjs
@@ -115,11 +115,16 @@ export default class BaseDataActor extends foundry.abstract.TypeDataModel {
             const typeForDefeated = ['character', 'adversary', 'companion'].find(x => x === this.parent.type);
             if (defeatedSettings.enabled && typeForDefeated) {
                 const resource = typeForDefeated === 'companion' ? 'stress' : 'hitPoints';
-                if (changes.system.resources[resource]) {
-                    const becameMax = changes.system.resources[resource].value === this.resources[resource].max;
+                const resourceValue = changes.system.resources[resource];
+                if (
+                    resourceValue &&
+                    this.resources[resource].max &&
+                    resourceValue.value !== this.resources[resource].value
+                ) {
+                    const becameMax = resourceValue.value === this.resources[resource].max;
                     const wasMax =
                         this.resources[resource].value === this.resources[resource].max &&
-                        this.resources[resource].value !== changes.system.resources[resource].value;
+                        this.resources[resource].value !== resourceValue.value;
                     if (becameMax) {
                         this.parent.toggleDefeated(true);
                     } else if (wasMax) {


### PR DESCRIPTION
Closes #1053 
Newly created actors would end up with the defeated status applied whenever you first edit their Hit Points. This happened because comparisons were made against the previous HP, which was zero.
Fixed this :+1: