### PR TITLE
[Community PR] Clean up loadout tab card name visual styling

### DIFF
--- a/styles/less/global/inventory-item.less
+++ b/styles/less/global/inventory-item.less
@@ -309,12 +309,14 @@
             background-color: @dark-blue;
             bottom: 0;
             mask-image: linear-gradient(180deg, transparent 0%, black 20%);
+            border-radius: 0 0 6px 6px;
 
             .card-name {
                 font-style: normal;
                 font-weight: 400;
                 font-size: var(--font-size-12);
                 line-height: 15px;
+                text-align: center;
 
                 color: @beige;
             }


### PR DESCRIPTION
## Description

Minor cleanup to styling that I ran into while I was working on a different PR, but was a related but disconnected thing.

## Screenshots (if applicable)

Before

<img width="564" height="182" alt="chrome_2025-10-12_02-15-40" src="https://github.com/user-attachments/assets/4ee8d6bd-ce71-4a02-b69b-b02cbc8d1d6c" />

After

<img width="562" height="174" alt="image" src="https://github.com/user-attachments/assets/4cd2a7a7-5ea4-4c99-9ac5-b45d7b453136" />

