### PR TITLE
Fix bottom gap of item settings and make header rows more rhythmic

### DIFF
--- a/styles/less/global/index.less
+++ b/styles/less/global/index.less
@@ -10,7 +10,6 @@
 @import './tab-description.less';
 @import './tab-features.less';
 @import './tab-effects.less';
-@import './tab-settings.less';
 @import './item-header.less';
 @import './feature-section.less';
 @import './inventory-item.less';

--- a/styles/less/global/item-header.less
+++ b/styles/less/global/item-header.less
@@ -160,7 +160,7 @@
             .item-description {
                 display: flex;
                 flex-direction: column;
-                gap: 10px;
+                gap: 7px;
             }
 
             h3 {

--- a/styles/less/global/tab-settings.less
+++ b/styles/less/global/tab-settings.less
@@ -1,8 +1,0 @@
-@import '../utils/colors.less';
-@import '../utils/fonts.less';
-
-.sheet.daggerheart.dh-style {
-    .tab.settings {
-        margin-bottom: 36px;
-    }
-}


### PR DESCRIPTION
<img width="467" height="714" alt="image" src="https://github.com/user-attachments/assets/09739f45-f352-42be-8e97-6a02bf1047b9" />

The big bottom space below the settings is gone (handled by scrollbar) and the gap between DOMAIN CARD and ABILITY - GRACE - LEVEL was reduced.