### PR TITLE
[Fix] Beastform Effect Stuck

### DIFF
--- a/module/data/activeEffect/beastformEffect.mjs
+++ b/module/data/activeEffect/beastformEffect.mjs
@@ -61,11 +61,12 @@ export default class BeastformEffect extends BaseEffect {
                 ...baseUpdate,
                 'texture': {
                     enabled: this.characterTokenData.usesDynamicToken,
-                    src: token.flags.daggerheart.beastformTokenImg
+                    src: token.flags.daggerheart?.beastformTokenImg ?? this.characterTokenData.tokenImg
                 },
                 'ring': {
                     subject: {
-                        texture: token.flags.daggerheart.beastformSubjectTexture
+                        texture:
+                            token.flags.daggerheart?.beastformSubjectTexture ?? this.characterTokenData.tokenRingImg
                     }
                 },
                 'flags.daggerheart': { '-=beastformTokenImg': null, '-=beastformSubjectTexture': null }

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
     "id": "daggerheart",
     "title": "Daggerheart",
     "description": "An unofficial implementation of the Daggerheart system",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "compatibility": {
         "minimum": "13",
         "verified": "13.351",


### PR DESCRIPTION
If a character was already transformed before the v1.2.2 update came, then they end up getting stuck without being able to transform back.
Added a fallback so that won't happen.