### PR TITLE
[Community PR] [Fix] Make biography sections take whole space

### DIFF
--- a/styles/less/sheets/actors/character/biography.less
+++ b/styles/less/sheets/actors/character/biography.less
@@ -15,6 +15,14 @@
 
             scrollbar-width: thin;
             scrollbar-color: light-dark(@dark-blue, @golden) transparent;
+
+            fieldset {
+                flex: 1;
+            }
+
+            fieldset:first-child {
+                max-height: max-content;
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

Small CSS adjustment to make biography look better

## Type of Change

Please check the relevant options:

- [ ] Bug fix
- [x] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x] Manual testing
- [ ] Other:

## Screenshots (if applicable)

<img width="1573" height="1170" alt="image" src="https://github.com/user-attachments/assets/088cb8b6-5e51-496a-a061-a873c0654478" />

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix or feature works
- [x] New and existing tests pass locally with my changes

---

> Thank you for your contribution! 🎉
