### PR TITLE
[Feature] Make the existing spotlight queue toggleable (default off)

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2504,6 +2504,11 @@
                     "hint": "Apply variant rules from the Daggerheart system",
                     "name": "Variant Rules",
                     "actionTokens": "Action Tokens"
+                },
+                "SpotlightRequestQueue": {
+                    "name": "Spotlight Request Queue",
+                    "label": "Spotlight Request Queue",
+                    "hint": "Adds more structure to spotlight requests by ordering them from oldest to newest"
                 }
             },
             "Resources": {

--- a/module/applications/ui/combatTracker.mjs
+++ b/module/applications/ui/combatTracker.mjs
@@ -57,21 +57,21 @@ export default class DhCombatTracker extends foundry.applications.sidebar.tabs.C
 
         const adversaries = context.turns?.filter(x => x.isNPC) ?? [];
         const characters = context.turns?.filter(x => !x.isNPC) ?? [];
+        const spotlightQueueEnabled = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.SpotlightRequestQueue);
 
         const spotlightRequests = characters
-            ?.filter(x => !x.isNPC)
+            ?.filter(x => !x.isNPC && spotlightQueueEnabled)
             .filter(x => x.system.spotlight.requestOrderIndex > 0)
             .sort((a, b) => {
                 const valueA = a.system.spotlight.requestOrderIndex;
                 const valueB = b.system.spotlight.requestOrderIndex;
-
                 return valueA - valueB;
             });
 
         Object.assign(context, {
             actionTokens: game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.variantRules).actionTokens,
             adversaries,
-            characters: characters?.filter(x => !x.isNPC).filter(x => x.system.spotlight.requestOrderIndex == 0),
+            characters: characters?.filter(x => !x.isNPC).filter(x => !spotlightQueueEnabled || x.system.spotlight.requestOrderIndex == 0),
             spotlightRequests
         });
     }

--- a/module/config/settingsConfig.mjs
+++ b/module/config/settingsConfig.mjs
@@ -28,7 +28,8 @@ export const gameSettings = {
     LevelTiers: 'LevelTiers',
     Countdowns: 'Countdowns',
     LastMigrationVersion: 'LastMigrationVersion',
-    TagTeamRoll: 'TagTeamRoll'
+    TagTeamRoll: 'TagTeamRoll',
+    SpotlightRequestQueue: 'SpotlightRequestQueue',
 };
 
 export const actionAutomationChoices = {

--- a/module/systemRegistration/settings.mjs
+++ b/module/systemRegistration/settings.mjs
@@ -13,6 +13,16 @@ export const registerDHSettings = () => {
     registerMenuSettings();
     registerMenus();
     registerNonConfigSettings();
+
+    game.settings.register(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.SpotlightRequestQueue, {
+        name: game.i18n.localize('DAGGERHEART.SETTINGS.Menu.SpotlightRequestQueue.name'),
+        label: game.i18n.localize('DAGGERHEART.SETTINGS.Menu.SpotlightRequestQueue.label'),
+        hint: game.i18n.localize('DAGGERHEART.SETTINGS.Menu.SpotlightRequestQueue.hint'),
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        onChange: () => ui.combat.render(),
+    })
 };
 
 const registerMenuSettings = () => {


### PR DESCRIPTION
This makes the spotlight ordering feature an opt-in feature rather than the default. The setting exists at the top level, but let me know if there is a better place for this. It doesn't seem like an automation setting and barely even an appearance settings, but my rubric might not be fine tuned.

I could also add a Enable/Disable context menu option to the encounter tracker itself, instead or in addition to the visible settings. Let me know what you think about that.

<img width="786" height="688" alt="image" src="https://github.com/user-attachments/assets/914a7de9-747c-4e7e-8daa-f8175ceb36fd" />
