### PR TITLE
[Community PR] Implement @Lookup enricher

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -501,6 +501,7 @@ export default class DhpActor extends Actor {
     /**@inheritdoc */
     getRollData() {
         const rollData = super.getRollData();
+        rollData.name = this.name;
         rollData.system = this.system.getRollData();
         rollData.prof = this.system.proficiency ?? 1;
         rollData.cast = this.system.spellcastModifier ?? 1;

--- a/module/enrichers/DamageEnricher.mjs
+++ b/module/enrichers/DamageEnricher.mjs
@@ -1,29 +1,8 @@
+import { parseInlineParams } from './parser.mjs';
+
 export default function DhDamageEnricher(match, _options) {
-    const parts = match[1].split('|').map(x => x.trim());
-
-    let value = null,
-        type = null,
-        inline = false;
-
-    parts.forEach(part => {
-        const split = part.split(':').map(x => x.toLowerCase().trim());
-        if (split.length === 2) {
-            switch (split[0]) {
-                case 'value':
-                    value = split[1];
-                    break;
-                case 'type':
-                    type = split[1];
-                    break;
-                case 'inline':
-                    inline = true;
-                    break;
-            }
-        }
-    });
-
-    if (!value || !value) return match[0];
-
+    const { value, type, inline } = parseInlineParams(match[1]);
+    if (!value || !type) return match[0];
     return getDamageMessage(value, type, inline, match[0]);
 }
 

--- a/module/enrichers/LookupEnricher.mjs
+++ b/module/enrichers/LookupEnricher.mjs
@@ -1,0 +1,8 @@
+import { parseInlineParams } from './parser.mjs';
+
+export default function DhLookupEnricher(match, { rollData }) {
+    const results = parseInlineParams(match[1], { first: 'formula'});
+    const element = document.createElement('span');
+    element.textContent = Roll.replaceFormulaData(String(results.formula), rollData);
+    return element;
+}

--- a/module/enrichers/TemplateEnricher.mjs
+++ b/module/enrichers/TemplateEnricher.mjs
@@ -1,49 +1,18 @@
+import { parseInlineParams } from './parser.mjs';
+
 export default function DhTemplateEnricher(match, _options) {
-    const parts = match[1].split('|').map(x => x.trim());
-
-    let type = null,
-        range = null,
-        angle = CONFIG.MeasuredTemplate.defaults.angle,
-        direction = 0,
-        inline = false;
-
-    parts.forEach(part => {
-        const split = part.split(':').map(x => x.toLowerCase().trim());
-        if (split.length === 2) {
-            switch (split[0]) {
-                case 'type':
-                    const matchedType = Object.values(CONFIG.DH.GENERAL.templateTypes).find(
-                        x => x.toLowerCase() === split[1]
-                    );
-                    type = matchedType;
-                    break;
-                case 'range':
-                    if (Number.isNaN(Number(split[1]))) {
-                        const matchedRange = Object.values(CONFIG.DH.GENERAL.templateRanges).find(
-                            x => x.id.toLowerCase() === split[1] || x.short === split[1]
-                        );
-                        range = matchedRange?.id;
-                    } else {
-                        range = split[1];
-                    }
-                    break;
-                case 'inline':
-                    inline = true;
-                    break;
-                case 'angle':
-                    angle = split[1];
-                    break;
-                case 'direction':
-                    direction = split[1];
-                    break;
-            }
-        }
-    });
-
-    if (!type || !range) return match[0];
+    const params = parseInlineParams(match[1]);
+    const { type, angle = CONFIG.MeasuredTemplate.defaults.angle, inline = false } = params;
+    const direction = Number(params.direction) || 0;
+    const range =
+        params.range && Number.isNaN(params.range)
+            ? Object.values(CONFIG.DH.GENERAL.templateRanges).find(
+                  x => x.id.toLowerCase() === split[1] || x.short === split[1]
+              )?.id
+            : params.range;
+    if (!(type in CONFIG.MeasuredTemplate.types) || !range) return match[0];
 
     const label = game.i18n.localize(`DAGGERHEART.CONFIG.TemplateTypes.${type}`);
-
     const rangeDisplay = Number.isNaN(Number(range)) ? game.i18n.localize(`DAGGERHEART.CONFIG.Range.${range}.name`) : range;
 
     let angleDisplay = '';

--- a/module/enrichers/_module.mjs
+++ b/module/enrichers/_module.mjs
@@ -2,6 +2,7 @@ import { default as DhDamageEnricher, renderDamageButton } from './DamageEnriche
 import { default as DhDualityRollEnricher, renderDualityButton } from './DualityRollEnricher.mjs';
 import { default as DhEffectEnricher } from './EffectEnricher.mjs';
 import { default as DhTemplateEnricher, renderMeasuredTemplate } from './TemplateEnricher.mjs';
+import { default as DhLookupEnricher } from './LookupEnricher.mjs';
 
 export { DhDamageEnricher, DhDualityRollEnricher, DhEffectEnricher, DhTemplateEnricher };
 
@@ -21,6 +22,10 @@ export const enricherConfig = [
     {
         pattern: /@Template\[(.*)\]({.*})?/g,
         enricher: DhTemplateEnricher
+    },
+    {
+        pattern: /@Lookup\[(.*)\]({.*})?/g,
+        enricher: DhLookupEnricher
     }
 ];
 

--- a/module/enrichers/parser.mjs
+++ b/module/enrichers/parser.mjs
@@ -1,0 +1,20 @@
+/**
+ * @param {string} paramString The parameter inside the brackets of something like @Template[] to parse 
+ * @param {Object} options
+ * @param {string} options.first If set, the first parameter is treated as a value with this as its key
+ * @returns {Record<string, string | undefined> | null}
+ */
+export function parseInlineParams(paramString, { first } = {}) {
+    const parts = paramString.split('|').map(x => x.trim());
+    const params = {};
+    for (const [idx, param] of parts.entries()) {
+        if (first && idx === 0) {
+            params[first] = param;
+        } else {
+            const parts = param.split(':');
+            params[parts[0]] = parts.length > 1 ? parts[1] : true;
+        }
+    }
+
+    return params;
+}


### PR DESCRIPTION
Implements a lookup inline enricher that can resolve formulas as inline text. For example, `@Lookup[@name]` returns the actor name of the current actor, or `@name` if there isn't one. It also refactors existing inline functions to use a new inline parser function. Closes #1096 

## Additional Comments

Although the feature was approved, there wasn't any discussion to its exact implementation. I'm happy to pivot based on the project needs. So far these are the points of contention, issues, and areas of possible improvement I've detected.

* 5e uses `[[lookup @name]]`. While the issue also requested that, 5e in general prefers [[blah]] based inlines, whereas this project does not. I called it `@Lookup` for project consistency, but let me know if this assumption is incorrect.
* I don't know how well it solves the problem, sometimes adversaries are referred to in plural such as in Group Attack. I wonder if optimizations in other areas, such as reusing the description in action, might be a better approach to solving the problem?
* An enrich parameter could facilitate description reuse, ex `@Lookup[@system.description|enrich]` in an adversary action. We would need special handling to dodge `<p>` nesting, an issue the PF2e system has to deal with on the `@Localize` inline

It didn't take me very long to implement, so no worries about anything.