### PR TITLE
[Fix] FlatRoll Fix

### DIFF
--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -115,7 +115,7 @@ export default class DHRoll extends Roll {
                 game.system.api.applications.dialogs.TagTeamDialog.assignRoll(message.speakerActor, message);
             }
 
-            if (game.modules.get('dice-so-nice')?.active) {
+            if (roll.formula !== '' && game.modules.get('dice-so-nice')?.active) {
                 await game.dice3d.waitFor3DAnimationByMessageID(message.id);
             }
 


### PR DESCRIPTION
Rolls that do not include any dice terms (IE, solely flat values) were shorting the logic in the rolls because we have an instance where we wait for the current DiceSoNice roll to finish. In this situation, there is no roll however, so it shorts out.
Fixed it by checking if there -is- a formula.