### PR TITLE
[Fix] 1334 - Attribute Roll Action Type

### DIFF
--- a/module/applications/dialogs/d20RollDialog.mjs
+++ b/module/applications/dialogs/d20RollDialog.mjs
@@ -197,7 +197,7 @@ export default class D20RollDialog extends HandlebarsApplicationMixin(Applicatio
             this.config.actionType = this.reactionOverride
                 ? CONFIG.DH.ITEM.actionTypes.reaction.id
                 : this.config.actionType === CONFIG.DH.ITEM.actionTypes.reaction.id
-                  ? null
+                  ? CONFIG.DH.ITEM.actionTypes.action.id
                   : this.config.actionType;
             this.render();
         }

--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -717,6 +717,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
         };
         const result = await this.document.diceRoll({
             ...config,
+            actionType: 'action',
             headerTitle: `${game.i18n.localize('DAGGERHEART.GENERAL.dualityRoll')}: ${this.actor.name}`,
             title: game.i18n.format('DAGGERHEART.UI.Chat.dualityRoll.abilityCheckTitle', {
                 ability: abilityLabel


### PR DESCRIPTION
Closes #1334 
- Fixed so that attribute rolls for characters are set as Action type
- Fixed so that if you swap a roll to be a Reaction and then switch it back, it correctly becomes ActionType='action' again.