### PR TITLE
Some Dev Bugfixes

### DIFF
--- a/module/config/generalConfig.mjs
+++ b/module/config/generalConfig.mjs
@@ -166,11 +166,16 @@ export const healingTypes = {
 
 export const defeatedConditions = () => {
     const defeated = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Automation).defeated;
-    return Object.values(defeatedConditionChoices).map(x => ({
-        ...x,
-        img: defeated[`${x.id}Icon`],
-        description: `DAGGERHEART.CONFIG.Condition.${x.id}.description`
-    }));
+    return Object.keys(defeatedConditionChoices).reduce((acc, key) => {
+        const choice = defeatedConditionChoices[key];
+        acc[key] = {
+            ...choice,
+            img: defeated[`${choice.id}Icon`],
+            description: `DAGGERHEART.CONFIG.Condition.${choice.id}.description`
+        };
+
+        return acc;
+    }, {});
 };
 
 const defeatedConditionChoices = {

--- a/module/data/fields/action/damageField.mjs
+++ b/module/data/fields/action/damageField.mjs
@@ -85,7 +85,7 @@ export default class DamageField extends fields.SchemaField {
         const targetDamage = [];
         const damagePromises = [];
         for (let target of targets) {
-            const actor = fromUuidSync(target.actorId);
+            const actor = foundry.utils.fromUuidSync(target.actorId);
             if (!actor) continue;
             if (!config.hasHealing && config.onSave && target.saved?.success === true) {
                 const mod = CONFIG.DH.ACTIONS.damageOnSave[config.onSave]?.mod ?? 1;
@@ -98,17 +98,16 @@ export default class DamageField extends fields.SchemaField {
                 });
             }
 
+            const token = game.scenes.find(x => x.active).tokens.find(x => x.id === target.id);
             if (config.hasHealing)
                 damagePromises.push(
-                    actor
-                        .takeHealing(config.damage)
-                        .then(updates => targetDamage.push({ token: actor.token ?? actor.prototypeToken, updates }))
+                    actor.takeHealing(config.damage).then(updates => targetDamage.push({ token, updates }))
                 );
             else
                 damagePromises.push(
                     actor
                         .takeDamage(config.damage, config.isDirect)
-                        .then(updates => targetDamage.push({ token: actor.token ?? actor.prototypeToken, updates }))
+                        .then(updates => targetDamage.push({ token, updates }))
                 );
         }
 

--- a/styles/less/hud/token-hud/token-hud.less
+++ b/styles/less/hud/token-hud/token-hud.less
@@ -1,3 +1,9 @@
+.theme-light .daggerheart.placeable-hud {
+    .status-effects .effect-control {
+        filter: none;
+    }
+}
+
 .daggerheart.placeable-hud {
     .col.right {
         .palette {


### PR DESCRIPTION
- Light mode made the status icons in the tokenHUD become neon bright and ugly. Fixed
- DefeatedConditions returned a value list instead of key-value pairs, this broke the automatic Defeated status application. Fixed.
- Clicking on the Summary message would give a "token no longer exists" message on clicking. Fixed so it properly pans the screen to the token.