### PR TITLE
[Fix] 1058 - Subclass Feature Transfer

### DIFF
--- a/module/documents/activeEffect.mjs
+++ b/module/documents/activeEffect.mjs
@@ -167,13 +167,11 @@ export default class DhActiveEffect extends foundry.documents.ActiveEffect {
 
                 if (subclass) {
                     const featureState = subclass.system.featureState;
-                    const featureType = subclass
-                        ? (subclass.system.features.find(x => x.item?.uuid === this.parent.uuid)?.type ?? null)
-                        : null;
 
                     if (
-                        (featureType === CONFIG.DH.ITEM.featureSubTypes.specialization && featureState < 2) ||
-                        (featureType === CONFIG.DH.ITEM.featureSubTypes.mastery && featureState < 3)
+                        (this.parent.system.identifier === CONFIG.DH.ITEM.featureSubTypes.specialization &&
+                            featureState < 2) ||
+                        (this.parent.system.identifier === CONFIG.DH.ITEM.featureSubTypes.mastery && featureState < 3)
                     ) {
                         this.transfer = false;
                     }


### PR DESCRIPTION
Closes #1058
The logic determining if subclass features should transfer to the character wasn't updated with the 1.1.0 model change. Fixed.