### PR TITLE
[PR] Remove Unnecessary Fallen Warlord chatDisplay

### DIFF
--- a/src/packs/adversaries/adversary_Fallen_Warlord__Undefeated_Champion_RXkZTwBRi4dJ3JE5.json
+++ b/src/packs/adversaries/adversary_Fallen_Warlord__Undefeated_Champion_RXkZTwBRi4dJ3JE5.json
@@ -153,8 +153,7 @@
           "bonus": 0,
           "dice": []
         }
-      },
-      "chatDisplay": false
+      }
     },
     "motivesAndTactics": "Dispatch merciless death, punish the defi ant, secure victory at any cost"
   },


### PR DESCRIPTION
## Description

#960 added an unnecessary `chatDisplay` in the `bonuses` section of the Fallen Warlord: Undefeated Champion adversary. No other adversary has this. This removes it.

- Closes #1170 

## Type of Change

Please check the relevant options:

- [ ] Bug fix
- [ ] New feature
- [x] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x] Manual testing
- [ ] Other:

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [x] New and existing tests pass locally with my changes
