### PR TITLE
[Fix] Loader CSS Issue

### DIFF
--- a/module/applications/ui/itemBrowser.mjs
+++ b/module/applications/ui/itemBrowser.mjs
@@ -22,7 +22,7 @@ export class ItemBrowser extends HandlebarsApplicationMixin(ApplicationV2) {
     /** @inheritDoc */
     static DEFAULT_OPTIONS = {
         id: 'itemBrowser',
-        classes: ['daggerheart', 'dh-style', 'dialog', 'compendium-browser', 'loader'],
+        classes: ['daggerheart', 'dh-style', 'dialog', 'compendium-browser', 'daggerheart-loader'],
         tag: 'div',
         window: {
             frame: true,
@@ -277,7 +277,7 @@ export class ItemBrowser extends HandlebarsApplicationMixin(ApplicationV2) {
     toggleLoader(state) {
         const container = this.element.querySelector('.item-list');
         return setTimeout(() => {
-            container.classList.toggle('loader', state);
+            container.classList.toggle('daggerheart-loader', state);
         }, 100);
     }
 

--- a/styles/less/global/global.less
+++ b/styles/less/global/global.less
@@ -24,7 +24,7 @@
         }
     }
 
-    .loader {
+    .daggerheart-loader {
         position: relative;
         overflow: hidden !important;
 


### PR DESCRIPTION
Changed from `.loader` to `.daggerheart-loader` as a css selector to avoid conflicts with modules applying broad classes.