### PR TITLE
[PR] The uuid is expected, not id

### DIFF
--- a/module/applications/sheets/api/application-mixin.mjs
+++ b/module/applications/sheets/api/application-mixin.mjs
@@ -401,7 +401,7 @@ export default function DHApplicationMixin(Base) {
                 options.push({
                     name: 'DAGGERHEART.APPLICATIONS.ContextMenu.sendToChat',
                     icon: 'fa-solid fa-message',
-                    callback: async target => (await getDocFromElement(target)).toChat(this.document.id)
+                    callback: async target => (await getDocFromElement(target)).toChat(this.document.uuid)
                 });
 
             if (deletable)


### PR DESCRIPTION
## Description

Use the uuid, not id for Send To Chat.

- Fixes #1119 
- Closes #1119 

## Type of Change

Please check the relevant options:

- [ x] Bug fix

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x ] Manual testing
