### PR TITLE
[Fix] SaveRoll Cost Not Working

### DIFF
--- a/module/data/fields/action/saveField.mjs
+++ b/module/data/fields/action/saveField.mjs
@@ -46,7 +46,7 @@ export default class SaveField extends fields.SchemaField {
         if (SaveField.getAutomation() !== CONFIG.DH.SETTINGS.actionAutomationChoices.never.id || force) {
             targets ??= config.targets.filter(t => !config.hasRoll || t.hit);
             await SaveField.rollAllSave.call(this, targets, config.event, message);
-        } else return false;
+        } else return;
     }
 
     /**


### PR DESCRIPTION
Fixed so that AttackActions with a save will not stop the workflow of the fields when save automation is not on. (it was faultily returning `false` instead of undefined which stopped the workflow)