### PR TITLE
[Fix] enriching multiple instances of the same inline type

### DIFF
--- a/module/enrichers/_module.mjs
+++ b/module/enrichers/_module.mjs
@@ -8,23 +8,23 @@ export { DhDamageEnricher, DhDualityRollEnricher, DhEffectEnricher, DhTemplateEn
 
 export const enricherConfig = [
     {
-        pattern: /@Damage\[(.*)\]({.*})?/g,
+        pattern: /@Damage\[([^\[\]]*)\]({[^}]*})?/g,
         enricher: DhDamageEnricher
     },
     {
-        pattern: /\[\[\/dr\s?(.*?)\]\]({.*})?/g,
+        pattern: /\[\[\/dr\s?(.*?)\]\]({[^}]*})?/g,
         enricher: DhDualityRollEnricher
     },
     {
-        pattern: /@Effect\[(.*)\]({.*})?/g,
+        pattern: /@Effect\[([^\[\]]*)\]({[^}]*})?/g,
         enricher: DhEffectEnricher
     },
     {
-        pattern: /@Template\[(.*)\]({.*})?/g,
+        pattern: /@Template\[([^\[\]]*)\]({[^}]*})?/g,
         enricher: DhTemplateEnricher
     },
     {
-        pattern: /@Lookup\[(.*)\]({.*})?/g,
+        pattern: /@Lookup\[([^\[\]]*)\]({[^}]*})?/g,
         enricher: DhLookupEnricher
     }
 ];


### PR DESCRIPTION
Closes https://github.com/Foundryborne/daggerheart/issues/1308

The `.*` in /dr is fine specifically because the opening closing is a double bracket. Dealing with insane regex is a problem with the `@Blah` type inlines. Luckily damage rolls in daggerheart aren't complicated or the thing I'd have to unveil for damage would be a monster.