### PR TITLE
[PR] Fix/filter error item browser config

### DIFF
--- a/module/config/itemBrowserConfig.mjs
+++ b/module/config/itemBrowserConfig.mjs
@@ -370,19 +370,6 @@ export const typeConfig = {
                 label: 'DAGGERHEART.ITEMS.Subclass.spellcastingTrait'
             }
         ],
-        filters: []
-    },
-    beastforms: {
-        columns: [
-            {
-                key: 'system.tier',
-                label: 'DAGGERHEART.GENERAL.Tiers.singular'
-            },
-            {
-                key: 'system.mainTrait',
-                label: 'DAGGERHEART.GENERAL.Trait.single'
-            }
-        ],
         filters: [
             {
                 key: 'system.linkedClass.uuid',


### PR DESCRIPTION
## Description

No issue created. I noticed a problem with the subclasses display in the character creation. Unfortunately in commit f1b6d3851dbed1559d88ecebc71d1bb537fd8b8b an error was made in merging? changes and we ended up with the subclass filter in the wrong location.

## Type of Change

Please check the relevant options:

- [x] Bug fix

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x] Manual testing
