### PR TITLE
[PR] Rune Ward reduces damage with flat 1d8

### DIFF
--- a/src/packs/domains/domainCard_Rune_Ward_GEhBUmv9Bj7oJfHk.json
+++ b/src/packs/domains/domainCard_Rune_Ward_GEhBUmv9Bj7oJfHk.json
@@ -47,7 +47,7 @@
           "bonus": null,
           "advState": "neutral",
           "diceRolling": {
-            "multiplier": "prof",
+            "multiplier": "flat",
             "flatMultiplier": 1,
             "dice": "d8",
             "compare": null,
@@ -71,12 +71,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.348",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.1.2",
     "createdTime": 1753922784506,
-    "modifiedTime": 1754253212120,
-    "lastModifiedBy": "Q9NoTaEarn3VMS6Z"
+    "modifiedTime": 1758364595206,
+    "lastModifiedBy": "mdk78Q6pOyHh6aBg"
   },
   "_id": "GEhBUmv9Bj7oJfHk",
   "sort": 3400000,


### PR DESCRIPTION
## Description

Rune Ward reduces damage with flat 1d8

- Closes #1187 

## Type of Change

Please check the relevant options:

- [x] Bug fix

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x] Manual testing
