### PR TITLE
[PR] Loadout Max detection when pulled from compendium

### DIFF
--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -978,16 +978,6 @@ export default class CharacterSheet extends DHBaseActorSheet {
             return super._onDropItem(event, item);
         }
 
-        // Handle domain card drops
-
-        if (item.type === 'domainCard') {
-            const {available} = this.document.system.loadoutSlot;
-            if (!item?.system.inVault && !available && !item?.system.loadoutIgnore) { //Check if there's space in loadout and if the item ignores loadout limits
-                item?.update({ 'system.inVault': true }); //Add to vault if no space (not working as intended. updateSource instead of update?)
-                return ui.notifications.warn(game.i18n.localize('DAGGERHEART.UI.Notifications.loadoutMaxReached')); //Notify user
-            }
-        }
-
         if (item.type === 'beastform') {
             if (this.document.effects.find(x => x.type === 'beastform')) {
                 return ui.notifications.warn(

--- a/module/data/item/domainCard.mjs
+++ b/module/data/item/domainCard.mjs
@@ -94,8 +94,10 @@ export default class DHDomainCard extends BaseDataItem {
                 return false;
             }
 
-            if (!this.actor.system.loadoutSlot.available) {
+            if (!this.actor.system.loadoutSlot.available && !this.loadoutIgnore) {
                 data.system.inVault = true;
+                await this.updateSource({ inVault: true });
+                ui.notifications.warn(game.i18n.localize('DAGGERHEART.UI.Notifications.loadoutMaxReached'));
             }
         }
     }


### PR DESCRIPTION
## Description

Additional condition added when domain card item is dropped to handle max loadout when pulled from folders

- Fixes #1410
- Closes #1410

## Type of Change

Please check the relevant options:

- [x] Bug fix
- [x] Code cleanup/refactor

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x] Manual testing

## Screenshots (if applicable)
<img width="1639" height="862" alt="image" src="https://github.com/user-attachments/assets/68cadafd-4b86-4500-bd3f-1660a4ba87cb" />

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
