### PR TITLE
[Feature] Adversary Critical Threshold

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -103,6 +103,7 @@
             "Settings": {
                 "attackBonus": "Attack Bonus",
                 "attackName": "Attack Name",
+                "criticalThreshold": "Critical Threshold",
                 "includeBase": { "label": "Include Item Damage" },
                 "multiplier": "Multiplier",
                 "saveHint": "Set a default Trait to enable Reaction Roll. It can be changed later in Reaction Roll Dialog.",

--- a/module/data/actor/adversary.mjs
+++ b/module/data/actor/adversary.mjs
@@ -39,6 +39,7 @@ export default class DhpAdversary extends BaseDataActor {
                 integer: true,
                 label: 'DAGGERHEART.GENERAL.hordeHp'
             }),
+            criticalThreshold: new fields.NumberField({ required: true, integer: true, min: 1, max: 20, initial: 20 }),
             damageThresholds: new fields.SchemaField({
                 major: new fields.NumberField({
                     required: true,
@@ -54,8 +55,20 @@ export default class DhpAdversary extends BaseDataActor {
                 })
             }),
             resources: new fields.SchemaField({
-                hitPoints: resourceField(0, 0, 'DAGGERHEART.GENERAL.HitPoints.plural', true),
-                stress: resourceField(0, 0, 'DAGGERHEART.GENERAL.stress', true)
+                hitPoints: resourceField(
+                    0,
+                    0,
+                    'DAGGERHEART.GENERAL.HitPoints.plural',
+                    true,
+                    game.i18n.localize('DAGGERHEART.GENERAL.max')
+                ),
+                stress: resourceField(
+                    0,
+                    0,
+                    'DAGGERHEART.GENERAL.stress',
+                    true,
+                    game.i18n.localize('DAGGERHEART.GENERAL.max')
+                )
             }),
             rules: new fields.SchemaField({
                 conditionImmunities: new fields.SchemaField({

--- a/module/dice/d20Roll.mjs
+++ b/module/dice/d20Roll.mjs
@@ -13,8 +13,6 @@ export default class D20Roll extends DHRoll {
         DISADVANTAGE: -1
     };
 
-    static CRITICAL_TRESHOLD = 20;
-
     static DefaultDialog = D20RollDialog;
 
     get title() {
@@ -37,7 +35,7 @@ export default class D20Roll extends DHRoll {
 
     get isCritical() {
         if (!this.d20._evaluated) return;
-        return this.d20.total >= this.constructor.CRITICAL_TRESHOLD;
+        return this.d20.total >= this.data.system.criticalThreshold;
     }
 
     get hasAdvantage() {

--- a/templates/sheets-settings/adversary-settings/attack.hbs
+++ b/templates/sheets-settings/adversary-settings/attack.hbs
@@ -8,8 +8,9 @@
         {{formGroup systemFields.attack.fields.img value=document._source.system.attack.img label="DAGGERHEART.GENERAL.imagePath" name="system.attack.img" localize=true}}
         {{formGroup systemFields.attack.fields.name value=document._source.system.attack.name label="DAGGERHEART.ACTIONS.Settings.attackName" name="system.attack.name" localize=true}}
     </fieldset>
-    <fieldset class="flex">
+    <fieldset class="one-column">
         <legend>{{localize "DAGGERHEART.GENERAL.attack"}}</legend>
+        <div class="nest-inputs">
             {{formField systemFields.attack.fields.roll.fields.bonus value=document._source.system.attack.roll.bonus label="DAGGERHEART.ACTIONS.Settings.attackBonus" name="system.attack.roll.bonus" localize=true}}
             {{formField systemFields.attack.fields.range value=document._source.system.attack.range label="DAGGERHEART.GENERAL.range" name="system.attack.range" localize=true}}
             {{#if systemFields.attack.fields.target.fields}}
@@ -18,6 +19,8 @@
                     {{ formField systemFields.attack.fields.target.fields.amount value=document._source.system.attack.target.amount label="DAGGERHEART.GENERAL.amount" name="system.attack.target.amount" localize=true}}
                 {{/if}}
             {{/if}}
+        </div>
+        {{formGroup systemFields.criticalThreshold value=document._source.system.criticalThreshold label="DAGGERHEART.ACTIONS.Settings.criticalThreshold" name="system.criticalThreshold" localize=true}}
     </fieldset>
     {{> 'systems/daggerheart/templates/actionTypes/damage.hbs' fields=systemFields.attack.fields.damage.fields.parts.element.fields source=document.system.attack.damage path="system.attack." directField=systemFields.attack.fields.damage.fields.direct horde=(eq document._source.system.type 'horde')}}
 </section>

--- a/templates/sheets/actors/adversary/sidebar.hbs
+++ b/templates/sheets/actors/adversary/sidebar.hbs
@@ -34,6 +34,16 @@
                     <h4>{{localize "DAGGERHEART.GENERAL.attack"}}</h4>
                 </div>
             </div>
+            {{#if (lt source.system.criticalThreshold 20)}}
+                <div class="status-number">
+                    <div class='status-value armor-slots'>
+                        <p>{{source.system.criticalThreshold}}+</p>
+                    </div>
+                    <div class="status-label">
+                        <h4>{{localize "DAGGERHEART.GENERAL.criticalShort"}}</h4>
+                    </div>
+                </div>
+            {{/if}}
         </div>
         <div class="status-section">
             <div class="threshold-section">


### PR DESCRIPTION
Added critical threshold for Adversaries, determining at what number they crit. It's only displayed in the View mode of the adversary sheet if it's been changed from critting at 20.