### PR TITLE
[Fix] Actor Roll Data

### DIFF
--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -164,14 +164,13 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
     getRollData(data = {}) {
         const actorData = this.actor ? this.actor.getRollData(false) : {};
 
-        return {
-            ...actorData,
-            result: data.roll?.total ?? 1,
-            scale: data.costs?.length // Right now only return the first scalable cost.
-                ? (data.costs.find(c => c.scalable)?.total ?? 1)
-                : 1,
-            roll: {}
-        };
+        actorData.result = data.roll?.total ?? 1;
+        actorData.scale = data.costs?.length // Right now only return the first scalable cost.
+            ? (data.costs.find(c => c.scalable)?.total ?? 1)
+            : 1;
+        actorData.roll = {};
+
+        return actorData;
     }
 
     /**

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -539,8 +539,10 @@ export default class DhpActor extends Actor {
 
     /**@inheritdoc */
     getRollData() {
+        const rollData = foundry.utils.deepClone(super.getRollData());
         /* system gets repeated infinately which causes issues when trying to use the data for document creation */
-        const { system, ...rollData } = foundry.utils.deepClone(super.getRollData());
+        delete rollData.system;
+
         rollData.name = this.name;
         rollData.system = this.system.getRollData();
         rollData.prof = this.system.proficiency ?? 1;


### PR DESCRIPTION
Fixes #1479 
Issues were: 
- Not deepcloning
- Using a spread operation (doing this devolves the `Actor` object to a basic object, which loses the parent property)