### PR TITLE
[Feature] Active Party

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3212,7 +3212,7 @@
                     "companion": "Level {level} - {partner}",
                     "companionNoPartner": "No Partner",
                     "duplicateToNewTier": "Duplicate to New Tier",
-                    "activateParty": "Make Activate Party",
+                    "activateParty": "Make Active Party",
                     "partyIsActive": "Active",
                     "createAdversary": "Create Adversary",
                     "pickTierTitle": "Pick a new tier for this adversary"

--- a/lang/en.json
+++ b/lang/en.json
@@ -236,6 +236,8 @@
                 },
                 "defaultHopeDice": "Default Hope Dice",
                 "defaultFearDice": "Default Fear Dice",
+                "defaultAdvantageDice": "Default Advantage Dice",
+                "defaultDisadvantageDice": "Default Disadvantage Dice",
                 "disadvantageSources": {
                     "label": "Disadvantage Sources",
                     "hint": "Add single words or short text as reminders and hints of what a character has disadvantage on."
@@ -3210,6 +3212,8 @@
                     "companion": "Level {level} - {partner}",
                     "companionNoPartner": "No Partner",
                     "duplicateToNewTier": "Duplicate to New Tier",
+                    "activateParty": "Make Activate Party",
+                    "partyIsActive": "Active",
                     "createAdversary": "Create Adversary",
                     "pickTierTitle": "Pick a new tier for this adversary"
                 },

--- a/module/applications/sidebar/tabs/actorDirectory.mjs
+++ b/module/applications/sidebar/tabs/actorDirectory.mjs
@@ -103,9 +103,7 @@ export default class DhActorDirectory extends foundry.applications.sidebar.tabs.
                     if (!actor) throw new Error('Unexpected missing actor');
 
                     const currentActiveParty = game.actors.find(x => x.type === 'party' && x.system.active);
-                    if (currentActiveParty)
-                        await currentActiveParty.update({ 'system.active': false });
-
+                    await currentActiveParty?.update({ 'system.active': false });
                     await actor.update({ 'system.active': true });
                     ui.actors.render();
                 }

--- a/module/applications/sidebar/tabs/actorDirectory.mjs
+++ b/module/applications/sidebar/tabs/actorDirectory.mjs
@@ -46,50 +46,71 @@ export default class DhActorDirectory extends foundry.applications.sidebar.tabs.
 
     _getEntryContextOptions() {
         const options = super._getEntryContextOptions();
-        options.push({
-            name: 'DAGGERHEART.UI.Sidebar.actorDirectory.duplicateToNewTier',
-            icon: `<i class="fa-solid fa-arrow-trend-up" inert></i>`,
-            condition: li => {
-                const actor = game.actors.get(li.dataset.entryId);
-                return actor?.type === 'adversary' && actor.system.type !== 'social';
-            },
-            callback: async li => {
-                const actor = game.actors.get(li.dataset.entryId);
-                if (!actor) throw new Error('Unexpected missing actor');
+        options.push(
+            {
+                name: 'DAGGERHEART.UI.Sidebar.actorDirectory.duplicateToNewTier',
+                icon: `<i class="fa-solid fa-arrow-trend-up" inert></i>`,
+                condition: li => {
+                    const actor = game.actors.get(li.dataset.entryId);
+                    return actor?.type === 'adversary' && actor.system.type !== 'social';
+                },
+                callback: async li => {
+                    const actor = game.actors.get(li.dataset.entryId);
+                    if (!actor) throw new Error('Unexpected missing actor');
 
-                const tiers = [1, 2, 3, 4].filter(t => t !== actor.system.tier);
-                const content = document.createElement('div');
-                const select = document.createElement('select');
-                select.name = 'tier';
-                select.append(
-                    ...tiers.map(t => {
-                        const option = document.createElement('option');
-                        option.value = t;
-                        option.textContent = game.i18n.localize(`DAGGERHEART.GENERAL.Tiers.${t}`);
-                        return option;
-                    })
-                );
-                content.append(select);
+                    const tiers = [1, 2, 3, 4].filter(t => t !== actor.system.tier);
+                    const content = document.createElement('div');
+                    const select = document.createElement('select');
+                    select.name = 'tier';
+                    select.append(
+                        ...tiers.map(t => {
+                            const option = document.createElement('option');
+                            option.value = t;
+                            option.textContent = game.i18n.localize(`DAGGERHEART.GENERAL.Tiers.${t}`);
+                            return option;
+                        })
+                    );
+                    content.append(select);
 
-                const tier = await foundry.applications.api.Dialog.input({
-                    classes: ['dh-style', 'dialog'],
-                    window: { title: 'DAGGERHEART.UI.Sidebar.actorDirectory.pickTierTitle' },
-                    content,
-                    ok: {
-                        label: 'DAGGERHEART.UI.Sidebar.actorDirectory.createAdversary',
-                        callback: (event, button, dialog) => Number(button.form.elements.tier.value)
+                    const tier = await foundry.applications.api.Dialog.input({
+                        classes: ['dh-style', 'dialog'],
+                        window: { title: 'DAGGERHEART.UI.Sidebar.actorDirectory.pickTierTitle' },
+                        content,
+                        ok: {
+                            label: 'DAGGERHEART.UI.Sidebar.actorDirectory.createAdversary',
+                            callback: (event, button, dialog) => Number(button.form.elements.tier.value)
+                        }
+                    });
+
+                    if (tier === actor.system.tier) {
+                        ui.notifications.warn('This actor is already at this tier');
+                    } else if (tier) {
+                        const source = actor.system.adjustForTier(tier);
+                        await Actor.create(source);
+                        ui.notifications.info(`Tier ${tier} ${actor.name} created`);
                     }
-                });
+                }
+            },
+            {
+                name: 'DAGGERHEART.UI.Sidebar.actorDirectory.activateParty',
+                icon: `<i class="fa-regular fa-square"></i>`,
+                condition: li => {
+                    const actor = game.actors.get(li.dataset.entryId);
+                    return actor && actor.type === 'party' && !actor.system.active;
+                },
+                callback: async li => {
+                    const actor = game.actors.get(li.dataset.entryId);
+                    if (!actor) throw new Error('Unexpected missing actor');
 
-                if (tier === actor.system.tier) {
-                    ui.notifications.warn('This actor is already at this tier');
-                } else if (tier) {
-                    const source = actor.system.adjustForTier(tier);
-                    await Actor.create(source);
-                    ui.notifications.info(`Tier ${tier} ${actor.name} created`);
+                    const currentActiveParty = game.actors.find(x => x.type === 'party' && x.system.active);
+                    if (currentActiveParty)
+                        await currentActiveParty.update({ 'system.active': false });
+
+                    await actor.update({ 'system.active': true });
+                    ui.actors.render();
                 }
             }
-        });
+        );
 
         return options;
     }

--- a/module/applications/sidebar/tabs/actorDirectory.mjs
+++ b/module/applications/sidebar/tabs/actorDirectory.mjs
@@ -102,9 +102,7 @@ export default class DhActorDirectory extends foundry.applications.sidebar.tabs.
                     const actor = game.actors.get(li.dataset.entryId);
                     if (!actor) throw new Error('Unexpected missing actor');
 
-                    const currentActiveParty = game.actors.find(x => x.type === 'party' && x.system.active);
-                    await currentActiveParty?.update({ 'system.active': false });
-                    await actor.update({ 'system.active': true });
+                    await game.settings.set(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.ActiveParty, actor.id);
                     ui.actors.render();
                 }
             }

--- a/module/config/settingsConfig.mjs
+++ b/module/config/settingsConfig.mjs
@@ -40,7 +40,8 @@ export const gameSettings = {
     LastMigrationVersion: 'LastMigrationVersion',
     SpotlightRequestQueue: 'SpotlightRequestQueue',
     CompendiumBrowserSettings: 'CompendiumBrowserSettings',
-    SpotlightTracker: 'SpotlightTracker'
+    SpotlightTracker: 'SpotlightTracker',
+    ActiveParty: 'ActiveParty',
 };
 
 export const actionAutomationChoices = {

--- a/module/data/actor/party.mjs
+++ b/module/data/actor/party.mjs
@@ -9,6 +9,7 @@ export default class DhParty extends BaseDataActor {
         const fields = foundry.data.fields;
         return {
             ...super.defineSchema(),
+            active: new fields.BooleanField(),
             partyMembers: new ForeignDocumentUUIDArrayField({ type: 'Actor' }, { prune: true }),
             notes: new fields.HTMLField(),
             gold: new fields.SchemaField({
@@ -42,6 +43,15 @@ export default class DhParty extends BaseDataActor {
                 member.parties?.add(this.parent);
             }
         }
+    }
+
+    /**@inheritdoc */
+    async _preCreate(data, options, user) {
+        const allowed = await super._preCreate(data, options, user);
+        if (allowed === false) return;
+
+        if (!game.actors.some(x => x.type === 'party' && x.active)) 
+            await this.updateSource({ active: true });
     }
 
     _onDelete(options, userId) {

--- a/module/data/actor/party.mjs
+++ b/module/data/actor/party.mjs
@@ -9,7 +9,6 @@ export default class DhParty extends BaseDataActor {
         const fields = foundry.data.fields;
         return {
             ...super.defineSchema(),
-            active: new fields.BooleanField(),
             partyMembers: new ForeignDocumentUUIDArrayField({ type: 'Actor' }, { prune: true }),
             notes: new fields.HTMLField(),
             gold: new fields.SchemaField({
@@ -21,6 +20,10 @@ export default class DhParty extends BaseDataActor {
             tagTeam: new fields.EmbeddedDataField(TagTeamData),
             groupRoll: new fields.EmbeddedDataField(GroupRollData)
         };
+    }
+
+    get active() {
+        return game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.ActiveParty) === this.parent.id;
     }
 
     /* -------------------------------------------- */
@@ -50,8 +53,15 @@ export default class DhParty extends BaseDataActor {
         const allowed = await super._preCreate(data, options, user);
         if (allowed === false) return;
 
-        if (!game.actors.some(x => x.type === 'party' && x.active)) 
-            await this.updateSource({ active: true });
+        if (!game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.ActiveParty)) 
+            game.settings.set(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.ActiveParty, this.parent.id);
+    }
+
+    async _preDelete() {
+        super._preDelete();
+    
+        if (this.active) 
+            game.settings.set(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.ActiveParty, null);
     }
 
     _onDelete(options, userId) {

--- a/module/data/actor/party.mjs
+++ b/module/data/actor/party.mjs
@@ -51,18 +51,11 @@ export default class DhParty extends BaseDataActor {
     _onCreate(data, options, userId) {
         super._onCreate(data, options, userId);
 
-        if (game.user.isActiveGM && !game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.ActiveParty)) {
+        if (game.user.isActiveGM && !game.actors.party) {
             game.settings.set(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.ActiveParty, this.parent.id).then(_ => {
                 ui.actors.render();
             });
         }
-    }
-
-    async _preDelete() {
-        super._preDelete();
-    
-        if (this.active) 
-            game.settings.set(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.ActiveParty, null);
     }
 
     _onDelete(options, userId) {
@@ -72,5 +65,11 @@ export default class DhParty extends BaseDataActor {
         for (const member of this.partyMembers) {
             member?.parties?.delete(this.parent);
         }
+
+        // If this *was* the active party, delete it. We can't use game.actors.party as this actor was already deleted
+        const isWorldActor = !this.parent?.parent && !this.parent.compendium;
+        const activePartyId = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.ActiveParty);
+        if (isWorldActor && this.id === activePartyId)
+            game.settings.set(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.ActiveParty, null);
     }
 }

--- a/module/data/actor/party.mjs
+++ b/module/data/actor/party.mjs
@@ -48,13 +48,14 @@ export default class DhParty extends BaseDataActor {
         }
     }
 
-    /**@inheritdoc */
-    async _preCreate(data, options, user) {
-        const allowed = await super._preCreate(data, options, user);
-        if (allowed === false) return;
+    _onCreate(data, options, userId) {
+        super._onCreate(data, options, userId);
 
-        if (!game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.ActiveParty)) 
-            game.settings.set(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.ActiveParty, this.parent.id);
+        if (game.user.isActiveGM && !game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.ActiveParty)) {
+            game.settings.set(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.ActiveParty, this.parent.id).then(_ => {
+                ui.actors.render();
+            });
+        }
     }
 
     async _preDelete() {

--- a/module/data/fields/action/summonField.mjs
+++ b/module/data/fields/action/summonField.mjs
@@ -1,3 +1,4 @@
+import { itemAbleRollParse } from '../../../helpers/utils.mjs';
 import FormulaField from '../formulaField.mjs';
 
 const fields = foundry.data.fields;
@@ -36,13 +37,12 @@ export default class DHSummonField extends fields.ArrayField {
         const rolls = [];
         const summonData = [];
         for (const summon of this.summon) {
-            let count = summon.count;
-            const roll = new Roll(summon.count);
-            if (!roll.isDeterministic) {
-                await roll.evaluate();
-                if (game.modules.get('dice-so-nice')?.active) rolls.push(roll);
-                count = roll.total;
-            }
+            const roll = new Roll(itemAbleRollParse(summon.count, this.actor, this.item));
+            await roll.evaluate();
+            const count = roll.total;
+            if (!roll.isDeterministic && game.modules.get('dice-so-nice')?.active) 
+                rolls.push(roll);
+            
 
             const actor = await DHSummonField.getWorldActor(await foundry.utils.fromUuid(summon.actorUUID));
             /* Extending summon data in memory so it's available in actionField.toChat. Think it's harmless, but ugly. Could maybe find a better way. */

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -125,6 +125,8 @@ export default class DhpActor extends Actor {
                 game.system.registeredTriggers.unregisterItemTriggers(token.actor.items);
             }
         }
+
+        if(this.system._preDelete() === false) return false;
     }
 
     _onDelete(options, userId) {

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -600,6 +600,7 @@ export default class DhpActor extends Actor {
         rollData.system = this.system.getRollData();
         rollData.prof = this.system.proficiency ?? 1;
         rollData.cast = this.system.spellcastModifier ?? 1;
+    
         return rollData;
     }
 

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -117,7 +117,9 @@ export default class DhpActor extends Actor {
         }
     }
 
-    async _preDelete() {
+    async _preDelete(options, user) {
+        if ((await super._preDelete(options, user)) === false) return false;
+
         if (this.prototypeToken.actorLink) {
             game.system.registeredTriggers.unregisterItemTriggers(this.items);
         } else {
@@ -125,8 +127,6 @@ export default class DhpActor extends Actor {
                 game.system.registeredTriggers.unregisterItemTriggers(token.actor.items);
             }
         }
-
-        if(this.system._preDelete() === false) return false;
     }
 
     _onDelete(options, userId) {

--- a/module/documents/collections/actorCollection.mjs
+++ b/module/documents/collections/actorCollection.mjs
@@ -1,4 +1,11 @@
 export default class DhActorCollection extends foundry.documents.collections.Actors {
+    /** @returns the active party */
+    get party() {
+        const id = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.ActiveParty);
+        const actor = game.actors.get(id);
+        return actor?.type === "party" ? actor : null;
+    }
+
     /** Ensure companions are initialized after all other subtypes. */
     _initialize() {
         super._initialize();

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -189,7 +189,15 @@ export const getDeleteKeys = (property, innerProperty, innerPropertyDefaultValue
 
 // Fix on Foundry native formula replacement for DH
 const nativeReplaceFormulaData = Roll.replaceFormulaData;
-Roll.replaceFormulaData = function (formula, data = {}, { missing, warn = false } = {}) {
+Roll.replaceFormulaData = function (formula, baseData = {}, { missing, warn = false } = {}) {
+    /* Inserting global data */
+    const data = { 
+        ...baseData, 
+        partySize: 
+            !game.actors ? 0 : 
+            game.actors.find(x => x.type === 'party' && x.system.active)?.system.partyMembers.length ?? 0,
+    };
+    
     const terms = Object.keys(CONFIG.DH.GENERAL.multiplierTypes).map(type => {
         return { term: type, default: 1 };
     });

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -191,13 +191,11 @@ export const getDeleteKeys = (property, innerProperty, innerPropertyDefaultValue
 const nativeReplaceFormulaData = Roll.replaceFormulaData;
 Roll.replaceFormulaData = function (formula, baseData = {}, { missing, warn = false } = {}) {
     /* Inserting global data */
-    const data = { 
-        ...baseData, 
-        partySize: 
-            !game.actors ? 0 : 
-            game.actors.find(x => x.type === 'party' && x.system.active)?.system.partyMembers.length ?? 0,
+    const data = {
+        ...baseData,
+        partySize: game.actors?.party?.system.partyMembers.length ?? 0
     };
-    
+
     const terms = Object.keys(CONFIG.DH.GENERAL.multiplierTypes).map(type => {
         return { term: type, default: 1 };
     });

--- a/module/systemRegistration/settings.mjs
+++ b/module/systemRegistration/settings.mjs
@@ -189,4 +189,11 @@ const registerNonConfigSettings = () => {
         config: false,
         type: SpotlightTracker
     });
+
+    game.settings.register(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.ActiveParty, {
+        scope: 'world',
+        config: false,
+        type: String,
+        default: null,
+    });
 };

--- a/src/packs/adversaries/adversary_Fallen_Warlord__Undefeated_Champion_RXkZTwBRi4dJ3JE5.json
+++ b/src/packs/adversaries/adversary_Fallen_Warlord__Undefeated_Champion_RXkZTwBRi4dJ3JE5.json
@@ -174,12 +174,9 @@
       "src": "systems/daggerheart/assets/icons/documents/actors/dragon-head.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -230,7 +227,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -256,7 +253,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "items": [
     {
@@ -496,34 +494,42 @@
         "description": "<p><strong>Spend a Fear</strong> to summon a number of @UUID[Compendium.daggerheart.adversaries.Actor.OsLG2BjaEdTZUJU9]{Fallen Shock Troops} equal to twice the number of PCs. The Shock Troops appear at Far range.</p>",
         "resource": null,
         "actions": {
-          "hGMzqw00JTlYfHYy": {
-            "type": "effect",
-            "_id": "hGMzqw00JTlYfHYy",
+          "SrU7qbh8LcOgfozT": {
+            "type": "summon",
+            "_id": "SrU7qbh8LcOgfozT",
             "systemPath": "actions",
+            "baseAction": false,
             "description": "",
             "chatDisplay": true,
+            "originItem": {
+              "type": "itemCollection"
+            },
             "actionType": "action",
+            "triggers": [],
             "cost": [
               {
                 "scalable": false,
                 "key": "fear",
                 "value": 1,
-                "step": null
+                "itemId": null,
+                "step": null,
+                "consumeOnSuccess": false
               }
             ],
             "uses": {
               "value": null,
               "max": "",
-              "recovery": null
+              "recovery": null,
+              "consumeOnSuccess": false
             },
-            "effects": [],
-            "target": {
-              "type": "self",
-              "amount": null
-            },
+            "summon": [
+              {
+                "actorUUID": "Compendium.daggerheart.adversaries.Actor.OsLG2BjaEdTZUJU9",
+                "count": "@partySize*2"
+              }
+            ],
             "name": "Spend Fear",
-            "img": "icons/magic/death/undead-skeleton-worn-blue.webp",
-            "range": ""
+            "range": "far"
           }
         },
         "originItemType": null,

--- a/src/packs/environments/environment_Abandoned_Grove_pGEdzdLkqYtBhxnG.json
+++ b/src/packs/environments/environment_Abandoned_Grove_pGEdzdLkqYtBhxnG.json
@@ -52,12 +52,9 @@
       "src": "systems/daggerheart/assets/icons/documents/actors/forest.svg",
       "anchorX": 0.5,
       "anchorY": 0.5,
-      "offsetX": 0,
-      "offsetY": 0,
       "fit": "contain",
       "scaleX": 1,
       "scaleY": 1,
-      "rotation": 0,
       "tint": "#ffffff",
       "alphaThreshold": 0.75
     },
@@ -108,7 +105,7 @@
       "saturation": 0,
       "contrast": 0
     },
-    "detectionModes": [],
+    "detectionModes": {},
     "occludable": {
       "radius": 0
     },
@@ -134,7 +131,8 @@
     "flags": {},
     "randomImg": false,
     "appendNumber": false,
-    "prependAdjective": false
+    "prependAdjective": false,
+    "depth": 1
   },
   "items": [
     {
@@ -323,7 +321,42 @@
       "system": {
         "description": "<p>A @UUID[Compendium.daggerheart.adversaries.Actor.8yUj2Mzvnifhxegm]{Young Dryad}, two @UUID[Compendium.daggerheart.adversaries.Actor.VtFBt9XBE0WrGGxP]{Sylvan Soldiers}, and a number of @UUID[Compendium.daggerheart.adversaries.Actor.G62k4oSkhkoXEs2D]{Minor Treants} equal to the number of PCs appear to confront the party for their intrusion.</p><section id=\"secret-01hkXuVJc5Kei4QW\" class=\"secret\"><p><em>What are the grove guardians concealing? What threat to the forest could the PCs confront to appease the Dryad?</em></p></section>",
         "resource": null,
-        "actions": {},
+        "actions": {
+          "TPm6rpKA4mbili82": {
+            "type": "summon",
+            "_id": "TPm6rpKA4mbili82",
+            "systemPath": "actions",
+            "baseAction": false,
+            "description": "",
+            "chatDisplay": true,
+            "originItem": {
+              "type": "itemCollection"
+            },
+            "actionType": "action",
+            "triggers": [],
+            "cost": [],
+            "uses": {
+              "value": null,
+              "max": null,
+              "recovery": null,
+              "consumeOnSuccess": false
+            },
+            "summon": [
+              {
+                "actorUUID": "Compendium.daggerheart.adversaries.Actor.8yUj2Mzvnifhxegm",
+                "count": "1"
+              },
+              {
+                "actorUUID": "Compendium.daggerheart.adversaries.Actor.VtFBt9XBE0WrGGxP",
+                "count": "2"
+              },
+              {
+                "actorUUID": "Compendium.daggerheart.adversaries.Actor.G62k4oSkhkoXEs2D",
+                "count": "@partySize"
+              }
+            ]
+          }
+        },
         "originItemType": null,
         "originId": null,
         "featureForm": "action"

--- a/templates/ui/sidebar/actor-document-partial.hbs
+++ b/templates/ui/sidebar/actor-document-partial.hbs
@@ -14,6 +14,10 @@
             {{else}}
                 <span class="entry-subtitle">{{localize "DAGGERHEART.UI.Sidebar.actorDirectory.companionNoPartner"}}</span>
             {{/if}}
+        {{else if (eq type "party")}}
+            {{#if system.active}}
+                <span class="entry-subtitle">{{localize "DAGGERHEART.UI.Sidebar.actorDirectory.partyIsActive"}}</span>
+            {{/if}}
         {{/if}}
     </a>
 </li>


### PR DESCRIPTION
- A Party can now be set as the `active` party via the context menu in the actor's tab. If no party is active and a new one is created, that one is autmatically marked as party.
- Made the active PartySize available as a parameter for formulas. I added this in our `replaceFormulaData` wrapper so that it's globally available anywhere a formula is evaluated.
- I fixed so that Summon Actions can actually evaluate rollData properties as part of updating the 2 SRD entries that use party size.