### PR TITLE
Traits on character creator and character edit dialog fix

### DIFF
--- a/styles/less/dialog/character-creation/selections-container.less
+++ b/styles/less/dialog/character-creation/selections-container.less
@@ -250,6 +250,11 @@
                     height: 65px;
                     background: url(../assets/svg/trait-shield.svg) no-repeat;
                     background-size: 100%;
+                    padding-top: 3px;
+                    display: flex;
+                    flex-direction: column;
+                    align-items: center;
+                    row-gap: 3px;
 
                     div {
                         filter: drop-shadow(0 0 3px black);

--- a/styles/less/sheets-settings/character-settings/sheet.less
+++ b/styles/less/sheets-settings/character-settings/sheet.less
@@ -27,10 +27,11 @@
                 height: 65px;
                 background: url(../assets/svg/trait-shield.svg) no-repeat;
                 background-size: 100%;
-                padding-top: 4px;
+                padding-top: 3px;
                 display: flex;
                 flex-direction: column;
                 align-items: center;
+                row-gap: 3px;
 
                 span {
                     font-size: var(--font-size-10);


### PR DESCRIPTION
## Description

Made changes to CSS to have a flex container for traits in character creator and slight css fix for traits in spanner dialog to make it consistent.

## Type of Change

- [x] Bug fix
- [x] Code cleanup/refactor

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x] Manual testing

## Screenshots (if applicable)

<img width="679" height="315" alt="image" src="https://github.com/user-attachments/assets/c21e83f2-d828-4eed-906a-651c25e119c9" />

<img width="442" height="261" alt="image" src="https://github.com/user-attachments/assets/b98fbb54-6af3-432c-969c-7d3ac55fb593" />


## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
