### PR TITLE
[PR] Use the token name in the chat message targets window

### DIFF
--- a/module/data/fields/action/targetField.mjs
+++ b/module/data/fields/action/targetField.mjs
@@ -79,7 +79,7 @@ export default class TargetField extends fields.SchemaField {
         return {
             id: token.id,
             actorId: token.actor.uuid,
-            name: token.actor.name,
+            name: token.name,
             img: token.actor.img,
             difficulty: token.actor.system.difficulty,
             evasion: token.actor.system.evasion,

--- a/templates/ui/chat/parts/target-part.hbs
+++ b/templates/ui/chat/parts/target-part.hbs
@@ -29,7 +29,7 @@
                     <div class="roll-target" data-token="{{id}}">
                         <img class="target-img" src="{{img}}">
                         <div class="target-data">
-                            <div class="target-name" data-perm-id="{{actorId}}"><span>{{name}}</span></div>
+                            <div class="target-name"><span>{{name}}</span></div>
                             {{#if (and ../hasRoll (hasProperty this "hit"))}}
                                 <div class="target-hit-status {{#if hit}}is-hit{{else}}is-miss{{/if}}" data-perm-id="{{actorId}}" data-perm-hidden="true">
                                     {{#if hit}}


### PR DESCRIPTION
## Description

As discussed briefly in discord (https://discord.com/channels/1374793429191491725/1399105650507649174/1451241668278882446) we should use the prototypeToken's name instead to sort out permissions.

## Type of Change

Please check the relevant options:

- [X] Bug fix
- [ ] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

Tested as GM and player. Tested changing the prototype token name. Changing the associated Actor's name now does nothing - hopefully that isn't confusing!

- [X] Manual testing
- [ ] Other:

## Screenshots (if applicable)

Before (from Discord user):
<img width="275" height="513" alt="image" src="https://github.com/user-attachments/assets/248572d3-6f4e-48a2-b232-fd55e99b6edc" />

After (from player's perspective):
<img width="295" height="367" alt="Screenshot 2025-12-18 103614" src="https://github.com/user-attachments/assets/ba73dcfa-f281-4bad-b11a-ff529c640412" />

## Checklist

- [X] My code follows the project style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code where necessary
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [X] New and existing tests pass locally with my changes

