### PR TITLE
[v14] Fix damage icon when retrieving tooltip for attack

### DIFF
--- a/module/helpers/handlebarsHelper.mjs
+++ b/module/helpers/handlebarsHelper.mjs
@@ -49,7 +49,8 @@ export default class RegisterHandlebarsHelpers {
     }
 
     static damageSymbols(damageParts) {
-        const symbols = [...new Set(damageParts.map(x => x.type))].map(p => CONFIG.DH.GENERAL.damageTypes[p].icon);
+        const allTypes = [...new Set([...damageParts].flatMap(x => Array.from(x.type)))];
+        const symbols = allTypes.map(p => CONFIG.DH.GENERAL.damageTypes[p].icon);
         return new Handlebars.SafeString(Array.from(symbols).map(symbol => `<i class="fa-solid ${symbol}"></i>`));
     }
 


### PR DESCRIPTION
I'm not sure how the original ever worked tbh, the damage type was always a set field wasn't it?