### PR TITLE
[Feature] Beastform Token Scale

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2284,7 +2284,8 @@
                         "placeholder": "Using character dimensions",
                         "disabledPlaceholder": "Set by character size",
                         "height": { "label": "Height" },
-                        "width": { "label": "Width" }
+                        "width": { "label": "Width" },
+                        "scale": { "label": "Token Scale" }
                     },
                     "evolved": {
                         "maximumTier": { "label": "Maximum Tier" },

--- a/module/data/activeEffect/beastformEffect.mjs
+++ b/module/data/activeEffect/beastformEffect.mjs
@@ -19,6 +19,7 @@ export default class BeastformEffect extends BaseEffect {
                     base64: false
                 }),
                 tokenSize: new fields.SchemaField({
+                    scale: new fields.NumberField({ nullable: false, initial: 1 }),
                     height: new fields.NumberField({ integer: false, nullable: true }),
                     width: new fields.NumberField({ integer: false, nullable: true })
                 })
@@ -55,7 +56,9 @@ export default class BeastformEffect extends BaseEffect {
             const update = {
                 ...baseUpdate,
                 texture: {
-                    src: this.characterTokenData.tokenImg
+                    src: this.characterTokenData.tokenImg,
+                    scaleX: this.characterTokenData.tokenSize.scale,
+                    scaleY: this.characterTokenData.tokenSize.scale
                 },
                 ring: {
                     enabled: this.characterTokenData.usesDynamicToken,
@@ -86,7 +89,9 @@ export default class BeastformEffect extends BaseEffect {
                     y,
                     'texture': {
                         enabled: this.characterTokenData.usesDynamicToken,
-                        src: token.flags.daggerheart?.beastformTokenImg ?? this.characterTokenData.tokenImg
+                        src: token.flags.daggerheart?.beastformTokenImg ?? this.characterTokenData.tokenImg,
+                        scaleX: this.characterTokenData.tokenSize.scale,
+                        scaleY: this.characterTokenData.tokenSize.scale
                     },
                     'ring': {
                         subject: {

--- a/module/data/item/beastform.mjs
+++ b/module/data/item/beastform.mjs
@@ -49,6 +49,7 @@ export default class DHBeastform extends BaseDataItem {
                     choices: CONFIG.DH.ACTOR.tokenSize,
                     initial: CONFIG.DH.ACTOR.tokenSize.custom.id
                 }),
+                scale: new fields.NumberField({ nullable: false, min: 0.2, max: 3, step: 0.05, initial: 1 }),
                 height: new fields.NumberField({ integer: true, min: 1, initial: null, nullable: true }),
                 width: new fields.NumberField({ integer: true, min: 1, initial: null, nullable: true })
             }),
@@ -184,6 +185,7 @@ export default class DHBeastform extends BaseDataItem {
                     tokenImg: this.parent.parent.prototypeToken.texture.src,
                     tokenRingImg: this.parent.parent.prototypeToken.ring.subject.texture,
                     tokenSize: {
+                        scale: this.parent.parent.prototypeToken.texture.scaleX,
                         height: this.parent.parent.prototypeToken.height,
                         width: this.parent.parent.prototypeToken.width
                     }
@@ -209,7 +211,9 @@ export default class DHBeastform extends BaseDataItem {
             height,
             width,
             texture: {
-                src: this.tokenImg
+                src: this.tokenImg,
+                scaleX: this.tokenSize.scale,
+                scaleY: this.tokenSize.scale
             },
             ring: {
                 subject: {

--- a/templates/sheets/items/beastform/settings.hbs
+++ b/templates/sheets/items/beastform/settings.hbs
@@ -47,6 +47,9 @@
                     disabled=dimensionsDisabled 
                 }}
             </div>
+            <div class="full-width">
+                {{formGroup systemFields.tokenSize.fields.scale value=source.system.tokenSize.scale localize=true }}
+            </div>
         {{else}}
             <span class="hint">{{localize "DAGGERHEART.ITEMS.Beastform.evolvedTokenHint"}}</span>
         {{/unless}}


### PR DESCRIPTION
Added so that beastforms can set a scale to their transform image, so it  can handle artwork with non-standard dimensions.
<img width="745" height="813" alt="image" src="https://github.com/user-attachments/assets/15788123-4b0b-4905-88a3-861075d1db9c" />