### PR TITLE
[PR] Fix incorrect adversary data (ranges, stats, types, names)

### DIFF
--- a/src/packs/adversaries/adversary_Adult_Flickerfly_G7jiltRjgvVhZewm.json
+++ b/src/packs/adversaries/adversary_Adult_Flickerfly_G7jiltRjgvVhZewm.json
@@ -82,7 +82,7 @@
                 "enabled": false
               },
               "flatMultiplier": 3,
-              "dice": "d10",
+              "dice": "d20",
               "bonus": null,
               "multiplier": "flat"
             },

--- a/src/packs/adversaries/adversary_Giant_Recruit_5s8wSvpyC5rxY5aD.json
+++ b/src/packs/adversaries/adversary_Giant_Recruit_5s8wSvpyC5rxY5aD.json
@@ -55,7 +55,7 @@
         "max": 1
       },
       "stress": {
-        "max": 1
+        "max": 2
       }
     },
     "attack": {

--- a/src/packs/adversaries/adversary_Hallowed_Soldier_VENwg7xEFcYObjmT.json
+++ b/src/packs/adversaries/adversary_Hallowed_Soldier_VENwg7xEFcYObjmT.json
@@ -55,7 +55,7 @@
         "max": 1
       },
       "stress": {
-        "max": 1
+        "max": 2
       }
     },
     "attack": {

--- a/src/packs/adversaries/adversary_Jagged_Knife_Sniper_1zuyof1XuIfi3aMG.json
+++ b/src/packs/adversaries/adversary_Jagged_Knife_Sniper_1zuyof1XuIfi3aMG.json
@@ -33,7 +33,7 @@
         "reduction": 0
       }
     },
-    "type": "standard",
+    "type": "ranged",
     "notes": "",
     "hordeHp": 1,
     "experiences": {

--- a/src/packs/adversaries/adversary_Minor_Demon_3tqCjDwJAQ7JKqMb.json
+++ b/src/packs/adversaries/adversary_Minor_Demon_3tqCjDwJAQ7JKqMb.json
@@ -104,6 +104,7 @@
         ]
       },
       "type": "attack",
+      "range": "melee",
       "chatDisplay": false
     },
     "attribution": {

--- a/src/packs/adversaries/adversary_Oak_Treant_XK78QUfY8c8Go8Uv.json
+++ b/src/packs/adversaries/adversary_Oak_Treant_XK78QUfY8c8Go8Uv.json
@@ -33,7 +33,7 @@
         "reduction": 0
       }
     },
-    "type": "standard",
+    "type": "bruiser",
     "notes": "",
     "hordeHp": 1,
     "experiences": {},
@@ -66,12 +66,12 @@
     "tier": 3,
     "description": "<p>A sturdy animate old-growth tree.</p>",
     "attack": {
-      "name": "Attack",
+      "name": "Branch",
       "roll": {
         "type": "attack",
         "bonus": 2
       },
-      "range": "close",
+      "range": "veryClose",
       "damage": {
         "parts": [
           {

--- a/src/packs/adversaries/adversary_Outer_Realms_Thrall_moJhHgKqTKPS2WYS.json
+++ b/src/packs/adversaries/adversary_Outer_Realms_Thrall_moJhHgKqTKPS2WYS.json
@@ -97,7 +97,7 @@
       },
       "img": "icons/creatures/claws/claw-talons-yellow-red.webp",
       "type": "attack",
-      "range": "melee",
+      "range": "veryClose",
       "chatDisplay": false
     },
     "attribution": {

--- a/src/packs/adversaries/adversary_Treant_Sapling_o63nS0k3wHu6EgKP.json
+++ b/src/packs/adversaries/adversary_Treant_Sapling_o63nS0k3wHu6EgKP.json
@@ -97,8 +97,8 @@
         ]
       },
       "type": "attack",
-      "chatDisplay": false,
-      "range": ""
+      "range": "melee",
+      "chatDisplay": false
     },
     "attribution": {
       "source": "Daggerheart SRD",

--- a/src/packs/adversaries/adversary_Young_Ice_Dragon_UGPiPLJsPvMTSKEF.json
+++ b/src/packs/adversaries/adversary_Young_Ice_Dragon_UGPiPLJsPvMTSKEF.json
@@ -110,7 +110,7 @@
       },
       "img": "icons/creatures/claws/claw-scaled-red.webp",
       "type": "attack",
-      "range": "melee",
+      "range": "close",
       "chatDisplay": false
     },
     "attribution": {

--- a/src/packs/adversaries/adversary_Zombie_Legion_YhJrP7rTBiRdX5Fp.json
+++ b/src/packs/adversaries/adversary_Zombie_Legion_YhJrP7rTBiRdX5Fp.json
@@ -97,7 +97,7 @@
           }
         ]
       },
-      "name": "Tentacles",
+      "name": "Undead Hands",
       "roll": {
         "bonus": 2,
         "type": "attack"


### PR DESCRIPTION
## Description

  Fix incorrect adversary data across 10 adversary pack files, including wrong attack ranges, stress values, adversary types, attack names, and damage dice.

  Changes:
  - **Adult Flickerfly**: Fixed damage dice (d10 → d20)
  - **Giant Recruit**: Fixed stress max (1 → 2)
  - **Hallowed Soldier**: Fixed stress max (1 → 2)
  - **Jagged Knife Sniper**: Fixed type (standard → ranged)
  - **Minor Demon**: Added missing melee range to attack (probably a default, but still added for... OCD reasons)
  - **Oak Treant**: Fixed type (standard → bruiser), attack name (Attack → Branch), range (close → veryClose)
  - **Outer Realms Thrall**: Fixed attack range (melee → veryClose)
  - **Treant Sapling**: Added missing melee range to attack (probably a default, but still added for... OCD reasons)
  - **Young Ice Dragon**: Fixed attack range (melee → close)
  - **Zombie Legion**: Fixed attack name (Tentacles → Undead Hands)

  Unfixable: 
  - **Outer Realms Abomination**: Has a damage bonus of 4 → 2d4, but a number is expected in the property

  ## Type of Change

  - [x] Bug fix

  ## How Has This Been Tested?

  - [x] Manual testing

  ## Checklist

  - [x] My code follows the project style guidelines
  - [x] I have performed a self-review of my code
  - [x] My changes generate no new warnings or errors

---

> Thank you for your contribution! 🎉
