### PR TITLE
[Fix] 1617 - Startup Escaped Spaces

### DIFF
--- a/tools/run-start.mjs
+++ b/tools/run-start.mjs
@@ -18,7 +18,7 @@ const foundryPath = process.env.FOUNDRY_MAIN_PATH || '../../../../FoundryDev/mai
 const dataPath = process.env.FOUNDRY_DATA_PATH || '../../../';
 
 // Run the original command with proper environment
-const args = ['rollup -c --watch', `node "${foundryPath}" --dataPath="${dataPath}" --noupnp`, 'gulp'];
+const args = ['rollup -c --watch', `node "\"${foundryPath}\"" --dataPath="${dataPath}" --noupnp`, 'gulp'];
 
 spawn('npx', ['concurrently', ...args.map(arg => `"${arg}"`)], {
     stdio: 'inherit',


### PR DESCRIPTION
Fixes #1617 
Fixed so that node start can accept escaped spaces in the path