### PR TITLE
[Feature] 1042 - Inline Enrichment

### DIFF
--- a/module/enrichers/DamageEnricher.mjs
+++ b/module/enrichers/DamageEnricher.mjs
@@ -2,7 +2,8 @@ export default function DhDamageEnricher(match, _options) {
     const parts = match[1].split('|').map(x => x.trim());
 
     let value = null,
-        type = null;
+        type = null,
+        inline = false;
 
     parts.forEach(part => {
         const split = part.split(':').map(x => x.toLowerCase().trim());
@@ -14,16 +15,19 @@ export default function DhDamageEnricher(match, _options) {
                 case 'type':
                     type = split[1];
                     break;
+                case 'inline':
+                    inline = true;
+                    break;
             }
         }
     });
 
     if (!value || !value) return match[0];
 
-    return getDamageMessage(value, type, match[0]);
+    return getDamageMessage(value, type, inline, match[0]);
 }
 
-function getDamageMessage(damage, type, defaultElement) {
+function getDamageMessage(damage, type, inline, defaultElement) {
     const typeIcons = type
         .replace('[', '')
         .replace(']', '')
@@ -40,7 +44,7 @@ function getDamageMessage(damage, type, defaultElement) {
 
     const dualityElement = document.createElement('span');
     dualityElement.innerHTML = `
-        <button class="enriched-damage-button" 
+        <button class="enriched-damage-button${inline ? ' inline' : ''}" 
             data-value="${damage}"
             data-type="${type}"
             data-tooltip="${game.i18n.localize('DAGGERHEART.GENERAL.damage')}"

--- a/module/enrichers/DualityRollEnricher.mjs
+++ b/module/enrichers/DualityRollEnricher.mjs
@@ -36,7 +36,7 @@ function getDualityMessage(roll, flavor) {
 
     const dualityElement = document.createElement('span');
     dualityElement.innerHTML = `
-        <button class="duality-roll-button" 
+        <button class="duality-roll-button${roll.inline ? ' inline' : ''}" 
             data-title="${label}"
             data-label="${dataLabel}"
             data-reaction="${roll.reaction ? 'true' : 'false'}"

--- a/module/enrichers/TemplateEnricher.mjs
+++ b/module/enrichers/TemplateEnricher.mjs
@@ -2,7 +2,8 @@ export default function DhTemplateEnricher(match, _options) {
     const parts = match[1].split('|').map(x => x.trim());
 
     let type = null,
-        range = null;
+        range = null,
+        inline = false;
 
     parts.forEach(part => {
         const split = part.split(':').map(x => x.toLowerCase().trim());
@@ -20,6 +21,9 @@ export default function DhTemplateEnricher(match, _options) {
                     );
                     range = matchedRange?.id;
                     break;
+                case 'inline':
+                    inline = true;
+                    break;
             }
         }
     });
@@ -30,7 +34,7 @@ export default function DhTemplateEnricher(match, _options) {
 
     const templateElement = document.createElement('span');
     templateElement.innerHTML = `
-        <button class="measured-template-button" data-type="${type}" data-range="${range}">
+        <button class="measured-template-button${inline ? ' inline' : ''}" data-type="${type}" data-range="${range}">
             ${label} - ${game.i18n.localize(`DAGGERHEART.CONFIG.Range.${range}.name`)}
         </button>
     `;

--- a/styles/less/global/enrichment.less
+++ b/styles/less/global/enrichment.less
@@ -1,0 +1,14 @@
+.measured-template-button,
+.enriched-damage-button,
+.duality-roll-button {
+    display: inline;
+
+    &.inline {
+        min-height: unset;
+        height: 18px;
+    }
+
+    i {
+        font-size: 12px;
+    }
+}

--- a/styles/less/global/index.less
+++ b/styles/less/global/index.less
@@ -2,6 +2,7 @@
 @import './dialog.less';
 @import './chat.less';
 @import './elements.less';
+@import './enrichment.less';
 @import './tab-navigation.less';
 @import './tab-form-footer.less';
 @import './tab-actions.less';


### PR DESCRIPTION
Closes #1042 
Fixed so enriched buttons are inline by default. Can be set to 'inline:true' to make them fit with the text better
<img width="791" height="400" alt="image" src="https://github.com/user-attachments/assets/16247b63-a529-4f44-9e21-129e429d80a5" />
