### PR TITLE
[Fix] 1313 - Countdown Looping Cocatenation

### DIFF
--- a/module/applications/ui/countdowns.mjs
+++ b/module/applications/ui/countdowns.mjs
@@ -184,9 +184,9 @@ export default class DhCountdowns extends HandlebarsApplicationMixin(Application
         const countdown = settings.countdowns[target.id];
         const newMax =
             countdown.progress.looping === CONFIG.DH.GENERAL.countdownLoopingTypes.increasing.id
-                ? countdown.progress.max + 1
+                ? Number(countdown.progress.max) + 1
                 : countdown.progress.looping === CONFIG.DH.GENERAL.countdownLoopingTypes.decreasing.id
-                  ? Math.max(countdown.progress.max - 1, 0)
+                  ? Math.max(Number(countdown.progress.max) - 1, 0)
                   : countdown.progress.max;
         await settings.updateSource({
             [`countdowns.${target.id}.progress`]: {


### PR DESCRIPTION
Closes #1313 
Fixed so that using the loop button actually increases/decreases max on looping instead of cocatenating to string