### PR TITLE
[Fix] 1713 - Homebrew Domain Tooltip Icon

### DIFF
--- a/templates/ui/tooltip/domainCard.hbs
+++ b/templates/ui/tooltip/domainCard.hbs
@@ -5,7 +5,7 @@
             <i class="fa-solid fa-bolt"></i>
         </span>
         <span class="item-icon">
-            {{#with (lookup config.DOMAIN.domains item.system.domain) as | domain |}}
+            {{#with (lookup allDomains item.system.domain) as | domain |}}
                 <img src="{{domain.src}}" alt="">
             {{/with}}
         </span>


### PR DESCRIPTION
Fixes #1713 
Fixed so that domaincard tooltips properly use the all domains including homebrew