### PR TITLE
[Fix] 1554 - SavingThrow Damage Mitigation

### DIFF
--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -241,6 +241,7 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
             hasHealing: this.hasHealing,
             hasEffect: this.hasEffect,
             hasSave: this.hasSave,
+            onSave: this.save?.damageMod,
             isDirect: !!this.damage?.direct,
             selectedRollMode: game.settings.get('core', 'rollMode'),
             data: this.getRollData(),

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -607,7 +607,7 @@ export default class DhpActor extends Actor {
         if (!updates.length) return;
 
         const hpDamage = updates.find(u => u.key === CONFIG.DH.GENERAL.healingTypes.hitPoints.id);
-        if (hpDamage) {
+        if (hpDamage?.value) {
             hpDamage.value = this.convertDamageToThreshold(hpDamage.value);
             if (
                 this.type === 'character' &&

--- a/module/documents/chatMessage.mjs
+++ b/module/documents/chatMessage.mjs
@@ -179,7 +179,7 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
             config = foundry.utils.deepClone(this.system);
         config.event = event;
 
-        if (this.system.onSave) {
+        if (config.hasSave) {
             const pendingingSaves = targets.filter(t => t.saved.success === null);
             if (pendingingSaves.length) {
                 const confirm = await foundry.applications.api.DialogV2.confirm({


### PR DESCRIPTION
Fixes #1554 
- Fixed so that saving throw damage mitigation works again. Unsure how that happened, but the required property `onSave` was not being set on actionConfig, and therefore not saved down into the chat message.
- Fixed a bug where applying 0 damage counted as minor damage.