### PR TITLE
[PR] Adding scrollable to various tabs in the homebrew settings

### DIFF
--- a/templates/settings/homebrew-settings/domains.hbs
+++ b/templates/settings/homebrew-settings/domains.hbs
@@ -1,5 +1,5 @@
 <section
-    class="tab {{tabs.domains.cssClass}} {{tabs.domains.id}}"
+    class="tab {{tabs.domains.cssClass}} {{tabs.domains.id}} scrollable"
     data-tab="{{tabs.domains.id}}"
     data-group="{{tabs.domains.group}}"
 >

--- a/templates/settings/homebrew-settings/downtime.hbs
+++ b/templates/settings/homebrew-settings/downtime.hbs
@@ -1,5 +1,5 @@
 <section
-    class="tab {{tabs.downtime.cssClass}} {{tabs.downtime.id}}"
+    class="tab {{tabs.downtime.cssClass}} {{tabs.downtime.id}} scrollable"
     data-tab="{{tabs.downtime.id}}"
     data-group="{{tabs.downtime.group}}"
 >

--- a/templates/settings/homebrew-settings/itemFeatures.hbs
+++ b/templates/settings/homebrew-settings/itemFeatures.hbs
@@ -1,5 +1,5 @@
 <section
-    class="tab {{tabs.itemFeatures.cssClass}} {{tabs.itemFeatures.id}}"
+    class="tab {{tabs.itemFeatures.cssClass}} {{tabs.itemFeatures.id}} scrollable"
     data-tab="{{tabs.itemFeatures.id}}"
     data-group="{{tabs.itemFeatures.group}}"
 >

--- a/templates/settings/homebrew-settings/settings.hbs
+++ b/templates/settings/homebrew-settings/settings.hbs
@@ -1,5 +1,5 @@
 <section
-    class="tab {{tabs.settings.cssClass}} {{tabs.settings.id}}"
+    class="tab {{tabs.settings.cssClass}} {{tabs.settings.id}} scrollable"
     data-tab="{{tabs.settings.id}}"
     data-group="{{tabs.settings.group}}"
 >

--- a/templates/settings/homebrew-settings/types.hbs
+++ b/templates/settings/homebrew-settings/types.hbs
@@ -1,5 +1,5 @@
 <section
-    class="tab {{tabs.types.cssClass}} {{tabs.types.id}}"
+    class="tab {{tabs.types.cssClass}} {{tabs.types.id}} scrollable"
     data-tab="{{tabs.types.id}}"
     data-group="{{tabs.types.group}}"
 >


### PR DESCRIPTION
## Description

Added scrollable to various tabs.

- Fixes #1480

## Type of Change

Please check the relevant options:

- [X] Bug fix
- [ ] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

Repeated what the original user did.

- [X] Manual testing
- [ ] Other:

## Screenshots (if applicable)

<img width="602" height="935" alt="fix" src="https://github.com/user-attachments/assets/d6b70d4d-61da-4f92-b786-561fb22ec5f8" />

## Checklist

- [X] My code follows the project style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [X] New and existing tests pass locally with my changes

## Additional Comments

It's possible to make the short rest or long rest dialogs overflow as well - either by having too many actions or too many refreshables. I fiddled around with a straightforward fix just like this one, but it didn't work. I must be missing something obvious in the css.