### PR TITLE
[Fix] Party TokenHUD

### DIFF
--- a/module/applications/hud/tokenHUD.mjs
+++ b/module/applications/hud/tokenHUD.mjs
@@ -34,7 +34,7 @@ export default class DHTokenHUD extends foundry.applications.hud.TokenHUD {
         context.systemStatusEffects = Object.keys(context.statusEffects).reduce((acc, key) => {
             const effect = context.statusEffects[key];
             if (effect.systemEffect) {
-                const disabled = !effect.isActive && this.actor.system.rules.conditionImmunities[key];
+                const disabled = !effect.isActive && this.actor.system.rules?.conditionImmunities?.[key];
                 acc[key] = { ...effect, disabled };
             }
 


### PR DESCRIPTION
Fixed so that the token hud for party tokens works again. Forgot to consider that the Party actor shouldn't check on conditionImmunities, so it error:ed out. 