### PR TITLE
[Fix] companion hope levelup feature and default stress

### DIFF
--- a/module/config/resourceConfig.mjs
+++ b/module/config/resourceConfig.mjs
@@ -60,12 +60,6 @@ const companionBaseResources = Object.freeze({
         max: 3,
         reverse: true,
         label: 'DAGGERHEART.GENERAL.stress'
-    },
-    hope: {
-        id: 'hope',
-        initial: 0,
-        reverse: false,
-        label: 'DAGGERHEART.GENERAL.hope'
     }
 });
 

--- a/module/config/resourceConfig.mjs
+++ b/module/config/resourceConfig.mjs
@@ -57,7 +57,7 @@ const companionBaseResources = Object.freeze({
     stress: {
         id: 'stress',
         initial: 0,
-        max: 0,
+        max: 3,
         reverse: true,
         label: 'DAGGERHEART.GENERAL.stress'
     },

--- a/module/data/actor/adversary.mjs
+++ b/module/data/actor/adversary.mjs
@@ -189,6 +189,9 @@ export default class DhpAdversary extends DhCreature {
     prepareDerivedData() {
         super.prepareDerivedData();
         this.attack.roll.isStandardAttack = true;
+
+        // Clamp resources (must be done last to ensure all updates occur)
+        this.resources.clamp();
     }
 
     _getTags() {

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -778,6 +778,8 @@ export default class DhCharacter extends DhCreature {
 
     prepareDerivedData() {
         super.prepareDerivedData();
+
+        this.resources.hope.max -= this.scars;
         if (this.companion) {
             for (let levelKey in this.companion.system.levelData.levelups) {
                 const level = this.companion.system.levelData.levelups[levelKey];
@@ -791,7 +793,6 @@ export default class DhCharacter extends DhCreature {
             }
         }
 
-        this.resources.hope.max -= this.scars;
         this.attack.roll.trait = this.rules.attack.roll.trait ?? this.attack.roll.trait;
 
         this.resources.armor = {
@@ -801,6 +802,9 @@ export default class DhCharacter extends DhCreature {
         };
 
         this.attack.damage.parts.hitPoints.value.custom.formula = `@prof${this.basicAttackDamageDice}${this.rules.attack.damage.bonus ? ` + ${this.rules.attack.damage.bonus}` : ''}`;
+
+        // Clamp resources (must be done last to ensure all updates occur)
+        this.resources.clamp();
     }
 
     getRollData() {

--- a/module/data/actor/companion.mjs
+++ b/module/data/actor/companion.mjs
@@ -145,7 +145,7 @@ export default class DhCompanion extends DhCreature {
             for (let selection of level.selections) {
                 switch (selection.type) {
                     case 'hope':
-                        this.resources.hope += selection.value;
+                        this.resources.hope.max += selection.value;
                         break;
                     case 'vicious':
                         if (selection.data[0] === 'damage') {
@@ -183,6 +183,9 @@ export default class DhCompanion extends DhCreature {
                 return acc;
             }, this.partner.system.companionData.levelupChoices);
         }
+
+        // Clamp resources (must be done last to ensure all updates occur)
+        this.resources.clamp();
     }
 
     async _preUpdate(changes, options, userId) {

--- a/module/data/actor/companion.mjs
+++ b/module/data/actor/companion.mjs
@@ -144,9 +144,6 @@ export default class DhCompanion extends DhCreature {
             const level = this.levelData.levelups[levelKey];
             for (let selection of level.selections) {
                 switch (selection.type) {
-                    case 'hope':
-                        this.resources.hope.max += selection.value;
-                        break;
                     case 'vicious':
                         if (selection.data[0] === 'damage') {
                             this.attack.damage.parts.hitPoints.value.dice = adjustDice(

--- a/module/data/actor/creature.mjs
+++ b/module/data/actor/creature.mjs
@@ -60,14 +60,4 @@ export default class DhCreature extends BaseDataActor {
             }
         }
     }
-
-    prepareDerivedData() {
-        const minLimitResource = resource => {
-            if (resource) resource.value = Math.min(resource.value, resource.max);
-        };
-
-        minLimitResource(this.resources.stress);
-        minLimitResource(this.resources.hitPoints);
-        minLimitResource(this.resources.hope);
-    }
 }

--- a/module/data/fields/actorField.mjs
+++ b/module/data/fields/actorField.mjs
@@ -80,6 +80,18 @@ class ResourcesField extends fields.TypedObjectField {
             value.isReversed = resources[key].reverse;
             value.max = typeof resource.max === 'number' ? (value.max ?? resource.max) : null;
         }
+        Object.defineProperty(data, 'clamp', {
+            value: function () {
+                for (const key of Object.keys(this)) {
+                    const resource = this[key];
+                    if (typeof resource?.max === 'number') {
+                        resource.value = Math.clamp(resource.value, 0, resource.max);
+                    }
+                }
+            },
+            enumerable: false
+        });
+
         return data;
     }
 


### PR DESCRIPTION
This is an issue in v13 as well. Can we remove the hope increase in the creature's data prep? Why does companion even have hope?