### PR TITLE
[Community PR] Adding direct damage to adversaries and environments

### DIFF
--- a/src/packs/adversaries/adversary_Adult_Flickerfly_G7jiltRjgvVhZewm.json
+++ b/src/packs/adversaries/adversary_Adult_Flickerfly_G7jiltRjgvVhZewm.json
@@ -427,7 +427,8 @@
                   }
                 }
               ],
-              "includeBase": false
+              "includeBase": false,
+              "direct": true
             },
             "target": {
               "type": "any",

--- a/src/packs/adversaries/adversary_Brawny_Zombie_2UeZ0tEe7AzgSJNd.json
+++ b/src/packs/adversaries/adversary_Brawny_Zombie_2UeZ0tEe7AzgSJNd.json
@@ -307,7 +307,8 @@
                   }
                 }
               ],
-              "includeBase": false
+              "includeBase": false,
+              "direct": true
             },
             "target": {
               "type": "any",
@@ -319,7 +320,7 @@
               "trait": null,
               "difficulty": null,
               "bonus": null,
-              "advState": "neutral",
+              "advState": "advantage",
               "diceRolling": {
                 "multiplier": "prof",
                 "flatMultiplier": 1,

--- a/src/packs/adversaries/adversary_Cave_Ogre_8Zkqk1jU09nKL2fy.json
+++ b/src/packs/adversaries/adversary_Cave_Ogre_8Zkqk1jU09nKL2fy.json
@@ -39,7 +39,8 @@
     "experiences": {
       "7GpgCWSe6hNwnOO7": {
         "name": "Throw",
-        "value": 2
+        "value": 2,
+        "description": ""
       }
     },
     "bonuses": {
@@ -105,7 +106,8 @@
             },
             "base": false
           }
-        ]
+        ],
+        "direct": true
       },
       "name": "Club",
       "img": "icons/weapons/clubs/club-banded-barbed-black.webp",
@@ -337,10 +339,11 @@
                 {
                   "value": {
                     "custom": {
-                      "enabled": false
+                      "enabled": false,
+                      "formula": ""
                     },
                     "flatMultiplier": 1,
-                    "dice": "d12",
+                    "dice": "d10",
                     "bonus": 2,
                     "multiplier": "flat"
                   },
@@ -356,12 +359,14 @@
                     "dice": "d6",
                     "bonus": null,
                     "custom": {
-                      "enabled": false
+                      "enabled": false,
+                      "formula": ""
                     }
                   }
                 }
               ],
-              "includeBase": false
+              "includeBase": false,
+              "direct": true
             },
             "target": {
               "type": "any",
@@ -528,7 +533,8 @@
                   }
                 }
               ],
-              "includeBase": false
+              "includeBase": false,
+              "direct": true
             },
             "target": {
               "type": "any",

--- a/src/packs/adversaries/adversary_Demon_of_Jealousy_SxSOkM4bcVOFyjbo.json
+++ b/src/packs/adversaries/adversary_Demon_of_Jealousy_SxSOkM4bcVOFyjbo.json
@@ -107,7 +107,8 @@
             },
             "base": false
           }
-        ]
+        ],
+        "direct": true
       },
       "img": "icons/magic/symbols/rune-sigil-rough-white-teal.webp",
       "type": "attack",

--- a/src/packs/adversaries/adversary_Demon_of_Wrath_5lphJAgzoqZI3VoG.json
+++ b/src/packs/adversaries/adversary_Demon_of_Wrath_5lphJAgzoqZI3VoG.json
@@ -108,7 +108,8 @@
             },
             "base": false
           }
-        ]
+        ],
+        "direct": true
       },
       "type": "attack",
       "chatDisplay": false
@@ -358,7 +359,8 @@
                   }
                 }
               ],
-              "includeBase": false
+              "includeBase": false,
+              "direct": true
             },
             "target": {
               "type": "any",

--- a/src/packs/adversaries/adversary_Dire_Wolf_wNzeuQLfLUMvgHlQ.json
+++ b/src/packs/adversaries/adversary_Dire_Wolf_wNzeuQLfLUMvgHlQ.json
@@ -377,7 +377,8 @@
                   }
                 }
               ],
-              "includeBase": false
+              "includeBase": false,
+              "direct": true
             },
             "target": {
               "type": "any",

--- a/src/packs/adversaries/adversary_Master_Assassin_dNta0cUzr96xcFhf.json
+++ b/src/packs/adversaries/adversary_Master_Assassin_dNta0cUzr96xcFhf.json
@@ -233,7 +233,89 @@
       "system": {
         "description": "<p> The Assassin deals direct damage while they’re <em>Hidden</em>.</p>",
         "resource": null,
-        "actions": {},
+        "actions": {
+          "xFBE0jLf96fbCY7K": {
+            "type": "attack",
+            "_id": "xFBE0jLf96fbCY7K",
+            "systemPath": "actions",
+            "baseAction": false,
+            "description": "<p>The Assassin deals direct damage while they’re <em>Hidden</em>.</p>",
+            "chatDisplay": true,
+            "originItem": {
+              "type": "itemCollection"
+            },
+            "actionType": "action",
+            "cost": [],
+            "uses": {
+              "value": null,
+              "max": "",
+              "recovery": null,
+              "consumeOnSuccess": false
+            },
+            "damage": {
+              "parts": [
+                {
+                  "value": {
+                    "custom": {
+                      "enabled": false,
+                      "formula": ""
+                    },
+                    "flatMultiplier": 2,
+                    "dice": "d10",
+                    "bonus": 2,
+                    "multiplier": "flat"
+                  },
+                  "applyTo": "hitPoints",
+                  "type": [
+                    "physical"
+                  ],
+                  "base": false,
+                  "resultBased": false,
+                  "valueAlt": {
+                    "multiplier": "prof",
+                    "flatMultiplier": 1,
+                    "dice": "d6",
+                    "bonus": null,
+                    "custom": {
+                      "enabled": false,
+                      "formula": ""
+                    }
+                  }
+                }
+              ],
+              "includeBase": false,
+              "direct": true
+            },
+            "target": {
+              "type": "any",
+              "amount": null
+            },
+            "effects": [],
+            "roll": {
+              "type": "attack",
+              "trait": null,
+              "difficulty": null,
+              "bonus": null,
+              "advState": "neutral",
+              "diceRolling": {
+                "multiplier": "prof",
+                "flatMultiplier": 1,
+                "dice": "d6",
+                "compare": null,
+                "treshold": null
+              },
+              "useDefault": false
+            },
+            "save": {
+              "trait": null,
+              "difficulty": null,
+              "damageMod": "none"
+            },
+            "name": "Hidden attack",
+            "img": "icons/magic/perception/silhouette-stealth-shadow.webp",
+            "range": "close"
+          }
+        },
         "originItemType": null,
         "originId": null
       },

--- a/src/packs/adversaries/adversary_Minotaur_Wrecker_rM9qCIYeWg9I0B4l.json
+++ b/src/packs/adversaries/adversary_Minotaur_Wrecker_rM9qCIYeWg9I0B4l.json
@@ -478,7 +478,8 @@
                   }
                 }
               ],
-              "includeBase": false
+              "includeBase": false,
+              "direct": true
             },
             "target": {
               "type": "any",

--- a/src/packs/adversaries/adversary_Mortal_Hunter_mVV7a7KQAORoPMgZ.json
+++ b/src/packs/adversaries/adversary_Mortal_Hunter_mVV7a7KQAORoPMgZ.json
@@ -340,6 +340,87 @@
             "name": "Curse",
             "img": "icons/magic/unholy/hand-marked-pink.webp",
             "range": "veryClose"
+          },
+          "zLKfwa8a2YBRLKAF": {
+            "type": "attack",
+            "_id": "zLKfwa8a2YBRLKAF",
+            "systemPath": "actions",
+            "baseAction": false,
+            "description": "<p> Attacks made by the Hunter against a Deathlocked target deal direct damage.</p>",
+            "chatDisplay": true,
+            "originItem": {
+              "type": "itemCollection"
+            },
+            "actionType": "action",
+            "cost": [],
+            "uses": {
+              "value": null,
+              "max": "",
+              "recovery": null,
+              "consumeOnSuccess": false
+            },
+            "damage": {
+              "parts": [
+                {
+                  "value": {
+                    "custom": {
+                      "enabled": false,
+                      "formula": ""
+                    },
+                    "flatMultiplier": 2,
+                    "dice": "d12",
+                    "bonus": 1,
+                    "multiplier": "flat"
+                  },
+                  "applyTo": "hitPoints",
+                  "type": [
+                    "physical"
+                  ],
+                  "base": false,
+                  "resultBased": false,
+                  "valueAlt": {
+                    "multiplier": "prof",
+                    "flatMultiplier": 1,
+                    "dice": "d6",
+                    "bonus": null,
+                    "custom": {
+                      "enabled": false,
+                      "formula": ""
+                    }
+                  }
+                }
+              ],
+              "includeBase": false,
+              "direct": true
+            },
+            "target": {
+              "type": "any",
+              "amount": null
+            },
+            "effects": [],
+            "roll": {
+              "type": "attack",
+              "trait": null,
+              "difficulty": null,
+              "bonus": null,
+              "advState": "neutral",
+              "diceRolling": {
+                "multiplier": "prof",
+                "flatMultiplier": 1,
+                "dice": "d6",
+                "compare": null,
+                "treshold": null
+              },
+              "useDefault": false
+            },
+            "save": {
+              "trait": null,
+              "difficulty": null,
+              "damageMod": "none"
+            },
+            "name": "Deathlocked attack",
+            "img": "icons/magic/unholy/hand-marked-pink.webp",
+            "range": "veryClose"
           }
         },
         "originItemType": null,

--- a/src/packs/adversaries/adversary_Tangle_Bramble_Swarm_PKSXFuaIHUCoH63A.json
+++ b/src/packs/adversaries/adversary_Tangle_Bramble_Swarm_PKSXFuaIHUCoH63A.json
@@ -312,9 +312,10 @@
                 {
                   "value": {
                     "custom": {
-                      "enabled": false
+                      "enabled": false,
+                      "formula": ""
                     },
-                    "flatMultiplier": 1,
+                    "flatMultiplier": 2,
                     "dice": "d6",
                     "bonus": 8,
                     "multiplier": "flat"
@@ -331,12 +332,14 @@
                     "dice": "d6",
                     "bonus": null,
                     "custom": {
-                      "enabled": false
+                      "enabled": false,
+                      "formula": ""
                     }
                   }
                 }
               ],
-              "includeBase": false
+              "includeBase": false,
+              "direct": true
             },
             "target": {
               "type": "any",

--- a/src/packs/adversaries/adversary_Volcanic_Dragon__Molten_Scourge_eArAPuB38CNR0ZIM.json
+++ b/src/packs/adversaries/adversary_Volcanic_Dragon__Molten_Scourge_eArAPuB38CNR0ZIM.json
@@ -804,7 +804,8 @@
                   }
                 }
               ],
-              "includeBase": false
+              "includeBase": false,
+              "direct": true
             },
             "target": {
               "type": "any",

--- a/src/packs/environments/environment_Burning_Heart_of_the_Woods_oY69NN4rYxoRE4hl.json
+++ b/src/packs/environments/environment_Burning_Heart_of_the_Woods_oY69NN4rYxoRE4hl.json
@@ -457,7 +457,8 @@
                   }
                 }
               ],
-              "includeBase": false
+              "includeBase": false,
+              "direct": true
             },
             "target": {
               "type": "any",


### PR DESCRIPTION
## Description

Adds direct damage to attacks that should cause direct damage. When there is an ability that sometime triggers direct damage, a new attack button was added. This worked for everything except for the Mortal Hunter's rampage ability where at most one target might take direct physical damage.

- Fixes #1409 

## Type of Change

Please check the relevant options:

- [X] Bug fix
- [ ] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [X] Manual testing
- [ ] Other:

## Checklist

- [X] My code follows the project style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code where necessary
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [X] New and existing tests pass locally with my changes

## Additional Comments

I'm not sure if you want to showcase these changes in a feature like #913
