### PR TITLE
[Fix] LightMode Touchups

### DIFF
--- a/styles/less/dialog/character-creation/selections-container.less
+++ b/styles/less/dialog/character-creation/selections-container.less
@@ -448,7 +448,7 @@
                         white-space: nowrap;
                         border: 1px solid light-dark(@dark-blue, @golden);
                         border-radius: 6px;
-                        color: light-dark(@beige, @dark);
+                        color: @dark;
                         background-image: url('../assets/parchments/dh-parchment-light.png');
                         padding: 0 2px;
                     }

--- a/styles/less/global/elements.less
+++ b/styles/less/global/elements.less
@@ -801,7 +801,7 @@
             padding: 10px 0;
             text-align: center;
             font-size: var(--font-size-16);
-            color: light-dark(@beige, @dark);
+            color: @dark;
             background-image: url(../assets/parchments/dh-parchment-light.png);
             border-radius: 0 0 4px 4px;
         }
@@ -834,7 +834,7 @@
                 font-variant: small-caps;
                 text-align: center;
                 font-style: italic;
-                color: light-dark(@dark-blue-60, @beige-80);
+                color: light-dark(@dark-blue, @beige-80);
             }
         }
     }

--- a/styles/less/ui/sidebar/tabs.less
+++ b/styles/less/ui/sidebar/tabs.less
@@ -1,3 +1,9 @@
+.theme-light #interface #ui-right #sidebar {
+    menu li button img {
+        filter: @grey-filter;
+    }
+}
+
 #interface #ui-right #sidebar {
     menu li button {
         img {

--- a/styles/less/utils/colors.less
+++ b/styles/less/utils/colors.less
@@ -56,6 +56,8 @@
 @dark-80: #22222280;
 @dark-filter: brightness(0) saturate(100%);
 
+@grey-filter: brightness(15%) saturate(20%);
+
 @deep-black: #0e0d15;
 
 @beige: #efe6d8;


### PR DESCRIPTION
Some fixes to places I found where the colour was too bright in lightmode.

In CharacterCreation & Levelup:
**Before**
<img width="872" height="1067" alt="image" src="https://github.com/user-attachments/assets/645100e9-843c-4335-b55b-82bd31bfaf4f" />
**After**
<img width="874" height="1065" alt="image" src="https://github.com/user-attachments/assets/a42d6e60-5a1c-48d9-9ade-19e4e02bbaf8" />

DaggerheartMenu
**Before**
<img width="58" height="202" alt="image" src="https://github.com/user-attachments/assets/5462b441-b8db-4a94-9f81-ffdce17ac0f9" />
**After**
<img width="58" height="199" alt="image" src="https://github.com/user-attachments/assets/f45cb000-9460-4f65-873a-05ba29777b30" />