### PR TITLE
[PR] Removing a potential reference error when creating a tag team roll.

### DIFF
--- a/module/applications/dialogs/tagTeamDialog.mjs
+++ b/module/applications/dialogs/tagTeamDialog.mjs
@@ -220,8 +220,8 @@ export default class TagTeamDialog extends HandlebarsApplicationMixin(Applicatio
                         !roll.system.isCritical && criticalRoll
                             ? (await getCritDamageBonus(damage.formula)) + damage.total
                             : damage.total;
+                    const updatedDamageParts = damage.parts;
                     if (systemData.damage[key]) {
-                        const updatedDamageParts = damage.parts;
                         if (!roll.system.isCritical && criticalRoll) {
                             for (let part of updatedDamageParts) {
                                 const criticalDamage = await getCritDamageBonus(part.formula);


### PR DESCRIPTION
## Description

Looking at the error message, it was very clear from looking at the code where this error came from. However, I wasn't ever able reproduce the user's error. I didn't know under what situation systemData.damage[key] would be empty (see line 242). The only keys I saw were 'hitPoints'. Maybe if one attack does stress or doesn't do hitPoint damage due to magic immunity or some such. Anyway, this change should fix the issue. That wouldn't explain the "try try again" issue from the user.

- Fixes #1402 

## Type of Change

Please check the relevant options:

- [X] Bug fix
- [ ] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

Played around with tag team rolls that both deal damage and do not deal damage.

- [X] Manual testing
- [ ] Other:

## Checklist

- [X] My code follows the project style guidelines
- [X] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [X] New and existing tests pass locally with my changes

## Additional Comments

*`updatedDamageParts`* is not defined:
```js
                    } else {
                        systemData.damage[key] = { ...damage, total: damageTotal, parts: updatedDamageParts };
                    }
```
