### PR TITLE
[Fix] Environment Drag Adversaries

### DIFF
--- a/module/applications/sheets/actors/environment.mjs
+++ b/module/applications/sheets/actors/environment.mjs
@@ -25,7 +25,7 @@ export default class DhpEnvironment extends DHBaseActorSheet {
             toggleResourceDice: DhpEnvironment.#toggleResourceDice,
             handleResourceDice: DhpEnvironment.#handleResourceDice
         },
-        dragDrop: [{ dragSelector: '.action-section .inventory-item', dropSelector: null }]
+        dragDrop: [{ dragSelector: '.inventory-item', dropSelector: null }]
     };
 
     /**@override */


### PR DESCRIPTION
Fixed the css selector so that you can drag out potential adversaries again. We had removed the selector used for drag-drop in environments and didn't update accordingly.