### PR TITLE
[Fix] Character Sheet Subclass Compendium Preset

### DIFF
--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -607,6 +607,15 @@ export default class CharacterSheet extends DHBaseActorSheet {
         const presets = {
             compendium: 'daggerheart',
             folder: key,
+            filter:
+                key === 'subclasses'
+                    ? {
+                          'system.linkedClass.uuid': {
+                              key: 'system.linkedClass.uuid',
+                              value: this.document.system.class.value._stats.compendiumSource
+                          }
+                      }
+                    : undefined,
             render: {
                 noFolder: true
             }

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
     "id": "daggerheart",
     "title": "Daggerheart",
     "description": "An unofficial implementation of the Daggerheart system",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "compatibility": {
         "minimum": "13",
         "verified": "13.347",


### PR DESCRIPTION
Added the preset for the subclass Compendium Browser from character sheet.
<img width="1278" height="853" alt="image" src="https://github.com/user-attachments/assets/20a06967-2df8-40b9-bfcd-c351141cd6c9" />
