### PR TITLE
[Feature] 1344 - Daggerheart Menu Render Hook

### DIFF
--- a/module/applications/sidebar/tabs/daggerheartMenu.mjs
+++ b/module/applications/sidebar/tabs/daggerheartMenu.mjs
@@ -44,6 +44,18 @@ export default class DaggerheartMenu extends HandlebarsApplicationMixin(Abstract
     /* -------------------------------------------- */
 
     /** @inheritDoc */
+    async _onRender(context, options) {
+        super._onRender(context, options);
+
+        Hooks.callAll(
+            CONFIG.DH.HOOKS.sidebarMenuRender,
+            this,
+            this.element.querySelector('[data-application-part="main"]'),
+            context
+        );
+    }
+
+    /** @inheritDoc */
     async _prepareContext(options) {
         const context = await super._prepareContext(options);
         context.refreshables = this.refreshSelections;

--- a/module/config/_module.mjs
+++ b/module/config/_module.mjs
@@ -4,6 +4,7 @@ export * as domainConfig from './domainConfig.mjs';
 export * as effectConfig from './effectConfig.mjs';
 export * as flagsConfig from './flagsConfig.mjs';
 export * as generalConfig from './generalConfig.mjs';
+export { default as hooksConfig } from './hooksConfig.mjs';
 export * as itemConfig from './itemConfig.mjs';
 export * as settingsConfig from './settingsConfig.mjs';
 export * as systemConfig from './system.mjs';

--- a/module/config/hooksConfig.mjs
+++ b/module/config/hooksConfig.mjs
@@ -1,0 +1,12 @@
+const systemHooks = {
+    /**
+     * Runs on render of the Daggerheart Sidebar menu.
+     * @param {App} app
+     * @param {Node} contentElement
+     * @param {ApplicationContext} context
+     * @returns {void}
+     */
+    sidebarMenuRender: 'sidebar-menu-render'
+};
+
+export default systemHooks;

--- a/module/config/system.mjs
+++ b/module/config/system.mjs
@@ -6,7 +6,8 @@ import * as SETTINGS from './settingsConfig.mjs';
 import * as EFFECTS from './effectConfig.mjs';
 import * as ACTIONS from './actionConfig.mjs';
 import * as FLAGS from './flagsConfig.mjs';
-import * as ITEMBROWSER from './itemBrowserConfig.mjs'
+import { default as HOOKS } from './hooksConfig.mjs';
+import * as ITEMBROWSER from './itemBrowserConfig.mjs';
 
 export const SYSTEM_ID = 'daggerheart';
 
@@ -20,5 +21,6 @@ export const SYSTEM = {
     EFFECTS,
     ACTIONS,
     FLAGS,
+    HOOKS,
     ITEMBROWSER
 };


### PR DESCRIPTION
Closes #1344 
Added a render hook for the daggerheartMenu. This lets modules easily extend the menu for custom functionality.
Ex:
```
Hooks.on(CONFIG.DH.HOOKS.sidebarMenuRender, (_app, contentElement, _context) => {
    const testFeature = document.createElement('button');
    testFeature.innerHTML = '<i class="fas fa-dice-d20"></i> My Feature';
    contentElement.appendChild(testFeature);
    testFeature.addEventListener('click', _event => {
        console.log('TestFeature Test');
    });
});
```
<img width="441" height="752" alt="image" src="https://github.com/user-attachments/assets/18f1c27b-5e88-4ac0-b360-a483e53b4426" />
