### PR TITLE
[PR] Prune missing party members

### DIFF
--- a/module/data/actor/party.mjs
+++ b/module/data/actor/party.mjs
@@ -7,7 +7,7 @@ export default class DhParty extends BaseDataActor {
         const fields = foundry.data.fields;
         return {
             ...super.defineSchema(),
-            partyMembers: new ForeignDocumentUUIDArrayField({ type: 'Actor' }),
+            partyMembers: new ForeignDocumentUUIDArrayField({ type: 'Actor' }, { prune: true }),
             notes: new fields.HTMLField(),
             gold: new fields.SchemaField({
                 coins: new fields.NumberField({ initial: 0, integer: true }),
@@ -27,7 +27,6 @@ export default class DhParty extends BaseDataActor {
 
     prepareBaseData() {
         super.prepareBaseData();
-        this.partyMembers = this.partyMembers.filter(p => !!p);
 
         // Register this party to all members
         if (game.actors.get(this.parent.id) === this.parent) {

--- a/module/data/fields/foreignDocumentUUIDArrayField.mjs
+++ b/module/data/fields/foreignDocumentUUIDArrayField.mjs
@@ -15,6 +15,9 @@ export default class ForeignDocumentUUIDArrayField extends foundry.data.fields.A
     /** @inheritdoc */
     initialize(value, model, options = {}) {
         const v = super.initialize(value, model, options);
-        return () => v.map(entry => (typeof entry === 'function' ? entry() : entry));
+        return () => {
+            const data = v.map(entry => (typeof entry === 'function' ? entry() : entry));
+            return this.options.prune ? data.filter((d) => !!d) : d;
+        };
     }
 }


### PR DESCRIPTION
Prunes invalid party members in the data model during data prep. Since updates check prepared data, this means that changing party members will remove them from the source data when that occurs.