### PR TITLE
[Fix] ChatMessage Description Auto Expand

### DIFF
--- a/module/applications/dialogs/deathMove.mjs
+++ b/module/applications/dialogs/deathMove.mjs
@@ -200,7 +200,6 @@ export default class DhDeathMove extends HandlebarsApplicationMixin(ApplicationV
                     description: game.i18n.localize(this.selectedMove.description),
                     result: result,
                     open: autoExpandDescription ? 'open' : '',
-                    chevron: autoExpandDescription ? 'fa-chevron-up' : 'fa-chevron-down',
                     showRiskItAllButton: this.showRiskItAllButton,
                     riskItAllButtonLabel: this.riskItAllButtonLabel,
                     riskItAllHope: this.riskItAllHope

--- a/module/applications/dialogs/downtime.mjs
+++ b/module/applications/dialogs/downtime.mjs
@@ -196,6 +196,9 @@ export default class DhpDowntime extends HandlebarsApplicationMixin(ApplicationV
             .filter(x => x.testUserPermission(game.user, 'LIMITED'))
             .filter(x => x.uuid !== this.actor.uuid);
 
+        const autoExpandDescription = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.appearance)
+            .expandRollMessage?.desc;
+
         const cls = getDocumentClass('ChatMessage');
         const msg = {
             user: game.user.id,
@@ -216,7 +219,8 @@ export default class DhpDowntime extends HandlebarsApplicationMixin(ApplicationV
                     actor: { name: this.actor.name, img: this.actor.img },
                     moves: moves,
                     characters: characters,
-                    selfId: this.actor.uuid
+                    selfId: this.actor.uuid,
+                    open: autoExpandDescription ? 'open' : ''
                 }
             ),
             flags: {

--- a/module/data/fields/actionField.mjs
+++ b/module/data/fields/actionField.mjs
@@ -262,6 +262,9 @@ export function ActionMixin(Base) {
         }
 
         async toChat(origin) {
+            const autoExpandDescription = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.appearance)
+                .expandRollMessage?.desc;
+
             const cls = getDocumentClass('ChatMessage');
             const systemData = {
                 title: game.i18n.localize('DAGGERHEART.CONFIG.FeatureForm.action'),
@@ -290,7 +293,7 @@ export function ActionMixin(Base) {
                 system: systemData,
                 content: await foundry.applications.handlebars.renderTemplate(
                     'systems/daggerheart/templates/ui/chat/action.hbs',
-                    systemData
+                    { ...systemData, open: autoExpandDescription ? 'open' : '' }
                 ),
                 flags: {
                     daggerheart: {

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
     "id": "daggerheart",
     "title": "Daggerheart",
     "description": "An unofficial implementation of the Daggerheart system",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "compatibility": {
         "minimum": "13.346",
         "verified": "13.351",

--- a/templates/ui/chat/action.hbs
+++ b/templates/ui/chat/action.hbs
@@ -1,5 +1,5 @@
 <div class="daggerheart chat action">
-    <details class="action-move">
+    <details class="action-move" {{this.open}}>
         <summary class="action-section">
             <img class="action-img" src="{{action.img}}" />
             <div class="action-header">

--- a/templates/ui/chat/deathMove.hbs
+++ b/templates/ui/chat/deathMove.hbs
@@ -7,7 +7,7 @@
                     <h2 class="title">{{this.title}}</h2>
                     <span class="label">{{localize 'DAGGERHEART.UI.Chat.deathMove.title'}}</span>
                 </div>
-                <i class="fa-solid {{this.chevron}}"></i>
+                <i class="fa-solid fa-chevron-down"></i>
             </summary>
             <div class="description">
                 {{{this.description}}}

--- a/templates/ui/chat/downtime.hbs
+++ b/templates/ui/chat/downtime.hbs
@@ -1,7 +1,7 @@
 <div class="daggerheart chat downtime">
     <ul class="downtime-moves-list">
         {{#each moves as | move index |}}
-            <details class="downtime-move">
+            <details class="downtime-move" {{@root.open}}>
                 <summary class="downtime-label">
                     <img class="downtime-image" src="{{move.img}}" />
                     <div class="header-label">


### PR DESCRIPTION
DeathMove/Downtime and basic Action chatmessages (not including a roll) were not properly following the Auto Expand Description setting. Fixed.