### PR TITLE
Use less ambiguous sort direction symbols

### DIFF
--- a/styles/less/ui/item-browser/item-browser.less
+++ b/styles/less/ui/item-browser/item-browser.less
@@ -279,11 +279,11 @@
                 }
 
                 &[data-sort-type='ASC']:after {
-                    content: '\f0d7';
+                    content: '\f884';
                 }
 
                 &[data-sort-type='DESC']:after {
-                    content: '\f0d8';
+                    content: '\f160';
                 }
             }
         }

--- a/styles/less/ui/item-browser/item-browser.less
+++ b/styles/less/ui/item-browser/item-browser.less
@@ -283,7 +283,7 @@
                 }
 
                 &[data-sort-type='DESC']:after {
-                    content: '\f160';
+                    content: '\f884';
                 }
             }
         }

--- a/styles/less/ui/item-browser/item-browser.less
+++ b/styles/less/ui/item-browser/item-browser.less
@@ -279,7 +279,7 @@
                 }
 
                 &[data-sort-type='ASC']:after {
-                    content: '\f884';
+                    content: '\f885';
                 }
 
                 &[data-sort-type='DESC']:after {

--- a/styles/less/ui/item-browser/item-browser.less
+++ b/styles/less/ui/item-browser/item-browser.less
@@ -279,11 +279,11 @@
                 }
 
                 &[data-sort-type='ASC']:after {
-                    content: '\f885';
+                    content: '\f884';
                 }
 
                 &[data-sort-type='DESC']:after {
-                    content: '\f884';
+                    content: '\f885';
                 }
             }
         }


### PR DESCRIPTION
## Description

From #1103, I mentioned in the PR that the sort arrows were in the wrong direction. During a discord discussion I discovered that the sort arrows mean different things to different people. This change is an attempt to use icons that are less ambiguous for everyone.

There is no issue associated with this change (except the PR mentioned above). 

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x ] Manual testing

Open the Compendium Browser and open Domain Cards (for example).  Sort the columns via the header bar. Note the different sort direction icons.