### PR TITLE
[Fix] Companion direct damage

### DIFF
--- a/templates/sheets-settings/companion-settings/attack.hbs
+++ b/templates/sheets-settings/companion-settings/attack.hbs
@@ -18,5 +18,5 @@
                 {{/if}}
             {{/if}}
     </fieldset>
-    {{> 'systems/daggerheart/templates/actionTypes/damage.hbs' fields=systemFields.attack.fields.damage.fields.parts.element.fields source=document.system.attack.damage path="system.attack."}}
+    {{> 'systems/daggerheart/templates/actionTypes/damage.hbs' fields=systemFields.attack.fields.damage.fields.parts.element.fields source=document.system.attack.damage path="system.attack." directField=systemFields.attack.fields.damage.fields.direct}}
 </section>


### PR DESCRIPTION
Makes the little checkbox show up in the companion attack configuration, and removes the console error from the formGroup helper.