### PR TITLE
[Feature] Increase the click area of sidebar and inventory control buttons

### DIFF
--- a/styles/less/global/inventory-item.less
+++ b/styles/less/global/inventory-item.less
@@ -103,10 +103,9 @@
                 display: flex;
                 align-items: center;
                 justify-content: end;
-                gap: 8px;
 
                 a {
-                    width: 15px;
+                    width: 20px;
                     text-align: center;
                 }
 
@@ -275,8 +274,10 @@
                 grid-area: controls;
                 align-self: start;
                 padding-top: 0.3125rem;
-                gap: 4px;
                 margin-bottom: -1px;
+                a {
+                    width: 18px;
+                }
             }
             > .item-labels {
                 align-self: start;

--- a/templates/sheets/global/partials/inventory-item-V2.hbs
+++ b/templates/sheets/global/partials/inventory-item-V2.hbs
@@ -109,7 +109,7 @@ Parameters:
         {{else if (eq type 'armor')}}
         <a class="{{#unless item.system.equipped}}unequipped{{/unless}}" data-action="toggleEquipItem"
           data-tooltip="DAGGERHEART.UI.Tooltip.{{ifThen item.system.equipped 'unequip' 'equip' }}">
-          <i class="fa-solid fa-shield"></i>
+          <i class="fa-solid fa-fw fa-shield"></i>
         </a>
         {{/if}}
         {{#if (eq type 'domainCard')}}
@@ -125,7 +125,7 @@ Parameters:
         {{/if}}
         {{#if (hasProperty item "toChat")}}
           <a data-action="toChat" data-tooltip="DAGGERHEART.UI.Tooltip.sendToChat">
-            <i class="fa-regular fa-message"></i>
+            <i class="fa-regular fa-fw fa-message"></i>
           </a>
         {{/if}}
       {{else}}
@@ -138,7 +138,7 @@ Parameters:
       {{/unless}}
       {{#unless hideContextMenu}}
       <a data-action="triggerContextMenu" data-tooltip="DAGGERHEART.UI.Tooltip.moreOptions">
-        <i class="fa-solid fa-ellipsis-vertical"></i>
+        <i class="fa-solid fa-fw fa-ellipsis-vertical"></i>
       </a>
       {{/unless}}
       {{/if}}


### PR DESCRIPTION
Replaces the gap for increased width. This should lead to almost equivalent controls, though some of the spacing has become part of the outside sides, so they're visually more clustered. Even so, they're easier to click.

Motivated because I missed the sidebar ellipses while testing twice.

Before
<img width="867" height="448" alt="image" src="https://github.com/user-attachments/assets/04783bf7-9f83-430b-9526-2d1aae4731e0" />

After
<img width="888" height="569" alt="image" src="https://github.com/user-attachments/assets/225f8ad3-f098-4308-be43-1675e052cd38" />
