### PR TITLE
[Fix] Actorless Player DR Command

### DIFF
--- a/module/applications/dialogs/d20RollDialog.mjs
+++ b/module/applications/dialogs/d20RollDialog.mjs
@@ -116,14 +116,14 @@ export default class D20RollDialog extends HandlebarsApplicationMixin(Applicatio
             context.isLite = this.config.roll?.lite;
             context.extraFormula = this.config.extraFormula;
             context.formula = this.roll.constructFormula(this.config);
-            if (this.actor.system.traits) context.abilities = this.getTraitModifiers();
+            if (this.actor?.system?.traits) context.abilities = this.getTraitModifiers();
 
             context.showReaction = !this.config.roll?.type && context.rollType === 'DualityRoll';
             context.reactionOverride = this.reactionOverride;
         }
 
         const tagTeamSetting = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.TagTeamRoll);
-        if (tagTeamSetting.members[this.actor.id] && !this.config.skips?.createMessage) {
+        if (this.actor && tagTeamSetting.members[this.actor.id] && !this.config.skips?.createMessage) {
             context.activeTagTeamRoll = true;
             context.tagTeamSelected = this.config.tagTeamSelected;
         }

--- a/templates/dialogs/dice-roll/rollSelection.hbs
+++ b/templates/dialogs/dice-roll/rollSelection.hbs
@@ -70,17 +70,20 @@
                     {{/if}}
                 </div>
 
-                <fieldset class="experience-container">
-                    <legend>{{localize "DAGGERHEART.GENERAL.experience.plural"}}</legend>
-                    {{#each experiences}}
-                        {{#if name}}
-                            <div class="experience-chip {{#if (includes ../selectedExperiences id)}}selected{{/if}}" data-action="selectExperience" data-key="{{id}}" data-tooltip="{{this.description}}">
-                                <span><i class="{{ifThen (includes ../selectedExperiences id) "fa-solid" "fa-regular"}} fa-circle"></i></span>
-                                <span class="label">{{name}} +{{value}}</span>
-                            </div>
-                        {{/if}}
-                    {{/each}}
-                </fieldset>
+                {{#if experiences.length}}
+                    <fieldset class="experience-container">
+                        <legend>{{localize "DAGGERHEART.GENERAL.experience.plural"}}</legend>
+                        {{#each experiences}}
+                            {{#if name}}
+                                <div class="experience-chip {{#if (includes ../selectedExperiences id)}}selected{{/if}}" data-action="selectExperience" data-key="{{id}}" data-tooltip="{{this.description}}">
+                                    <span><i class="{{ifThen (includes ../selectedExperiences id) "fa-solid" "fa-regular"}} fa-circle"></i></span>
+                                    <span class="label">{{name}} +{{value}}</span>
+                                </div>
+                            {{/if}}
+                        {{/each}}
+                    </fieldset>
+                {{/if}}
+
                 <fieldset class="modifier-container {{#if (eq @root.rollType 'DualityRoll')}}two-columns{{else}}one-column{{/if}}">
                     <legend>{{localize "DAGGERHEART.GENERAL.Modifier.plural"}}</legend>
                     <div class="nest-inputs">


### PR DESCRIPTION
- Fixed so that the /dr command doesn't fail when a player doesn't have an actor assigned.
- Hiding the Experience section in the roll dialog if there are no experiences.