### PR TITLE
[Fix] 1086 - Enrichment Buttons

### DIFF
--- a/module/enrichers/DamageEnricher.mjs
+++ b/module/enrichers/DamageEnricher.mjs
@@ -71,6 +71,11 @@ export const renderDamageButton = async event => {
         title: game.i18n.localize('Damage Roll'),
         data: { bonuses: [] },
         source: {},
+        hasDamage: true,
+        hasTarget: true,
+        targets: Array.from(game.user.targets).map(t =>
+            game.system.api.fields.ActionFields.TargetField.formatTarget(t)
+        ),
         roll: [
             {
                 formula: value,

--- a/module/enrichers/DamageEnricher.mjs
+++ b/module/enrichers/DamageEnricher.mjs
@@ -44,7 +44,7 @@ function getDamageMessage(damage, type, inline, defaultElement) {
 
     const dualityElement = document.createElement('span');
     dualityElement.innerHTML = `
-        <button class="enriched-damage-button${inline ? ' inline' : ''}" 
+        <button type="button" class="enriched-damage-button${inline ? ' inline' : ''}" 
             data-value="${damage}"
             data-type="${type}"
             data-tooltip="${game.i18n.localize('DAGGERHEART.GENERAL.damage')}"

--- a/module/enrichers/DualityRollEnricher.mjs
+++ b/module/enrichers/DualityRollEnricher.mjs
@@ -36,7 +36,7 @@ function getDualityMessage(roll, flavor) {
 
     const dualityElement = document.createElement('span');
     dualityElement.innerHTML = `
-        <button class="duality-roll-button${roll.inline ? ' inline' : ''}" 
+        <button type="button" class="duality-roll-button${roll.inline ? ' inline' : ''}" 
             data-title="${label}"
             data-label="${dataLabel}"
             data-reaction="${roll.reaction ? 'true' : 'false'}"

--- a/module/enrichers/TemplateEnricher.mjs
+++ b/module/enrichers/TemplateEnricher.mjs
@@ -34,7 +34,7 @@ export default function DhTemplateEnricher(match, _options) {
 
     const templateElement = document.createElement('span');
     templateElement.innerHTML = `
-        <button class="measured-template-button${inline ? ' inline' : ''}" data-type="${type}" data-range="${range}">
+        <button type="button" class="measured-template-button${inline ? ' inline' : ''}" data-type="${type}" data-range="${range}">
             ${label} - ${game.i18n.localize(`DAGGERHEART.CONFIG.Range.${range}.name`)}
         </button>
     `;


### PR DESCRIPTION
Closes #1086
Closes #1014  

- Fixed so enriched buttons are button type and don't trigger on enter click.
- Fixed so DamageEnriched button works properly again.