### PR TITLE
[Fix] 1776 - Longrest Repair Armor Error

### DIFF
--- a/module/config/generalConfig.mjs
+++ b/module/config/generalConfig.mjs
@@ -484,7 +484,7 @@ export const defaultRestOptions = {
                                 value: {
                                     custom: {
                                         enabled: true,
-                                        formula: '@system.armorScore'
+                                        formula: '@system.armorScore.max'
                                     }
                                 }
                             }

--- a/module/systemRegistration/migrations.mjs
+++ b/module/systemRegistration/migrations.mjs
@@ -1,3 +1,4 @@
+import { defaultRestOptions } from '../config/generalConfig.mjs';
 import { RefreshType, socketEvent } from './socket.mjs';
 
 export async function runMigrations() {
@@ -340,6 +341,18 @@ export async function runMigrations() {
         progress.close();
 
         lastMigrationVersion = '2.0.0';
+    }
+
+    if (foundry.utils.isNewerVersion('2.0.4', lastMigrationVersion)) {
+        const downtimeMoves = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Homebrew);
+        if (restMoves.longRest.moves.repairArmor) {
+            await downtimeMoves.updateSource({
+                'restMoves.longRest.moves.repairArmor': defaultRestOptions.longRest().repairArmor
+            });
+            game.settings.set(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Homebrew, downtimeMoves.toObject());
+        }
+
+        lastMigrationVersion = '2.0.4';
     }
     //#endregion
 

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
     "id": "daggerheart",
     "title": "Daggerheart",
     "description": "An unofficial implementation of the Daggerheart system",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "compatibility": {
         "minimum": "14.359",
         "verified": "14.359",


### PR DESCRIPTION
Fixes #1776 
Updated the longrest repair armor to the new armor max path.
I made a migration that resets that downtime move to the now updated default in existing worlds. Usually we don't touch the downtime moves since they could have been homebrewed, but in this case I think a reset is warranted.