### PR TITLE
[Fix] 1697 - DamageRolls DiceSoNice

### DIFF
--- a/module/dice/damageRoll.mjs
+++ b/module/dice/damageRoll.mjs
@@ -51,7 +51,8 @@ export default class DamageRoll extends DHRoll {
         await super.buildPost(roll, config, message);
         if (config.source?.message) {
             chatMessage.update({ 'system.damage': config.damage });
-            foundry.audio.AudioHelper.play({ src: CONFIG.sounds.dice });
+
+            if (!game.modules.get('dice-so-nice')?.active) foundry.audio.AudioHelper.play({ src: CONFIG.sounds.dice });
         }
     }
 


### PR DESCRIPTION
Fixes #1697 

Fixed three errors for DiceSoNice rolls with DamageActions:
- Because we sent in `config.rollMode` to the diceSoNice simulation method which by default is undefined, it ended up defaulting to whisper - meaning only the one rolling saw the dice roll. Now defaulting to Public instead.
- After a DiceSoNice roll was made for a damage action it also played the stock foundry dice rolling sound. It's now muted in that case.
- If DiceSoNice is -not- active, and the damage roll is coming from an roll message in chat, then no dice sound was played at all. Now it is.