### PR TITLE
This is psuedo fix to the incorrect resource usage when using multipl…

### DIFF
--- a/module/data/fields/action/costField.mjs
+++ b/module/data/fields/action/costField.mjs
@@ -95,6 +95,14 @@ export default class CostField extends fields.ArrayField {
 
     static getRealCosts(costs) {
         const realCosts = costs?.length ? costs.filter(c => c.enabled) : [];
+
+        // Reset totals in case of repeat calls.
+        realCosts.forEach(c => {
+            c.scale = c.scale ?? 0;
+            c.step = c.step ?? 1;
+            c.total = c.value + c.scale * c.step;
+        });
+
         let mergedCosts = [];
         realCosts.forEach(c => {
             const getCost = Object.values(mergedCosts).find(gc => gc.key === c.key);

--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -226,16 +226,16 @@ export const registerRollDiceHooks = () => {
         let updates = [];
         if (!actor) return;
         if (config.roll.isCritical || config.roll.result.duality === 1)
-            updates.push({ key: 'hope', value: 1, total: -1, enabled: true });
-        if (config.roll.isCritical) updates.push({ key: 'stress', value: 1, total: -1, enabled: true });
-        if (config.roll.result.duality === -1) updates.push({ key: 'fear', value: 1, total: -1, enabled: true });
+            updates.push({ key: 'hope', value: -1, total: -1, enabled: true });
+        if (config.roll.isCritical) updates.push({ key: 'stress', value: -1, total: -1, enabled: true });
+        if (config.roll.result.duality === -1) updates.push({ key: 'fear', value: -1, total: -1, enabled: true });
 
         if (config.rerolledRoll) {
             if (config.rerolledRoll.isCritical || config.rerolledRoll.result.duality === 1)
-                updates.push({ key: 'hope', value: -1, total: 1, enabled: true });
-            if (config.rerolledRoll.isCritical) updates.push({ key: 'stress', value: -1, total: 1, enabled: true });
+                updates.push({ key: 'hope', value: -1, total: -1, enabled: true });
+            if (config.rerolledRoll.isCritical) updates.push({ key: 'stress', value: -1, total: -1, enabled: true });
             if (config.rerolledRoll.result.duality === -1)
-                updates.push({ key: 'fear', value: -1, total: 1, enabled: true });
+                updates.push({ key: 'fear', value: -1, total: -1, enabled: true });
         }
 
         if (updates.length) {


### PR DESCRIPTION
…e experiences.

## Description

CostField.getRealCosts is being called multiple times - after each experience is selected. The totals were being added/merged incorrectly. This psuedo-fix resets the totals before doing the merged total costs. Note that the values for when a crit/with hope/with fear roll being pushed into the updates needed changing as well.

Ideally this draft PR is used to sort out a better solution.  

- Fixes #1144 

## Type of Change

Please check the relevant options:

- [ x] Bug fix
- [x ] Other (please describe): See comments above

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [ x] Manual testing

Tested for 0,1,2,3 experiences used, and results of crit, with Hope, with Fear.
