### PR TITLE
Add minor styling fixes

### DIFF
--- a/styles/less/global/tab-description.less
+++ b/styles/less/global/tab-description.less
@@ -5,7 +5,7 @@
     .tab.active.description {
         display: flex;
         flex-direction: column;
-        height: -webkit-fill-available !important;
+        flex: 1;
         overflow-y: hidden !important;
         padding-top: 10px;
 

--- a/styles/less/sheets/actors/character/biography.less
+++ b/styles/less/sheets/actors/character/biography.less
@@ -10,7 +10,7 @@
             height: 100%;
             overflow-y: auto;
             mask-image: linear-gradient(0deg, transparent 0%, black 10%, black 98%, transparent 100%);
-            padding-bottom: 40px;
+            padding-bottom: 10px;
             height: 100%;
 
             scrollbar-width: thin;


### PR DESCRIPTION
Fixes item descriptions on firefox, and makes the biography outer scroll not happen on the default size. The side padding for the biography is 10px, so I made the bottom match.
