### PR TITLE
[PR][Fix] Fix invalid form control is not focusable error on gold fields

### DIFF
--- a/module/applications/sheets/api/application-mixin.mjs
+++ b/module/applications/sheets/api/application-mixin.mjs
@@ -183,7 +183,6 @@ export default function DHApplicationMixin(Base) {
             for (const deltaInput of htmlElement.querySelectorAll('input[data-allow-delta]')) {
                 deltaInput.dataset.numValue = deltaInput.value;
                 deltaInput.inputMode = 'numeric';
-                deltaInput.pattern = '^[+=\\-]?\d*';
 
                 const handleUpdate = (delta = 0) => {
                     const min = Number(deltaInput.min) || 0;


### PR DESCRIPTION
Fixes some console noise that occurs when you start a group roll. The pattern doesn't seem to actually be useful for anything.