### PR TITLE
[Community PR] Restore margins between paragraphs

### DIFF
--- a/styles/less/global/elements.less
+++ b/styles/less/global/elements.less
@@ -210,7 +210,13 @@
     }
 
     p {
-        margin: 0;
+        &:first-child {
+            margin-top: 0;
+        }
+
+        &:last-child {
+            margin-bottom: 0;
+        }
     }
 
     ul {


### PR DESCRIPTION
## Description

Replaces the global paragraph margin removal with removing the top margin of the first paragraph and the bottom margin of the last paragraph. This keeps the spacing between paragraphs and other elements unchanged.

It is still possible to make two (visual) paragraphs hug each other by pressing shift+enter, which inserts a breakline instead.

- Closes #1006

## Type of Change

Please check the relevant options:

- [x] Bug fix
- [ ] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x] Manual testing
- [ ] Other:

## Screenshots

<img width="554" height="221" alt="image" src="https://github.com/user-attachments/assets/4542b558-2cd2-42bc-85aa-9c6bc1ee9a2d" />

<img width="299" height="650" alt="image" src="https://github.com/user-attachments/assets/b51b1988-0430-46e6-9ab1-fcfa00a2f0db" />

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [x] New and existing tests pass locally with my changes

