### PR TITLE
Fixed the Cult Initiate Group Attack to use Fear instead of marking S…

### DIFF
--- a/src/packs/adversaries/adversary_Cult_Initiate_zx99sOGTXicP4SSD.json
+++ b/src/packs/adversaries/adversary_Cult_Initiate_zx99sOGTXicP4SSD.json
@@ -265,7 +265,7 @@
             "cost": [
               {
                 "scalable": false,
-                "key": "stress",
+                "key": "fear",
                 "value": 1,
                 "keyIsID": false,
                 "step": null
@@ -281,7 +281,7 @@
               "type": "self",
               "amount": null
             },
-            "name": "Mark Stress",
+            "name": "Spend Fear",
             "img": "icons/creatures/abilities/tail-strike-bone-orange.webp",
             "range": ""
           }


### PR DESCRIPTION
…tress

## Description

Change the Group Attack on Cult Initiate to Spend Fear instead of Mark Stress.

I also checked anything else that had Group Attack, but they were all correct.

- Fixes #1045 
- Closes #1045 

## Type of Change

Please check the relevant options:

- [ x] Bug fix

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x ] Manual testing
