### PR TITLE
[Fix] Weapon Tooltip Secondary Type

### DIFF
--- a/templates/ui/tooltip/weapon.hbs
+++ b/templates/ui/tooltip/weapon.hbs
@@ -6,7 +6,7 @@
     <div class="tooltip-information-section">
         <div class="tooltip-information">
             <label>{{localize "DAGGERHEART.ITEMS.Weapon.weaponType"}}</label>
-            <div>{{#if item.system.secondaryWeapon}}{{localize "DAGGERHEART.ITEMS.Weapon.secondaryWeapon"}}{{else}}{{localize "DAGGERHEART.ITEMS.Weapon.primaryWeapon"}}{{/if}}</div>
+            <div>{{#if item.system.secondary}}{{localize "DAGGERHEART.ITEMS.Weapon.secondaryWeapon"}}{{else}}{{localize "DAGGERHEART.ITEMS.Weapon.primaryWeapon"}}{{/if}}</div>
         </div>
         <div class="tooltip-information">
             <label>{{localize "DAGGERHEART.GENERAL.burden"}}</label>


### PR DESCRIPTION
Corrected so secondary weapons will show that they are secondary in the tooltip.