### PR TITLE
[Community PR] Allow viewing domain card item sheet by clicking the name in grid view

### DIFF
--- a/module/applications/sheets/api/application-mixin.mjs
+++ b/module/applications/sheets/api/application-mixin.mjs
@@ -99,6 +99,7 @@ export default function DHApplicationMixin(Base) {
                 deleteDoc: DHSheetV2.#deleteDoc,
                 toChat: DHSheetV2.#toChat,
                 useItem: DHSheetV2.#useItem,
+                viewItem: DHSheetV2.#viewItem,
                 toggleEffect: DHSheetV2.#toggleEffect,
                 toggleExtended: DHSheetV2.#toggleExtended,
                 addNewItem: DHSheetV2.#addNewItem,
@@ -710,7 +711,7 @@ export default function DHApplicationMixin(Base) {
          * @type {ApplicationClickAction}
          */
         static async #toChat(_event, target) {
-            let doc = await getDocFromElement(target);
+            const doc = await getDocFromElement(target);
             return doc.toChat(doc.uuid);
         }
 
@@ -719,8 +720,17 @@ export default function DHApplicationMixin(Base) {
          * @type {ApplicationClickAction}
          */
         static async #useItem(event, target) {
-            let doc = await getDocFromElement(target);
+            const doc = await getDocFromElement(target);
             await doc.use(event);
+        }
+
+        /**
+         * View an item by opening its sheet
+         * @type {ApplicationClickAction}
+         */
+        static async #viewItem(_, target) {
+            const doc = await getDocFromElement(target);
+            await doc.sheet.render({ force: true });
         }
 
         /**

--- a/templates/sheets/global/partials/domain-card-item.hbs
+++ b/templates/sheets/global/partials/domain-card-item.hbs
@@ -19,6 +19,6 @@
                 </a>
             </div>
         </div>
-        <span class="card-name">{{item.name}}</span>
+        <span class="card-name" data-action="viewItem">{{item.name}}</span>
     </div>
 </li>


### PR DESCRIPTION
## Description

On the player character sheet in the loadout tab, in grid view, opens the item sheet by clicking on the name. Closes https://github.com/Foundryborne/daggerheart/issues/1120 since I think most of the improvements necessary have been done (I have a PR open for the last remaining one). 

## Type of Change

Please check the relevant options:

- [ ] Bug fix
- [x] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## Screenshots (if applicable)

Clicking on name here opens the item sheet
<img width="127" height="172" alt="image" src="https://github.com/user-attachments/assets/365b2c4f-8174-4c4c-8791-9effab4d204d" />

## Other Comments

https://github.com/Foundryborne/daggerheart/pull/1214 attempts to handle the "View Improvements" part of the issue.