### PR TITLE
[Feature] Fill entire tab when editing the biography and tweak rendering when not

### DIFF
--- a/styles/less/sheets/actors/character/biography.less
+++ b/styles/less/sheets/actors/character/biography.less
@@ -16,5 +16,24 @@
             scrollbar-width: thin;
             scrollbar-color: light-dark(@dark-blue, @golden) transparent;
         }
+
+        .biography-section {
+            prose-mirror {
+                --min-height: 50px;
+            }
+
+            prose-mirror.inactive .editor-content {
+                position: relative;
+            }
+        }
+
+        &:has(.prosemirror.active) {
+            .biography-section {
+                flex: 1;
+                &:not(:has(prose-mirror.active)) {
+                    display: none;
+                }
+            }
+        }
     }
 }

--- a/templates/sheets/actors/character/biography.hbs
+++ b/templates/sheets/actors/character/biography.hbs
@@ -3,7 +3,6 @@
     data-tab='{{tabs.biography.id}}'
     data-group='{{tabs.biography.group}}'
 >
-
     <div class="items-section">
         <fieldset class="flex">
             <legend>{{localize 'DAGGERHEART.ACTORS.Character.story.characteristics'}}</legend>
@@ -22,13 +21,14 @@
                 <span>{{localize 'DAGGERHEART.ACTORS.Character.faith'}}</span>
                 {{formInput systemFields.biography.fields.characteristics.fields.faith value=source.system.biography.characteristics.faith enriched=source.system.biography.characteristics.faith localize=true toggled=true}}
             </div>
-
         </fieldset>
-        <fieldset>
+
+        <fieldset class="biography-section">
             <legend>{{localize 'DAGGERHEART.ACTORS.Character.story.backgroundTitle'}}</legend>
             {{formInput background.field value=background.value enriched=background.enriched toggled=true}}
         </fieldset>
-        <fieldset>
+
+        <fieldset class="biography-section">
             <legend>{{localize 'DAGGERHEART.ACTORS.Character.story.connectionsTitle'}}</legend>
             {{formInput connections.field value=connections.value enriched=connections.enriched toggled=true}}
         </fieldset>


### PR DESCRIPTION
What happens while editing is obvious from the video, but for viewing this attempts to do something more similar to the inventory where you have to scroll down to see each section. Something more similar to how in a longer form page you'd keep scrolling down to read everything, rather than having a bunch of small sections with scrollbars.

If this turns out to be meh, we can roll back the min height and position relative tweaks and add flex: 1.

https://github.com/user-attachments/assets/0fc6b7a3-88f8-4e70-95c2-747565caa94d

