### PR TITLE
Re-render party when members update

### DIFF
--- a/module/data/actor/party.mjs
+++ b/module/data/actor/party.mjs
@@ -24,4 +24,25 @@ export default class DhParty extends BaseDataActor {
     static DEFAULT_ICON = 'systems/daggerheart/assets/icons/documents/actors/dark-squad.svg';
 
     /* -------------------------------------------- */
+
+    prepareBaseData() {
+        super.prepareBaseData();
+        this.partyMembers = this.partyMembers.filter((p) => !!p);
+
+        // Register this party to all members
+        if (fromUuidSync(this.parent.uuid) === this.parent) {
+            for (const member of this.partyMembers) {
+                member.parties?.add(this.parent);
+            }
+        }
+    }
+
+    _onDelete(options, userId) {
+        super._onDelete(options, userId);
+                
+        // Clear this party from all members that aren't deleted
+        for (const member of this.partyMembers) {
+            member.parties?.delete(this.parent);
+        }
+    }
 }

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -5,6 +5,8 @@ import { createScrollText, damageKeyToNumber } from '../helpers/utils.mjs';
 import DhCompanionLevelUp from '../applications/levelup/companionLevelup.mjs';
 
 export default class DhpActor extends Actor {
+    parties = new Set();
+
     #scrollTextQueue = [];
     #scrollTextInterval;
 
@@ -81,6 +83,20 @@ export default class DhpActor extends Actor {
                 disposition: CONST.TOKEN_DISPOSITIONS.FRIENDLY
             });
         this.updateSource({ prototypeToken });
+    }
+
+    _onUpdate(changes, options, userId) {
+        super._onUpdate(changes, options, userId);
+        for (const party of this.parties) {
+            party.render();
+        }
+    }
+
+    _onDelete(options, userId) {
+        super._onDelete(options, userId);
+        for (const party of this.parties) {
+            party.render();
+        }
     }
 
     async updateLevel(newLevel) {


### PR DESCRIPTION
Adds very basic re-render capability on character update to the party. We may need to consider debouncing the re-render and maybe use the options so that only some tabs get re-rendered on character updates. We might need the inventory to not be re-rendered for example. But I'm down to wait to see if the need is required later first.

The parties are defined on the actor, not the system data, so that they're not wiped during character data prep.