### PR TITLE
Fix party sheet tab height when expanded

### DIFF
--- a/module/applications/sheets/actors/party.mjs
+++ b/module/applications/sheets/actors/party.mjs
@@ -20,7 +20,8 @@ export default class Party extends DHBaseActorSheet {
     static DEFAULT_OPTIONS = {
         classes: ['party'],
         position: {
-            width: 550
+            width: 550,
+            height: 900,
         },
         window: {
             resizable: true

--- a/styles/less/sheets/actors/party/sheet.less
+++ b/styles/less/sheets/actors/party/sheet.less
@@ -14,11 +14,11 @@
 
 .application.sheet.daggerheart.actor.dh-style.party {
     .tab {
-        height: -webkit-fill-available;
-        max-height: 514px;
+        flex: 1;
         overflow-y: auto;
         scrollbar-width: thin;
         scrollbar-color: light-dark(@dark-blue, @golden) transparent;
+        scrollbar-gutter: stable;
 
         &.active {
             overflow: auto;


### PR DESCRIPTION
Fixes the party sheet's tab size when resized.

Before: 
<img width="634" height="1106" alt="image" src="https://github.com/user-attachments/assets/a6d9589d-9ee2-4cdf-946a-7ebf247b8145" />

After:
<img width="587" height="933" alt="image" src="https://github.com/user-attachments/assets/70464298-27a5-4f01-ab13-86abce510d3b" />

However, as a consequence, it opens up larger on the member list, even if its empty, because it no longer tries to auto-size per tab. However, unless there's a way to set a max height only for the auto-size in foundry that I didn't realize exists, I don't think its possible to have that and allow the contents to scale properly without letting it get very large.