### PR TITLE
[PR] Sync countdown current with max when equal

### DIFF
--- a/module/applications/ui/countdownEdit.mjs
+++ b/module/applications/ui/countdownEdit.mjs
@@ -110,6 +110,18 @@ export default class CountdownEdit extends HandlebarsApplicationMixin(Applicatio
 
     static async updateData(_event, _, formData) {
         const { hideNewCountdowns, ...settingsData } = foundry.utils.expandObject(formData.object);
+        
+        // Sync current and max if max is changing and they were equal before
+        for (const [id, countdown] of Object.entries(settingsData.countdowns ?? {})) {
+            const existing = this.data.countdowns[id];
+            const wasEqual = existing && existing.progress.current === existing.progress.max;
+            if (wasEqual && countdown.progress.max !== existing.progress.max) {
+                countdown.progress.current = countdown.progress.max;
+            } else {
+                countdown.progress.current = Math.min(countdown.progress.current, countdown.progress.max);
+            }
+        }       
+
         this.hideNewCountdowns = hideNewCountdowns;
         this.updateSetting(settingsData);
     }

--- a/styles/less/ui/countdown/countdown-edit.less
+++ b/styles/less/ui/countdown/countdown-edit.less
@@ -126,6 +126,9 @@
 
                 &.tiny {
                     flex: 0;
+                    input {                    
+                        min-width: 2.5rem;
+                    }
                 }
 
                 input,

--- a/templates/ui/countdown-edit.hbs
+++ b/templates/ui/countdown-edit.hbs
@@ -50,11 +50,11 @@
                     <div class="countdown-edit-subrow">
                         <div class="countdown-edit-input tiny">
                             <label>{{localize "DAGGERHEART.APPLICATIONS.CountdownEdit.current"}}</label>
-                            <input type="text" name="{{concat "countdowns." id ".progress.current"}}" value="{{countdown.progress.current}}" />
+                            <input type="number" name="{{concat "countdowns." id ".progress.current"}}" value="{{countdown.progress.current}}" />
                         </div>
                         <div class="countdown-edit-input tiny">
                             <label>{{localize "DAGGERHEART.APPLICATIONS.CountdownEdit.max"}}</label>
-                            <input type="text" name="{{concat "countdowns." id ".progress.max"}}" value="{{countdown.progress.max}}" />
+                            <input type="number" name="{{concat "countdowns." id ".progress.max"}}" value="{{countdown.progress.max}}" />
                         </div>
                         <div class="countdown-edit-input">
                             <label>{{localize "DAGGERHEART.APPLICATIONS.CountdownEdit.category"}}</label>


### PR DESCRIPTION
Merges to the in progress PR

It makes it so that adjusting max will also adjust current if they were equal before the adjustment. If this feels weird I have an alternative in mind.

This also allows arrow key behavior on countdown progress inputs and makes it so that certain double digit numbers aren't cut off for max. 
