### PR TITLE
[Feature] Updates to inventory icons, context menus, action use, and observer visibility

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3233,6 +3233,7 @@
             "Tooltip": {
                 "disableEffect": "Disable Effect",
                 "enableEffect": "Enable Effect",
+                "edit": "Edit",
                 "openItemWorld": "Open Item World",
                 "openActorWorld": "Open Actor World",
                 "sendToChat": "Send to Chat",

--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -323,11 +323,11 @@ export default class CharacterSheet extends DHBaseActorSheet {
         /**@type {import('@client/applications/ux/context-menu.mjs').ContextMenuEntry[]} */
         const options = [
             {
-                name: 'toLoadout',
+                label: 'toLoadout',
                 icon: 'fa-solid fa-arrow-up',
-                condition: target => {
+                visible: target => {
                     const doc = getDocFromElementSync(target);
-                    return doc && doc.system.inVault;
+                    return doc?.isOwner && doc.system.inVault;
                 },
                 callback: async target => {
                     const doc = await getDocFromElement(target);
@@ -337,11 +337,11 @@ export default class CharacterSheet extends DHBaseActorSheet {
                 }
             },
             {
-                name: 'recall',
+                label: 'recall',
                 icon: 'fa-solid fa-bolt-lightning',
-                condition: target => {
+                visible: target => {
                     const doc = getDocFromElementSync(target);
-                    return doc && doc.system.inVault;
+                    return doc?.isOwner && doc.system.inVault;
                 },
                 callback: async (target, event) => {
                     const doc = await getDocFromElement(target);
@@ -376,17 +376,17 @@ export default class CharacterSheet extends DHBaseActorSheet {
                 }
             },
             {
-                name: 'toVault',
+                label: 'toVault',
                 icon: 'fa-solid fa-arrow-down',
-                condition: target => {
+                visible: target => {
                     const doc = getDocFromElementSync(target);
-                    return doc && !doc.system.inVault;
+                    return doc?.isOwner && !doc.system.inVault;
                 },
                 callback: async target => (await getDocFromElement(target)).update({ 'system.inVault': true })
             }
         ].map(option => ({
             ...option,
-            name: `DAGGERHEART.APPLICATIONS.ContextMenu.${option.name}`,
+            label: `DAGGERHEART.APPLICATIONS.ContextMenu.${option.label}`,
             icon: `<i class="${option.icon}"></i>`
         }));
 
@@ -402,18 +402,18 @@ export default class CharacterSheet extends DHBaseActorSheet {
     static #getEquipmentContextOptions() {
         const options = [
             {
-                name: 'equip',
+                label: 'equip',
                 icon: 'fa-solid fa-hands',
-                condition: target => {
+                visible: target => {
                     const doc = getDocFromElementSync(target);
                     return doc.isOwner && doc && !doc.system.equipped;
                 },
                 callback: (target, event) => CharacterSheet.#toggleEquipItem.call(this, event, target)
             },
             {
-                name: 'unequip',
+                label: 'unequip',
                 icon: 'fa-solid fa-hands',
-                condition: target => {
+                visible: target => {
                     const doc = getDocFromElementSync(target);
                     return doc.isOwner && doc && doc.system.equipped;
                 },
@@ -421,7 +421,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
             }
         ].map(option => ({
             ...option,
-            name: `DAGGERHEART.APPLICATIONS.ContextMenu.${option.name}`,
+            label: `DAGGERHEART.APPLICATIONS.ContextMenu.${option.label}`,
             icon: `<i class="${option.icon}"></i>`
         }));
 

--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -12,8 +12,6 @@ export default class CharacterSheet extends DHBaseActorSheet {
     static DEFAULT_OPTIONS = {
         classes: ['character'],
         position: { width: 850, height: 800 },
-        /* Foundry adds disabled to all buttons and inputs if editPermission is missing. This is not desired. */
-        editPermission: CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER,
         actions: {
             toggleVault: CharacterSheet.#toggleVault,
             rollAttribute: CharacterSheet.#rollAttribute,
@@ -68,7 +66,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
                 }
             },
             {
-                handler: CharacterSheet.#getEquipamentContextOptions,
+                handler: CharacterSheet.#getEquipmentContextOptions,
                 selector: '[data-item-uuid][data-type="armor"], [data-item-uuid][data-type="weapon"]',
                 options: {
                     parentClassHooks: false,
@@ -168,6 +166,16 @@ export default class CharacterSheet extends DHBaseActorSheet {
         }
 
         return applicationOptions;
+    }
+
+    /** @inheritdoc */
+    _toggleDisabled(disabled) {
+        // Overriden to only disable text inputs by default.
+        // Everything else is done by checking @root.editable in the sheet
+        const form = this.form;
+        for (const input of form.querySelectorAll("input:not([type=search])")) {
+            input.disabled = disabled;
+        }
     }
 
     /** @inheritDoc */
@@ -391,14 +399,14 @@ export default class CharacterSheet extends DHBaseActorSheet {
      * @this {CharacterSheet}
      * @protected
      */
-    static #getEquipamentContextOptions() {
+    static #getEquipmentContextOptions() {
         const options = [
             {
                 name: 'equip',
                 icon: 'fa-solid fa-hands',
                 condition: target => {
                     const doc = getDocFromElementSync(target);
-                    return doc && !doc.system.equipped;
+                    return doc.isOwner && doc && !doc.system.equipped;
                 },
                 callback: (target, event) => CharacterSheet.#toggleEquipItem.call(this, event, target)
             },
@@ -407,7 +415,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
                 icon: 'fa-solid fa-hands',
                 condition: target => {
                     const doc = getDocFromElementSync(target);
-                    return doc && doc.system.equipped;
+                    return doc.isOwner && doc && doc.system.equipped;
                 },
                 callback: (target, event) => CharacterSheet.#toggleEquipItem.call(this, event, target)
             }

--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -173,7 +173,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
         // Overriden to only disable text inputs by default.
         // Everything else is done by checking @root.editable in the sheet
         const form = this.form;
-        for (const input of form.querySelectorAll("input:not([type=search])")) {
+        for (const input of form.querySelectorAll("input:not([type=search]), .editor.prosemirror")) {
             input.disabled = disabled;
         }
     }

--- a/module/applications/sheets/api/application-mixin.mjs
+++ b/module/applications/sheets/api/application-mixin.mjs
@@ -475,7 +475,7 @@ export default function DHApplicationMixin(Base) {
                         const doc = getDocFromElementSync(target);
                         return (
                             (!dataset.noCompendiumEdit && !doc) ||
-                            (doc && (!doc?.hasOwnProperty('systemPath') || doc?.inCollection))
+                            (doc?.isOwner && (!doc?.hasOwnProperty('systemPath') || doc?.inCollection))
                         );
                     },
                     callback: async target => (await getDocFromElement(target)).sheet.render({ force: true })
@@ -489,6 +489,7 @@ export default function DHApplicationMixin(Base) {
                     condition: target => {
                         const doc = getDocFromElementSync(target);
                         return (
+                            doc?.isOwner &&
                             !foundry.utils.isEmpty(doc?.system?.attack?.damage.parts) ||
                             !foundry.utils.isEmpty(doc?.damage?.parts)
                         );
@@ -511,7 +512,7 @@ export default function DHApplicationMixin(Base) {
                     icon: 'fa-solid fa-burst',
                     condition: target => {
                         const doc = getDocFromElementSync(target);
-                        return doc && !(doc.type === 'domainCard' && doc.system.inVault);
+                        return doc?.isOwner && !(doc.type === 'domainCard' && doc.system.inVault);
                     },
                     callback: async (target, event) => (await getDocFromElement(target)).use(event)
                 });
@@ -530,7 +531,8 @@ export default function DHApplicationMixin(Base) {
                     icon: 'fa-solid fa-trash',
                     condition: element => {
                         const target = element.closest('[data-item-uuid]');
-                        return target.dataset.itemType !== 'beastform';
+                        const doc = getDocFromElementSync(target);
+                        return doc?.isOwner && target.dataset.itemType !== 'beastform';
                     },
                     callback: async (target, event) => {
                         const doc = await getDocFromElement(target);

--- a/module/applications/sheets/api/application-mixin.mjs
+++ b/module/applications/sheets/api/application-mixin.mjs
@@ -418,18 +418,18 @@ export default function DHApplicationMixin(Base) {
             /**@type {import('@client/applications/ux/context-menu.mjs').ContextMenuEntry[]} */
             const options = [
                 {
-                    name: 'disableEffect',
+                    label: 'disableEffect',
                     icon: 'fa-solid fa-lightbulb',
-                    condition: element => {
+                    visible: element => {
                         const target = element.closest('[data-item-uuid]');
                         return !target.dataset.disabled && target.dataset.itemType !== 'beastform';
                     },
                     callback: async target => (await getDocFromElement(target)).update({ disabled: true })
                 },
                 {
-                    name: 'enableEffect',
+                    label: 'enableEffect',
                     icon: 'fa-regular fa-lightbulb',
-                    condition: element => {
+                    visible: element => {
                         const target = element.closest('[data-item-uuid]');
                         return target.dataset.disabled && target.dataset.itemType !== 'beastform';
                     },
@@ -437,7 +437,7 @@ export default function DHApplicationMixin(Base) {
                 }
             ].map(option => ({
                 ...option,
-                name: `DAGGERHEART.APPLICATIONS.ContextMenu.${option.name}`,
+                label: `DAGGERHEART.APPLICATIONS.ContextMenu.${option.label}`,
                 icon: `<i class="${option.icon}"></i>`
             }));
 
@@ -468,9 +468,9 @@ export default function DHApplicationMixin(Base) {
         _getContextMenuCommonOptions({ usable = false, toChat = false, deletable = true }) {
             const options = [
                 {
-                    name: 'CONTROLS.CommonEdit',
+                    label: 'CONTROLS.CommonEdit',
                     icon: 'fa-solid fa-pen-to-square',
-                    condition: target => {
+                    visible: target => {
                         const { dataset } = target.closest('[data-item-uuid]');
                         const doc = getDocFromElementSync(target);
                         return (
@@ -484,9 +484,9 @@ export default function DHApplicationMixin(Base) {
 
             if (usable) {
                 options.unshift({
-                    name: 'DAGGERHEART.GENERAL.damage',
+                    label: 'DAGGERHEART.GENERAL.damage',
                     icon: 'fa-solid fa-explosion',
-                    condition: target => {
+                    visible: target => {
                         const doc = getDocFromElementSync(target);
                         return (
                             doc?.isOwner &&
@@ -508,9 +508,9 @@ export default function DHApplicationMixin(Base) {
                 });
 
                 options.unshift({
-                    name: 'DAGGERHEART.APPLICATIONS.ContextMenu.useItem',
+                    label: 'DAGGERHEART.APPLICATIONS.ContextMenu.useItem',
                     icon: 'fa-solid fa-burst',
-                    condition: target => {
+                    visible: target => {
                         const doc = getDocFromElementSync(target);
                         return doc?.isOwner && !(doc.type === 'domainCard' && doc.system.inVault);
                     },
@@ -520,16 +520,16 @@ export default function DHApplicationMixin(Base) {
 
             if (toChat)
                 options.push({
-                    name: 'DAGGERHEART.APPLICATIONS.ContextMenu.sendToChat',
+                    label: 'DAGGERHEART.APPLICATIONS.ContextMenu.sendToChat',
                     icon: 'fa-solid fa-message',
                     callback: async target => (await getDocFromElement(target)).toChat(this.document.uuid)
                 });
 
             if (deletable)
                 options.push({
-                    name: 'CONTROLS.CommonDelete',
+                    label: 'CONTROLS.CommonDelete',
                     icon: 'fa-solid fa-trash',
-                    condition: element => {
+                    visible: element => {
                         const target = element.closest('[data-item-uuid]');
                         const doc = getDocFromElementSync(target);
                         return doc?.isOwner && target.dataset.itemType !== 'beastform';

--- a/module/applications/sidebar/tabs/actorDirectory.mjs
+++ b/module/applications/sidebar/tabs/actorDirectory.mjs
@@ -48,9 +48,9 @@ export default class DhActorDirectory extends foundry.applications.sidebar.tabs.
         const options = super._getEntryContextOptions();
         options.push(
             {
-                name: 'DAGGERHEART.UI.Sidebar.actorDirectory.duplicateToNewTier',
+                label: 'DAGGERHEART.UI.Sidebar.actorDirectory.duplicateToNewTier',
                 icon: `<i class="fa-solid fa-arrow-trend-up" inert></i>`,
-                condition: li => {
+                visible: li => {
                     const actor = game.actors.get(li.dataset.entryId);
                     return actor?.type === 'adversary' && actor.system.type !== 'social';
                 },
@@ -92,9 +92,9 @@ export default class DhActorDirectory extends foundry.applications.sidebar.tabs.
                 }
             },
             {
-                name: 'DAGGERHEART.UI.Sidebar.actorDirectory.activateParty',
+                label: 'DAGGERHEART.UI.Sidebar.actorDirectory.activateParty',
                 icon: `<i class="fa-regular fa-square"></i>`,
-                condition: li => {
+                visible: li => {
                     const actor = game.actors.get(li.dataset.entryId);
                     return actor && actor.type === 'party' && !actor.system.active;
                 },

--- a/module/applications/ui/chatLog.mjs
+++ b/module/applications/ui/chatLog.mjs
@@ -103,23 +103,10 @@ export default class DhpChatLog extends foundry.applications.sidebar.tabs.ChatLo
     _getEntryContextOptions() {
         return [
             ...super._getEntryContextOptions(),
-            // {
-            //     name: 'Reroll',
-            //     icon: '<i class="fa-solid fa-dice"></i>',
-            //     condition: li => {
-            //         const message = game.messages.get(li.dataset.messageId);
-
-            //         return (game.user.isGM || message.isAuthor) && message.rolls.length > 0;
-            //     },
-            //     callback: li => {
-            //         const message = game.messages.get(li.dataset.messageId);
-            //         new game.system.api.applications.dialogs.RerollDialog(message).render({ force: true });
-            //     }
-            // },
             {
-                name: game.i18n.localize('DAGGERHEART.UI.ChatLog.rerollDamage'),
+                label: 'DAGGERHEART.UI.ChatLog.rerollDamage',
                 icon: '<i class="fa-solid fa-dice"></i>',
-                condition: li => {
+                visible: li => {
                     const message = game.messages.get(li.dataset.messageId);
                     const hasRolledDamage = message.system.hasDamage
                         ? Object.keys(message.system.damage).length > 0

--- a/module/applications/ui/combatTracker.mjs
+++ b/module/applications/ui/combatTracker.mjs
@@ -84,15 +84,15 @@ export default class DhCombatTracker extends foundry.applications.sidebar.tabs.C
     _getCombatContextOptions() {
         return [
             {
-                name: 'COMBAT.ClearMovementHistories',
+                label: 'COMBAT.ClearMovementHistories',
                 icon: '<i class="fa-solid fa-shoe-prints"></i>',
-                condition: () => game.user.isGM && this.viewed?.combatants.size > 0,
+                visible: () => game.user.isGM && this.viewed?.combatants.size > 0,
                 callback: () => this.viewed.clearMovementHistories()
             },
             {
-                name: 'COMBAT.Delete',
+                label: 'COMBAT.Delete',
                 icon: '<i class="fa-solid fa-trash"></i>',
-                condition: () => game.user.isGM && !!this.viewed,
+                visible: () => game.user.isGM && !!this.viewed,
                 callback: () => this.viewed.endCombat()
             }
         ];

--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -148,6 +148,12 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
               : null;
     }
 
+    /** Returns true if the action is usable */
+    get usable() {
+        const actor = this.actor;
+        return this.isOwner && actor?.type === 'character';
+    }
+
     static getRollType(parent) {
         return 'trait';
     }

--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -110,6 +110,11 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
         return this._id;
     }
 
+    /** Returns true if the current user is the owner of the containing item */
+    get isOwner() {
+        return this.item?.isOwner ?? true; 
+    }
+
     /**
      * Return Item the action is attached too.
      */

--- a/module/data/item/base.mjs
+++ b/module/data/item/base.mjs
@@ -108,6 +108,8 @@ export default class BaseDataItem extends foundry.abstract.TypeDataModel {
     }
 
     get actionsList() {
+        // No actions on non-characters
+        if (this.actor && this.actor.type !== 'character') return [];
         return this.actions;
     }
 

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -99,7 +99,9 @@ export default class DHWeapon extends AttachableItem {
     /* -------------------------------------------- */
 
     get actionsList() {
-        return [this.attack, ...this.actions];
+        // No actions on non-characters
+        if (this.actor && this.actor.type !== 'character') return [];
+        return [this.attack, ...super.actionsList];
     }
 
     get customActions() {

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -76,6 +76,13 @@ export default class DHItem extends foundry.documents.Item {
         return this.system.metadata.isInventoryItem ?? false;
     }
 
+    /** Returns true if the item can be used */
+    get usable() {
+        const actor = this.actor;
+        const actionsList = this.system.actionsList;
+        return this.isOwner && actor?.type === 'character' && (actionsList?.size || actionsList?.length);
+    }
+
     /** @inheritdoc */
     static async createDialog(data = {}, createOptions = {}, options = {}) {
         const { folders, types, template, context = {}, ...dialogOptions } = options;

--- a/styles/less/sheets/actors/character/sheet.less
+++ b/styles/less/sheets/actors/character/sheet.less
@@ -11,21 +11,6 @@
         padding-bottom: 0;
         overflow-x: auto;
 
-        &.viewMode {
-            button:not(.btn-toggle-view),
-            input:not(.search),
-            .controls,
-            .character-sidebar-sheet,
-            .img-portait,
-            .name-row,
-            .hope-section,
-            .downtime-section,
-            .character-traits,
-            .card-list {
-                pointer-events: none;
-            }
-        }
-
         .character-sidebar-sheet {
             grid-row: 1 / span 2;
             grid-column: 1;

--- a/styles/less/sheets/actors/character/sidebar.less
+++ b/styles/less/sheets/actors/character/sidebar.less
@@ -316,9 +316,9 @@
                     border-radius: 3px;
                     background: light-dark(@dark-blue, @golden);
                     clip-path: none;
-                    cursor: pointer;
                     display: flex;
                     align-items: center;
+                    justify-content: center;
                     gap: 4px;
                     border: 1px solid transparent;
                     transition: all 0.3s ease;

--- a/templates/sheets/actors/adversary/effects.hbs
+++ b/templates/sheets/actors/adversary/effects.hbs
@@ -6,7 +6,7 @@
         type='effect'
         isGlassy=true
         collection=effects.actives
-        canCreate=true
+        canCreate=@root.editable
         hideResources=true
         }}
 
@@ -15,7 +15,7 @@
         type='effect'
         isGlassy=true
         collection=effects.inactives
-        canCreate=true
+        canCreate=@root.editable
         hideResources=true
         }}
     </div>

--- a/templates/sheets/actors/adversary/features.hbs
+++ b/templates/sheets/actors/adversary/features.hbs
@@ -6,8 +6,8 @@
             type='feature'
             collection=@root.features
             hideContextMenu=true
-            canCreate=true
-            showActions=true
+            canCreate=@root.editable
+            showActions=@root.editable
         }}
     </div>
 </section>

--- a/templates/sheets/actors/character/effects.hbs
+++ b/templates/sheets/actors/character/effects.hbs
@@ -7,7 +7,7 @@
         type='effect'
         isGlassy=true
         collection=effects.actives
-        canCreate=true
+        canCreate=@root.editable
         hideResources=true
         }}
 
@@ -16,7 +16,7 @@
         type='effect'
         isGlassy=true
         collection=effects.inactives
-        canCreate=true
+        canCreate=@root.editable
         hideResources=true
         disabled=true
         }}

--- a/templates/sheets/actors/character/features.hbs
+++ b/templates/sheets/actors/character/features.hbs
@@ -8,8 +8,8 @@
             type='feature'
             actorType='character'
             collection=category.values
-            canCreate=true
-            showActions=true
+            canCreate=@root.editable
+            showActions=@root.editable
         }}
         {{else if category.values}}
         {{> 'daggerheart.inventory-items'
@@ -18,7 +18,7 @@
             actorType='character'
             collection=category.values
             canCreate=false
-            showActions=true
+            showActions=@root.editable
         }}
 
         {{/if}}

--- a/templates/sheets/actors/character/header.hbs
+++ b/templates/sheets/actors/character/header.hbs
@@ -4,22 +4,24 @@
         <h1 class="actor-name input" contenteditable="plaintext-only" data-property="name" placeholder="{{localize "DAGGERHEART.GENERAL.actorName"}}">{{source.name}}</h1>
         <div class='level-div'>
             <h3 class='label'>
-                {{#if document.system.needsCharacterSetup}}
-                    <button
-                        type="button"
-                        class="level-button glow"
-                        data-action="levelManagement"
-                    >
-                        {{localize "DAGGERHEART.APPLICATIONS.CharacterCreation.buttonTitle"}}
-                    </button>
-                {{else if document.system.levelData.canLevelUp}}
-                    <button
-                        type="button"
-                        class="level-button glow" data-tooltip="{{localize "DAGGERHEART.ACTORS.Character.levelUp"}}"
-                        data-action="levelManagement"
-                    >
-                        <i class="fa-solid fa-angles-up"></i>
-                    </button>
+                {{#if @root.editable}}
+                    {{#if document.system.needsCharacterSetup}}
+                        <button
+                            type="button"
+                            class="level-button glow"
+                            data-action="levelManagement"
+                        >
+                            {{localize "DAGGERHEART.APPLICATIONS.CharacterCreation.buttonTitle"}}
+                        </button>
+                    {{else if document.system.levelData.canLevelUp}}
+                        <button
+                            type="button"
+                            class="level-button glow" data-tooltip="{{localize "DAGGERHEART.ACTORS.Character.levelUp"}}"
+                            data-action="levelManagement"
+                        >
+                            <i class="fa-solid fa-angles-up"></i>
+                        </button>
+                    {{/if}}
                 {{/if}}
                 {{#unless document.system.needsCharacterSetup}}
                     {{localize 'DAGGERHEART.GENERAL.level'}}
@@ -110,12 +112,14 @@
                     <i class="fa-solid fa-fw fa-users"></i>
                 </button>
             {{/if}}
-            <button type="button" data-action="useDowntime" data-type="shortRest" data-tooltip="DAGGERHEART.APPLICATIONS.Downtime.shortRest.title">
-                <i class="fa-solid fa-fw fa-utensils"></i>
-            </button>
-            <button type="button" data-action="useDowntime" data-type="longRest" data-tooltip="DAGGERHEART.APPLICATIONS.Downtime.longRest.title">
-                <i class="fa-solid fa-fw fa-bed"></i>
-            </button>
+            {{#if @root.editable}}
+                <button type="button" data-action="useDowntime" data-type="shortRest" data-tooltip="DAGGERHEART.APPLICATIONS.Downtime.shortRest.title">
+                    <i class="fa-solid fa-fw fa-utensils"></i>
+                </button>
+                <button type="button" data-action="useDowntime" data-type="longRest" data-tooltip="DAGGERHEART.APPLICATIONS.Downtime.longRest.title">
+                    <i class="fa-solid fa-fw fa-bed"></i>
+                </button>
+            {{/if}}
         </div>
     </div>
 

--- a/templates/sheets/actors/character/inventory.hbs
+++ b/templates/sheets/actors/character/inventory.hbs
@@ -22,7 +22,7 @@
         type='weapon'
         collection=@root.inventory.weapons
         isGlassy=true
-        canCreate=true
+        canCreate=@root.editable
         hideResources=true
         }}
         {{> 'daggerheart.inventory-items'
@@ -30,7 +30,7 @@
         type='armor'
         collection=@root.inventory.armor
         isGlassy=true
-        canCreate=true
+        canCreate=@root.editable
         hideResources=true
         }}
         {{> 'daggerheart.inventory-items'
@@ -38,7 +38,7 @@
         type='consumable'
         collection=@root.inventory.consumables
         isGlassy=true
-        canCreate=true
+        canCreate=@root.editable
         isQuantifiable=true
         }}
         {{> 'daggerheart.inventory-items'
@@ -46,8 +46,8 @@
         type='loot'
         collection=@root.inventory.loot
         isGlassy=true
-        canCreate=true
-        showActions=true
+        canCreate=@root.editable
+        showActions=@root.editable
         isQuantifiable=true
         }}
     </div>

--- a/templates/sheets/actors/character/loadout.hbs
+++ b/templates/sheets/actors/character/loadout.hbs
@@ -27,7 +27,7 @@
         isGlassy=true
         cardView=cardView
         collection=document.system.domainCards.loadout
-        canCreate=true
+        canCreate=@root.editable
         }}
         {{> 'daggerheart.inventory-items'
         title='DAGGERHEART.GENERAL.Tabs.vault'
@@ -35,7 +35,7 @@
         isGlassy=true
         cardView=cardView
         collection=document.system.domainCards.vault
-        canCreate=true
+        canCreate=@root.editable
         inVault=true
         }}
     </div>

--- a/templates/sheets/actors/character/sidebar.hbs
+++ b/templates/sheets/actors/character/sidebar.hbs
@@ -45,11 +45,11 @@
                             </a>
                         {{/times}}
                         </div>
-                        <a class="slot-label" data-action="toggleArmorMangement">
+                        <a class="slot-label" data-action="toggleArmorMangement" {{disabled (not @root.editable)}}>
                             <span class="label">{{localize "DAGGERHEART.GENERAL.armorSlots"}}</span>
                             <div class="slot-value-container">
                                 <span class="value">{{document.system.armorScore.value}} / {{document.system.armorScore.max}}</span>
-                                <i class="fa-solid fa-gear"></i>
+                                {{#if @root.editable}}<i class="fa-solid fa-gear" inert></i>{{/if}}
                             </div>
                         </a> 
                     </div>
@@ -64,9 +64,9 @@
                         value='{{document.system.armorScore.value}}'
                         max='{{document.system.armorScore.max}}'
                     ></progress>
-                    <a class="status-label" data-action="toggleArmorMangement">
+                    <a class="status-label" data-action="toggleArmorMangement" {{disabled (not @root.editable)}}>
                         <h4>{{localize "DAGGERHEART.GENERAL.armorSlots"}}</h4>
-                        <i class="fa-solid fa-gear"></i>
+                        {{#if @root.editable}}<i class="fa-solid fa-gear" inert></i>{{/if}}
                     </a>
                     {{/if}}
                 </div>

--- a/templates/sheets/actors/companion/effects.hbs
+++ b/templates/sheets/actors/companion/effects.hbs
@@ -6,7 +6,7 @@
         type='effect'
         isGlassy=true
         collection=effects.actives
-        canCreate=true
+        canCreate=@root.editable
         hideResources=true
         }}
 
@@ -15,7 +15,7 @@
         type='effect'
         isGlassy=true
         collection=effects.inactives
-        canCreate=true
+        canCreate=@root.editable
         hideResources=true
         }}
     </div>

--- a/templates/sheets/actors/environment/features.hbs
+++ b/templates/sheets/actors/environment/features.hbs
@@ -9,8 +9,8 @@
         type='feature'
         collection=@root.features
         hideContextMenu=true
-        canCreate=true
-        showActions=true
+        canCreate=@root.editable
+        showActions=@root.editable
         }}
     </div>
 </section>

--- a/templates/sheets/actors/party/inventory.hbs
+++ b/templates/sheets/actors/party/inventory.hbs
@@ -26,7 +26,7 @@
         actorType='party'
         collection=@root.inventory.weapons
         isGlassy=true
-        canCreate=true
+        canCreate=@root.editable
         hideResources=true
         hideContextMenu=true
         isQuantifiable=true
@@ -37,7 +37,7 @@
         actorType='party'
         collection=@root.inventory.armor
         isGlassy=true
-        canCreate=true
+        canCreate=@root.editable
         hideResources=true
         hideContextMenu=true
         isQuantifiable=true
@@ -48,7 +48,7 @@
         actorType='party'
         collection=@root.inventory.consumables
         isGlassy=true
-        canCreate=true
+        canCreate=@root.editable
         hideContextMenu=true
         isQuantifiable=true
         }}
@@ -58,7 +58,7 @@
         actorType='party'
         collection=@root.inventory.loot
         isGlassy=true
-        canCreate=true
+        canCreate=@root.editable
         hideContextMenu=true
         isQuantifiable=true
         }}

--- a/templates/sheets/global/partials/inventory-fieldset-items-V2.hbs
+++ b/templates/sheets/global/partials/inventory-fieldset-items-V2.hbs
@@ -52,12 +52,11 @@ Parameters:
   {{else}}
   <ul class="items-list">
     {{#each collection as |item|}}
-
     {{> 'daggerheart.inventory-item'
     item=item
     type=../type
     disabledEffect=../disabledEffect
-    actorType=../actorType
+    actorType=(ifThen ../actorType ../actorType @root.document.type)
     hideControls=../hideControls
     hideContextMenu=../hideContextMenu
     isActor=../isActor

--- a/templates/sheets/global/partials/inventory-item-V2.hbs
+++ b/templates/sheets/global/partials/inventory-item-V2.hbs
@@ -71,66 +71,63 @@ Parameters:
 
     {{!-- Controls --}}
     {{#unless hideControls}}
-    <div class="controls">
-    {{#if isActor}}
-      <a data-action="editDoc" data-tooltip="DAGGERHEART.UI.Tooltip.openActorWorld">
-        <i class="fa-solid fa-globe"></i>
-      </a>
-      {{#if (eq type 'adversary')}}
-      <a data-action='deleteAdversary' data-category="{{categoryAdversary}}" data-tooltip="CONTROLS.CommonDelete">
-        <i class='fas fa-trash'></i>
-      </a>
-      {{/if}}
-      {{#if (eq type 'character')}}
-      <a data-action='deletePartyMember' data-tooltip="CONTROLS.CommonDelete">
-        <i class='fas fa-trash'></i>
-      </a>
-      {{/if}}
-    {{else}}
-      {{#unless (eq actorType 'party')}}
-        {{#if (eq type 'weapon')}}
-        <a class="{{#unless item.system.equipped}}unequipped{{/unless}}" data-action="toggleEquipItem"
-          data-tooltip="DAGGERHEART.UI.Tooltip.{{ifThen item.system.equipped 'unequip' 'equip' }}">
-          <i class="fa-solid fa-hands"></i>
-        </a>
-        {{else if (eq type 'armor')}}
-        <a class="{{#unless item.system.equipped}}unequipped{{/unless}}" data-action="toggleEquipItem"
-          data-tooltip="DAGGERHEART.UI.Tooltip.{{ifThen item.system.equipped 'unequip' 'equip' }}">
-          <i class="fa-solid fa-fw fa-shield"></i>
-        </a>
-        {{/if}}
-        {{#if (eq type 'domainCard')}}
-        <a data-action="toggleVault"
-          data-tooltip="DAGGERHEART.UI.Tooltip.{{ifThen item.system.inVault 'sendToLoadout' 'sendToVault' }}">
-          <i class="fa-solid {{ifThen item.system.inVault 'fa-arrow-up' 'fa-arrow-down'}}"></i>
-        </a>
-        {{else if (and (eq type 'effect') (not (eq item.type 'beastform')))}}
-        <a data-action="toggleEffect"
-          data-tooltip="DAGGERHEART.UI.Tooltip.{{ifThen item.disabled 'enableEffect' 'disableEffect' }}">
-          <i class="{{ifThen item.disabled 'fa-solid fa-toggle-off' 'fa-solid fa-toggle-on'}}"></i>
-        </a>
-        {{/if}}
-        {{#if (hasProperty item "toChat")}}
-          <a data-action="toChat" data-tooltip="DAGGERHEART.UI.Tooltip.sendToChat">
-            <i class="fa-regular fa-fw fa-message"></i>
-          </a>
-        {{/if}}
-      {{else}}
-        <a data-action="editDoc" data-tooltip="DAGGERHEART.UI.Tooltip.openActorWorld">
-          <i class="fa-solid fa-globe"></i>
-        </a>
-        <a data-action="deleteItem" data-tooltip="DAGGERHEART.UI.Tooltip.deleteItem">
-          <i class="fa-solid fa-trash"></i>
-        </a>
-      {{/unless}}
-      {{#unless hideContextMenu}}
-      <a data-action="triggerContextMenu" data-tooltip="DAGGERHEART.UI.Tooltip.moreOptions">
-        <i class="fa-solid fa-fw fa-ellipsis-vertical"></i>
-      </a>
-      {{/unless}}
-      {{/if}}
-    </div>
-  {{/unless}}
+        <div class="controls">
+            {{!-- Toggle/Equip buttons --}}
+            {{#if @root.editable}}
+                {{#if (and (eq actorType 'character') (eq type 'weapon'))}}
+                    <a class="{{#unless item.system.equipped}}unequipped{{/unless}}" data-action="toggleEquipItem"
+                        data-tooltip="DAGGERHEART.UI.Tooltip.{{ifThen item.system.equipped 'unequip' 'equip' }}">
+                        <i class="fa-solid fa-hands" inert></i>
+                    </a>
+                {{/if}}
+                {{#if (and (eq actorType 'character') (eq type 'armor'))}}
+                    <a class="{{#unless item.system.equipped}}unequipped{{/unless}}" data-action="toggleEquipItem"
+                        data-tooltip="DAGGERHEART.UI.Tooltip.{{ifThen item.system.equipped 'unequip' 'equip' }}">
+                        <i class="fa-solid fa-fw fa-shield" inert></i>
+                    </a>
+                {{/if}}
+                {{#if (and (eq type 'domainCard'))}}
+                    <a data-action="toggleVault"
+                        data-tooltip="DAGGERHEART.UI.Tooltip.{{ifThen item.system.inVault 'sendToLoadout' 'sendToVault' }}">
+                        <i class="fa-solid {{ifThen item.system.inVault 'fa-arrow-up' 'fa-arrow-down'}}" inert></i>
+                    </a>
+                {{/if}}
+                {{#if (and (and (eq type 'effect') (not (eq item.type 'beastform'))))}}
+                    <a data-action="toggleEffect"
+                        data-tooltip="DAGGERHEART.UI.Tooltip.{{ifThen item.disabled 'enableEffect' 'disableEffect' }}">
+                        <i class="{{ifThen item.disabled 'fa-solid fa-toggle-off' 'fa-solid fa-toggle-on'}}" inert></i>
+                    </a>
+                {{/if}}
+            {{/if}}
+
+            {{!-- Send to Chat --}}
+            {{#if (hasProperty item "toChat")}}
+                <a data-action="toChat" data-tooltip="DAGGERHEART.UI.Tooltip.sendToChat">
+                    <i class="fa-regular fa-fw fa-message" inert></i>
+                </a>
+            {{/if}}
+
+            {{!-- Document management buttons or context menu --}}
+            {{#if (and (not isActor) (not hideContextMenu))}}
+                <a data-action="triggerContextMenu" data-tooltip="DAGGERHEART.UI.Tooltip.moreOptions">
+                    <i class="fa-solid fa-fw fa-ellipsis-vertical" inert></i>
+                </a>
+            {{else if @root.editable}}
+                <a data-action="editDoc" data-tooltip="DAGGERHEART.UI.Tooltip.edit">
+                    <i class="fa-solid fa-edit" inert></i>
+                </a>
+                {{#if (not isActor)}}
+                    <a data-action="deleteItem" data-tooltip="DAGGERHEART.UI.Tooltip.deleteItem">
+                        <i class="fa-solid fa-trash" inert></i>
+                    </a>
+                {{else if (eq type 'adversary')}}
+                    <a data-action='deleteAdversary' data-category="{{categoryAdversary}}" data-tooltip="CONTROLS.CommonDelete">
+                        <i class="fas fa-trash" inert></i>
+                    </a>
+                {{/if}}
+            {{/if}}
+        </div>
+    {{/unless}}
   </div>
   <div class="inventory-item-content{{#unless noExtensible}} extensible{{/unless}}">
     {{!-- Description --}}

--- a/templates/sheets/global/partials/inventory-item-V2.hbs
+++ b/templates/sheets/global/partials/inventory-item-V2.hbs
@@ -25,11 +25,11 @@ Parameters:
 >
   <div class="inventory-item-header {{#if hideContextMenu}}padded{{/if}}" {{#unless noExtensible}}data-action="toggleExtended" {{/unless}}>
     {{!-- Image --}}
-    <div class="img-portait" data-action='{{ifThen (or (hasProperty item "use") (eq type "attack")) "useItem" (ifThen
+    <div class="img-portait" data-action='{{ifThen item.usable "useItem" (ifThen
       (hasProperty item "toChat" ) "toChat" "editDoc" ) }}' {{#unless hideTooltip}} {{#if (eq type 'attack' )}}
       data-tooltip="#attack#{{item.actor.uuid}}" {{else}} data-tooltip="#item#{{item.uuid}}" {{/if}} {{/unless}} draggable="true">
       <img src="{{item.img}}" class="item-img {{#if isActor}}actor-img{{/if}}" />
-      {{#if (or item.system.actionsList.size item.system.actionsList.length item.actionType)}}
+      {{#if item.usable}}
         {{#if @root.isNPC}}
           <img class="roll-img d20" src="systems/daggerheart/assets/icons/dice/default/d20.svg" alt="d20">
         {{else}}

--- a/templates/sheets/global/partials/inventory-item-compact.hbs
+++ b/templates/sheets/global/partials/inventory-item-compact.hbs
@@ -48,26 +48,28 @@
                 </a>
             {{/if}}
         {{else}}
-            {{#if (eq type 'weapon')}}
-            <a class="{{#unless item.system.equipped}}unequipped{{/unless}}" data-action="toggleEquipItem"
-                data-tooltip="DAGGERHEART.UI.Tooltip.{{ifThen item.system.equipped 'unequip' 'equip' }}">
-                <i class="fa-solid fa-fw fa-hands"></i>
-            </a>
-            {{else if (eq type 'armor')}}
-            <a class="{{#unless item.system.equipped}}unequipped{{/unless}}" data-action="toggleEquipItem"
-                data-tooltip="DAGGERHEART.UI.Tooltip.{{ifThen item.system.equipped 'unequip' 'equip' }}">
-                <i class="fa-solid fa-fw fa-shield"></i>
-            </a>
-            {{else if (eq type 'domainCard')}}
-            <a data-action="toggleVault"
-                data-tooltip="DAGGERHEART.UI.Tooltip.{{ifThen item.system.inVault 'sendToLoadout' 'sendToVault' }}">
-                <i class="fa-solid fa-fw {{ifThen item.system.inVault 'fa-arrow-up' 'fa-arrow-down'}}"></i>
-            </a>
-            {{else if (eq type 'effect')}}
-            <a data-action="toggleEffect"
-                data-tooltip="DAGGERHEART.UI.Tooltip.{{ifThen item.disabled 'enableEffect' 'disableEffect' }}">
-                <i class="fa-solid fa-fw {{ifThen item.disabled 'fa-toggle-off' 'fa-toggle-on'}}"></i>
-            </a>
+            {{#if @root.editable}}
+                {{#if (eq type 'weapon')}}
+                <a class="{{#unless item.system.equipped}}unequipped{{/unless}}" data-action="toggleEquipItem"
+                    data-tooltip="DAGGERHEART.UI.Tooltip.{{ifThen item.system.equipped 'unequip' 'equip' }}">
+                    <i class="fa-solid fa-fw fa-hands"></i>
+                </a>
+                {{else if (eq type 'armor')}}
+                <a class="{{#unless item.system.equipped}}unequipped{{/unless}}" data-action="toggleEquipItem"
+                    data-tooltip="DAGGERHEART.UI.Tooltip.{{ifThen item.system.equipped 'unequip' 'equip' }}">
+                    <i class="fa-solid fa-fw fa-shield"></i>
+                </a>
+                {{else if (eq type 'domainCard')}}
+                <a data-action="toggleVault"
+                    data-tooltip="DAGGERHEART.UI.Tooltip.{{ifThen item.system.inVault 'sendToLoadout' 'sendToVault' }}">
+                    <i class="fa-solid fa-fw {{ifThen item.system.inVault 'fa-arrow-up' 'fa-arrow-down'}}"></i>
+                </a>
+                {{else if (eq type 'effect')}}
+                <a data-action="toggleEffect"
+                    data-tooltip="DAGGERHEART.UI.Tooltip.{{ifThen item.disabled 'enableEffect' 'disableEffect' }}">
+                    <i class="fa-solid fa-fw {{ifThen item.disabled 'fa-toggle-off' 'fa-toggle-on'}}"></i>
+                </a>
+                {{/if}}
             {{/if}}
             {{#if (hasProperty item "toChat")}}
             <a data-action="toChat" data-tooltip="DAGGERHEART.UI.Tooltip.sendToChat">

--- a/templates/sheets/global/tabs/tab-actions.hbs
+++ b/templates/sheets/global/tabs/tab-actions.hbs
@@ -8,6 +8,6 @@
     title='DAGGERHEART.GENERAL.Action.plural'
     collection=document.system.actions
     type='action'
-    canCreate=true
+    canCreate=@root.editable
 }}
 </section>

--- a/templates/sheets/global/tabs/tab-effects.hbs
+++ b/templates/sheets/global/tabs/tab-effects.hbs
@@ -6,7 +6,7 @@
         type='effect'
         isGlassy=true
         collection=effects.actives
-        canCreate=true
+        canCreate=@root.editable
         hideResources=true
     }}
 
@@ -16,7 +16,7 @@
         disabledEffect=true
         isGlassy=true
         collection=effects.inactives
-        canCreate=true
+        canCreate=@root.editable
         hideResources=true
     }}
 </section>


### PR DESCRIPTION
Refactor to facilitate item usage on more actor types, and fixes some bugs and quirks with icon and context menus as a result. It also fixes some deprecation warnings.

- The globe was turned into a pencil.
- Send to chat is now available in the party sheet
- More `<i>` elements are now inert. This is better for screen readers.
- Visibility of elements as well as the options available are now more resilient to the observer status across all sheets. It is now possible for observers to interact with the sheet, though still not edit anything.
- Actions and items no longer show that they are usable from the party sheet

<img width="590" height="316" alt="image" src="https://github.com/user-attachments/assets/ae2b5e82-b7ff-4667-aeaf-3119e459c4c9" />
