### PR TITLE
[PR] Attempt #2 preventing getRollData from returning infinite recursion on the system property

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -526,7 +526,7 @@ export default class DhpActor extends Actor {
 
     /**@inheritdoc */
     getRollData() {
-        const rollData = { ...super.getRollData() };
+        const rollData = super.getRollData().clone();
         rollData.name = this.name;
         rollData.system = this.system.getRollData();
         rollData.prof = this.system.proficiency ?? 1;


### PR DESCRIPTION
## Description

Prevents the DhpActor class from munging its system with a self-reference every time getRollData() is called. Uses the clone() method.

- Fixes #867

## Type of Change

Please check the relevant options:

- [X] Bug fix
- [ ] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

* I tested in the console whether items and actors have infinite recursion.
* I checked a few different ways of doing rolls - attacking, clicking on traits and /dr. Attacking with items required clone() rather than just a plain old Object.
* I made sure the Seraph prayer dice behaved correctly (this one required the system property to be set to begin with)

- [X] Manual testing
- [ ] Other:

## Checklist

- [X] My code follows the project style guidelines
- [X] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [X] New and existing tests pass locally with my changes

## Additional Comments

See #1435 for a prior attempt to fix this same issue.
