### PR TITLE
[Fix] Character Hope Directionality

### DIFF
--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -41,7 +41,8 @@ export default class DhCharacter extends BaseDataActor {
                         min: 0,
                         integer: true,
                         label: 'DAGGERHEART.GENERAL.hope'
-                    })
+                    }),
+                    isReversed: new fields.BooleanField({ initial: false })
                 })
             }),
             traits: new fields.SchemaField({


### PR DESCRIPTION
Fixed character hopeResource to be set as 'isReversed' again, so damage and healing is applied correctly