### PR TITLE
[Fix] DiceSoNice Reroll Fixing

### DIFF
--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -246,7 +246,7 @@ export default class DHRoll extends Roll {
         return (this._formula = this.constructor.getFormula(this.terms));
     }
 
-    /** 
+    /**
      * Calculate total modifiers of any rolls, including non-dh rolls.
      * This exists because damage rolls still may receive base roll classes
      */
@@ -256,7 +256,7 @@ export default class DHRoll extends Roll {
             if (!roll.terms[i].isDeterministic) continue;
             const termTotal = roll.terms[i].total;
             if (typeof termTotal === 'number') {
-                const multiplier = roll.terms[i - 1]?.operator === " - " ? -1 : 1;
+                const multiplier = roll.terms[i - 1]?.operator === ' - ' ? -1 : 1;
                 modifierTotal += multiplier * termTotal;
             }
         }
@@ -272,7 +272,7 @@ export default class DHRoll extends Roll {
         const changeKeys = this.getActionChangeKeys();
         return (
             this.options.effects?.reduce((acc, effect) => {
-                if (effect.system.changes.some(x => changeKeys.some(key => x.key.includes(key)))) {
+                if (effect.system.changes.some(x => changeKeys.some(key => x.key?.includes(key)))) {
                     acc[effect.id] = {
                         id: effect.id,
                         name: effect.name,

--- a/module/dice/die/_module.mjs
+++ b/module/dice/die/_module.mjs
@@ -1,9 +1,13 @@
 import DualityDie from './dualityDie.mjs';
+import HopeDie from './hopeDie.mjs';
+import FearDie from './fearDie.mjs';
 import AdvantageDie from './advantageDie.mjs';
 import DisadvantageDie from './disadvantageDie.mjs';
 
 export const diceTypes = {
     DualityDie,
+    HopeDie,
+    FearDie,
     AdvantageDie,
     DisadvantageDie
 };

--- a/module/dice/die/dualityDie.mjs
+++ b/module/dice/die/dualityDie.mjs
@@ -43,9 +43,10 @@ export default class DualityDie extends foundry.dice.terms.Die {
                     options: { appearance: {} }
                 };
 
-                const preset = await getDiceSoNicePreset(diceSoNice[key], faces);
-                diceSoNiceRoll.dice[0].options.appearance = preset.appearance;
-                diceSoNiceRoll.dice[0].options.modelFile = preset.modelFile;
+                const diceAppearance = await this.getDiceSoNiceAppearance(options.liveRoll.roll);
+                diceSoNiceRoll.dice[0].options.appearance = diceAppearance.appearance;
+                diceSoNiceRoll.dice[0].options.modelFile = diceAppearance.modelFile;
+                diceSoNiceRoll.dice[0].results = diceSoNiceRoll.dice[0].results.filter(x => x.active);
 
                 await game.dice3d.showForRoll(diceSoNiceRoll, game.user, true);
             } else {
@@ -58,5 +59,12 @@ export default class DualityDie extends foundry.dice.terms.Die {
             const newDuality = this.#getDualityState(options.liveRoll.roll);
             this.#updateResources(oldDuality, newDuality, options.liveRoll.actor);
         }
+    }
+
+    /**
+     * Overridden by extending classes HopeDie and FearDie
+     */
+    async getDiceSoNiceAppearance() {
+        return {};
     }
 }

--- a/module/dice/die/fearDie.mjs
+++ b/module/dice/die/fearDie.mjs
@@ -1,0 +1,9 @@
+import { getDiceSoNicePresets } from '../../config/generalConfig.mjs';
+import DualityDie from './dualityDie.mjs';
+
+export default class FearDie extends DualityDie {
+    async getDiceSoNiceAppearance(roll) {
+        const { fear } = await getDiceSoNicePresets(roll, this.denomination, this.denomination);
+        return fear;
+    }
+}

--- a/module/dice/die/hopeDie.mjs
+++ b/module/dice/die/hopeDie.mjs
@@ -1,0 +1,9 @@
+import { getDiceSoNicePresets } from '../../config/generalConfig.mjs';
+import DualityDie from './dualityDie.mjs';
+
+export default class HopeDie extends DualityDie {
+    async getDiceSoNiceAppearance(roll) {
+        const { hope } = await getDiceSoNicePresets(roll, this.denomination, this.denomination);
+        return hope;
+    }
+}

--- a/module/dice/dualityRoll.mjs
+++ b/module/dice/dualityRoll.mjs
@@ -24,7 +24,7 @@ export default class DualityRoll extends D20Roll {
     }
 
     get dHope() {
-        if (!(this.dice[0] instanceof game.system.api.dice.diceTypes.DualityDie)) this.createBaseDice();
+        if (!(this.dice[0] instanceof game.system.api.dice.diceTypes.HopeDie)) this.createBaseDice();
         return this.dice[0];
     }
 
@@ -34,7 +34,7 @@ export default class DualityRoll extends D20Roll {
     }
 
     get dFear() {
-        if (!(this.dice[1] instanceof game.system.api.dice.diceTypes.DualityDie)) this.createBaseDice();
+        if (!(this.dice[1] instanceof game.system.api.dice.diceTypes.FearDie)) this.createBaseDice();
         return this.dice[1];
     }
 
@@ -68,8 +68,8 @@ export default class DualityRoll extends D20Roll {
     }
 
     get extraDice() {
-        const { DualityDie, AdvantageDie, DisadvantageDie } = game.system.api.dice.diceTypes;
-        return this.dice.filter(x => ![DualityDie, AdvantageDie, DisadvantageDie].some(die => x instanceof die));
+        const { HopeDie, FearDie, AdvantageDie, DisadvantageDie } = game.system.api.dice.diceTypes;
+        return this.dice.filter(x => ![HopeDie, FearDie, AdvantageDie, DisadvantageDie].some(die => x instanceof die));
     }
 
     setRallyChoices() {
@@ -125,8 +125,8 @@ export default class DualityRoll extends D20Roll {
 
     /** @inheritDoc */
     static fromData(data) {
-        data.terms[0].class = 'DualityDie';
-        data.terms[2].class = 'DualityDie';
+        data.terms[0].class = 'HopeDie';
+        data.terms[2].class = 'FearDie';
         if (data.options.roll.advantage?.type && data.terms[4]?.faces) {
             data.terms[4].class = data.options.roll.advantage.type === 1 ? 'AdvantageDie' : 'DisadvantageDie';
         }
@@ -135,18 +135,18 @@ export default class DualityRoll extends D20Roll {
 
     createBaseDice() {
         if (
-            this.dice[0] instanceof game.system.api.dice.diceTypes.DualityDie &&
-            this.dice[1] instanceof game.system.api.dice.diceTypes.DualityDie
+            this.dice[0] instanceof game.system.api.dice.diceTypes.HopeDie &&
+            this.dice[1] instanceof game.system.api.dice.diceTypes.FearDie
         ) {
             this.terms = [this.terms[0], this.terms[1], this.terms[2]];
             return;
         }
 
-        this.terms[0] = new game.system.api.dice.diceTypes.DualityDie({
+        this.terms[0] = new game.system.api.dice.diceTypes.HopeDie({
             faces: this.data.rules.dualityRoll?.defaultHopeDice ?? 12
         });
         this.terms[1] = new foundry.dice.terms.OperatorTerm({ operator: '+' });
-        this.terms[2] = new game.system.api.dice.diceTypes.DualityDie({
+        this.terms[2] = new game.system.api.dice.diceTypes.FearDie({
             faces: this.data.rules.dualityRoll?.defaultFearDice ?? 12
         });
     }


### PR DESCRIPTION
Now that DiceSoNice is updated, I could actually test the duality roll functionality.
I fixed it - and I made a further subtyping of HopeDie and FearDie as a neat way to know which sort of styling the dice should have on rerolling.