### PR TITLE
Fix Include Item Damage error in v14 damage system

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,34 +1,49 @@
 ---
-name: Bug report
-about: Create a bug report to help us identify issues and resolve them
-title: "[Bug] <Insert Title here> "
-labels: bug
-type: bug
+name: 🐛 Bug Report
+about: Create a report to help us improve
+title: '[BUG] '
+labels: 'bug'
 assignees: ''
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+## Bug Description
 
-**To Reproduce**
-Steps to reproduce the behavior:
+<!-- A clear and concise description of what the bug is -->
+
+## Steps To Reproduce
+
+<!-- Steps to reproduce the behavior -->
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+## Expected Behavior
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+<!-- A clear and concise description of what you expected to happen -->
 
-**Setup Information:**
- - OS: [e.g. iOS, Windows]
- - Browser [e.g. chrome, safari]
- - Foundry Version [e.g. v13 b342]
-- System Version [e.g. v.1.0, v.1.0.1]
+## Actual Behavior
 
+<!-- What actually happened -->
 
-**Additional context**
-Add any other context about the problem here.
+## Screenshots
+
+<!-- If applicable, add screenshots to help explain your problem -->
+
+## Environment
+
+<!-- Please complete the following information -->
+
+- Foundry VTT Version: [e.g. 12.331]
+- Daggerheart System Version: [e.g. 1.0.0]
+- Browser: [e.g. Chrome, Firefox, Edge]
+- OS: [e.g. Windows, macOS, Linux]
+
+## Additional Context
+
+<!-- Add any other context about the problem here -->
+
+## Possible Solution
+
+<!-- Optional: If you have suggestions on how to fix the bug -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,46 @@
+## Description
+
+<!-- Provide a brief description of what this PR does -->
+
+## Type of Change
+
+<!-- Check all that apply -->
+
+- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
+- [ ] ✨ New feature (non-breaking change which adds functionality)
+- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] 📝 Documentation update
+- [ ] 🎨 UI/UX improvement
+- [ ] 🔧 Code refactoring
+- [ ] ⚡ Performance improvement
+
+## Testing
+
+<!-- Describe the tests you ran and how to reproduce them -->
+
+- [ ] I have tested this locally in Foundry VTT
+- [ ] All existing tests pass
+- [ ] I have added tests that prove my fix is effective or that my feature works
+
+## Screenshots (if applicable)
+
+<!-- Add screenshots or GIFs to demonstrate UI/UX changes -->
+
+## Checklist
+
+- [ ] My code follows the project's style guidelines
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] Any dependent changes have been merged and published
+
+## Related Issues
+
+<!-- Link any related issues using #issue-number -->
+
+Fixes #
+
+## Additional Notes
+
+<!-- Add any other context about the PR here -->

--- a/lang/en.json
+++ b/lang/en.json
@@ -39,6 +39,11 @@
 
     "DAGGERHEART": {
         "CharacterSheet": "Character Sheet",
+        "ITEM_GROUPS": {
+            "INVENTORY": "Inventory Items",
+            "CHARACTER": "Character Items",
+            "OTHER": "Other"
+        },
         "ACTIONS": {
             "TYPES": {
                 "attack": {
@@ -1942,6 +1947,9 @@
                 }
             }
         },
+        "ACTIVE_EFFECT": {
+            "NEW_EFFECT": "New Effect"
+        },
         "EFFECTS": {
             "ApplyLocations": {
                 "attackRoll": {
@@ -2623,8 +2631,10 @@
             }
         },
         "ROLLTABLES": {
+            "DEFAULT_FORMULA_NAME": "Roll Formula",
             "FIELDS": {
-                "formulaName": { "label": "Formula Name" }
+                "formulaName": { "label": "Formula Name" },
+                "formula": { "label": "Formula Roll" }
             },
             "formula": "Formula"
         },

--- a/module/data/action/attackAction.mjs
+++ b/module/data/action/attackAction.mjs
@@ -11,9 +11,13 @@ export default class DHAttackAction extends DHDamageAction {
     prepareData() {
         super.prepareData();
         if (!!this.item?.system?.attack) {
+            // In v14, we only allow a single instance of damage
+            // If includeBase is checked, use the weapon's damage instead of the action's damage
             if (this.damage.includeBase) {
                 const baseDamage = this.getParentDamage();
-                this.damage.parts.unshift(new DHDamageData(baseDamage));
+                // Replace the action damage with the weapon's base damage
+                this.damage.parts = new Map();
+                this.damage.parts.set('hitPoints', new DHDamageData(baseDamage));
             }
             if (this.roll.useDefault) {
                 this.roll.trait = this.item.system.attack.roll.trait;

--- a/module/data/activeEffect/baseEffect.mjs
+++ b/module/data/activeEffect/baseEffect.mjs
@@ -133,7 +133,7 @@ export default class BaseEffect extends foundry.data.ActiveEffectTypeDataModel {
 
     static getDefaultObject() {
         return {
-            name: 'New Effect',
+            name: game.i18n.localize('DAGGERHEART.ACTIVE_EFFECT.NEW_EFFECT'),
             id: foundry.utils.randomID(),
             disabled: false,
             img: 'icons/magic/life/heart-cross-blue.webp',

--- a/module/data/fields/action/damageField.mjs
+++ b/module/data/fields/action/damageField.mjs
@@ -16,7 +16,7 @@ export default class DamageField extends fields.SchemaField {
             parts: new IterableTypedObjectField(DHDamageData),
             includeBase: new fields.BooleanField({
                 initial: false,
-                label: 'DAGGERHEART.ACTIONS.Settings.includeBase.label'
+                label: 'DAGGERHEART.ACTIONS.Settings.useItemDamage.label'
             }),
             direct: new fields.BooleanField({ initial: false, label: 'DAGGERHEART.CONFIG.DamageType.direct.name' }),
             groupAttack: new fields.StringField({

--- a/module/data/rollTable.mjs
+++ b/module/data/rollTable.mjs
@@ -9,7 +9,7 @@ export default class DhRollTable extends foundry.abstract.TypeDataModel {
             formulaName: new fields.StringField({
                 required: true,
                 nullable: false,
-                initial: 'Roll Formula',
+                initial: () => game.i18n.localize('DAGGERHEART.ROLLTABLES.DEFAULT_FORMULA_NAME'),
                 label: 'DAGGERHEART.ROLLTABLES.FIELDS.formulaName.label'
             }),
             altFormula: new fields.TypedObjectField(
@@ -17,10 +17,10 @@ export default class DhRollTable extends foundry.abstract.TypeDataModel {
                     name: new fields.StringField({
                         required: true,
                         nullable: false,
-                        initial: 'Roll Formula',
+                        initial: () => game.i18n.localize('DAGGERHEART.ROLLTABLES.DEFAULT_FORMULA_NAME'),
                         label: 'DAGGERHEART.ROLLTABLES.FIELDS.formulaName.label'
                     }),
-                    formula: new FormulaField({ label: 'Formula Roll', initial: '1d20' })
+                    formula: new FormulaField({ label: 'DAGGERHEART.ROLLTABLES.FIELDS.formula.label', initial: '1d20' })
                 })
             ),
             activeAltFormula: new fields.StringField({ nullable: true, initial: null })

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -87,10 +87,10 @@ export default class DHItem extends foundry.documents.Item {
                 const isInventoryItem = CONFIG.Item.dataModels[type]?.metadata?.isInventoryItem;
                 const group =
                     isInventoryItem === true
-                        ? 'Inventory Items' //TODO localize
+                        ? game.i18n.localize('DAGGERHEART.ITEM_GROUPS.INVENTORY')
                         : isInventoryItem === false
-                          ? 'Character Items' //TODO localize
-                          : 'Other'; //TODO localize
+                          ? game.i18n.localize('DAGGERHEART.ITEM_GROUPS.CHARACTER')
+                          : game.i18n.localize('DAGGERHEART.ITEM_GROUPS.OTHER');
 
                 return { value: type, label, group };
             }


### PR DESCRIPTION
- Change behavior from 'Include Item Damage' to 'Use Item Damage'
- Replace action damage with weapon base damage instead of unshift
- Fixes error where unshift fails due to v14 single damage instance limit
- Update label to reflect new behavior

Fixes Foundryborne/daggerheart#1794

---
name: Pull Request
about: Create a new pull request
title: '[PR] <Insert Title here>'
labels: pr
assignees: ''
---

Is this a community PR? Please go to preview tab and click [here](?expand=1&template=community_pull_request_template.md). If not, delete this line.

## Description

Please include a summary of the change and which issue is fixed (if applicable). Also include relevant context or motivation for the change.

- Fixes #(issue)
- Closes #(issue)

## Type of Change

Please check the relevant options:

- [ ] Bug fix
- [ ] New feature
- [ ] Code cleanup/refactor
- [ ] Documentation update
- [ ] Test coverage
- [ ] Dependency update
- [ ] Configuration change
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [ ] Manual testing
- [ ] Other:

## Screenshots (if applicable)

Include screenshots or GIFs to help explain your changes visually.

## Checklist

- [ ] My code follows the project style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix or feature works
- [ ] New and existing tests pass locally with my changes

## Additional Comments

Add any other context or questions here.

---

> Thank you for your contribution! 🎉
