### PR TITLE
[Fix] 1637 - Typos

### DIFF
--- a/src/packs/adversaries/adversary_Assassin_Poisoner_h5RuhzGL17dW5FBT.json
+++ b/src/packs/adversaries/adversary_Assassin_Poisoner_h5RuhzGL17dW5FBT.json
@@ -388,7 +388,7 @@
       "name": "Fumigation",
       "type": "feature",
       "system": {
-        "description": "<p>Drop a smoke bomb that fi lls the air within Close range with smoke, Dizzying all targets in this area. Dizzied targets have disadvantage on their next action roll, then clear the condition.</p><p>@Template[type:emanation|range:c]</p>",
+        "description": "<p>Drop a smoke bomb that fills the air within Close range with smoke, Dizzying all targets in this area. Dizzied targets have disadvantage on their next action roll, then clear the condition.</p><p>@Template[type:emanation|range:c]</p>",
         "resource": null,
         "actions": {
           "sp7RfJRQJsEUm09m": {

--- a/src/packs/domains/domainCard_Bold_Presence_tdsL00yTSLNgZWs6.json
+++ b/src/packs/domains/domainCard_Bold_Presence_tdsL00yTSLNgZWs6.json
@@ -110,7 +110,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "<p class=\"Body-Foundation\">Add your Strength to the presence roll roll.</p>",
+      "description": "<p class=\"Body-Foundation\">Add your Strength to the presence roll.</p>",
       "tint": "#ffffff",
       "statuses": [],
       "sort": 0,


### PR DESCRIPTION
Fixes #1637 
Fixed fumigation and bold presence descriptions