### PR TITLE
[Fix] Player Initial Load Error

### DIFF
--- a/module/applications/ui/effectsDisplay.mjs
+++ b/module/applications/ui/effectsDisplay.mjs
@@ -76,6 +76,8 @@ export default class DhEffectsDisplay extends HandlebarsApplicationMixin(Applica
     };
 
     toggleHidden(token, focused) {
+        if (!this.element) return;
+
         const effects = DhEffectsDisplay.getTokenEffects(focused ? token : null);
         this.element.hidden = effects.length === 0;
 


### PR DESCRIPTION
Fixed an error where a player having their token initially selected caused an error in effectsDisplay.mjs