### PR TITLE
[Fix] StatusEffect loosening

### DIFF
--- a/module/applications/hud/tokenHUD.mjs
+++ b/module/applications/hud/tokenHUD.mjs
@@ -197,6 +197,8 @@ export default class DHTokenHUD extends foundry.applications.hud.TokenHUD {
         for (const effect of activeEffects) {
             for (const statusId of effect.statuses) {
                 const status = choices[statusId];
+                if (!status) continue;
+
                 status.instances = 1 + (status.instances ?? 0);
                 status.locked = status.locked || effect.condition || status.instances > 1;
                 if (!status) continue;

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -854,7 +854,7 @@ export default class DhpActor extends Actor {
                 acc.push(effect);
 
                 const currentStatusActiveEffects = acc.filter(
-                    x => x.statuses.size === 1 && x.name === game.i18n.localize(statusMap.get(x.statuses.first()).name)
+                    x => x.statuses.size === 1 && x.name === game.i18n.localize(statusMap.get(x.statuses.first())?.name)
                 );
 
                 for (var status of effect.statuses) {

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
     "id": "daggerheart",
     "title": "Daggerheart",
     "description": "An unofficial implementation of the Daggerheart system",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "compatibility": {
         "minimum": "13.346",
         "verified": "13.351",


### PR DESCRIPTION
Loosened checks on statuses to make module compatible. We were expecting all statuses on effects to be present in CONFIG.statusEffects, and they aren't always if modules fail to register them.