### PR TITLE
[Feature] Show notification when invalid item types are added to actors

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -213,6 +213,9 @@
                     "headerTitle": "Adversary Reaction Roll"
                 }
             },
+            "Base": {
+                "CannotAddType": "Cannot add {itemType} items to {actorType} actors."
+            },
             "Character": {
                 "advantageSources": {
                     "label": "Advantage Sources",

--- a/module/applications/sheets/api/base-actor.mjs
+++ b/module/applications/sheets/api/base-actor.mjs
@@ -73,7 +73,7 @@ export default class DHBaseActorSheet extends DHApplicationMixin(ActorSheetV2) {
             .hideAttribution;
 
         // Prepare inventory data
-        if (['party', 'character'].includes(this.document.type)) {
+        if (this.document.system.metadata.hasInventory) {
             context.inventory = {
                 currencies: {},
                 weapons: this.document.itemTypes.weapon.sort((a, b) => a.sort - b.sort),
@@ -283,11 +283,7 @@ export default class DHBaseActorSheet extends DHApplicationMixin(ActorSheetV2) {
     async _onDropItem(event, item) {
         const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
         const originActor = item.actor;
-        if (
-            item.actor?.uuid === this.document.uuid ||
-            !originActor ||
-            !['character', 'party'].includes(this.document.type)
-        ) {
+        if (!originActor || originActor.uuid === this.document.uuid || !this.document.system.metadata.hasInventory) {
             return super._onDropItem(event, item);
         }
 

--- a/module/applications/sheets/items/ancestry.mjs
+++ b/module/applications/sheets/items/ancestry.mjs
@@ -31,11 +31,12 @@ export default class AncestrySheet extends DHHeritageSheet {
         if (data.type === 'ActiveEffect') return super._onDrop(event);
 
         const target = event.target.closest('fieldset.drop-section');
-        const typeField =
-            this.document.system[target.dataset.type === 'primary' ? 'primaryFeature' : 'secondaryFeature'];
-
-        if (!typeField) {
-            super._onDrop(event);
+        if (target) {
+            const typeField =
+                this.document.system[target.dataset.type === 'primary' ? 'primaryFeature' : 'secondaryFeature'];
+            if (!typeField) {
+                super._onDrop(event);
+            }
         }
     }
 }

--- a/module/data/actor/adversary.mjs
+++ b/module/data/actor/adversary.mjs
@@ -133,7 +133,7 @@ export default class DhpAdversary extends DhCreature {
     }
 
     isItemValid(source) {
-        return source.type === 'feature';
+        return super.isItemValid(source) || source.type === 'feature';
     }
 
     async _preUpdate(changes, options, user) {

--- a/module/data/actor/base.mjs
+++ b/module/data/actor/base.mjs
@@ -107,7 +107,8 @@ export default class BaseDataActor extends foundry.abstract.TypeDataModel {
             hasResistances: true,
             hasAttribution: false,
             hasLimitedView: true,
-            usesSize: false
+            usesSize: false,
+            hasInventory: false
         };
     }
 
@@ -167,6 +168,11 @@ export default class BaseDataActor extends foundry.abstract.TypeDataModel {
     }
 
     /* -------------------------------------------- */
+
+    isItemValid(source) {
+        const inventoryTypes = ['weapon', 'armor', 'consumable', 'loot'];
+        return this.metadata.hasInventory && inventoryTypes.includes(source.type);
+    }
 
     /**
      * Obtain a data object used to evaluate any dice rolls associated with this Item Type

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -18,7 +18,8 @@ export default class DhCharacter extends DhCreature {
             label: 'TYPES.Actor.character',
             type: 'character',
             settingSheet: DHCharacterSettings,
-            isNPC: false
+            isNPC: false,
+            hasInventory: true
         });
     }
 
@@ -427,6 +428,11 @@ export default class DhCharacter extends DhCreature {
             attack.img = 'icons/creatures/claws/claw-straight-brown.webp';
         }
         return attack;
+    }
+
+    /* All items are valid on characters */
+    isItemValid() {
+        return true; 
     }
 
     /** @inheritDoc */

--- a/module/data/actor/companion.mjs
+++ b/module/data/actor/companion.mjs
@@ -118,10 +118,6 @@ export default class DhCompanion extends DhCreature {
         return this.levelupChoicesLeft > 0;
     }
 
-    isItemValid() {
-        return false;
-    }
-
     prepareBaseData() {
         super.prepareBaseData();
         this.attack.roll.bonus = this.partner?.system?.spellcastModifier ?? 0;

--- a/module/data/actor/environment.mjs
+++ b/module/data/actor/environment.mjs
@@ -56,7 +56,7 @@ export default class DhEnvironment extends BaseDataActor {
     }
 
     isItemValid(source) {
-        return source.type === 'feature';
+        return super.isItemValid(source) || source.type === 'feature';
     }
 
     _onUpdate(changes, options, userId) {

--- a/module/data/actor/party.mjs
+++ b/module/data/actor/party.mjs
@@ -5,6 +5,13 @@ import GroupRollData from '../groupRollData.mjs';
 import { GoldField } from '../fields/actorField.mjs';
 
 export default class DhParty extends BaseDataActor {
+    /** @inheritdoc */
+    static get metadata() {
+        return foundry.utils.mergeObject(super.metadata, {
+            hasInventory: true
+        });
+    }
+
     /**@inheritdoc */
     static defineSchema() {
         const fields = foundry.data.fields;
@@ -28,10 +35,6 @@ export default class DhParty extends BaseDataActor {
     static DEFAULT_ICON = 'systems/daggerheart/assets/icons/documents/actors/dark-squad.svg';
 
     /* -------------------------------------------- */
-
-    isItemValid(source) {
-        return ['weapon', 'armor', 'consumable', 'loot'].includes(source.type);
-    }
 
     prepareBaseData() {
         super.prepareBaseData();

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -31,8 +31,13 @@ export default class DHItem extends foundry.documents.Item {
     static async createDocuments(sources, operation) {
         // Ensure that items being created are valid to the actor its being added to
         const actor = operation.parent;
-        sources = actor?.system?.isItemValid ? sources.filter(s => actor.system.isItemValid(s)) : sources;
-        return super.createDocuments(sources, operation);
+        const filtered = actor ? sources.filter(s => actor.system.isItemValid(s)) : sources;
+        if (actor && filtered.length === 0 && sources.length > 0) {
+            const itemType = _loc(`TYPES.Item.${sources[0].type}`);
+            const actorType = _loc(`TYPES.Actor.${actor.type}`);
+            ui.notifications.error('DAGGERHEART.ACTORS.Base.CannotAddType', { format: { itemType, actorType } });
+        }
+        return super.createDocuments(filtered, operation);
     }
 
     /* -------------------------------------------- */


### PR DESCRIPTION
Internally this refactors isItemValid() to use metadata for the inventory items and to exist on all actor types. The createDocuments() implementation now checks if all items were filtered out, and if so, it will warn about the first item type in the attempted list. This will get the right results in most cases, since batch adding is normally a module invoked thing, not drag/drop.

<img width="755" height="89" alt="image" src="https://github.com/user-attachments/assets/f0b42918-91d6-45a3-8255-68c30b873f32" />

Also stealth fixes an error in the ancestry sheet on drop that's of minor importance.