### PR TITLE
[Fix] Status Effect Error

### DIFF
--- a/module/applications/sheets-configs/activeEffectConfig.mjs
+++ b/module/applications/sheets-configs/activeEffectConfig.mjs
@@ -112,7 +112,7 @@ export default class DhActiveEffectConfig extends foundry.applications.sheets.Ac
                     CONFIG.DH.SETTINGS.gameSettings.appearance
                 ).showGenericStatusEffects;
                 if (!useGeneric) {
-                    partContext.statuses = Object.values(CONFIG.DH.GENERAL.conditions).map(status => ({
+                    partContext.statuses = Object.values(CONFIG.DH.GENERAL.conditions()).map(status => ({
                         value: status.id,
                         label: game.i18n.localize(status.name)
                     }));


### PR DESCRIPTION
Fixed so that status effects are shown on ActiveEffectConfig again when useGeneric is not active.
`CONFIG.DH.GENERAL.conditions` had been changed from a constant to a function in a previous change, but it was still being used as a value here, making it fail.