### PR TITLE
Fix the damage output of the Takedown Beastform feature

### DIFF
--- a/src/packs/beastforms/feature_Takedown_0ey4kM9ssj2otHvb.json
+++ b/src/packs/beastforms/feature_Takedown_0ey4kM9ssj2otHvb.json
@@ -32,16 +32,18 @@
               "resultBased": false,
               "value": {
                 "custom": {
-                  "enabled": true,
-                  "formula": "(@prof+2)@basicAttackDamageDice"
+                  "enabled": false,
+                  "formula": ""
                 },
                 "multiplier": "prof",
-                "flatMultiplier": 1,
-                "dice": "d6",
-                "bonus": null
+                "dice": "d8",
+                "bonus": 6,
+                "flatMultiplier": 1
               },
               "applyTo": "hitPoints",
-              "type": [],
+              "type": [
+                "physical"
+              ],
               "base": false,
               "valueAlt": {
                 "multiplier": "prof",
@@ -49,9 +51,64 @@
                 "dice": "d6",
                 "bonus": null,
                 "custom": {
-                  "enabled": false
+                  "enabled": false,
+                  "formula": ""
                 }
               }
+            },
+            {
+              "resultBased": false,
+              "value": {
+                "custom": {
+                  "enabled": false,
+                  "formula": ""
+                },
+                "multiplier": "flat",
+                "flatMultiplier": 2,
+                "dice": "d8",
+                "bonus": null
+              },
+              "applyTo": "hitPoints",
+              "type": [
+                "physical"
+              ],
+              "base": false,
+              "valueAlt": {
+                "multiplier": "prof",
+                "flatMultiplier": 1,
+                "dice": "d6",
+                "bonus": null,
+                "custom": {
+                  "enabled": false,
+                  "formula": ""
+                }
+              }
+            },
+            {
+              "resultBased": false,
+              "value": {
+                "custom": {
+                  "enabled": true,
+                  "formula": "1"
+                },
+                "multiplier": "prof",
+                "flatMultiplier": 1,
+                "dice": "d6",
+                "bonus": null
+              },
+              "applyTo": "stress",
+              "base": false,
+              "valueAlt": {
+                "multiplier": "prof",
+                "flatMultiplier": 1,
+                "dice": "d6",
+                "bonus": null,
+                "custom": {
+                  "enabled": false,
+                  "formula": ""
+                }
+              },
+              "type": []
             }
           ],
           "includeBase": false
@@ -150,12 +207,12 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.347",
+    "coreVersion": "13.350",
     "systemId": "daggerheart",
-    "systemVersion": "1.1.0",
+    "systemVersion": "1.1.2",
     "createdTime": 1753621786000,
-    "modifiedTime": 1756041242273,
-    "lastModifiedBy": "vUIbuan0U50nfKBE"
+    "modifiedTime": 1762341337917,
+    "lastModifiedBy": "9HOfUKAXuCu7hUPY"
   },
   "_id": "0ey4kM9ssj2otHvb",
   "sort": 600000,


### PR DESCRIPTION
## Description

Changed Takedown for Pouncing Predator (Tier 2 Beastform) to have the correct damage output - Hit Points and Stress.

- Closes #1188

## Type of Change

Please check the relevant options:

- [x] Bug fix

## How Has This Been Tested?

- [x] Manual testing
