### PR TITLE
[Fix] Show loot actions in sheet

### DIFF
--- a/templates/sheets/actors/character/inventory.hbs
+++ b/templates/sheets/actors/character/inventory.hbs
@@ -53,6 +53,7 @@
         collection=document.itemTypes.loot
         isGlassy=true
         canCreate=true
+        showActions=true
         }}
     </div>
 </section>

--- a/templates/sheets/global/partials/inventory-item-V2.hbs
+++ b/templates/sheets/global/partials/inventory-item-V2.hbs
@@ -139,7 +139,7 @@ Parameters:
   {{> "systems/daggerheart/templates/sheets/global/partials/item-resource.hbs"}}
   {{/if}}
   {{!-- Actions Buttons --}}
-  {{#if (and showActions (eq item.type 'feature'))}}
+  {{#if (and showActions item.system.actions.size)}}
   <div class="item-buttons">
     {{#each item.system.actions as | action |}}
     <div class="item-button">


### PR DESCRIPTION
Makes PR loot items actions and uses visible

<img width="552" height="210" alt="image" src="https://github.com/user-attachments/assets/f05d1c1f-da1a-4666-91a1-c0a319d3d122" />
