### PR TITLE
[PR][Fix][TYPO] Template removed from Stardrop consumable item

### DIFF
--- a/src/packs/items/consumables/consumable_Stardrop_y4c1jrlHrf0wBWOq.json
+++ b/src/packs/items/consumables/consumable_Stardrop_y4c1jrlHrf0wBWOq.json
@@ -4,7 +4,7 @@
   "_id": "y4c1jrlHrf0wBWOq",
   "img": "icons/magic/light/projectiles-star-purple.webp",
   "system": {
-    "description": "<p>You can use this stardrop to summon a hailstorm of comets that deals 8d20 physical damage to all targets within Very Far range.</p><p>@Template[type:emanation|range:vf]</p>",
+    "description": "<p>You can use this stardrop to summon a hailstorm of comets that deals 8d20 physical damage to all targets within Very Far range.</p>",
     "quantity": 1,
     "actions": {
       "pt5U6hlyx4T7MUOa": {


### PR DESCRIPTION
## Description

`vf` is not a configured range by either settings so it is pointless to have a template for Stardrop since `vf` range is generally anywhere on the map and not a defined range.

- Fixes #1509
- Closes #1509

## Type of Change

Please check the relevant options:

- [x] Documentation update

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x] Manual testing

## Screenshots (if applicable)

<img width="596" height="661" alt="image" src="https://github.com/user-attachments/assets/6ea3225c-ef1a-42d2-b90a-ee3f4033795c" />

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors

## Additional Comments

Enricher wasn't touched but to be considered if `vf` does indeed become a defined range for future. 
