### PR TITLE
[Fix] LookupEnricher Without Actor

### DIFF
--- a/module/enrichers/LookupEnricher.mjs
+++ b/module/enrichers/LookupEnricher.mjs
@@ -1,8 +1,14 @@
 import { parseInlineParams } from './parser.mjs';
 
 export default function DhLookupEnricher(match, { rollData }) {
-    const results = parseInlineParams(match[1], { first: 'formula' });
+    const lookupParam = match[1];
     const element = document.createElement('span');
-    element.textContent = Roll.replaceFormulaData(String(results.formula), rollData);
+    element.textContent = match[0];
+    if (rollData && lookupParam) {
+        const results = parseInlineParams(match[1], { first: 'formula' });
+        const text = Roll.replaceFormulaData(String(results.formula), rollData);
+        element.textContent = text !== lookupParam ? text : element.textContent;
+    }
+
     return element;
 }


### PR DESCRIPTION
- Fixed so that lookupEnricher's fallback state is securely returning the lookup string when the lookup fails.

The specific issue that was raised was that when pulling out a feature from an adversary that was making use of `@Lookup[@name]` to the item sidebar to be standalone. It would throw an error on viewing the sheet as the lookupEnricher would fail.