### PR TITLE
[Community PR] Pulling out hope method and always updating the resources.

### DIFF
--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -685,8 +685,6 @@ export default class CharacterSheet extends DHBaseActorSheet {
                 ability: abilityLabel
             })
         });
-
-        if (result) game.system.api.fields.ActionFields.CostField.execute.call(this, result);
     }
 
     //TODO: redo toggleEquipItem method

--- a/module/applications/ui/chatLog.mjs
+++ b/module/applications/ui/chatLog.mjs
@@ -245,7 +245,6 @@ export default class DhpChatLog extends foundry.applications.sidebar.tabs.ChatLo
         });
 
         if (!result) return;
-        await game.system.api.fields.ActionFields.CostField.execute.call({ actor }, result);
 
         const newMessageData = foundry.utils.deepClone(message.system);
         foundry.utils.setProperty(newMessageData, `${path}.result`, result.roll);

--- a/module/dice/dualityRoll.mjs
+++ b/module/dice/dualityRoll.mjs
@@ -262,8 +262,7 @@ export default class DualityRoll extends D20Roll {
             targets: message.system.targets,
             tagTeamSelected: Object.values(tagTeamSettings.members).some(x => x.messageId === message._id),
             roll: newRoll,
-            rerolledRoll:
-                newRoll.result.duality !== message.system.roll.result.duality ? message.system.roll : undefined
+            rerolledRoll: message.system.roll
         });
         return { newRoll, parsedRoll };
     }

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -679,6 +679,10 @@ export default class DhpActor extends Actor {
         return updates;
     }
 
+    /**
+     * Resources are modified asynchronously, so be careful not to update the same resource in
+     * quick succession.
+     */
     async modifyResource(resources) {
         if (!resources?.length) return;
 


### PR DESCRIPTION
## Description

Updating the dice automation to actually work again. I did some bisecting of the repo and it hasn't worked for some time. I pulled out the hope/fear automation into it's own private method, which makes this a bit harder to review. However, that was necessary to fix another obvious bug - the code below the hope/fear automation would not be run if hope/fear automation was off. Also, while testing this, I discovered that stress was _increased_ instead of decreased on a critical, so I fixed that too.

- Fixes #1130 

## Type of Change

Please check the relevant options:

- [X] Bug fix
- [ ] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

I rolled a bunch of times with automation on and off as the GM.

- [X] Manual testing
- [ ] Other:

## Checklist

- [X] My code follows the project style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code where necessary
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [X] New and existing tests pass locally with my changes

## Additional Comments

If you want this as 3 different PRs to fix the 3 things I changed, let me know. Also, let me know if you prefer a different layout for private methods, since I couldn't find any great examples of private function use or naming convention in the code base.