### PR TITLE
[Fix] 1484 - Resource Generation Fix

### DIFF
--- a/module/dice/dualityRoll.mjs
+++ b/module/dice/dualityRoll.mjs
@@ -298,7 +298,7 @@ export default class DualityRoll extends D20Roll {
 
         if (looseSpotlight && game.combat?.active) {
             const currentCombatant = game.combat.combatants.get(game.combat.current?.combatantId);
-            if (currentCombatant?.actorId == actor.id) ui.combat.setCombatantSpotlight(currentCombatant.id);
+            if (currentCombatant?.actorId == config.data.id) ui.combat.setCombatantSpotlight(currentCombatant.id);
         }
     }
 

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -543,6 +543,7 @@ export default class DhpActor extends Actor {
         /* system gets repeated infinately which causes issues when trying to use the data for document creation */
         delete rollData.system;
 
+        rollData.id = this.id;
         rollData.name = this.name;
         rollData.system = this.system.getRollData();
         rollData.prof = this.system.proficiency ?? 1;


### PR DESCRIPTION
Fixes #1484 
If the spotlight is lost due to duality automation, it currently errors out because we're referencing an undefined variable. Fixes this to correctly be the actorId.