### PR TITLE
[Fix] PouncingPredator Beastform

### DIFF
--- a/src/packs/beastforms/feature_Takedown_0ey4kM9ssj2otHvb.json
+++ b/src/packs/beastforms/feature_Takedown_0ey4kM9ssj2otHvb.json
@@ -33,7 +33,7 @@
               "value": {
                 "custom": {
                   "enabled": true,
-                  "formula": "(@prof+2)@basicAttackDamageDice + @rules.attack.damage.bonus"
+                  "formula": "(@prof+2)@basicAttackDamageDice + 6"
                 },
                 "multiplier": "prof",
                 "flatMultiplier": 1,


### PR DESCRIPTION
Closes #1300 
Closes #1301
- Now targets 1 Enemy instead of Self.
- Now adds the bonus +6 damage on the Takedown feature.