### PR TITLE
[Feature] Customize Defeated Icons

### DIFF
--- a/daggerheart.mjs
+++ b/daggerheart.mjs
@@ -34,15 +34,6 @@ Hooks.once('init', () => {
 
     CONFIG.TextEditor.enrichers.push(...enricherConfig);
 
-    CONFIG.statusEffects = [
-        ...CONFIG.statusEffects.filter(x => !['dead', 'unconscious'].includes(x.id)),
-        ...Object.values(SYSTEM.GENERAL.conditions).map(x => ({
-            ...x,
-            name: game.i18n.localize(x.name),
-            systemEffect: true
-        }))
-    ];
-
     CONFIG.Dice.daggerheart = {
         DHRoll: DHRoll,
         DualityRoll: DualityRoll,
@@ -158,6 +149,17 @@ Hooks.once('init', () => {
     RegisterHandlebarsHelpers.registerHelpers();
 
     return handlebarsRegistration();
+});
+
+Hooks.on('setup', () => {
+    CONFIG.statusEffects = [
+        ...CONFIG.statusEffects.filter(x => !['dead', 'unconscious'].includes(x.id)),
+        ...Object.values(SYSTEM.GENERAL.conditions()).map(x => ({
+            ...x,
+            name: game.i18n.localize(x.name),
+            systemEffect: true
+        }))
+    ];
 });
 
 Hooks.on('ready', async () => {

--- a/module/config/generalConfig.mjs
+++ b/module/config/generalConfig.mjs
@@ -164,28 +164,31 @@ export const healingTypes = {
     }
 };
 
-export const defeatedConditions = {
-    defeated: {
-        id: 'defeated',
-        name: 'DAGGERHEART.CONFIG.Condition.defeated.name',
-        img: 'icons/magic/control/fear-fright-mask-orange.webp',
-        description: 'DAGGERHEART.CONFIG.Condition.defeated.description'
-    },
-    unconscious: {
-        id: 'unconscious',
-        name: 'DAGGERHEART.CONFIG.Condition.unconscious.name',
-        img: 'icons/magic/control/sleep-bubble-purple.webp',
-        description: 'DAGGERHEART.CONFIG.Condition.unconscious.description'
-    },
-    dead: {
-        id: 'dead',
-        name: 'DAGGERHEART.CONFIG.Condition.dead.name',
-        img: 'icons/magic/death/grave-tombstone-glow-teal.webp',
-        description: 'DAGGERHEART.CONFIG.Condition.dead.description'
-    }
+export const defeatedConditions = () => {
+    const defeated = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Automation).defeated;
+    return {
+        defeated: {
+            id: 'defeated',
+            name: 'DAGGERHEART.CONFIG.Condition.defeated.name',
+            img: defeated.defeatedIcon,
+            description: 'DAGGERHEART.CONFIG.Condition.defeated.description'
+        },
+        unconscious: {
+            id: 'unconscious',
+            name: 'DAGGERHEART.CONFIG.Condition.unconscious.name',
+            img: defeated.unconsciousIcon,
+            description: 'DAGGERHEART.CONFIG.Condition.unconscious.description'
+        },
+        dead: {
+            id: 'dead',
+            name: 'DAGGERHEART.CONFIG.Condition.dead.name',
+            img: defeated.deadIcon,
+            description: 'DAGGERHEART.CONFIG.Condition.dead.description'
+        }
+    };
 };
 
-export const conditions = {
+export const conditions = () => ({
     vulnerable: {
         id: 'vulnerable',
         name: 'DAGGERHEART.CONFIG.Condition.vulnerable.name',
@@ -204,8 +207,8 @@ export const conditions = {
         img: 'icons/magic/control/debuff-chains-shackle-movement-red.webp',
         description: 'DAGGERHEART.CONFIG.Condition.restrained.description'
     },
-    ...defeatedConditions
-};
+    ...defeatedConditions()
+});
 
 export const defaultRestOptions = {
     shortRest: () => ({

--- a/module/data/settings/Automation.mjs
+++ b/module/data/settings/Automation.mjs
@@ -68,21 +68,39 @@ export default class DhAutomation extends foundry.abstract.DataModel {
                 }),
                 characterDefault: new fields.StringField({
                     required: true,
-                    choices: CONFIG.DH.GENERAL.defeatedConditions,
-                    initial: CONFIG.DH.GENERAL.defeatedConditions.unconscious.id,
+                    choices: () => CONFIG.DH.GENERAL.defeatedConditions(),
+                    initial: 'unconscious',
                     label: 'DAGGERHEART.SETTINGS.Automation.FIELDS.defeated.characterDefault.label'
                 }),
                 adversaryDefault: new fields.StringField({
                     required: true,
-                    choices: CONFIG.DH.GENERAL.defeatedConditions,
-                    initial: CONFIG.DH.GENERAL.defeatedConditions.defeated.id,
+                    choices: () => CONFIG.DH.GENERAL.defeatedConditions(),
+                    initial: 'defeated',
                     label: 'DAGGERHEART.SETTINGS.Automation.FIELDS.defeated.adversaryDefault.label'
                 }),
                 companionDefault: new fields.StringField({
                     required: true,
-                    choices: CONFIG.DH.GENERAL.defeatedConditions,
-                    initial: CONFIG.DH.GENERAL.defeatedConditions.defeated.id,
+                    choices: () => CONFIG.DH.GENERAL.defeatedConditions(),
+                    initial: 'defeated',
                     label: 'DAGGERHEART.SETTINGS.Automation.FIELDS.defeated.companionDefault.label'
+                }),
+                deadIcon: new fields.FilePathField({
+                    initial: 'icons/magic/death/grave-tombstone-glow-teal.webp',
+                    categories: ['IMAGE'],
+                    base64: false,
+                    label: 'Dead'
+                }),
+                defeatedIcon: new fields.FilePathField({
+                    initial: 'icons/magic/control/fear-fright-mask-orange.webp',
+                    categories: ['IMAGE'],
+                    base64: false,
+                    label: 'Defeated'
+                }),
+                unconsciousIcon: new fields.FilePathField({
+                    initial: 'icons/magic/control/sleep-bubble-purple.webp',
+                    categories: ['IMAGE'],
+                    base64: false,
+                    label: 'Unconcious'
                 })
             }),
             roll: new fields.SchemaField({

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -753,7 +753,7 @@ export default class DhpActor extends Actor {
 
     async toggleDefeated(defeatedState) {
         const settings = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Automation).defeated;
-        const { unconscious, defeated, dead } = CONFIG.DH.GENERAL.conditions;
+        const { unconscious, defeated, dead } = CONFIG.DH.GENERAL.conditions();
         const defeatedConditions = new Set([unconscious.id, defeated.id, dead.id]);
         if (!defeatedState) {
             for (let defeatedId of defeatedConditions) {

--- a/templates/settings/automation-settings/rules.hbs
+++ b/templates/settings/automation-settings/rules.hbs
@@ -13,5 +13,9 @@
         {{formGroup settingFields.schema.fields.defeated.fields.characterDefault value=settingFields._source.defeated.characterDefault labelAttr="name" localize=true}}  
         {{formGroup settingFields.schema.fields.defeated.fields.adversaryDefault value=settingFields._source.defeated.adversaryDefault labelAttr="name" localize=true}}  
         {{formGroup settingFields.schema.fields.defeated.fields.companionDefault value=settingFields._source.defeated.companionDefault labelAttr="name" localize=true}}  
+
+        {{formGroup settingFields.schema.fields.defeated.fields.deadIcon value=settingFields._source.defeated.deadIcon localize=true}}  
+        {{formGroup settingFields.schema.fields.defeated.fields.defeatedIcon value=settingFields._source.defeated.defeatedIcon localize=true}}  
+        {{formGroup settingFields.schema.fields.defeated.fields.unconsciousIcon value=settingFields._source.defeated.unconsciousIcon localize=true}}  
     </fieldset>
 </section>


### PR DESCRIPTION
Added system options for the defeated icons (Dead, Defeated, Unconscious)
<img width="772" height="964" alt="image" src="https://github.com/user-attachments/assets/17472e36-aa96-4e71-a3bf-d7162b54a953" />
