### PR TITLE
[Community PR] Anchor chat message image crop to top

### DIFF
--- a/styles/less/global/chat.less
+++ b/styles/less/global/chat.less
@@ -61,6 +61,7 @@
                         width: 40px;
                         height: 40px;
                         object-fit: cover;
+                        object-position: top center;
                     }
 
                     .message-sub-header-container {


### PR DESCRIPTION
## Description

Applies the object-position css property to the chat message avatar so that it is cropped similarly to the actor sheet.

- Fixes #1192 

## Type of Change

Please check the relevant options:

- [x] Bug fix
- [ ] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x] Manual testing
- [ ] Other:

## Screenshots (if applicable)

Before
<img width="303" height="71" alt="image" src="https://github.com/user-attachments/assets/bad8bd6d-3c90-437d-8fb8-0c5e3cdb5b82" />
After
<img width="305" height="70" alt="image" src="https://github.com/user-attachments/assets/181be54a-50f3-4c67-b7d3-84c7cdcc76da" />


## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [x] New and existing tests pass locally with my changes

