### PR TITLE
[PR] [Feature] Refocus consumable quantity and simple resource fields on change

### DIFF
--- a/templates/sheets/global/partials/inventory-item-V2.hbs
+++ b/templates/sheets/global/partials/inventory-item-V2.hbs
@@ -61,7 +61,7 @@ Parameters:
     {{/if}}
     {{#if (and (not hideResources) (gte item.system.quantity 0))}}
     <div class="item-resource">
-      <input type="number" id="{{@root.rootId}}-Item-{{item.id}}-Quantity" class="inventory-item-quantity" value="{{item.system.quantity}}" min="0" />
+      <input type="number" id="{{item.uuid}}-quantity" class="inventory-item-quantity" value="{{item.system.quantity}}" min="0" />
     </div>
     {{/if}}
 

--- a/templates/sheets/global/partials/item-resource.hbs
+++ b/templates/sheets/global/partials/item-resource.hbs
@@ -1,7 +1,7 @@
 {{#if (eq item.system.resource.type 'simple')}}
     <div class="item-resource">
         <i class="{{#if item.system.resource.icon}}{{item.system.resource.icon}}{{else}}fa-solid fa-hashtag{{/if}}"></i>
-        <input type="number" id="{{@root.rootId}}-Item-{{item.id}}-Resource" class="inventory-item-resource" value="{{item.system.resource.value}}" min="0" max="{{rollParsed item.system.resource.max item.actor item true}}" />
+        <input type="number" id="{{item.uuid}}-resource" class="inventory-item-resource" value="{{item.system.resource.value}}" min="0" max="{{rollParsed item.system.resource.max item.actor item true}}" />
     </div>
 {{else if (eq item.system.resource.type 'diceValue')}}
     <div class="item-resources">


### PR DESCRIPTION
Assigning an id allows the core handlebars helper to refocus it on re-render. However upstream doesn't maintain cursor position on refocus, so this only ends up improving the use of arrow keys the increment/decrement the numbers.