### PR TITLE
[Fix] Item Browser Corrections

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2570,7 +2570,7 @@
                 "evasionMin": "Evasion (Min)",
                 "evasionMax": "Evasion (Max)",
                 "subtype": "Subtype",
-                "missing": "<Missing>",
+                "missing": "<i>Missing</i>",
                 "folders": {
                     "characters": "Characters",
                     "adversaries": "Adversaries",

--- a/module/applications/ui/itemBrowser.mjs
+++ b/module/applications/ui/itemBrowser.mjs
@@ -294,7 +294,7 @@ export class ItemBrowser extends HandlebarsApplicationMixin(ApplicationV2) {
         const property = foundry.utils.getProperty(item, field.key);
         if (Array.isArray(property)) property.join(', ');
         if (typeof field.format !== 'function') return property ?? '-';
-        return field.format(property);
+        return game.i18n.localize(field.format(property));
     }
 
     formatChoices(data) {

--- a/module/config/itemBrowserConfig.mjs
+++ b/module/config/itemBrowserConfig.mjs
@@ -363,7 +363,7 @@ export const typeConfig = {
             {
                 key: 'system.linkedClass',
                 label: 'Class',
-                format: linkedClass => linkedClass?.name ?? game.i18n.localize('DAGGERHEART.UI.ItemBrowser.missing')
+                format: linkedClass => linkedClass?.name ?? 'DAGGERHEART.UI.ItemBrowser.missing'
             },
             {
                 key: 'system.spellcastingTrait',


### PR DESCRIPTION
- Fixed so that the lists do not fail to show because the search is empty (the common problem)
- Fixed so that hitting the clear button actually loads all the items again instead of an empty list