### PR TITLE
Protect from error when no actor (e.g. enricher)

### DIFF
--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -29,9 +29,11 @@ export default class DHRoll extends Roll {
         config.hooks = [...this.getHooks(), ''];
         config.dialog ??= {};
 
-        const actorIdSplit = config.source.actor.split('.');
-        const tagTeamSettings = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.TagTeamRoll);
-        config.tagTeamSelected = tagTeamSettings.members[actorIdSplit[actorIdSplit.length - 1]];
+        const actorIdSplit = config.source?.actor?.split('.');
+        if (actorIdSplit) {
+            const tagTeamSettings = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.TagTeamRoll);
+            config.tagTeamSelected = tagTeamSettings.members[actorIdSplit[actorIdSplit.length - 1]];
+        }
 
         for (const hook of config.hooks) {
             if (Hooks.call(`${CONFIG.DH.id}.preRoll${hook.capitalize()}`, config, message) === false) return null;


### PR DESCRIPTION
## Description

Fixes an error in the dhRoll when the actor was not defined.  See image below for details.
No issue raised.

## Type of Change

Please check the relevant options:

- [x] Bug fix

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x] Manual testing

## Screenshots (if applicable)

Include screenshots or GIFs to help explain your changes visually.

<img width="1024" height="760" alt="dhroll" src="https://github.com/user-attachments/assets/ba456886-456e-430d-be0c-c65471b7bba4" />
