### PR TITLE
Fix typo in AttributionDialog class name

### DIFF
--- a/module/applications/dialogs/attributionDialog.mjs
+++ b/module/applications/dialogs/attributionDialog.mjs
@@ -2,7 +2,7 @@ import autocomplete from 'autocompleter';
 
 const { HandlebarsApplicationMixin, ApplicationV2 } = foundry.applications.api;
 
-export default class AttriubtionDialog extends HandlebarsApplicationMixin(ApplicationV2) {
+export default class AttributionDialog extends HandlebarsApplicationMixin(ApplicationV2) {
     constructor(item) {
         super({});
 


### PR DESCRIPTION
## Description

Noticed a typo in a class name, so this fixes it.

## Type of Change

Please check the relevant options:

- [x] Code cleanup/refactor

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x] Other:

grep plus build.