### PR TITLE
[Fix] Multiterm Armor Effect Max

### DIFF
--- a/module/data/activeEffect/changeTypes/armor.mjs
+++ b/module/data/activeEffect/changeTypes/armor.mjs
@@ -44,7 +44,8 @@ export default class ArmorChange extends foundry.abstract.DataModel {
         label: 'Armor',
         defaultPriority: 20,
         handler: (actor, change, _options, _field, replacementData) => {
-            const parsedMax = itemAbleRollParse(change.value.max, actor, change.effect.parent);
+            const baseParsedMax = itemAbleRollParse(change.value.max, actor, change.effect.parent);
+            const parsedMax = new Roll(baseParsedMax).evaluateSync().total;
             game.system.api.documents.DhActiveEffect.applyChange(
                 actor,
                 {

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
     "id": "daggerheart",
     "title": "Daggerheart",
     "description": "An unofficial implementation of the Daggerheart system",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "compatibility": {
         "minimum": "14.359",
         "verified": "14.359",


### PR DESCRIPTION
Fixed so that multi term expressions get evaluated into a single number.
EX: Bare bones is set to max: `3 + @system.traits.strength.value`. After `itemAbleRollParse` that ends up as `3 + 2` which isn't a number, so it doesn't get applied. Now I use a roll to grab a total number. Might be another way to do it, don't recall.