### PR TITLE
[Fix] Compendium Advantage Sources

### DIFF
--- a/src/packs/ancestries/feature_Retract_UFR67BUOhNGLFyg9.json
+++ b/src/packs/ancestries/feature_Retract_UFR67BUOhNGLFyg9.json
@@ -68,31 +68,33 @@
           "type": "withinRange",
           "target": "hostile",
           "range": "melee"
+        },
+        "changes": [
+          {
+            "key": "system.resistance.physical.resistance",
+            "type": "override",
+            "value": 1,
+            "priority": null,
+            "phase": "initial"
+          },
+          {
+            "key": "system.disadvantageSources",
+            "type": "add",
+            "value": "Action rolls",
+            "priority": null,
+            "phase": "initial"
+          }
+        ],
+        "duration": {
+          "type": ""
         }
       },
-      "changes": [
-        {
-          "key": "system.resistance.physical.resistance",
-          "mode": 5,
-          "value": "1",
-          "priority": null
-        },
-        {
-          "key": "system.disadvantageSources",
-          "mode": 2,
-          "value": "Retract",
-          "priority": null
-        }
-      ],
       "disabled": true,
       "duration": {
-        "startTime": null,
-        "combat": null,
-        "seconds": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "<p>While in your shell, you have resistance to physical damage, you have disadvantage on action rolls, and you can’t move.</p>",
       "tint": "#ffffff",
@@ -102,6 +104,16 @@
       "_stats": {
         "compendiumSource": null
       },
+      "start": {
+        "time": 0,
+        "combat": null,
+        "combatant": null,
+        "initiative": null,
+        "round": null,
+        "turn": null
+      },
+      "showIcon": 1,
+      "folder": null,
       "_key": "!items.effects!UFR67BUOhNGLFyg9.3V4FPoyjJUnFP9WS"
     }
   ],

--- a/src/packs/communities/feature_Low_Light_Living_aMla3xQuCHEwORGD.json
+++ b/src/packs/communities/feature_Low_Light_Living_aMla3xQuCHEwORGD.json
@@ -29,39 +29,28 @@
           "type": "withinRange",
           "target": "hostile",
           "range": "melee"
+        },
+        "changes": [
+          {
+            "key": "system.advantageSources",
+            "type": "add",
+            "value": "Rolls to hide, investigate, or perceive details in low light",
+            "priority": null,
+            "phase": "initial"
+          }
+        ],
+        "duration": {
+          "type": ""
         }
       },
-      "changes": [
-        {
-          "key": "system.advantageSources",
-          "mode": 2,
-          "value": "In an area with low light or heavy shadow: hide, investigate, or perceive",
-          "priority": null
-        },
-        {
-          "key": "system.advantageSources",
-          "mode": 2,
-          "value": "",
-          "priority": null
-        },
-        {
-          "key": "",
-          "mode": 2,
-          "value": "",
-          "priority": null
-        }
-      ],
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null,
-        "seconds": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
-      "description": "",
+      "description": "<p>When you’re in an area with low light or heavy shadow, you have advantage on rolls to hide, investigate, or perceive details within that area.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -71,6 +60,16 @@
       "_stats": {
         "compendiumSource": null
       },
+      "start": {
+        "time": 0,
+        "combat": null,
+        "combatant": null,
+        "initiative": null,
+        "round": null,
+        "turn": null
+      },
+      "showIcon": 1,
+      "folder": null,
       "_key": "!items.effects!aMla3xQuCHEwORGD.pCp32u7UwqxCI4WW"
     }
   ],

--- a/src/packs/domains/domainCard_Battle_Cry_Ef1JsUG50LIoKx2F.json
+++ b/src/packs/domains/domainCard_Battle_Cry_Ef1JsUG50LIoKx2F.json
@@ -132,27 +132,29 @@
           "type": "withinRange",
           "target": "hostile",
           "range": "melee"
+        },
+        "changes": [
+          {
+            "key": "system.advantageSources",
+            "type": "add",
+            "value": "On Attacks",
+            "priority": null,
+            "phase": "initial"
+          }
+        ],
+        "duration": {
+          "type": "temporary",
+          "description": "<p>Until you or an ally rolls a failure with Fear.</p>"
         }
       },
-      "changes": [
-        {
-          "key": "system.advantageSources",
-          "mode": 2,
-          "value": "1",
-          "priority": null
-        }
-      ],
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null,
-        "seconds": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
-      "description": "",
+      "description": "<p>You gain advantage on attack rolls until you or an ally rolls a failure with Fear.</p>",
       "tint": "#ffffff",
       "statuses": [],
       "sort": 0,
@@ -160,6 +162,16 @@
       "_stats": {
         "compendiumSource": null
       },
+      "start": {
+        "time": 0,
+        "combat": null,
+        "combatant": null,
+        "initiative": null,
+        "round": null,
+        "turn": null
+      },
+      "showIcon": 1,
+      "folder": null,
       "_key": "!items.effects!Ef1JsUG50LIoKx2F.s7ma4TNgAvt0ZgEW"
     }
   ],

--- a/templates/sheets/activeEffect/settings.hbs
+++ b/templates/sheets/activeEffect/settings.hbs
@@ -26,11 +26,11 @@
 
         {{formGroup systemFields.duration.fields.type value=source.system.duration.type localize=true }}
 
-            <div class="form-group slim duration-description">
-                <div class="form-fields">
-                    {{formInput systemFields.duration.fields.description value=source.system.duration.description localize=true }}
-                </div>
+        <div class="form-group slim duration-description {{#if (eq source.system.duration.type 'temporary')}}visible{{/if}}">
+            <div class="form-fields">
+                {{formInput systemFields.duration.fields.description value=source.system.duration.description localize=true }}
             </div>
+        </div>
 
         <div class="custom-duration-section">
             {{formGroup fields.start.fields.time value=source.start.time localize=true }}


### PR DESCRIPTION
- Active Effect duration description field didn't show initially when the type was temporary
- Fixed SRD cases where advantageSource/disadvantageSource was set to a bad value.