### PR TITLE
[Fix] TagTeam Crit Damage

### DIFF
--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -471,5 +471,5 @@ export function refreshIsAllowed(allowedTypes, typeToCheck) {
 
 export async function getCritDamageBonus(formula) {
     const critRoll = new Roll(formula);
-    return critRoll.dice.reduce((acc, dice) => acc + dice.faces, 0);
+    return critRoll.dice.reduce((acc, dice) => acc + dice.faces * dice.number, 0);
 }


### PR DESCRIPTION
Closes #1385 
Fixed so that the crit damage should be correct. Forgot that a dice has `dice.number = 2` for something like "2d6", rather than it appearing as two separate dice.