### PR TITLE
[Fix] Dragging features between different environment settings applications

### DIFF
--- a/module/applications/sheets-configs/environment-settings.mjs
+++ b/module/applications/sheets-configs/environment-settings.mjs
@@ -109,9 +109,9 @@ export default class DHEnvironmentSettings extends DHBaseActorSettings {
 
     async _onDrop(event) {
         const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
-        if (data.fromInternal) return;
-
         const item = await fromUuid(data.uuid);
+        if (data.fromInternal && item?.parent?.uuid === this.actor.uuid) return;
+
         if (item.type === 'adversary' && event.target.closest('.category-container')) {
             const target = event.target.closest('.category-container');
             const path = `system.potentialAdversaries.${target.dataset.potentialAdversary}.adversaries`;


### PR DESCRIPTION
Fixes an issue reported on the discord, where you could not drag drop features from one environment edit window to another.