### PR TITLE
[PR] Add view party button to character sheet

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -226,6 +226,7 @@
                     "confirmText": "Would you like to level up your companion {name} by {levelChange} levels at this time? (You can do it manually later)"
                 },
                 "viewLevelups": "View Levelups",
+                "viewParty": "View Party",
                 "InvalidOldCharacterImportTitle": "Old Character Import",
                 "InvalidOldCharacterImportText": "Character data exported prior to system version 1.1 will not generate a complete character. Do you wish to continue?",
                 "cancelBeastform": "Cancel Beastform"

--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -32,7 +32,8 @@ export default class CharacterSheet extends DHBaseActorSheet {
             handleResourceDice: CharacterSheet.#handleResourceDice,
             advanceResourceDie: CharacterSheet.#advanceResourceDie,
             cancelBeastform: CharacterSheet.#cancelBeastform,
-            useDowntime: this.useDowntime
+            useDowntime: this.useDowntime,
+            viewParty: CharacterSheet.#viewParty,
         },
         window: {
             resizable: true,
@@ -890,6 +891,41 @@ export default class CharacterSheet extends DHBaseActorSheet {
         const item = await getDocFromElement(target);
         if (!item) return;
         game.system.api.fields.ActionFields.BeastformField.handleActiveTransformations.call(item);
+    }
+
+    static async #viewParty(_, target) {
+        const parties = this.document.parties;
+        if (parties.size <= 1) {
+            parties.first()?.sheet.render({ force: true });
+            return;
+        }
+
+        const buttons = parties.map((p) => {
+            const button = document.createElement("button");
+            button.type = "button";
+            button.classList.add("plain");
+            const img = document.createElement("img");
+            img.src = p.img;
+            button.append(img);
+            const name = document.createElement("span");
+            name.textContent = p.name;
+            button.append(name);
+            button.addEventListener("click", () => {
+                p.sheet?.render({ force: true });
+                game.tooltip.dismissLockedTooltips();
+            });
+            return button;
+        });
+
+        const html = document.createElement("div");
+        html.classList.add("party-list");
+        html.append(...buttons);
+        
+        game.tooltip.dismissLockedTooltips();
+        game.tooltip.activate(target, {
+            html,
+            locked: true,
+        })
     }
 
     /**

--- a/styles/less/sheets/actors/character/header.less
+++ b/styles/less/sheets/actors/character/header.less
@@ -145,6 +145,11 @@
 
                 button {
                     flex: 1;
+                    padding: 0 0.375rem;
+                }
+
+                button[data-action=viewParty] {
+                    margin-right: 6px;
                 }
             }
 

--- a/styles/less/ux/tooltip/tooltip.less
+++ b/styles/less/ux/tooltip/tooltip.less
@@ -344,4 +344,20 @@ aside[role='tooltip'].locked-tooltip:has(div.daggerheart.dh-style.tooltip.card-s
             margin-bottom: 4px;
         }
     }
+
+    .party-list {
+        display: flex;
+        flex-direction: column;
+        button {
+            width: 100%;
+            align-items: center;
+            justify-content: start;
+            img {
+                border: none;
+                width: 1rem;
+                height: 1rem;
+                object-fit: contain;
+            }
+        }
+    }
 }

--- a/templates/sheets/actors/character/header.hbs
+++ b/templates/sheets/actors/character/header.hbs
@@ -87,11 +87,16 @@
             </div>
         {{/if}}
         <div class="downtime-section">
-            <button type="button" data-action="useDowntime" data-type="shortRest" data-tooltip="{{localize "DAGGERHEART.APPLICATIONS.Downtime.shortRest.title"}}">
-                <i class="fa-solid fa-utensils"></i>
+            {{#if document.parties.size}}
+                <button type="button" data-action="viewParty" data-tooltip="DAGGERHEART.ACTORS.Character.viewParty">
+                    <i class="fa-solid fa-fw fa-users"></i>
+                </button>
+            {{/if}}
+            <button type="button" data-action="useDowntime" data-type="shortRest" data-tooltip="DAGGERHEART.APPLICATIONS.Downtime.shortRest.title">
+                <i class="fa-solid fa-fw fa-utensils"></i>
             </button>
-            <button type="button" data-action="useDowntime" data-type="longRest" data-tooltip="{{localize "DAGGERHEART.APPLICATIONS.Downtime.longRest.title"}}">
-                <i class="fa-solid fa-bed"></i>
+            <button type="button" data-action="useDowntime" data-type="longRest" data-tooltip="DAGGERHEART.APPLICATIONS.Downtime.longRest.title">
+                <i class="fa-solid fa-fw fa-bed"></i>
             </button>
         </div>
     </div>


### PR DESCRIPTION
Adds a view party button to the character sheet

<img width="870" height="682" alt="image" src="https://github.com/user-attachments/assets/9f0f14d5-c6e9-4aa2-a88e-552648ff040c" />

If the character is in multiple parties, a tooltip will be shown to the select the party when clicking it.

<img width="578" height="287" alt="image" src="https://github.com/user-attachments/assets/c12aad00-3170-454b-b0cd-7e0880632460" />
