### PR TITLE
[Community PR] Add actions to prepare downtime actions

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -446,6 +446,10 @@
                         "description": "Describe how you are preparing for the next day's adventure, then gain a Hope. If you choose to Prepare with one or more members of your party, you may each take two Hope.",
                         "name": "Prepare"
                     },
+                    "prepareWithFriends": {
+                        "description": "Describe how you are preparing for the next day's adventure, then gain a Hope. If you choose to Prepare with one or more members of your party, you may each take two Hope.",
+                        "name": "Prepare (with Friends)"
+                    },
                     "repairArmor": {
                         "description": "Describe how you spend time repairing your armor and clear all of its Armor Slots. You may also do this to an ally's armor instead.",
                         "name": "Repair Armor"
@@ -476,6 +480,10 @@
                     },
                     "prepare": {
                         "name": "Prepare",
+                        "description": "Describe how you prepare yourself for the path ahead, then gain a Hope. If you choose to Prepare with one or more members of your party, you each gain 2 Hope."
+                    },
+                    "prepareWithFriends": {
+                        "name": "Prepare (with Friends)",
                         "description": "Describe how you prepare yourself for the path ahead, then gain a Hope. If you choose to Prepare with one or more members of your party, you each gain 2 Hope."
                     }
                 },

--- a/module/config/generalConfig.mjs
+++ b/module/config/generalConfig.mjs
@@ -331,7 +331,56 @@ export const defaultRestOptions = {
             icon: 'fa-solid fa-dumbbell',
             img: 'icons/skills/trades/academics-merchant-scribe.webp',
             description: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.shortRest.prepare.description'),
-            actions: {},
+            actions: {
+                prepare: {
+                    type: 'healing',
+                    systemPath: 'restMoves.shortRest.moves.prepare.actions',
+                    name: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.shortRest.prepare.name'),
+                    img: 'icons/skills/trades/academics-merchant-scribe.webp',
+                    actionType: 'action',
+                    chatDisplay: false,
+                    target: {
+                        type: 'self'
+                    },
+                    damage: {
+                        parts: [
+                            {
+                                applyTo: healingTypes.hope.id,
+                                value: {
+                                    custom: {
+                                        enabled: true,
+                                        formula: '1'
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                prepareWithFriends: {
+                    type: 'healing',
+                    systemPath: 'restMoves.shortRest.moves.prepare.actions',
+                    name: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.shortRest.prepareWithFriends.name'),
+                    img: 'icons/skills/trades/academics-merchant-scribe.webp',
+                    actionType: 'action',
+                    chatDisplay: false,
+                    target: {
+                        type: 'self'
+                    },
+                    damage: {
+                        parts: [
+                            {
+                                applyTo: healingTypes.hope.id,
+                                value: {
+                                    custom: {
+                                        enabled: true,
+                                        formula: '2'
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
             effects: []
         }
     }),
@@ -446,7 +495,56 @@ export const defaultRestOptions = {
             icon: 'fa-solid fa-dumbbell',
             img: 'icons/skills/trades/academics-merchant-scribe.webp',
             description: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.longRest.prepare.description'),
-            actions: {},
+            actions: {
+                prepare: {
+                    type: 'healing',
+                    systemPath: 'restMoves.longRest.moves.prepare.actions',
+                    name: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.longRest.prepare.name'),
+                    img: 'icons/skills/trades/academics-merchant-scribe.webp',
+                    actionType: 'action',
+                    chatDisplay: false,
+                    target: {
+                        type: 'self'
+                    },
+                    damage: {
+                        parts: [
+                            {
+                                applyTo: healingTypes.hope.id,
+                                value: {
+                                    custom: {
+                                        enabled: true,
+                                        formula: '1'
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                prepareWithFriends: {
+                    type: 'healing',
+                    systemPath: 'restMoves.longRest.moves.prepare.actions',
+                    name: game.i18n.localize('DAGGERHEART.APPLICATIONS.Downtime.longRest.prepareWithFriends.name'),
+                    img: 'icons/skills/trades/academics-merchant-scribe.webp',
+                    actionType: 'action',
+                    chatDisplay: false,
+                    target: {
+                        type: 'self'
+                    },
+                    damage: {
+                        parts: [
+                            {
+                                applyTo: healingTypes.hope.id,
+                                value: {
+                                    custom: {
+                                        enabled: true,
+                                        formula: '2'
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
             effects: []
         },
         workOnAProject: {


### PR DESCRIPTION

## Description

Adds actual usable actions to the “Prepare” downtime actions (short/long rest).

This way you don’t have to manually add hope.

## Type of Change

Please check the relevant options:

- [ ] Bug fix
- [X] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [X] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [X] Manual testing
- [ ] Other:

## Checklist

- [X] My code follows the project style guidelines
- [X] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [ ] New and existing tests pass locally with my changes