### PR TITLE
[Fix] 1294 - DragDrop Ancestry/Community

### DIFF
--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -907,6 +907,14 @@ export default class CharacterSheet extends DHBaseActorSheet {
             itemData.system.inVault = true;
         }
 
+        const typesThatReplace = ['ancestry', 'community'];
+        if (typesThatReplace.includes(item.type)) {
+            await this.document.deleteEmbeddedDocuments(
+                'Item',
+                this.document.items.filter(x => x.type === item.type).map(x => x.id)
+            );
+        }
+
         if (item.type === 'beastform') {
             if (this.document.effects.find(x => x.type === 'beastform')) {
                 return ui.notifications.warn(


### PR DESCRIPTION
Closes #1294 
Ancestry and community is now updated when dragging in a new one onto the sheet. The features of the old one are kept to allow manual patching together of a mixed Ancestry.