### PR TITLE
fix: 2 improvements across 2 files

### DIFF
--- a/daggerheart.d.ts
+++ b/daggerheart.d.ts
@@ -10,8 +10,8 @@ declare global {
      * This class manages the registration and execution of hooked callback functions.
      */
     class Hooks extends foundry.helpers.Hooks {}
-    const fromUuid = foundry.utils.fromUuid;
-    const fromUuidSync = foundry.utils.fromUuidSync;
+    const fromUuid: typeof foundry.utils.fromUuid;
+    const fromUuidSync: typeof foundry.utils.fromUuidSync;
 
     /**
      * The singleton game canvas

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,9 +2,8 @@
 var gulp = require('gulp');
 var less = require('gulp-less');
 
-gulp.task('less', function (cb) {
-    gulp.src('styles/daggerheart.less').pipe(less()).pipe(gulp.dest('styles'));
-    cb();
+gulp.task('less', function () {
+    return gulp.src('styles/daggerheart.less').pipe(less()).pipe(gulp.dest('styles'));
 });
 
 gulp.task(


### PR DESCRIPTION
## Summary

fix: 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `daggerheart.d.ts:L13`

Inside `declare global`, `const fromUuid = foundry.utils.fromUuid;` and `const fromUuidSync = foundry.utils.fromUuidSync;` use runtime initializers. In declaration files (`.d.ts`), ambient declarations must not include value initializers. This can cause TypeScript declaration parsing/emit failures.

## Solution

Replace with ambient typed declarations, e.g. `const fromUuid: typeof foundry.utils.fromUuid;` and `const fromUuidSync: typeof foundry.utils.fromUuidSync;`.

## Changes

- `daggerheart.d.ts` (modified)
- `gulpfile.js` (modified)