### PR TITLE
[Fix]Environment Attack Error

### DIFF
--- a/module/data/fields/action/damageField.mjs
+++ b/module/data/fields/action/damageField.mjs
@@ -109,8 +109,8 @@ export default class DamageField extends fields.SchemaField {
                 );
             else {
                 const configDamage = foundry.utils.deepClone(config.damage);
-                const hpDamageMultiplier = config.actionActor?.system.rules?.attack.damage.hpDamageMultiplier ?? 1;
-                const hpDamageTakenMultiplier = actor.system.rules.attack.damage.hpDamageTakenMultiplier;
+                const hpDamageMultiplier = config.actionActor?.system.rules?.attack?.damage?.hpDamageMultiplier ?? 1;
+                const hpDamageTakenMultiplier = actor.system.rules?.attack?.damage?.hpDamageTakenMultiplier;
                 if (configDamage.hitPoints) {
                     for (const part of configDamage.hitPoints.parts) {
                         part.total = Math.ceil(part.total * hpDamageMultiplier * hpDamageTakenMultiplier);


### PR DESCRIPTION
Fixed so that environment attacks don't error when trying to deal damage. We're performing a check if the source of damage should multiply it's damage based on a rule - and it doesn't exist on environments.
Made it go to the fallback.