### PR TITLE
[PR] Fixing Summon Swarm to do damage threshold reduction

### DIFF
--- a/src/packs/domains/domainCard_Conjure_Swarm_rZPH0BY8Sznc9sFG.json
+++ b/src/packs/domains/domainCard_Conjure_Swarm_rZPH0BY8Sznc9sFG.json
@@ -208,13 +208,13 @@
       },
       "changes": [
         {
-          "key": "system.resistance.magical.reduction",
+          "key": "system.rules.damageReduction.reduceSeverity.magical",
           "mode": 2,
           "value": "1",
           "priority": null
         },
         {
-          "key": "system.resistance.magical.reduction",
+          "key": "system.rules.damageReduction.reduceSeverity.physical",
           "mode": 2,
           "value": "1",
           "priority": null


### PR DESCRIPTION
## Description

Changes a damage reduction of 1 to a damage threshold reduction of 1.

I didn't test others similar effects like "Get Back Up" and "Shrug it off", but they look fine. They use stress costs to reduce thresholds, which is a different mechanism. "Unyielding armor" has no effects and is vaguely similar.

- Fixes #1424 

## Type of Change

Please check the relevant options:

- [X] Bug fix
- [ ] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

Manually tested what the user tried in issue #1424.

- [X] Manual testing
- [ ] Other:

## Checklist

- [X] My code follows the project style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [X] New and existing tests pass locally with my changes

## Additional Comments

We should document how to re-import a subclass feature like this in order to fix a character with an old broken version.
