### PR TITLE
[Community PR] Moving chat display to be after processing

### DIFF
--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -193,8 +193,6 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
     async use(event) {
         if (!this.actor) throw new Error("An Action can't be used outside of an Actor context.");
 
-        if (this.chatDisplay) await this.toChat();
-
         let config = this.prepareConfig(event);
         if (!config) return;
 
@@ -210,6 +208,8 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
         await this.executeWorkflow(config);
 
         if (Hooks.call(`${CONFIG.DH.id}.postUseAction`, this, config) === false) return;
+
+        if (this.chatDisplay) await this.toChat();
 
         return config;
     }


### PR DESCRIPTION
## Description

Moved where the chatDisplay command is run. It isn't until after all postProcessing and execution is handled. The code was clean enough that this seemed like a safe change.

- Fixes #1403 

## Type of Change

Please check the relevant options:

- [X] Bug fix
- [ ] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

Manually went through a few skills that use (and don't use) this functionality. Nothing exhaustive by any means.

- [X] Manual testing
- [ ] Other:

## Checklist

- [X] My code follows the project style guidelines
- [X] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [X] New and existing tests pass locally with my changes
