### PR TITLE
[Fix] Easier to see light theme header buttons

### DIFF
--- a/styles/less/global/sheet.less
+++ b/styles/less/global/sheet.less
@@ -36,7 +36,7 @@ body.game:is(.performance-low, .noblur) {
         }
 
         button {
-            background: light-dark(transparent, @deep-black);
+            background: light-dark(#e8e6e3, @deep-black);
             color: light-dark(@dark-blue, @beige);
             border: 1px solid light-dark(@dark-blue, transparent);
             padding: 0;


### PR DESCRIPTION
Fixes the hard to see buttons on the party and item sheet header. I don't know what to call the color value, its kinda imitating the parchment color as a flat color, but for a one off light theme only thing, its maybe fine?

<img width="335" height="192" alt="image" src="https://github.com/user-attachments/assets/d400b874-378d-4f61-8c19-2d551ef0673d" />

