### PR TITLE
Fix styling of used action tokens for players

### DIFF
--- a/styles/less/ui/combat-sidebar/token-actions.less
+++ b/styles/less/ui/combat-sidebar/token-actions.less
@@ -21,11 +21,6 @@
                 padding: 8px;
                 --button-size: 0;
 
-                &.used {
-                    opacity: 0.5;
-                    background: transparent;
-                }
-
                 &.inactive {
                     background: var(--color-warm-2);
                     color: var(--color-light-1);
@@ -34,6 +29,11 @@
                     &:hover {
                         filter: none;
                     }
+                }
+
+                &.used {
+                    opacity: 0.5;
+                    background: transparent;
                 }
             }
         }


### PR DESCRIPTION
Fixes the styling of used action tokens of actors not owned by the current viewer.

Before:
<img width="300" height="141" alt="image" src="https://github.com/user-attachments/assets/52e279e9-9563-4477-bde2-5e35a0fc839e" />

After:
<img width="305" height="150" alt="image" src="https://github.com/user-attachments/assets/697d8811-359c-41a1-88f4-7c7086f64f12" />

