### PR TITLE
[Fix] origin change values and prioritize item options

### DIFF
--- a/module/data/actor/base.mjs
+++ b/module/data/actor/base.mjs
@@ -1,6 +1,6 @@
 import DHBaseActorSettings from '../../applications/sheets/api/actor-setting.mjs';
 import DHItem from '../../documents/item.mjs';
-import { getScrollTextData } from '../../helpers/utils.mjs';
+import { createShallowProxy, getScrollTextData } from '../../helpers/utils.mjs';
 
 const fields = foundry.data.fields;
 
@@ -180,8 +180,7 @@ export default class BaseDataActor extends foundry.abstract.TypeDataModel {
      * @returns {object}
      */
     getRollData() {
-        const data = { ...this };
-        return data;
+        return createShallowProxy(this);
     }
 
     /**

--- a/module/data/item/base.mjs
+++ b/module/data/item/base.mjs
@@ -160,7 +160,8 @@ export default class BaseDataItem extends foundry.abstract.TypeDataModel {
      */
     getRollData(options = {}) {
         const actorRollData = this.actor?.getRollData() ?? {};
-        const data = { ...actorRollData, item: { ...this } };
+        const data = Object.assign(actorRollData, {});
+        data.item = Object.assign(this, {});
         return data;
     }
 

--- a/module/data/item/base.mjs
+++ b/module/data/item/base.mjs
@@ -165,7 +165,7 @@ export default class BaseDataItem extends foundry.abstract.TypeDataModel {
      */
     getRollData(options = {}) {
         const data = this.actor?.getRollData() ?? {};
-        data.item = this;
+        data.item = shallowCopyWithGetters(this);
         return data;
     }
 

--- a/module/data/item/base.mjs
+++ b/module/data/item/base.mjs
@@ -7,7 +7,12 @@
  * @property {boolean} isInventoryItem- Indicates whether items of this type is a Inventory Item
  */
 
-import { addLinkedItemsDiff, getScrollTextData, updateLinkedItemApps } from '../../helpers/utils.mjs';
+import {
+    addLinkedItemsDiff,
+    getScrollTextData,
+    shallowCopyWithGetters,
+    updateLinkedItemApps
+} from '../../helpers/utils.mjs';
 import { ActionsField } from '../fields/actionField.mjs';
 import FormulaField from '../fields/formulaField.mjs';
 
@@ -159,9 +164,8 @@ export default class BaseDataItem extends foundry.abstract.TypeDataModel {
      * @returns {object}
      */
     getRollData(options = {}) {
-        const actorRollData = this.actor?.getRollData() ?? {};
-        const data = Object.assign(actorRollData, {});
-        data.item = Object.assign(this, {});
+        const data = this.actor?.getRollData() ?? {};
+        data.item = this;
         return data;
     }
 

--- a/module/data/item/base.mjs
+++ b/module/data/item/base.mjs
@@ -10,7 +10,7 @@
 import {
     addLinkedItemsDiff,
     getScrollTextData,
-    shallowCopyWithGetters,
+    createShallowProxy,
     updateLinkedItemApps
 } from '../../helpers/utils.mjs';
 import { ActionsField } from '../fields/actionField.mjs';
@@ -165,7 +165,7 @@ export default class BaseDataItem extends foundry.abstract.TypeDataModel {
      */
     getRollData(options = {}) {
         const data = this.actor?.getRollData() ?? {};
-        data.item = shallowCopyWithGetters(this);
+        data.item = createShallowProxy(this);
         return data;
     }
 

--- a/module/documents/activeEffect.mjs
+++ b/module/documents/activeEffect.mjs
@@ -170,10 +170,10 @@ export default class DhActiveEffect extends foundry.documents.ActiveEffect {
     }
 
     static getChangeValue(model, change, effect) {
-        let key = change.value.toString();
+        let value = change.value.toString();
         let origin = null;
-        if (key.toLowerCase().includes('origin.@') && effect.origin) {
-            key = key.replaceAll(/origin\.@/gi, '@');
+        if (value.toLowerCase().includes('origin.@') && effect.origin) {
+            value = value.replaceAll(/origin\.@/gi, '@');
             try {
                 const originEffect = foundry.utils.fromUuidSync(effect.origin);
                 origin =
@@ -187,10 +187,10 @@ export default class DhActiveEffect extends foundry.documents.ActiveEffect {
         const actor = model.parent instanceof Actor ? model.parent : model;
         const item = origin ?? null;
         const stackingParsedValue = effect.system.stacking
-            ? Roll.replaceFormulaData(key, { stacks: effect.system.stacking.value })
-            : key;
+            ? Roll.replaceFormulaData(value, { stacks: effect.system.stacking.value })
+            : value;
         const evalValue = itemAbleRollParse(stackingParsedValue, actor, item);
-        return evalValue ?? key;
+        return evalValue ?? value;
     }
 
     /**

--- a/module/documents/activeEffect.mjs
+++ b/module/documents/activeEffect.mjs
@@ -171,24 +171,25 @@ export default class DhActiveEffect extends foundry.documents.ActiveEffect {
 
     static getChangeValue(model, change, effect) {
         let key = change.value.toString();
-        const isOriginTarget = key.toLowerCase().includes('origin.@');
-        let parseModel = model;
-        if (isOriginTarget && effect.origin) {
-            key = change.key.replaceAll(/origin\.@/gi, '@');
+        let origin = null;
+        if (key.toLowerCase().includes('origin.@') && effect.origin) {
+            key = key.replaceAll(/origin\.@/gi, '@');
             try {
                 const originEffect = foundry.utils.fromUuidSync(effect.origin);
-                const doc =
+                origin =
                     originEffect.parent?.parent instanceof game.system.api.documents.DhpActor
                         ? originEffect.parent
                         : originEffect.parent.parent;
-                if (doc) parseModel = doc;
             } catch (_) {}
         }
 
+        // Get the actor and item documents. Note that actor roll data is inclusive of system roll data
+        const actor = model.parent instanceof Actor ? model.parent : model;
+        const item = origin ?? null;
         const stackingParsedValue = effect.system.stacking
             ? Roll.replaceFormulaData(key, { stacks: effect.system.stacking.value })
             : key;
-        const evalValue = itemAbleRollParse(stackingParsedValue, parseModel, effect.parent);
+        const evalValue = itemAbleRollParse(stackingParsedValue, actor, item);
         return evalValue ?? key;
     }
 

--- a/module/documents/activeEffect.mjs
+++ b/module/documents/activeEffect.mjs
@@ -169,23 +169,31 @@ export default class DhActiveEffect extends foundry.documents.ActiveEffect {
         super._applyChangeUnguided(actor, change, changes, options);
     }
 
+    /** Recursively finds the first parent document of the given object */
+    static #resolveParentDocument(model, documentClass) {
+        return model instanceof documentClass
+            ? model
+            : model.parent
+              ? this.#resolveParentDocument(model.parent, documentClass)
+              : null;
+    }
+
     static getChangeValue(model, change, effect) {
         let value = change.value.toString();
+        const useOrigin = value.toLowerCase().includes('origin.@') && effect.origin;
         let origin = null;
-        if (value.toLowerCase().includes('origin.@') && effect.origin) {
-            value = value.replaceAll(/origin\.@/gi, '@');
-            try {
-                const originEffect = foundry.utils.fromUuidSync(effect.origin);
-                origin =
-                    originEffect.parent?.parent instanceof game.system.api.documents.DhpActor
-                        ? originEffect.parent
-                        : originEffect.parent.parent;
-            } catch (_) {}
+        if (effect.origin) {
+            if (useOrigin) value = value.replaceAll(/origin\.@/gi, '@');
+            const originEffect = foundry.utils.fromUuidSync(effect.origin);
+            origin = this.#resolveParentDocument(originEffect, Item);
         }
 
         // Get the actor and item documents. Note that actor roll data is inclusive of system roll data
-        const actor = model.parent instanceof Actor ? model.parent : model;
-        const item = origin ?? effect.parent;
+        const actor = this.#resolveParentDocument(model, Actor);
+        const item =
+            (useOrigin ? origin : null) ??
+            this.#resolveParentDocument(effect.parent, Item) ??
+            (origin?.actor === actor ? origin : null);
         const stackingParsedValue = effect.system.stacking
             ? Roll.replaceFormulaData(value, { stacks: effect.system.stacking.value })
             : value;

--- a/module/documents/activeEffect.mjs
+++ b/module/documents/activeEffect.mjs
@@ -185,11 +185,11 @@ export default class DhActiveEffect extends foundry.documents.ActiveEffect {
 
         // Get the actor and item documents. Note that actor roll data is inclusive of system roll data
         const actor = model.parent instanceof Actor ? model.parent : model;
-        const item = origin ?? null;
+        const item = origin ?? effect.parent;
         const stackingParsedValue = effect.system.stacking
             ? Roll.replaceFormulaData(value, { stacks: effect.system.stacking.value })
             : value;
-        const evalValue = itemAbleRollParse(stackingParsedValue, actor, item);
+        const evalValue = this.effectSafeEval(itemAbleRollParse(stackingParsedValue, actor, item));
         return evalValue ?? value;
     }
 

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1,7 +1,7 @@
 import { emitAsGM, GMUpdateEvent } from '../systemRegistration/socket.mjs';
 import { LevelOptionType } from '../data/levelTier.mjs';
 import DHFeature from '../data/item/feature.mjs';
-import { createScrollText, damageKeyToNumber, getDamageKey, shallowCopyWithGetters } from '../helpers/utils.mjs';
+import { createScrollText, damageKeyToNumber, getDamageKey, createShallowProxy } from '../helpers/utils.mjs';
 import DhCompanionLevelUp from '../applications/levelup/companionLevelup.mjs';
 import { ResourceUpdateMap } from '../data/action/baseAction.mjs';
 import { abilities } from '../config/actorConfig.mjs';
@@ -595,7 +595,7 @@ export default class DhpActor extends Actor {
 
     /**@inheritdoc */
     getRollData() {
-        const rollData = shallowCopyWithGetters(super.getRollData());
+        const rollData = createShallowProxy(super.getRollData());
         rollData.id = this.id;
         rollData.name = this.name;
         rollData.system = this.system.getRollData();

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1,7 +1,7 @@
 import { emitAsGM, GMUpdateEvent } from '../systemRegistration/socket.mjs';
 import { LevelOptionType } from '../data/levelTier.mjs';
 import DHFeature from '../data/item/feature.mjs';
-import { createScrollText, damageKeyToNumber, getDamageKey } from '../helpers/utils.mjs';
+import { createScrollText, damageKeyToNumber, getDamageKey, shallowCopyWithGetters } from '../helpers/utils.mjs';
 import DhCompanionLevelUp from '../applications/levelup/companionLevelup.mjs';
 import { ResourceUpdateMap } from '../data/action/baseAction.mjs';
 import { abilities } from '../config/actorConfig.mjs';
@@ -595,10 +595,7 @@ export default class DhpActor extends Actor {
 
     /**@inheritdoc */
     getRollData() {
-        const rollData = foundry.utils.deepClone(super.getRollData());
-        /* system gets repeated infinately which causes issues when trying to use the data for document creation */
-        delete rollData.system;
-
+        const rollData = shallowCopyWithGetters(super.getRollData());
         rollData.id = this.id;
         rollData.name = this.name;
         rollData.system = this.system.getRollData();

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -54,13 +54,7 @@ export default class DHItem extends foundry.documents.Item {
      * @returns
      */
     getRollData(options = {}) {
-        let data;
-        if (this.system.getRollData) data = this.system.getRollData(options);
-        else {
-            const actorRollData = this.actor?.getRollData(options) ?? {};
-            data = { ...actorRollData, item: { ...this.system } };
-        }
-
+        let data = this.system.getRollData(options);
         if (data?.item) {
             data.item.flags = { ...this.flags };
             data.item.name = this.name;

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -373,9 +373,10 @@ export const itemAbleRollParse = (value, actor, item) => {
     const isItemTarget = value.toLowerCase().includes('item.@');
     const slicedValue = isItemTarget ? value.replaceAll(/item\.@/gi, '@') : value;
     const model = isItemTarget || item instanceof Item ? item : actor;
+    const rollData = isItemTarget || !model?.getRollData ? model : model.getRollData();
 
     try {
-        return Roll.replaceFormulaData(slicedValue, isItemTarget || !model?.getRollData ? model : model.getRollData());
+        return Roll.replaceFormulaData(slicedValue, rollData);
     } catch (_) {
         return '';
     }
@@ -831,6 +832,9 @@ export function createShallowProxy(obj) {
         deleteProperty(_target, prop) {
             delete overrides[prop];
             return true;
+        },
+        has(target, key) {
+            return key in overrides || key in target;
         }
     });
 }

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -810,25 +810,24 @@ export function sortBy(arr, fn) {
     return arr.sort(cmp);
 }
 
+function getAllPropertyNames(obj, names = new Set()) {
+    if (!obj) return names;
+
+    for (const name of Object.getOwnPropertyNames(obj)) {
+        names.add(name);
+    }
+
+    return getAllPropertyNames(Object.getPrototypeOf(obj), names);
+}
+
 /**
  * Returns a shallow copy including getters of the given object.
  * Generally used for expanding roll data without side effects
  */
 export function shallowCopyWithGetters(obj) {
-    function getAllPropertyDescriptors(obj) {
-        if (!obj) {
-            return Object.create(null);
-        }
-
-        return {
-            ...getAllPropertyDescriptors(Object.getPrototypeOf(obj)),
-            ...Object.getOwnPropertyDescriptors(obj)
-        };
-    }
-
-    const props = getAllPropertyDescriptors(obj);
+    const props = getAllPropertyNames(obj);
     const result = {};
-    for (const key of Object.keys(props)) {
+    for (const key of props) {
         const value = obj[key];
         if (key !== '__proto__' && typeof value !== 'function') {
             result[key] = obj[key];

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -810,28 +810,23 @@ export function sortBy(arr, fn) {
     return arr.sort(cmp);
 }
 
-function getAllPropertyNames(obj, names = new Set()) {
-    if (!obj) return names;
-
-    for (const name of Object.getOwnPropertyNames(obj)) {
-        names.add(name);
-    }
-
-    return getAllPropertyNames(Object.getPrototypeOf(obj), names);
-}
-
 /**
- * Returns a shallow copy including getters of the given object.
- * Generally used for expanding roll data without side effects
+ * Creates a proxy that allows retrieval of top data but diverts updates to a different object.
+ * Generally used for roll data
  */
-export function shallowCopyWithGetters(obj) {
-    const props = getAllPropertyNames(obj);
-    const result = {};
-    for (const key of props) {
-        const value = obj[key];
-        if (key !== '__proto__' && typeof value !== 'function') {
-            result[key] = obj[key];
+export function createShallowProxy(obj) {
+    if (obj._isShallowProxy) return obj;
+
+    const overrides = {};
+    return new Proxy(obj, {
+        get(target, prop, receiver) {
+            if (prop === '_isShallowProxy') return true;
+            if (prop in overrides) return overrides[prop];
+            return Reflect.get(target, prop, receiver);
+        },
+        set(_target, prop, newValue) {
+            overrides[prop] = newValue;
+            return true;
         }
-    }
-    return result;
+    });
 }

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -809,3 +809,30 @@ export function sortBy(arr, fn) {
     };
     return arr.sort(cmp);
 }
+
+/**
+ * Returns a shallow copy including getters of the given object.
+ * Generally used for expanding roll data without side effects
+ */
+export function shallowCopyWithGetters(obj) {
+    function getAllPropertyDescriptors(obj) {
+        if (!obj) {
+            return Object.create(null);
+        }
+
+        return {
+            ...getAllPropertyDescriptors(Object.getPrototypeOf(obj)),
+            ...Object.getOwnPropertyDescriptors(obj)
+        };
+    }
+
+    const props = getAllPropertyDescriptors(obj);
+    const result = {};
+    for (const key of Object.keys(props)) {
+        const value = obj[key];
+        if (key !== '__proto__' && typeof value !== 'function') {
+            result[key] = obj[key];
+        }
+    }
+    return result;
+}

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -827,6 +827,10 @@ export function createShallowProxy(obj) {
         set(_target, prop, newValue) {
             overrides[prop] = newValue;
             return true;
+        },
+        deleteProperty(_target, prop) {
+            delete overrides[prop];
+            return true;
         }
     });
 }

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -375,7 +375,7 @@ export const itemAbleRollParse = (value, actor, item) => {
 
     const isItemTarget = value.toLowerCase().includes('item.@');
     const slicedValue = isItemTarget ? value.replaceAll(/item\.@/gi, '@') : value;
-    const model = isItemTarget ? item : actor;
+    const model = isItemTarget || item instanceof Item ? item : actor;
 
     try {
         return Roll.replaceFormulaData(slicedValue, isItemTarget || !model?.getRollData ? model : model.getRollData());


### PR DESCRIPTION
Fixes unstoppable, supercedes https://github.com/Foundryborne/daggerheart/pull/1834

Since this change is much more foundational, I would like help testing this. In short, these are the changes:
1) When doing the origin replacement, we removed origin from the change key instead of the evaluated value. Now we replace origin on the value instead. This was also done by #1834 
2) We ensure that an actor is assigned to actor and item is assigned to item when passed to itemAbleRollParse. We prioritize the actor document over the actor system model as it's roll data is a superset.
3) itemAbleRollParse now prioritizes item roll data over actor props IF the item is an item document. Those are a superset of the actor roll data and shouldn't cause any regressions.

After this unstoppable works without any changes to the expression. In the future we can make it always retrieve the origin item if the origin item is on the same actor, though I don't know of a quick way to do that. effect.item is null for some reason as well. After that, ORIGIN would only be required for effects that come from other actors.