### PR TITLE
[Fix] Lookup For Actions

### DIFF
--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -162,18 +162,16 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
      * @returns {object}
      */
     getRollData(data = {}) {
-        if (!this.actor) return null;
-        const actorData = this.actor.getRollData(false);
+        const actorData = this.actor ? this.actor.getRollData(false) : {};
 
-        // Add Roll results to RollDatas
-        actorData.result = data.roll?.total ?? 1;
-
-        actorData.scale = data.costs?.length // Right now only return the first scalable cost.
-            ? (data.costs.find(c => c.scalable)?.total ?? 1)
-            : 1;
-        actorData.roll = {};
-
-        return actorData;
+        return {
+            ...actorData,
+            result: data.roll?.total ?? 1,
+            scale: data.costs?.length // Right now only return the first scalable cost.
+                ? (data.costs.find(c => c.scalable)?.total ?? 1)
+                : 1,
+            roll: {}
+        };
     }
 
     /**

--- a/module/enrichers/LookupEnricher.mjs
+++ b/module/enrichers/LookupEnricher.mjs
@@ -3,6 +3,11 @@ import { parseInlineParams } from './parser.mjs';
 export default function DhLookupEnricher(match, { rollData }) {
     const results = parseInlineParams(match[1], { first: 'formula' });
     const element = document.createElement('span');
-    element.textContent = Roll.replaceFormulaData(String(results.formula), rollData);
+
+    const lookupCommand = match[0];
+    const lookupParam = match[1];
+    const lookupText = Roll.replaceFormulaData(String(results.formula), rollData);
+    element.textContent = lookupText === lookupParam ? lookupCommand : lookupText;
+
     return element;
 }


### PR DESCRIPTION
Fixed rollData for actions and fallback for lookup enricher.

Actions should always return rollData. They just don't always have actor data available. The actor data is added to the action roll data specifically so that Lookup commands and such have access to it in the action description field.