### PR TITLE
[PR] Checking for empty data in renderChatMessageHTML calls

### DIFF
--- a/daggerheart.mjs
+++ b/daggerheart.mjs
@@ -193,11 +193,9 @@ Hooks.on('ready', async () => {
 
 Hooks.once('dicesoniceready', () => {});
 
-Hooks.on('renderChatMessageHTML', (app, element, _) => {
+Hooks.on('renderChatMessageHTML', (document, element) => {
     enricherRenderSetup(element);
-    // Despite documentation, the third parameter may be empty as per
-    // https://github.com/foundryvtt/foundryvtt/issues/11984
-    const cssClass = app.flags?.daggerheart?.cssClass;
+    const cssClass = document.flags?.daggerheart?.cssClass;
     if (cssClass) cssClass.split(' ').forEach(cls => element.classList.add(cls));
 });
 

--- a/module/applications/ui/chatLog.mjs
+++ b/module/applications/ui/chatLog.mjs
@@ -55,10 +55,8 @@ export default class DhpChatLog extends foundry.applications.sidebar.tabs.ChatLo
         ];
     }
 
-    addChatListeners = async (app, html, data) => {
-        // Despite documentation, the third parameter may be empty as per
-        // https://github.com/foundryvtt/foundryvtt/issues/11984
-        const message = data?.message ?? app.toObject(false);
+    addChatListeners = async (document, html, data) => {
+        const message = data?.message ?? document.toObject(false);
         html.querySelectorAll('.simple-roll-button').forEach(element =>
             element.addEventListener('click', event => this.onRollSimple(event, message))
         );


### PR DESCRIPTION
## Description

To support modules modification of chat messages (ie. via https://github.com/foundryvtt/foundryvtt/issues/11984), made some of the calls optional in renderChatMessageHTML callbacks.

- Fixes #1199 

## Type of Change

Please check the relevant options:

- [X] Bug fix
- [ ] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

1. Added a roll to the chat message bar
2. Put the code snipped below into `module/data/chat-message/actorRoll.mjs` - this might be something a module would do to fully customize the content of a chat message
3. Refreshed the application
4. Saw that the roll was replaced with dummy content.

```js
     renderHTML(_) {
         return foundry.utils.parseHTML('<div>dummy content</div>');
     }
```

- [X] Manual testing
- [ ] Other:

## Checklist

- [X] My code follows the project style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [X] New and existing tests pass locally with my changes
