### PR TITLE
Partial implementation of Galapa Retract ancestry ability

### DIFF
--- a/src/packs/ancestries/feature_Retract_UFR67BUOhNGLFyg9.json
+++ b/src/packs/ancestries/feature_Retract_UFR67BUOhNGLFyg9.json
@@ -12,16 +12,30 @@
         "type": "effect",
         "_id": "HfiAg14hrYt7Yvnj",
         "systemPath": "actions",
-        "description": "",
+        "description": "<p><span style=\"box-sizing: border-box; scrollbar-width: thin; scrollbar-color: rgb(93, 20, 43) rgba(0, 0, 0, 0); color: rgb(239, 230, 216); font-family: Montserrat, sans-serif; font-size: 15.75px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgba(24, 22, 46, 0.376); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial\"><strong>Mark a Stress</strong></span><span style=\"color: rgb(239, 230, 216); font-family: Montserrat, sans-serif; font-size: 15.75px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgba(24, 22, 46, 0.376); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; display: inline !important; float: none\"> to retract into your shell. While in your shell, you have resistance to physical damage, you have disadvantage on action rolls, and you can’t move.</span></p>",
         "chatDisplay": true,
         "actionType": "action",
-        "cost": [],
+        "cost": [
+          {
+            "scalable": false,
+            "key": "stress",
+            "value": 1,
+            "keyIsID": false,
+            "step": null,
+            "consumeOnSuccess": false
+          }
+        ],
         "uses": {
           "value": null,
           "max": "",
           "recovery": null
         },
-        "effects": [],
+        "effects": [
+          {
+            "_id": "tTTyNKnbYvtWtulG",
+            "onSave": false
+          }
+        ],
         "target": {
           "type": "any",
           "amount": null
@@ -37,10 +51,12 @@
   },
   "effects": [
     {
-      "name": "Base",
-      "type": "base",
-      "_id": "KoHQg8KurugHlga0",
+      "name": "Retract",
       "img": "icons/magic/defensive/shield-barrier-flaming-diamond-teal.webp",
+      "origin": "Compendium.daggerheart.ancestries.Item.UFR67BUOhNGLFyg9",
+      "transfer": false,
+      "_id": "tTTyNKnbYvtWtulG",
+      "type": "base",
       "system": {
         "rangeDependence": {
           "enabled": false,
@@ -52,18 +68,12 @@
       "changes": [
         {
           "key": "system.resistance.physical.resistance",
-          "mode": 5,
-          "value": "1",
-          "priority": null
-        },
-        {
-          "key": "system.disadvantageSources",
           "mode": 2,
-          "value": "Action Rolls",
+          "value": "1",
           "priority": null
         }
       ],
-      "disabled": true,
+      "disabled": false,
       "duration": {
         "startTime": null,
         "combat": null,
@@ -73,10 +83,8 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "<p><span style=\"color:rgb(239, 230, 216);font-family:Montserrat, sans-serif;font-size:14px;font-style:normal;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-align:start;text-indent:0px;text-transform:none;widows:2;word-spacing:0px;-webkit-text-stroke-width:0px;white-space:normal;background-color:rgba(24, 22, 46, 0.376);text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial;display:inline !important;float:none\">While in your shell, you have resistance to physical damage, you have disadvantage on action rolls, and you can’t move.</span></p>",
-      "origin": null,
+      "description": "<p><span style=\"box-sizing:border-box;scrollbar-width:thin;scrollbar-color:rgb(93, 20, 43) rgba(0, 0, 0, 0);color:rgb(239, 230, 216);font-family:Montserrat, sans-serif;font-size:15.75px;font-style:normal;font-variant-ligatures:normal;font-variant-caps:normal;letter-spacing:normal;orphans:2;text-align:start;text-indent:0px;text-transform:none;widows:2;word-spacing:0px;-webkit-text-stroke-width:0px;white-space:normal;background-color:rgba(24, 22, 46, 0.376);text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial\">Mark a Stress</span><span style=\"color:rgb(239, 230, 216);font-family:Montserrat, sans-serif;font-size:15.75px;font-style:normal;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-align:start;text-indent:0px;text-transform:none;widows:2;word-spacing:0px;-webkit-text-stroke-width:0px;white-space:normal;background-color:rgba(24, 22, 46, 0.376);text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial;display:inline !important;float:none\"> to retract into your shell. While in your shell, you have resistance to physical damage, you have disadvantage on action rolls, and you can’t move.</span></p>",
       "tint": "#ffffff",
-      "transfer": true,
       "statuses": [],
       "sort": 0,
       "flags": {},
@@ -84,14 +92,14 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "13.348",
         "systemId": "daggerheart",
-        "systemVersion": "0.0.1",
-        "createdTime": 1753996568678,
-        "modifiedTime": 1753996633306,
-        "lastModifiedBy": "MQSznptE5yLT7kj8"
+        "systemVersion": "1.1.2",
+        "createdTime": 1759913858975,
+        "modifiedTime": 1759922272005,
+        "lastModifiedBy": "9HOfUKAXuCu7hUPY"
       },
-      "_key": "!items.effects!UFR67BUOhNGLFyg9.KoHQg8KurugHlga0"
+      "_key": "!items.effects!UFR67BUOhNGLFyg9.tTTyNKnbYvtWtulG"
     }
   ],
   "sort": 0,
@@ -104,12 +112,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.348",
     "systemId": "daggerheart",
-    "systemVersion": "0.0.1",
+    "systemVersion": "1.1.2",
     "createdTime": 1753996513763,
-    "modifiedTime": 1753996553192,
-    "lastModifiedBy": "MQSznptE5yLT7kj8"
+    "modifiedTime": 1759922364297,
+    "lastModifiedBy": "9HOfUKAXuCu7hUPY"
   },
   "_key": "!items!UFR67BUOhNGLFyg9"
 }


### PR DESCRIPTION
## Description

Implements the Physical Damage Resistance of the Galapa Retract ability. Effect applied to character, although it requires the character to self target, as using "Self" in the effects config did not work.

The no move and disadvantage have to be handled manually.

- Closes #1157 

## Type of Change

Please check the relevant options:

- [x] Bug fix

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x] Manual testing

Create Galapa, target self, hit Retract, apply effects. Should see Retract in Effects and Physical Damage Resistance applied.