### PR TITLE
[Community PR] Preventing getRollData from returning infinite recursion on the system property

### DIFF
--- a/module/data/item/base.mjs
+++ b/module/data/item/base.mjs
@@ -131,7 +131,7 @@ export default class BaseDataItem extends foundry.abstract.TypeDataModel {
      */
     getRollData(options = {}) {
         const actorRollData = this.actor?.getRollData() ?? {};
-        const data = { ...actorRollData, item: { ...this, system: this.system } };
+        const data = { ...actorRollData, item: { ...this } };
         return data;
     }
 


### PR DESCRIPTION
## Description

Adds system explicitly to getRollData's output so that it doesn't infinitely recurse.

- Fixes #867

## Type of Change

Please check the relevant options:

- [X] Bug fix
- [ ] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

* I tested in the console whether items and actors have infinite recursion.
* I checked a few different ways of doing rolls - attacking, clicking on traits and /dr.
* I made sure the Seraph prayer dice behaved correctly (this one didn't work unless there was at least 1 layer of system depth for some reason)

- [X] Manual testing
- [ ] Other:

## Checklist

- [X] My code follows the project style guidelines
- [X] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [X] New and existing tests pass locally with my changes

## Additional Comments

I had a bit of trouble verifying that the `item/base.mjs` change is necessary. Triggering it in the console was tricky. I think I did it, but if you have suggestions of more things to test, that would be helpful.
