### PR TITLE
[Fix] Roll Parse Getter Values

### DIFF
--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -189,17 +189,14 @@ export const getDeleteKeys = (property, innerProperty, innerPropertyDefaultValue
 
 // Fix on Foundry native formula replacement for DH
 const nativeReplaceFormulaData = Roll.replaceFormulaData;
-Roll.replaceFormulaData = function (formula, baseData = {}, { missing, warn = false } = {}) {
+Roll.replaceFormulaData = function (formula, data = {}, { missing, warn = false } = {}) {
     /* Inserting global data */
-    const data = {
-        ...baseData,
-        partySize: game.actors?.party?.system.partyMembers.length ?? 0
-    };
+    const defaultingTypes = [
+        ...Object.keys(CONFIG.DH.GENERAL.multiplierTypes).map(x => ({ term: x, default: 1 })),
+        { term: 'partySize', default: game.actors?.party?.system.partyMembers.length ?? 0 }
+    ];
 
-    const terms = Object.keys(CONFIG.DH.GENERAL.multiplierTypes).map(type => {
-        return { term: type, default: 1 };
-    });
-    formula = terms.reduce((a, c) => a.replaceAll(`@${c.term}`, data[c.term] ?? c.default), formula);
+    formula = defaultingTypes.reduce((a, c) => a.replaceAll(`@${c.term}`, data[c.term] ?? c.default), formula);
     return nativeReplaceFormulaData(formula, data, { missing, warn });
 };
 


### PR DESCRIPTION
Fixed so that replaceFormulaValue doesn't loose getter values by not spreading the rollData object