### PR TITLE
[Fix] Gridless Hover Distance

### DIFF
--- a/module/canvas/placeables/token.mjs
+++ b/module/canvas/placeables/token.mjs
@@ -1,4 +1,4 @@
-import DhMeasuredTemplate from "./measuredTemplate.mjs";
+import DhMeasuredTemplate from './measuredTemplate.mjs';
 
 export default class DhTokenPlaceable extends foundry.canvas.placeables.Token {
     /** @inheritdoc */
@@ -63,7 +63,7 @@ export default class DhTokenPlaceable extends foundry.canvas.placeables.Token {
             const originRadius = (this.bounds.width * boundsCorrection) / 2;
             const targetRadius = (target.bounds.width * boundsCorrection) / 2;
             const distance = canvas.grid.measurePath([originPoint, destinationPoint]).distance;
-            return distance - originRadius - targetRadius + canvas.grid.distance;
+            return Math.floor(distance - originRadius - targetRadius + canvas.grid.distance);
         }
 
         // Compute what the closest grid space of each token is, then compute that distance
@@ -85,7 +85,7 @@ export default class DhTokenPlaceable extends foundry.canvas.placeables.Token {
 
         // Check if the setting is enabled
         const setting = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.appearance).showTokenDistance;
-        if (setting === "never" || (setting === "encounters" && !game.combat?.started)) return;
+        if (setting === 'never' || (setting === 'encounters' && !game.combat?.started)) return;
 
         // Check if this token isn't invisible and is actually being hovered
         const isTokenValid =


### PR DESCRIPTION
Made gridless distances lean towards being in the lower range by applying `Math.floor` to the calculated distance.
We could make it just `Math.round` to give it just a little bit of wiggleroom - but I think it makes for a better experience to give the wider interpretation of being in range to make melee a less annoying distance to get into.