### PR TITLE
[Fix] SRD Weapon Touchups

### DIFF
--- a/module/applications/dialogs/actionSelectionDialog.mjs
+++ b/module/applications/dialogs/actionSelectionDialog.mjs
@@ -57,7 +57,11 @@ export default class ActionSelectionDialog extends HandlebarsApplicationMixin(Ap
 
     /** @inheritDoc */
     async _prepareContext(options) {
-        const actions = this.#item.system.actionsList,
+        const actions = this.#item.system.actionsList.map(action => ({
+                ...action.toObject(),
+                id: action.id,
+                img: action.baseAction ? action.parent.parent.img : action.img
+            })),
             itemName = this.#item.name;
         return {
             ...(await super._prepareContext(options)),

--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -22,6 +22,7 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
             _id: new fields.DocumentIdField({ initial: () => foundry.utils.randomID() }),
             systemPath: new fields.StringField({ required: true, initial: 'actions' }),
             type: new fields.StringField({ initial: undefined, readonly: true, required: true }),
+            baseAction: new fields.BooleanField({ initial: false }),
             name: new fields.StringField({ initial: undefined }),
             description: new fields.HTMLField(),
             img: new fields.FilePathField({ initial: undefined, categories: ['IMAGE'], base64: false }),

--- a/module/data/fields/actionField.mjs
+++ b/module/data/fields/actionField.mjs
@@ -258,7 +258,11 @@ export function ActionMixin(Base) {
             const systemData = {
                 title: game.i18n.localize('DAGGERHEART.CONFIG.ActionType.action'),
                 origin: origin,
-                action: { name: this.name, img: this.img, tags: this.tags ? this.tags : ['Spell', 'Arcana', 'Lv 10'] },
+                action: {
+                    name: this.name,
+                    img: this.baseAction ? this.parent.parent.img : this.img,
+                    tags: this.tags ? this.tags : ['Spell', 'Arcana', 'Lv 10']
+                },
                 itemOrigin: this.item,
                 description: this.description || (this.item instanceof Item ? this.item.system.description : '')
             };

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -51,6 +51,8 @@ export default class DHWeapon extends AttachableItem {
                     name: 'Attack',
                     img: 'icons/skills/melee/blood-slash-foam-red.webp',
                     _id: foundry.utils.randomID(),
+                    baseAction: true,
+                    chatDisplay: false,
                     systemPath: 'attack',
                     type: 'attack',
                     range: 'melee',

--- a/src/packs/items/weapons/weapon_Aantari_Bow_ijodu5yNBoMxpkHV.json
+++ b/src/packs/items/weapons/weapon_Aantari_Bow_ijodu5yNBoMxpkHV.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "31XEMDUyjpqFA7H9",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Arcane_Frame_Wheelchair_la3sAWgnvadc4NvP.json
+++ b/src/packs/items/weapons/weapon_Advanced_Arcane_Frame_Wheelchair_la3sAWgnvadc4NvP.json
@@ -24,6 +24,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "fKTeCKjfyQauf5bA",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -78,7 +79,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Arcane_Gauntlets_hXR56fTKwZ6s1obs.json
+++ b/src/packs/items/weapons/weapon_Advanced_Arcane_Gauntlets_hXR56fTKwZ6s1obs.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "8j3yjH0TiwwZsaBW",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Battleaxe_FcbvY1ydbNVMjKvk.json
+++ b/src/packs/items/weapons/weapon_Advanced_Battleaxe_FcbvY1ydbNVMjKvk.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "tSwiEa50USNh6uEJ",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Broadsword_WtQAGz0TUgz8Xg70.json
+++ b/src/packs/items/weapons/weapon_Advanced_Broadsword_WtQAGz0TUgz8Xg70.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "tSwiEa50USNh6uEJ",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Crossbow_3HGs0AgVrdIBTaKG.json
+++ b/src/packs/items/weapons/weapon_Advanced_Crossbow_3HGs0AgVrdIBTaKG.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "tSwiEa50USNh6uEJ",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Cutlass_bw9WO9lxkM9bWZxQ.json
+++ b/src/packs/items/weapons/weapon_Advanced_Cutlass_bw9WO9lxkM9bWZxQ.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "tSwiEa50USNh6uEJ",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Dagger_mrioysDjNQEIE8hN.json
+++ b/src/packs/items/weapons/weapon_Advanced_Dagger_mrioysDjNQEIE8hN.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "tSwiEa50USNh6uEJ",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Dualstaff_X5x3sC7v2f3L9sjL.json
+++ b/src/packs/items/weapons/weapon_Advanced_Dualstaff_X5x3sC7v2f3L9sjL.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "8j3yjH0TiwwZsaBW",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Glowing_Rings_InQoh8mZPnwarQkX.json
+++ b/src/packs/items/weapons/weapon_Advanced_Glowing_Rings_InQoh8mZPnwarQkX.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "8j3yjH0TiwwZsaBW",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryClose",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Grappler_7vvhVl4TDJHtjpFK.json
+++ b/src/packs/items/weapons/weapon_Advanced_Grappler_7vvhVl4TDJHtjpFK.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "close",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Greatstaff_4UzxqfkwF8gDSdu7.json
+++ b/src/packs/items/weapons/weapon_Advanced_Greatstaff_4UzxqfkwF8gDSdu7.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "8j3yjH0TiwwZsaBW",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryFar",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Greatsword_MAC6YWTo4lzSotQc.json
+++ b/src/packs/items/weapons/weapon_Advanced_Greatsword_MAC6YWTo4lzSotQc.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "tSwiEa50USNh6uEJ",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Halberd_C8gQn7onAc9wsrCs.json
+++ b/src/packs/items/weapons/weapon_Advanced_Halberd_C8gQn7onAc9wsrCs.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "tSwiEa50USNh6uEJ",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryClose",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Hallowed_Axe_BiyXKX2Mo1TQbKgk.json
+++ b/src/packs/items/weapons/weapon_Advanced_Hallowed_Axe_BiyXKX2Mo1TQbKgk.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "8j3yjH0TiwwZsaBW",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Hand_Crossbow_Lsvocst8aGqkBj7g.json
+++ b/src/packs/items/weapons/weapon_Advanced_Hand_Crossbow_Lsvocst8aGqkBj7g.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -73,7 +74,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Hand_Runes_PQACczSghZIVTdgZ.json
+++ b/src/packs/items/weapons/weapon_Advanced_Hand_Runes_PQACczSghZIVTdgZ.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "8j3yjH0TiwwZsaBW",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryClose",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Heavy_Frame_Wheelchair_eT2Qwb0RdrLX2hH1.json
+++ b/src/packs/items/weapons/weapon_Advanced_Heavy_Frame_Wheelchair_eT2Qwb0RdrLX2hH1.json
@@ -24,6 +24,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "fKTeCKjfyQauf5bA",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -78,7 +79,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Light_Frame_Wheelchair_BuMfupnCzHbziQ8o.json
+++ b/src/packs/items/weapons/weapon_Advanced_Light_Frame_Wheelchair_BuMfupnCzHbziQ8o.json
@@ -53,6 +53,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "fKTeCKjfyQauf5bA",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -107,7 +108,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Longbow_M5CywMAyPKGgebsJ.json
+++ b/src/packs/items/weapons/weapon_Advanced_Longbow_M5CywMAyPKGgebsJ.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "tSwiEa50USNh6uEJ",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryFar",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Longsword_9xkB3MWXahrsVP4N.json
+++ b/src/packs/items/weapons/weapon_Advanced_Longsword_9xkB3MWXahrsVP4N.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "tSwiEa50USNh6uEJ",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Mace_WreMYiH5uhVDaoVw.json
+++ b/src/packs/items/weapons/weapon_Advanced_Mace_WreMYiH5uhVDaoVw.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "tSwiEa50USNh6uEJ",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Quarterstaff_zJtm2f9ZFKZRtCRg.json
+++ b/src/packs/items/weapons/weapon_Advanced_Quarterstaff_zJtm2f9ZFKZRtCRg.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "tSwiEa50USNh6uEJ",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Rapier_KxFne76d7cak15dO.json
+++ b/src/packs/items/weapons/weapon_Advanced_Rapier_KxFne76d7cak15dO.json
@@ -54,6 +54,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "tSwiEa50USNh6uEJ",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -108,7 +109,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Returning_Blade_sIGXA4KMeYBUjcEO.json
+++ b/src/packs/items/weapons/weapon_Advanced_Returning_Blade_sIGXA4KMeYBUjcEO.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "8j3yjH0TiwwZsaBW",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "close",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Round_Shield_hiEOGF2reabGLUoi.json
+++ b/src/packs/items/weapons/weapon_Advanced_Round_Shield_hiEOGF2reabGLUoi.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Scepter_2Khzuj768yoWN9QK.json
+++ b/src/packs/items/weapons/weapon_Advanced_Scepter_2Khzuj768yoWN9QK.json
@@ -91,6 +91,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "8j3yjH0TiwwZsaBW",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -145,7 +146,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Shortbow_JpSlJvDR0X8VFDns.json
+++ b/src/packs/items/weapons/weapon_Advanced_Shortbow_JpSlJvDR0X8VFDns.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "tSwiEa50USNh6uEJ",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Shortstaff_T5exRCqOXhrjSYnI.json
+++ b/src/packs/items/weapons/weapon_Advanced_Shortstaff_T5exRCqOXhrjSYnI.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "8j3yjH0TiwwZsaBW",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "close",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Shortsword_p3nz5CaGUoyuGVg0.json
+++ b/src/packs/items/weapons/weapon_Advanced_Shortsword_p3nz5CaGUoyuGVg0.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Small_Dagger_0thN0BpN05KT8Avx.json
+++ b/src/packs/items/weapons/weapon_Advanced_Small_Dagger_0thN0BpN05KT8Avx.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Spear_pK6dsNABKKp1CIGN.json
+++ b/src/packs/items/weapons/weapon_Advanced_Spear_pK6dsNABKKp1CIGN.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "tSwiEa50USNh6uEJ",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryClose",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Tower_Shield_OfOzQbs4hg6QbfTG.json
+++ b/src/packs/items/weapons/weapon_Advanced_Tower_Shield_OfOzQbs4hg6QbfTG.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Wand_jU9jWIardjtdAQcs.json
+++ b/src/packs/items/weapons/weapon_Advanced_Wand_jU9jWIardjtdAQcs.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "8j3yjH0TiwwZsaBW",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Warhammer_8Lipw3RRKDgBVP0p.json
+++ b/src/packs/items/weapons/weapon_Advanced_Warhammer_8Lipw3RRKDgBVP0p.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "tSwiEa50USNh6uEJ",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Advanced_Whip_01izMUSJcAUo79IX.json
+++ b/src/packs/items/weapons/weapon_Advanced_Whip_01izMUSJcAUo79IX.json
@@ -54,6 +54,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryClose",
@@ -108,7 +109,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Arcane_Frame_Wheelchair_XRChepscgr75Uug7.json
+++ b/src/packs/items/weapons/weapon_Arcane_Frame_Wheelchair_XRChepscgr75Uug7.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "fKTeCKjfyQauf5bA",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Arcane_Gauntlets_PC5EyEIq7NWBV0n5.json
+++ b/src/packs/items/weapons/weapon_Arcane_Gauntlets_PC5EyEIq7NWBV0n5.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "ZSdAawliPNsoA7nP",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Axe_of_Fortunis_YcS1rHgfnSlla8Xf.json
+++ b/src/packs/items/weapons/weapon_Axe_of_Fortunis_YcS1rHgfnSlla8Xf.json
@@ -54,6 +54,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "8j3yjH0TiwwZsaBW",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -108,7 +109,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Battleaxe_fbDYUja3ll9vCtrB.json
+++ b/src/packs/items/weapons/weapon_Battleaxe_fbDYUja3ll9vCtrB.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "ZSdAawliPNsoA7nP",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Black_Powder_Revolver_AokqTusPzn0hghkE.json
+++ b/src/packs/items/weapons/weapon_Black_Powder_Revolver_AokqTusPzn0hghkE.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "tSwiEa50USNh6uEJ",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Bladed_Whip_5faflfNz20cFW1EM.json
+++ b/src/packs/items/weapons/weapon_Bladed_Whip_5faflfNz20cFW1EM.json
@@ -54,6 +54,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "6lmY7PMkxI3kmkpb",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryClose",
@@ -108,7 +109,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Blessed_Anlace_n1oPTk5czTIGTkVj.json
+++ b/src/packs/items/weapons/weapon_Blessed_Anlace_n1oPTk5czTIGTkVj.json
@@ -93,6 +93,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "8j3yjH0TiwwZsaBW",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -147,7 +148,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Bloodstaff_IoMVDz92WVvfGGdc.json
+++ b/src/packs/items/weapons/weapon_Bloodstaff_IoMVDz92WVvfGGdc.json
@@ -54,6 +54,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "B2LewQYZb9Jhl4A6",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -108,7 +109,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Blunderbuss_SLFrK0WmldPo0shz.json
+++ b/src/packs/items/weapons/weapon_Blunderbuss_SLFrK0WmldPo0shz.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "6lmY7PMkxI3kmkpb",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "close",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Braveshield_QEvgVoz9xKBSKsGi.json
+++ b/src/packs/items/weapons/weapon_Braveshield_QEvgVoz9xKBSKsGi.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Bravesword_QZrWAkprA2tL2MOI.json
+++ b/src/packs/items/weapons/weapon_Bravesword_QZrWAkprA2tL2MOI.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "tSwiEa50USNh6uEJ",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Broadsword_1cwWNt4sqlgA8gCT.json
+++ b/src/packs/items/weapons/weapon_Broadsword_1cwWNt4sqlgA8gCT.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "ZSdAawliPNsoA7nP",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Buckler_EmFTp9wzT6MHSaNz.json
+++ b/src/packs/items/weapons/weapon_Buckler_EmFTp9wzT6MHSaNz.json
@@ -63,6 +63,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -117,7 +118,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Casting_Sword_2Fbf2cxLfbdGkU4I.json
+++ b/src/packs/items/weapons/weapon_Casting_Sword_2Fbf2cxLfbdGkU4I.json
@@ -89,6 +89,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "YHE291ruSIJAh44F",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -143,7 +144,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Crossbow_cw7HG1Z7hp7OOLD0.json
+++ b/src/packs/items/weapons/weapon_Crossbow_cw7HG1Z7hp7OOLD0.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "ZSdAawliPNsoA7nP",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Curved_Dagger_Fk69R40svV0kanZD.json
+++ b/src/packs/items/weapons/weapon_Curved_Dagger_Fk69R40svV0kanZD.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "31XEMDUyjpqFA7H9",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Cutlass_CWrbnethuILXrEpA.json
+++ b/src/packs/items/weapons/weapon_Cutlass_CWrbnethuILXrEpA.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "ZSdAawliPNsoA7nP",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Dagger_iStO0BbeMTTR0rQi.json
+++ b/src/packs/items/weapons/weapon_Dagger_iStO0BbeMTTR0rQi.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "ZSdAawliPNsoA7nP",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Devouring_Dagger_C5wSGglR8e0euQnY.json
+++ b/src/packs/items/weapons/weapon_Devouring_Dagger_C5wSGglR8e0euQnY.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "YHE291ruSIJAh44F",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Double_Flail_xm1yU7k58fMgXxRR.json
+++ b/src/packs/items/weapons/weapon_Double_Flail_xm1yU7k58fMgXxRR.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "tSwiEa50USNh6uEJ",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryClose",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Dual_Ended_Sword_nXjuBa215H1sTUK3.json
+++ b/src/packs/items/weapons/weapon_Dual_Ended_Sword_nXjuBa215H1sTUK3.json
@@ -54,6 +54,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "31XEMDUyjpqFA7H9",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -108,7 +109,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Dualstaff_j8cdNeIUYxxzFVji.json
+++ b/src/packs/items/weapons/weapon_Dualstaff_j8cdNeIUYxxzFVji.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "ZSdAawliPNsoA7nP",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Ego_Blade_G7rH31KQ5eEZXcv0.json
+++ b/src/packs/items/weapons/weapon_Ego_Blade_G7rH31KQ5eEZXcv0.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "YHE291ruSIJAh44F",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Elder_Bow_JdWcn9W1edhAEInL.json
+++ b/src/packs/items/weapons/weapon_Elder_Bow_JdWcn9W1edhAEInL.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "YHE291ruSIJAh44F",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Extended_Polearm_fJHKMxZokVP34MCi.json
+++ b/src/packs/items/weapons/weapon_Extended_Polearm_fJHKMxZokVP34MCi.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "31XEMDUyjpqFA7H9",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryClose",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Finehair_Bow_ykF3jouxHZ6YR8Bg.json
+++ b/src/packs/items/weapons/weapon_Finehair_Bow_ykF3jouxHZ6YR8Bg.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "6lmY7PMkxI3kmkpb",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryFar",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Firestaff_BtCm2RhWEfs00g38.json
+++ b/src/packs/items/weapons/weapon_Firestaff_BtCm2RhWEfs00g38.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "8j3yjH0TiwwZsaBW",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Flickerfly_Blade_xLJ5RRpUoTRmAC3G.json
+++ b/src/packs/items/weapons/weapon_Flickerfly_Blade_xLJ5RRpUoTRmAC3G.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "tSwiEa50USNh6uEJ",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Floating_Bladeshards_3vti3xfo0wJND7ew.json
+++ b/src/packs/items/weapons/weapon_Floating_Bladeshards_3vti3xfo0wJND7ew.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "B2LewQYZb9Jhl4A6",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "close",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Fusion_Gloves_uK1RhtYAsDeoPNGx.json
+++ b/src/packs/items/weapons/weapon_Fusion_Gloves_uK1RhtYAsDeoPNGx.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "B2LewQYZb9Jhl4A6",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryFar",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Ghostblade_6gFvOFTE97QZ74Zr.json
+++ b/src/packs/items/weapons/weapon_Ghostblade_6gFvOFTE97QZ74Zr.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "8j3yjH0TiwwZsaBW",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -72,7 +73,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Gilded_Bow_ctTgFfMbM3YtmsYU.json
+++ b/src/packs/items/weapons/weapon_Gilded_Bow_ctTgFfMbM3YtmsYU.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "8j3yjH0TiwwZsaBW",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Gilded_Falchion_VwcOgqnzjf9LBj2S.json
+++ b/src/packs/items/weapons/weapon_Gilded_Falchion_VwcOgqnzjf9LBj2S.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "6lmY7PMkxI3kmkpb",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Glowing_Rings_wG9f5NpCwSbaLy8t.json
+++ b/src/packs/items/weapons/weapon_Glowing_Rings_wG9f5NpCwSbaLy8t.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "ZSdAawliPNsoA7nP",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryClose",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Grappler_iEzPscUc18GuFoB6.json
+++ b/src/packs/items/weapons/weapon_Grappler_iEzPscUc18GuFoB6.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "i9jZXe5K5nIc58AG",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "close",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Greatbow_MXBpbqQsZFln4rZk.json
+++ b/src/packs/items/weapons/weapon_Greatbow_MXBpbqQsZFln4rZk.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "6lmY7PMkxI3kmkpb",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Greatstaff_Yk8pTEmyLLi4095S.json
+++ b/src/packs/items/weapons/weapon_Greatstaff_Yk8pTEmyLLi4095S.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "ZSdAawliPNsoA7nP",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryFar",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Greatsword_70ysaFJDREwTgvZa.json
+++ b/src/packs/items/weapons/weapon_Greatsword_70ysaFJDREwTgvZa.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "ZSdAawliPNsoA7nP",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Halberd_qT7FfmauAumOjJoq.json
+++ b/src/packs/items/weapons/weapon_Halberd_qT7FfmauAumOjJoq.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "ZSdAawliPNsoA7nP",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryClose",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Hallowed_Axe_Vayg7CnRTFBrunjM.json
+++ b/src/packs/items/weapons/weapon_Hallowed_Axe_Vayg7CnRTFBrunjM.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "ZSdAawliPNsoA7nP",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Hammer_of_Exota_0lAkBEUvbM9Osmqb.json
+++ b/src/packs/items/weapons/weapon_Hammer_of_Exota_0lAkBEUvbM9Osmqb.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "YHE291ruSIJAh44F",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Hammer_of_Wrath_1R4uzOpWD8bkYRUm.json
+++ b/src/packs/items/weapons/weapon_Hammer_of_Wrath_1R4uzOpWD8bkYRUm.json
@@ -54,6 +54,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "tSwiEa50USNh6uEJ",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -108,7 +109,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Hand_Cannon_MyGz8nd5sieRQ7zl.json
+++ b/src/packs/items/weapons/weapon_Hand_Cannon_MyGz8nd5sieRQ7zl.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "31XEMDUyjpqFA7H9",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryFar",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Hand_Crossbow_zxKt6qXe7uZB6ljm.json
+++ b/src/packs/items/weapons/weapon_Hand_Crossbow_zxKt6qXe7uZB6ljm.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "i9jZXe5K5nIc58AG",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Hand_Runes_3whiedn0jBMNRdIb.json
+++ b/src/packs/items/weapons/weapon_Hand_Runes_3whiedn0jBMNRdIb.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "ZSdAawliPNsoA7nP",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryClose",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Hand_Sling_RAIaoMi6iO1PKIlK.json
+++ b/src/packs/items/weapons/weapon_Hand_Sling_RAIaoMi6iO1PKIlK.json
@@ -89,6 +89,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryFar",
@@ -143,7 +144,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Heavy_Frame_Wheelchair_XjPQjhRCH08VUIbr.json
+++ b/src/packs/items/weapons/weapon_Heavy_Frame_Wheelchair_XjPQjhRCH08VUIbr.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "fKTeCKjfyQauf5bA",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Ilmari_s_Rifle_TMrUzVC3KvcHmdt8.json
+++ b/src/packs/items/weapons/weapon_Ilmari_s_Rifle_TMrUzVC3KvcHmdt8.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "Zz0k98NVLRpebKgq",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryFar",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Impact_Gauntlet_Zg6IutksQVOqAg8K.json
+++ b/src/packs/items/weapons/weapon_Impact_Gauntlet_Zg6IutksQVOqAg8K.json
@@ -54,6 +54,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "31XEMDUyjpqFA7H9",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -108,7 +109,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Arcane_Frame_Wheelchair_N9P695V5KKlJbAY5.json
+++ b/src/packs/items/weapons/weapon_Improved_Arcane_Frame_Wheelchair_N9P695V5KKlJbAY5.json
@@ -24,6 +24,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "fKTeCKjfyQauf5bA",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -78,7 +79,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Arcane_Gauntlets_kENTDpa1hr5LDhIT.json
+++ b/src/packs/items/weapons/weapon_Improved_Arcane_Gauntlets_kENTDpa1hr5LDhIT.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "YHE291ruSIJAh44F",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Battleaxe_nxGUpuHLmuKdKsDC.json
+++ b/src/packs/items/weapons/weapon_Improved_Battleaxe_nxGUpuHLmuKdKsDC.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "6lmY7PMkxI3kmkpb",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Broadsword_OcKeLJxvmdT81VBc.json
+++ b/src/packs/items/weapons/weapon_Improved_Broadsword_OcKeLJxvmdT81VBc.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "6lmY7PMkxI3kmkpb",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Crossbow_55NwHIIZHUeKSE3M.json
+++ b/src/packs/items/weapons/weapon_Improved_Crossbow_55NwHIIZHUeKSE3M.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "6lmY7PMkxI3kmkpb",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Cutlass_ddRjXnp2vbohu7rJ.json
+++ b/src/packs/items/weapons/weapon_Improved_Cutlass_ddRjXnp2vbohu7rJ.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "6lmY7PMkxI3kmkpb",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Dagger_ScjTkb9qrndhlk9S.json
+++ b/src/packs/items/weapons/weapon_Improved_Dagger_ScjTkb9qrndhlk9S.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "6lmY7PMkxI3kmkpb",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Dualstaff_f7hhHlZ5nL3AhYEM.json
+++ b/src/packs/items/weapons/weapon_Improved_Dualstaff_f7hhHlZ5nL3AhYEM.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "YHE291ruSIJAh44F",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Glowing_Rings_N5amhkxR1xn3B7r2.json
+++ b/src/packs/items/weapons/weapon_Improved_Glowing_Rings_N5amhkxR1xn3B7r2.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "YHE291ruSIJAh44F",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryClose",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Grappler_3T3o9zfe61t22L1H.json
+++ b/src/packs/items/weapons/weapon_Improved_Grappler_3T3o9zfe61t22L1H.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "close",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Greatstaff_LCuTrYXi4lhg6LqW.json
+++ b/src/packs/items/weapons/weapon_Improved_Greatstaff_LCuTrYXi4lhg6LqW.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "YHE291ruSIJAh44F",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryFar",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Greatsword_FPX4ouDrxXiQ5MDf.json
+++ b/src/packs/items/weapons/weapon_Improved_Greatsword_FPX4ouDrxXiQ5MDf.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "6lmY7PMkxI3kmkpb",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Halberd_F9PETfCQGwczBPif.json
+++ b/src/packs/items/weapons/weapon_Improved_Halberd_F9PETfCQGwczBPif.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "6lmY7PMkxI3kmkpb",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryClose",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Hallowed_Axe_wFOXMN2uiX4j6Gd9.json
+++ b/src/packs/items/weapons/weapon_Improved_Hallowed_Axe_wFOXMN2uiX4j6Gd9.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "YHE291ruSIJAh44F",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Hand_Crossbow_XEDRkuw3BhMoVBn9.json
+++ b/src/packs/items/weapons/weapon_Improved_Hand_Crossbow_XEDRkuw3BhMoVBn9.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Hand_Runes_jMEukC3VpNDz5AOD.json
+++ b/src/packs/items/weapons/weapon_Improved_Hand_Runes_jMEukC3VpNDz5AOD.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "YHE291ruSIJAh44F",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryClose",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Heavy_Frame_Wheelchair_L5KeCtrs768PmYWW.json
+++ b/src/packs/items/weapons/weapon_Improved_Heavy_Frame_Wheelchair_L5KeCtrs768PmYWW.json
@@ -24,6 +24,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "fKTeCKjfyQauf5bA",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -78,7 +79,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Light_Frame_Wheelchair_ZJsetdHKV77ygtCE.json
+++ b/src/packs/items/weapons/weapon_Improved_Light_Frame_Wheelchair_ZJsetdHKV77ygtCE.json
@@ -53,6 +53,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "fKTeCKjfyQauf5bA",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -107,7 +108,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Longbow_NacNonjbzyoVMNhI.json
+++ b/src/packs/items/weapons/weapon_Improved_Longbow_NacNonjbzyoVMNhI.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "6lmY7PMkxI3kmkpb",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryFar",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Longsword_QyBZ5NxM8F9nCL9s.json
+++ b/src/packs/items/weapons/weapon_Improved_Longsword_QyBZ5NxM8F9nCL9s.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "6lmY7PMkxI3kmkpb",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Mace_zSLx52U4Yltqx8F1.json
+++ b/src/packs/items/weapons/weapon_Improved_Mace_zSLx52U4Yltqx8F1.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "6lmY7PMkxI3kmkpb",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Quarterstaff_BEmAR60PM3ZaiNXa.json
+++ b/src/packs/items/weapons/weapon_Improved_Quarterstaff_BEmAR60PM3ZaiNXa.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "6lmY7PMkxI3kmkpb",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Rapier_LFPH8nD2f4Blv3AM.json
+++ b/src/packs/items/weapons/weapon_Improved_Rapier_LFPH8nD2f4Blv3AM.json
@@ -54,6 +54,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "6lmY7PMkxI3kmkpb",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -108,7 +109,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Returning_Blade_SKNwkW23eVQjN4Zy.json
+++ b/src/packs/items/weapons/weapon_Improved_Returning_Blade_SKNwkW23eVQjN4Zy.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "YHE291ruSIJAh44F",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "close",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Round_Shield_DlinEBGZfIlvreO3.json
+++ b/src/packs/items/weapons/weapon_Improved_Round_Shield_DlinEBGZfIlvreO3.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "i9jZXe5K5nIc58AG",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Scepter_tj26lbNkwy8bORF4.json
+++ b/src/packs/items/weapons/weapon_Improved_Scepter_tj26lbNkwy8bORF4.json
@@ -91,6 +91,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "YHE291ruSIJAh44F",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -145,7 +146,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Shortbow_6ZWl6ARfvYBaAMwY.json
+++ b/src/packs/items/weapons/weapon_Improved_Shortbow_6ZWl6ARfvYBaAMwY.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "6lmY7PMkxI3kmkpb",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Shortstaff_Mn8ja5Oi1sXvvPSk.json
+++ b/src/packs/items/weapons/weapon_Improved_Shortstaff_Mn8ja5Oi1sXvvPSk.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "YHE291ruSIJAh44F",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "close",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Shortsword_rSyBNRwemBVuTo3H.json
+++ b/src/packs/items/weapons/weapon_Improved_Shortsword_rSyBNRwemBVuTo3H.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "i9jZXe5K5nIc58AG",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Small_Dagger_nMuF8ZDZ2aXZVTg6.json
+++ b/src/packs/items/weapons/weapon_Improved_Small_Dagger_nMuF8ZDZ2aXZVTg6.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Spear_j5Pt1thLfcvopBij.json
+++ b/src/packs/items/weapons/weapon_Improved_Spear_j5Pt1thLfcvopBij.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "6lmY7PMkxI3kmkpb",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryClose",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Tower_Shield_bxt3NsbMqTSdI5ab.json
+++ b/src/packs/items/weapons/weapon_Improved_Tower_Shield_bxt3NsbMqTSdI5ab.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Wand_6d9B2b5X2d2U56jt.json
+++ b/src/packs/items/weapons/weapon_Improved_Wand_6d9B2b5X2d2U56jt.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "YHE291ruSIJAh44F",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Warhammer_pxaN4ZK4eqKrjtWj.json
+++ b/src/packs/items/weapons/weapon_Improved_Warhammer_pxaN4ZK4eqKrjtWj.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "6lmY7PMkxI3kmkpb",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Improved_Whip_ftTp8VlsBQ1r4LFD.json
+++ b/src/packs/items/weapons/weapon_Improved_Whip_ftTp8VlsBQ1r4LFD.json
@@ -54,6 +54,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryClose",
@@ -108,7 +109,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Keeper_s_Staff_q382JqMkqLaaFLIr.json
+++ b/src/packs/items/weapons/weapon_Keeper_s_Staff_q382JqMkqLaaFLIr.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "YHE291ruSIJAh44F",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Knuckle_Blades_U8gfyvxoHm024inM.json
+++ b/src/packs/items/weapons/weapon_Knuckle_Blades_U8gfyvxoHm024inM.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "6lmY7PMkxI3kmkpb",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Knuckle_Claws_SFqganS8Du4aEKjQ.json
+++ b/src/packs/items/weapons/weapon_Knuckle_Claws_SFqganS8Du4aEKjQ.json
@@ -48,6 +48,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -102,7 +103,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Labrys_Axe_ijWppQzSOqVCb3rE.json
+++ b/src/packs/items/weapons/weapon_Labrys_Axe_ijWppQzSOqVCb3rE.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "tSwiEa50USNh6uEJ",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Arcane_Frame_Wheelchair_gA2tiET9VHGhwMoO.json
+++ b/src/packs/items/weapons/weapon_Legendary_Arcane_Frame_Wheelchair_gA2tiET9VHGhwMoO.json
@@ -24,6 +24,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "fKTeCKjfyQauf5bA",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -78,7 +79,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Arcane_Gauntlets_umADDPYCaykXDc1v.json
+++ b/src/packs/items/weapons/weapon_Legendary_Arcane_Gauntlets_umADDPYCaykXDc1v.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "B2LewQYZb9Jhl4A6",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Battleaxe_1nztpLzoHGfbKf5x.json
+++ b/src/packs/items/weapons/weapon_Legendary_Battleaxe_1nztpLzoHGfbKf5x.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "31XEMDUyjpqFA7H9",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Broadsword_y3hfTPfZhMognyaJ.json
+++ b/src/packs/items/weapons/weapon_Legendary_Broadsword_y3hfTPfZhMognyaJ.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "31XEMDUyjpqFA7H9",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Crossbow_1G6xX2QL9O0Rsgz7.json
+++ b/src/packs/items/weapons/weapon_Legendary_Crossbow_1G6xX2QL9O0Rsgz7.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "31XEMDUyjpqFA7H9",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Cutlass_Rpyz0jbFJ1SwqfyD.json
+++ b/src/packs/items/weapons/weapon_Legendary_Cutlass_Rpyz0jbFJ1SwqfyD.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "31XEMDUyjpqFA7H9",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Dagger_GmTg3Fdne1UPNs8t.json
+++ b/src/packs/items/weapons/weapon_Legendary_Dagger_GmTg3Fdne1UPNs8t.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "31XEMDUyjpqFA7H9",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Dualstaff_o3rsLvImcLAx5TvD.json
+++ b/src/packs/items/weapons/weapon_Legendary_Dualstaff_o3rsLvImcLAx5TvD.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "B2LewQYZb9Jhl4A6",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Glowing_Rings_PReWrfuPjoNQuieo.json
+++ b/src/packs/items/weapons/weapon_Legendary_Glowing_Rings_PReWrfuPjoNQuieo.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "B2LewQYZb9Jhl4A6",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryClose",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Grappler_IrtUj0UntBMNn49G.json
+++ b/src/packs/items/weapons/weapon_Legendary_Grappler_IrtUj0UntBMNn49G.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "close",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Greatstaff_jDtvEabkHY1GFgfc.json
+++ b/src/packs/items/weapons/weapon_Legendary_Greatstaff_jDtvEabkHY1GFgfc.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "B2LewQYZb9Jhl4A6",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryFar",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Greatsword_zMZ46F9VR7zdTxb9.json
+++ b/src/packs/items/weapons/weapon_Legendary_Greatsword_zMZ46F9VR7zdTxb9.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "31XEMDUyjpqFA7H9",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Halberd_1AuMNiJz96Ez9fur.json
+++ b/src/packs/items/weapons/weapon_Legendary_Halberd_1AuMNiJz96Ez9fur.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "31XEMDUyjpqFA7H9",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryClose",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Hallowed_Axe_0HmhnZnv1I6uX69c.json
+++ b/src/packs/items/weapons/weapon_Legendary_Hallowed_Axe_0HmhnZnv1I6uX69c.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "B2LewQYZb9Jhl4A6",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Hand_Crossbow_32nYyMaeDWaakSxz.json
+++ b/src/packs/items/weapons/weapon_Legendary_Hand_Crossbow_32nYyMaeDWaakSxz.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Hand_Runes_DWLkswhluXuMy3bB.json
+++ b/src/packs/items/weapons/weapon_Legendary_Hand_Runes_DWLkswhluXuMy3bB.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "B2LewQYZb9Jhl4A6",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryClose",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Heavy_Frame_Wheelchair_S6nB0CNlzdU05o5U.json
+++ b/src/packs/items/weapons/weapon_Legendary_Heavy_Frame_Wheelchair_S6nB0CNlzdU05o5U.json
@@ -24,6 +24,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "fKTeCKjfyQauf5bA",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -78,7 +79,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Light_Frame_Wheelchair_Xt8tVSn5Fu6ly6LF.json
+++ b/src/packs/items/weapons/weapon_Legendary_Light_Frame_Wheelchair_Xt8tVSn5Fu6ly6LF.json
@@ -53,6 +53,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "fKTeCKjfyQauf5bA",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -107,7 +108,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Longbow_Utt1GpoH1fhaTOtN.json
+++ b/src/packs/items/weapons/weapon_Legendary_Longbow_Utt1GpoH1fhaTOtN.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "31XEMDUyjpqFA7H9",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryFar",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Longsword_14abPqQcROJfDChR.json
+++ b/src/packs/items/weapons/weapon_Legendary_Longsword_14abPqQcROJfDChR.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "31XEMDUyjpqFA7H9",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Mace_RsDsy7tIhrhaAQQc.json
+++ b/src/packs/items/weapons/weapon_Legendary_Mace_RsDsy7tIhrhaAQQc.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "31XEMDUyjpqFA7H9",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Quarterstaff_1ZciqG7vIKLYpKsP.json
+++ b/src/packs/items/weapons/weapon_Legendary_Quarterstaff_1ZciqG7vIKLYpKsP.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "31XEMDUyjpqFA7H9",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Rapier_BakN97v4jTePcXiZ.json
+++ b/src/packs/items/weapons/weapon_Legendary_Rapier_BakN97v4jTePcXiZ.json
@@ -54,6 +54,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "31XEMDUyjpqFA7H9",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -108,7 +109,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Returning_Blade_mcj3CPkcSSDdAcBB.json
+++ b/src/packs/items/weapons/weapon_Legendary_Returning_Blade_mcj3CPkcSSDdAcBB.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "B2LewQYZb9Jhl4A6",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "close",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Round_Shield_A28WL9E2lJ3iLZHW.json
+++ b/src/packs/items/weapons/weapon_Legendary_Round_Shield_A28WL9E2lJ3iLZHW.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Scepter_IZ4CWNxfuM46JeCN.json
+++ b/src/packs/items/weapons/weapon_Legendary_Scepter_IZ4CWNxfuM46JeCN.json
@@ -91,6 +91,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "B2LewQYZb9Jhl4A6",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -145,7 +146,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Shortbow_j7kp36jaetfn5jb3.json
+++ b/src/packs/items/weapons/weapon_Legendary_Shortbow_j7kp36jaetfn5jb3.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "31XEMDUyjpqFA7H9",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Shortstaff_D3SbNvNJZAFuzfhg.json
+++ b/src/packs/items/weapons/weapon_Legendary_Shortstaff_D3SbNvNJZAFuzfhg.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "B2LewQYZb9Jhl4A6",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "close",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Shortsword_dEumq3BIZBk5xYTk.json
+++ b/src/packs/items/weapons/weapon_Legendary_Shortsword_dEumq3BIZBk5xYTk.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Small_Dagger_Px3Rh3kIvAqyISxJ.json
+++ b/src/packs/items/weapons/weapon_Legendary_Small_Dagger_Px3Rh3kIvAqyISxJ.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Spear_4e5pWxi2qohuGsWh.json
+++ b/src/packs/items/weapons/weapon_Legendary_Spear_4e5pWxi2qohuGsWh.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "31XEMDUyjpqFA7H9",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Tower_Shield_MaJIROht7A9LxIZx.json
+++ b/src/packs/items/weapons/weapon_Legendary_Tower_Shield_MaJIROht7A9LxIZx.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Wand_wPjg0LufJH9vUfVM.json
+++ b/src/packs/items/weapons/weapon_Legendary_Wand_wPjg0LufJH9vUfVM.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "B2LewQYZb9Jhl4A6",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Warhammer_W9ymfEDck2icfvla.json
+++ b/src/packs/items/weapons/weapon_Legendary_Warhammer_W9ymfEDck2icfvla.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "31XEMDUyjpqFA7H9",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Legendary_Whip_Wcdbf6yS3LEt7nsg.json
+++ b/src/packs/items/weapons/weapon_Legendary_Whip_Wcdbf6yS3LEt7nsg.json
@@ -54,6 +54,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryClose",
@@ -108,7 +109,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Light_Frame_Wheelchair_iaGnlUkShBgdeMo0.json
+++ b/src/packs/items/weapons/weapon_Light_Frame_Wheelchair_iaGnlUkShBgdeMo0.json
@@ -54,6 +54,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "fKTeCKjfyQauf5bA",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -108,7 +109,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Longbow_YfVs6Se903az4Yet.json
+++ b/src/packs/items/weapons/weapon_Longbow_YfVs6Se903az4Yet.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "ZSdAawliPNsoA7nP",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryFar",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Longsword_Iv8BZM1R24QMT72M.json
+++ b/src/packs/items/weapons/weapon_Longsword_Iv8BZM1R24QMT72M.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "ZSdAawliPNsoA7nP",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Mace_cKQCDyM2UopDL9zF.json
+++ b/src/packs/items/weapons/weapon_Mace_cKQCDyM2UopDL9zF.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "ZSdAawliPNsoA7nP",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Mage_Orb_XKBmBUEoGLdLcuqQ.json
+++ b/src/packs/items/weapons/weapon_Mage_Orb_XKBmBUEoGLdLcuqQ.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "Zz0k98NVLRpebKgq",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Magus_Revolver_jGykNGQiKm63tCiE.json
+++ b/src/packs/items/weapons/weapon_Magus_Revolver_jGykNGQiKm63tCiE.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "B2LewQYZb9Jhl4A6",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryFar",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Meridian_Cutlass_Gi26Zk9VqlAAgx3E.json
+++ b/src/packs/items/weapons/weapon_Meridian_Cutlass_Gi26Zk9VqlAAgx3E.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "tSwiEa50USNh6uEJ",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Midas_Scythe_BdLfy5i488VZgkjP.json
+++ b/src/packs/items/weapons/weapon_Midas_Scythe_BdLfy5i488VZgkjP.json
@@ -54,6 +54,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "B2LewQYZb9Jhl4A6",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -108,7 +109,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Parrying_Dagger_taAZDkDCpeNgxhnn.json
+++ b/src/packs/items/weapons/weapon_Parrying_Dagger_taAZDkDCpeNgxhnn.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Powered_Gauntlet_bW3xw5S9DbaLCN3E.json
+++ b/src/packs/items/weapons/weapon_Powered_Gauntlet_bW3xw5S9DbaLCN3E.json
@@ -61,6 +61,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "close",
@@ -115,7 +116,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Primer_Shard_SxcblanBvqaest3A.json
+++ b/src/packs/items/weapons/weapon_Primer_Shard_SxcblanBvqaest3A.json
@@ -48,6 +48,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryClose",
@@ -102,7 +103,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Quarterstaff_mlIj88p1wcQNjEDG.json
+++ b/src/packs/items/weapons/weapon_Quarterstaff_mlIj88p1wcQNjEDG.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "ZSdAawliPNsoA7nP",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Rapier_zkAgEW6zMkRZalEm.json
+++ b/src/packs/items/weapons/weapon_Rapier_zkAgEW6zMkRZalEm.json
@@ -54,6 +54,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "ZSdAawliPNsoA7nP",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -108,7 +109,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Retractable_Saber_i8CqVTzqoRoCewNe.json
+++ b/src/packs/items/weapons/weapon_Retractable_Saber_i8CqVTzqoRoCewNe.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "tSwiEa50USNh6uEJ",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Returning_Axe_FtsQGwOg3r8uUCST.json
+++ b/src/packs/items/weapons/weapon_Returning_Axe_FtsQGwOg3r8uUCST.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "close",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Returning_Blade_4fQpVfQ3NVwTHStA.json
+++ b/src/packs/items/weapons/weapon_Returning_Blade_4fQpVfQ3NVwTHStA.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "ZSdAawliPNsoA7nP",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "close",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Ricochet_Axes_E9QDh5o9eQ1Qx0kH.json
+++ b/src/packs/items/weapons/weapon_Ricochet_Axes_E9QDh5o9eQ1Qx0kH.json
@@ -54,6 +54,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "31XEMDUyjpqFA7H9",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -108,7 +109,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Round_Shield_mxwWKDujgsRcZWPT.json
+++ b/src/packs/items/weapons/weapon_Round_Shield_mxwWKDujgsRcZWPT.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "h3g8PT67I6xr3xsW",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Runes_of_Ruination_EG6mZhr3ib56r974.json
+++ b/src/packs/items/weapons/weapon_Runes_of_Ruination_EG6mZhr3ib56r974.json
@@ -54,6 +54,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "8j3yjH0TiwwZsaBW",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryClose",
@@ -108,7 +109,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Scepter_GZh345N8fmuS4Jeh.json
+++ b/src/packs/items/weapons/weapon_Scepter_GZh345N8fmuS4Jeh.json
@@ -91,6 +91,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "ZSdAawliPNsoA7nP",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -145,7 +146,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Scepter_of_Elias_acPGwIaUhx3R0mTq.json
+++ b/src/packs/items/weapons/weapon_Scepter_of_Elias_acPGwIaUhx3R0mTq.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "YHE291ruSIJAh44F",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Shortbow_p9tdjQr2AZP19RYm.json
+++ b/src/packs/items/weapons/weapon_Shortbow_p9tdjQr2AZP19RYm.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "ZSdAawliPNsoA7nP",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Shortstaff_vHDHG3STcxTEfYAM.json
+++ b/src/packs/items/weapons/weapon_Shortstaff_vHDHG3STcxTEfYAM.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "ZSdAawliPNsoA7nP",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "close",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Shortsword_cjGZpXCoshEqi1FI.json
+++ b/src/packs/items/weapons/weapon_Shortsword_cjGZpXCoshEqi1FI.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "VS5Gc43b6SmYuaVF",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Siphoning_Gauntlets_1N1jggda5DfdzdMj.json
+++ b/src/packs/items/weapons/weapon_Siphoning_Gauntlets_1N1jggda5DfdzdMj.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "B2LewQYZb9Jhl4A6",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Sledge_Axe_OxsEmffWriiQmqJK.json
+++ b/src/packs/items/weapons/weapon_Sledge_Axe_OxsEmffWriiQmqJK.json
@@ -80,6 +80,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "31XEMDUyjpqFA7H9",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -134,7 +135,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Small_Dagger_wKklDxs5nkzILNp4.json
+++ b/src/packs/items/weapons/weapon_Small_Dagger_wKklDxs5nkzILNp4.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "AVjlF2Mv5AMDflgy",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Spear_TF85tKJetUjLwh54.json
+++ b/src/packs/items/weapons/weapon_Spear_TF85tKJetUjLwh54.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "ZSdAawliPNsoA7nP",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryClose",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Spiked_Bow_O1w8KPYH85ZS8X64.json
+++ b/src/packs/items/weapons/weapon_Spiked_Bow_O1w8KPYH85ZS8X64.json
@@ -89,6 +89,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "tSwiEa50USNh6uEJ",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryFar",
@@ -143,7 +144,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Spiked_Shield_vzyzFwLUniWZV1rt.json
+++ b/src/packs/items/weapons/weapon_Spiked_Shield_vzyzFwLUniWZV1rt.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "qY9ylkwxFwRlPy6a",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Steelforged_Halberd_6bkbw4Ap644KZGvJ.json
+++ b/src/packs/items/weapons/weapon_Steelforged_Halberd_6bkbw4Ap644KZGvJ.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "6lmY7PMkxI3kmkpb",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryClose",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Swinging_Ropeblade_1jOJHHKdtk3s2jaY.json
+++ b/src/packs/items/weapons/weapon_Swinging_Ropeblade_1jOJHHKdtk3s2jaY.json
@@ -54,6 +54,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "31XEMDUyjpqFA7H9",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "close",
@@ -108,7 +109,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Sword_of_Light___Flame_TVPCWnSELOVBv6G1.json
+++ b/src/packs/items/weapons/weapon_Sword_of_Light___Flame_TVPCWnSELOVBv6G1.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "B2LewQYZb9Jhl4A6",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Talon_Blades_jlLtgK468rO5IssR.json
+++ b/src/packs/items/weapons/weapon_Talon_Blades_jlLtgK468rO5IssR.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "tSwiEa50USNh6uEJ",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "close",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Thistlebow_I1nDGpulg29GpWOW.json
+++ b/src/packs/items/weapons/weapon_Thistlebow_I1nDGpulg29GpWOW.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "B2LewQYZb9Jhl4A6",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Tower_Shield_C9aWpK1shVMWP4m5.json
+++ b/src/packs/items/weapons/weapon_Tower_Shield_C9aWpK1shVMWP4m5.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "h3g8PT67I6xr3xsW",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Urok_Broadsword_zGm6Wa1fGF6cECY5.json
+++ b/src/packs/items/weapons/weapon_Urok_Broadsword_zGm6Wa1fGF6cECY5.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "6lmY7PMkxI3kmkpb",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Wand_ItWisJFNGMNWeaCV.json
+++ b/src/packs/items/weapons/weapon_Wand_ItWisJFNGMNWeaCV.json
@@ -17,6 +17,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "ZSdAawliPNsoA7nP",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -71,7 +72,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Wand_of_Enthrallment_tP6vmnrmTq2h5sj7.json
+++ b/src/packs/items/weapons/weapon_Wand_of_Enthrallment_tP6vmnrmTq2h5sj7.json
@@ -61,6 +61,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "YHE291ruSIJAh44F",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -115,7 +116,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Wand_of_Essek_ZrRGNjGCgZTTfgDG.json
+++ b/src/packs/items/weapons/weapon_Wand_of_Essek_ZrRGNjGCgZTTfgDG.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "B2LewQYZb9Jhl4A6",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_War_Scythe_z6yEdFYQJ5IzgTX3.json
+++ b/src/packs/items/weapons/weapon_War_Scythe_z6yEdFYQJ5IzgTX3.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "6lmY7PMkxI3kmkpb",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryClose",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Warhammer_ZXh1GQahBiODfSTC.json
+++ b/src/packs/items/weapons/weapon_Warhammer_ZXh1GQahBiODfSTC.json
@@ -25,6 +25,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "ZSdAawliPNsoA7nP",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "melee",
@@ -79,7 +80,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Whip_CmtWqw6DwoePnX7W.json
+++ b/src/packs/items/weapons/weapon_Whip_CmtWqw6DwoePnX7W.json
@@ -54,6 +54,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "AVjlF2Mv5AMDflgy",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "veryClose",
@@ -108,7 +109,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Widogast_Pendant_8Z5QrThfwkYPXNco.json
+++ b/src/packs/items/weapons/weapon_Widogast_Pendant_8Z5QrThfwkYPXNco.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "8j3yjH0TiwwZsaBW",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "close",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {

--- a/src/packs/items/weapons/weapon_Yutari_Bloodbow_0XpSBYXxtywvBFQi.json
+++ b/src/packs/items/weapons/weapon_Yutari_Bloodbow_0XpSBYXxtywvBFQi.json
@@ -47,6 +47,7 @@
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
       "_id": "YHE291ruSIJAh44F",
+      "baseAction": true,
       "systemPath": "attack",
       "type": "attack",
       "range": "far",
@@ -101,7 +102,7 @@
         "includeBase": false
       },
       "description": "",
-      "chatDisplay": true,
+      "chatDisplay": false,
       "actionType": "action",
       "cost": [],
       "uses": {


### PR DESCRIPTION
- The basic weapon attack actions in the SRD didn't have `chatDisplay: false`. Fixed that.
- Added the Action property `baseAction` which I added to the weapons in the SRD. It makes us able to distinguish the basic attack action so we can use the right picture for it.

Simple PR, but a lot of touches files 😆 