### PR TITLE
[Community PR] Allowing coundown automations to work for players on action rolls

### DIFF
--- a/module/applications/ui/combatTracker.mjs
+++ b/module/applications/ui/combatTracker.mjs
@@ -161,9 +161,11 @@ export default class DhCombatTracker extends foundry.applications.sidebar.tabs.C
 
         if (this.viewed.turn !== toggleTurn) {
             const { updateCountdowns } = game.system.api.applications.ui.DhCountdowns;
-            await updateCountdowns(CONFIG.DH.GENERAL.countdownProgressionTypes.spotlight.id);
             if (combatant.actor.type === 'character') {
-                await updateCountdowns(CONFIG.DH.GENERAL.countdownProgressionTypes.characterSpotlight.id);
+                await updateCountdowns(CONFIG.DH.GENERAL.countdownProgressionTypes.spotlight.id,
+                    CONFIG.DH.GENERAL.countdownProgressionTypes.characterSpotlight.id);
+            } else {
+                await updateCountdowns(CONFIG.DH.GENERAL.countdownProgressionTypes.spotlight.id);
             }
 
             const autoPoints = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Automation).actionPoints;

--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -247,10 +247,12 @@ export const registerRollDiceHooks = () => {
             !config.skips?.updateCountdowns
         ) {
             const { updateCountdowns } = game.system.api.applications.ui.DhCountdowns;
-            await updateCountdowns(CONFIG.DH.GENERAL.countdownProgressionTypes.actionRoll.id);
 
             if (config.roll.result.duality === -1) {
-                await updateCountdowns(CONFIG.DH.GENERAL.countdownProgressionTypes.fear.id);
+                await updateCountdowns(CONFIG.DH.GENERAL.countdownProgressionTypes.actionRoll.id,
+                    CONFIG.DH.GENERAL.countdownProgressionTypes.fear.id);
+            } else {
+                await updateCountdowns(CONFIG.DH.GENERAL.countdownProgressionTypes.actionRoll.id);
             }
         }
 


### PR DESCRIPTION
## Description

Switched the updateCountdown method to use emitAsGM like other methods in the same file. However, this also meant that at the end of this method, the world settings for countdowns aren't yet updated (still being handled on the GM side). Instead of setting up a complex call and response for handling countdowns, I went with the approach of updating all countdowns at one time. This is still somewhat brittle compared to a complex call - since there could still be race conditions. However, they should be very unlikely.

- Fixes #1415 
- Fixed #1370 

## Type of Change

Please check the relevant options:

- [X] Bug fix
- [ ] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

I created all 4 types of countdowns that are impacted and checked whether both the GM and player could alter them. In the case of the combat tracker, this can't be triggered by the player, so the change is actually unnecessary.

- [X] Manual testing
- [ ] Other:

## Checklist

- [X] My code follows the project style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code where necessary
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [X] New and existing tests pass locally with my changes

## Additional Comments

"I have added tests that prove my fix or feature works" -- currently, the project doesn't have any tests, but I still can't in good conscience check that one.
