### PR TITLE
[Fix] Homebrew Weapons/Armor Feature Titles

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2344,6 +2344,9 @@
             },
             "Homebrew": {
                 "newDowntimeMove": "Downtime Move",
+                "downtimeMove": "Downtime Move",
+                "armorFeature": "Armor Feature",
+                "weaponFeature": "Weapon Feaure",
                 "newFeature": "New ItemFeature",
                 "downtimeMoves": "Downtime Moves",
                 "itemFeatures": "Item Features",

--- a/module/applications/settings/homebrewSettings.mjs
+++ b/module/applications/settings/homebrewSettings.mjs
@@ -147,7 +147,14 @@ export default class DhHomebrewSettings extends HandlebarsApplicationMixin(Appli
         const path = isDowntime ? `restMoves.${type}.moves.${id}` : `itemFeatures.${type}.${id}`;
         const featureBase = isDowntime ? this.settings.restMoves[type].moves[id] : this.settings.itemFeatures[type][id];
 
+        const configTitle = isDowntime
+            ? game.i18n.localize('DAGGERHEART.SETTINGS.Homebrew.downtimeMove')
+            : type === 'armorFeatures'
+              ? game.i18n.localize('DAGGERHEART.SETTINGS.Homebrew.armorFeature')
+              : game.i18n.localize('DAGGERHEART.SETTINGS.Homebrew.weaponFeature');
+
         const editedBase = await game.system.api.applications.sheetConfigs.SettingFeatureConfig.configure(
+            configTitle,
             featureBase,
             path,
             this.settings,

--- a/module/applications/sheets-configs/setting-feature-config.mjs
+++ b/module/applications/sheets-configs/setting-feature-config.mjs
@@ -4,9 +4,10 @@ import DHActionConfig from './action-config.mjs';
 const { HandlebarsApplicationMixin, ApplicationV2 } = foundry.applications.api;
 
 export default class SettingFeatureConfig extends HandlebarsApplicationMixin(ApplicationV2) {
-    constructor(move, movePath, settings, optionalParts, options) {
+    constructor(configTitle, move, movePath, settings, optionalParts, options) {
         super(options);
 
+        this.configTitle = configTitle;
         this.move = move;
 
         this.movePath = movePath;
@@ -19,7 +20,7 @@ export default class SettingFeatureConfig extends HandlebarsApplicationMixin(App
     }
 
     get title() {
-        return game.i18n.localize('DAGGERHEART.SETTINGS.Homebrew.downtimeMoves');
+        return this.configTitle;
     }
 
     static DEFAULT_OPTIONS = {
@@ -200,9 +201,9 @@ export default class SettingFeatureConfig extends HandlebarsApplicationMixin(App
         if (!options.submitted) this.move = null;
     }
 
-    static async configure(move, movePath, settings, optionalParts, options = {}) {
+    static async configure(configTitle, move, movePath, settings, optionalParts, options = {}) {
         return new Promise(resolve => {
-            const app = new this(move, movePath, settings, optionalParts, options);
+            const app = new this(configTitle, move, movePath, settings, optionalParts, options);
             app.addEventListener('close', () => resolve(app.move), { once: true });
             app.render({ force: true });
         });


### PR DESCRIPTION
Fixed so that the Homebrew settings screen for homebrew weapon/armor features gets a correct title instead of 'Downtime Moves'