### PR TITLE
[Feature] Fallback action description to item description when posted in chat

### DIFF
--- a/module/data/fields/actionField.mjs
+++ b/module/data/fields/actionField.mjs
@@ -260,7 +260,7 @@ export function ActionMixin(Base) {
                 origin: origin,
                 action: { name: this.name, img: this.img, tags: this.tags ? this.tags : ['Spell', 'Arcana', 'Lv 10'] },
                 itemOrigin: this.item,
-                description: this.description
+                description: this.description || (this.item instanceof Item ? this.item.system.description : "")
             };
             const msg = {
                 type: 'abilityUse',


### PR DESCRIPTION
Closes https://github.com/Foundryborne/daggerheart/issues/1198

When an action with no description is posted to chat, it will post the item's description. This does not give the action a description in the actions tab proper. 

You can test with Fire Jar (there seems to be an issue with uses right now, but its unrelated)

<img width="1475" height="563" alt="image" src="https://github.com/user-attachments/assets/2c36ae6f-de45-403d-8d6e-5c85a939e9b8" />
