### PR TITLE
[Feature] 1773 - More obvious character setup button

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -353,7 +353,7 @@
                 "selectSecondaryWeapon": "Select Secondary Weapon",
                 "selectSubclass": "Select Subclass",
                 "setupSkipTitle": "Skipping Character Setup",
-                "setupSkipContent": "You are skipping the Character Setup by adding this manually. The character setup is the blinking arrows in the top-right. Are you sure you want to continue?",
+                "setupSkipContent": "You are skipping the Character Setup by adding this manually. The character setup is the blinking button in the top-right. Are you sure you want to continue?",
                 "startingItems": "Starting Items",
                 "story": "Story",
                 "storyExplanation": "Select which background and connection prompts you want to copy into your character's background.",

--- a/templates/sheets/actors/character/header.hbs
+++ b/templates/sheets/actors/character/header.hbs
@@ -4,17 +4,27 @@
         <h1 class="actor-name input" contenteditable="plaintext-only" data-property="name" placeholder="{{localize "DAGGERHEART.GENERAL.actorName"}}">{{source.name}}</h1>
         <div class='level-div'>
             <h3 class='label'>
-                {{#if (or document.system.needsCharacterSetup document.system.levelData.canLevelUp)}}
+                {{#if document.system.needsCharacterSetup}}
                     <button
                         type="button"
-                        class="level-button glow" data-tooltip="{{#if document.system.needsCharacterSetup}}{{localize "DAGGERHEART.APPLICATIONS.CharacterCreation.buttonTitle"}}{{else}}{{localize "DAGGERHEART.ACTORS.Character.levelUp"}}{{/if}}"
+                        class="level-button glow"
+                        data-action="levelManagement"
+                    >
+                        {{localize "DAGGERHEART.APPLICATIONS.CharacterCreation.buttonTitle"}}
+                    </button>
+                {{else if document.system.levelData.canLevelUp}}
+                    <button
+                        type="button"
+                        class="level-button glow" data-tooltip="{{localize "DAGGERHEART.ACTORS.Character.levelUp"}}"
                         data-action="levelManagement"
                     >
                         <i class="fa-solid fa-angles-up"></i>
                     </button>
                 {{/if}}
-                {{localize 'DAGGERHEART.GENERAL.level'}}
-                <input type="text" data-dtype="Number" class="level-value" value={{#if document.system.needsCharacterSetup}}0{{else}}{{document.system.levelData.level.changed}}{{/if}} {{#if document.system.needsCharacterSetup}}disabled{{/if}} />
+                {{#unless document.system.needsCharacterSetup}}
+                    {{localize 'DAGGERHEART.GENERAL.level'}}
+                    <input type="text" data-dtype="Number" class="level-value" value={{#if document.system.needsCharacterSetup}}0{{else}}{{document.system.levelData.level.changed}}{{/if}} {{#if document.system.needsCharacterSetup}}disabled{{/if}} />
+                {{/unless}}
             </h3>
         </div>
     </div>


### PR DESCRIPTION
Fixes #1773 
Changed the character setup button to be more obvious and not rendering the level field in this state
<img width="346" height="147" alt="image" src="https://github.com/user-attachments/assets/12e2efdb-2f45-4097-b8b0-b7db854dda27" />
