### PR TITLE
[Fix] Beastform Actor Wildcard Image

### DIFF
--- a/module/data/activeEffect/beastformEffect.mjs
+++ b/module/data/activeEffect/beastformEffect.mjs
@@ -6,6 +6,7 @@ export default class BeastformEffect extends BaseEffect {
         const fields = foundry.data.fields;
         return {
             characterTokenData: new fields.SchemaField({
+                usesDynamicToken: new fields.BooleanField({ initial: false }),
                 tokenImg: new fields.FilePathField({
                     categories: ['IMAGE'],
                     base64: false,
@@ -49,6 +50,7 @@ export default class BeastformEffect extends BaseEffect {
                     src: this.characterTokenData.tokenImg
                 },
                 ring: {
+                    enabled: this.characterTokenData.usesDynamicToken,
                     subject: {
                         texture: this.characterTokenData.tokenRingImg
                     }
@@ -58,6 +60,7 @@ export default class BeastformEffect extends BaseEffect {
             const updateToken = token => ({
                 ...baseUpdate,
                 'texture': {
+                    enabled: this.characterTokenData.usesDynamicToken,
                     src: token.flags.daggerheart.beastformTokenImg
                 },
                 'ring': {

--- a/module/data/item/beastform.mjs
+++ b/module/data/item/beastform.mjs
@@ -174,6 +174,7 @@ export default class DHBeastform extends BaseDataItem {
             ],
             system: {
                 characterTokenData: {
+                    usesDynamicToken: this.parent.parent.prototypeToken.ring.enabled,
                     tokenImg: this.parent.parent.prototypeToken.texture.src,
                     tokenRingImg: this.parent.parent.prototypeToken.ring.subject.texture,
                     tokenSize: {

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -251,6 +251,12 @@ export const adjustRange = (rangeVal, decrease) => {
     return range[rangeKeys[newIndex]];
 };
 
+/**
+ *
+ * @param {DhActor} actor - The actor for which all tokens will run a data update.
+ * @param {string} update - The data update to be applied to all tokens.
+ * @param {func} updateToken - Optional, specific data update for the non-prototype tokens as a function using the token data. Useful to handle wildcard images where each token has a different image but the prototype has a wildcard path.
+ */
 export const updateActorTokens = async (actor, update, updateToken) => {
     await actor.prototypeToken.update({ ...update });
 


### PR DESCRIPTION
Closes #1129
- Fixed so that the BeastformEffect datamodel stores the PrototypeToken images.
- The individual tokens belonging to the actor store a flag of their original images that can then be restored when the beastform ends.

With this you can have three tokens out on the canvas from an Actor that has a wildcard image path, with three different pictures.
-->
Transform to a beast
--> 
Turn Back
-->
The tokens have the individual pictures they had before and the ProtoType token has the path with the wildcard.
