### PR TITLE
[Bugfix] Fix chat styles breaking in stream mode

### DIFF
--- a/styles/less/global/chat.less
+++ b/styles/less/global/chat.less
@@ -25,6 +25,7 @@
     padding: 8px;
 }
 
+.vtt.stream.system-daggerheart .chat-sidebar,
 .daggerheart.chat-sidebar,
 #chat-notifications {
     .chat-log {

--- a/styles/less/ui/chat/chat.less
+++ b/styles/less/ui/chat/chat.less
@@ -152,6 +152,7 @@
     }
 }
 
+.vtt.stream.system-daggerheart .chat-sidebar,
 .daggerheart,
 #chat-notifications {
     .chat-message {


### PR DESCRIPTION
## Description

Fix Chat Styles breaking in stream mode when acessing `/stream` page

- Fixes #1466 

## Type of Change

Please check the relevant options:

- [x] Bug fix

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x] Manual testing

## Screenshots (if applicable)

<img width="326" height="499" alt="image" src="https://github.com/user-attachments/assets/e6b4b9a0-88d9-43a5-82ca-db4e5a1fee4b" />
<img width="315" height="871" alt="image" src="https://github.com/user-attachments/assets/9bce3972-451a-40ba-a6a8-fe656d10c5c8" />

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code

---

> Thank you for your contribution! 🎉
