### PR TITLE
[PR] Updating the logic for rangeDependencies so that paired weapons work with multiple adversaries

### DIFF
--- a/daggerheart.mjs
+++ b/daggerheart.mjs
@@ -269,9 +269,8 @@ const updateActorsRangeDependentEffects = async (token) => {
             }
 
             const distanceBetween = canvas.grid.measurePath([
-                // TODO: missing { ...movedToken.toObject(), x: data.destination.x, y: data.destination.y }
-                userTarget.document,
-                token
+                userTarget.document.movement.destination,
+                token.movement.destination
             ]).distance;
             const distance = rangeMeasurement[range];
 


### PR DESCRIPTION
## Description

1. Changed how effects are collected for enabling/disables, so that effects hidden inside Items will be considered.
2. Re-wrote the logic for rangeDependencies entirely basing it around who the GM or the player is targeting.
3. Added a hook for this to happen when targetToken changes, in addition to moveToken.
4. Tried to add minimal complexity to handle some corner cases.

The basic logic is that _most_ tokens will use the GMs targeting logic to decide which effects are enabled. However, if there is a logged in player who is associated with a character, then *their* token will use *their* targets to decide which effects are enabled.

This will totally miss out on a player controlling multiple tokens or a trusted GM trying to use *their* targeting. If we wanted to do that, we _could_ try to access `canvas.tokens.controlled`, check for ownership and run on the `highlightObjects` hook. But, there are a few more corner cases to handle, not the least of which is what to do when multiple players are highlighting the same token they own (eg. GM and player). There aren't enough examples of features using rangeDependencies for this to likely be a practical issue.

- Fixes #1154

## Type of Change

Please check the relevant options:

- [X] Bug fix
- [ ] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

I tested with a rogue and a seraph with body basher both as the GM and as the player logged in. I also tested with a manually added effect that mimicked paired, but didn't come from a feature.

- [X] Manual testing
- [ ] Other:

## Checklist

- [X] My code follows the project style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [X] New and existing tests pass locally with my changes

## Additional Comments

This actually removes a bunch of console errors players would get when moving a token would try to update something they didn't have access to change.