### PR TITLE
[Fix] Multiclass Spellcast Modifier

### DIFF
--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -368,7 +368,7 @@ export default class DhCharacter extends BaseDataActor {
         const modifiers = subClasses
             ?.map(sc => ({ ...this.traits[sc.system.spellcastingTrait], key: sc.system.spellcastingTrait }))
             .filter(x => x);
-        return modifiers.sort((a, b) => a.value - b.value)[0];
+        return modifiers.sort((a, b) => (b.value ?? 0) - (a.value ?? 0))[0];
     }
 
     get spellcastModifier() {

--- a/templates/sheets/actors/character/sidebar.hbs
+++ b/templates/sheets/actors/character/sidebar.hbs
@@ -1,12 +1,12 @@
 <aside class="character-sidebar-sheet">
     <div class="portrait {{#if isDeath}}death-roll{{/if}}">
         <img src="{{document.img}}" alt="{{document.name}}" data-action='editImage' data-edit="img">
-        {{#if document.system.class.subclass.system.spellcastingTrait}}
+        {{#if document.system.spellcastModifierTrait.key}}
             <div class="icons-list">
                 <span class="spellcast-icon {{#if isDeath}}no-label{{/if}}">
                     <span class="spellcast-label">
                         {{localize "DAGGERHEART.ITEMS.Subclass.spellcastingTrait"}}: 
-                        {{localize (concat 'DAGGERHEART.CONFIG.Traits.' document.system.class.subclass.system.spellcastingTrait '.short')}}
+                        {{localize (concat 'DAGGERHEART.CONFIG.Traits.' document.system.spellcastModifierTrait.key '.short')}}
                     </span>
                     <i class="fa-solid fa-wand-sparkles"></i>
                 </span>


### PR DESCRIPTION
Spellcast modifiers were not being sorted correctly for use on multiclass, making it not available.