### PR TITLE
[Fix] Contextmenu Delete In Compendiums

### DIFF
--- a/module/applications/sheets/api/application-mixin.mjs
+++ b/module/applications/sheets/api/application-mixin.mjs
@@ -531,7 +531,7 @@ export default function DHApplicationMixin(Base) {
                     visible: element => {
                         const target = element.closest('[data-item-uuid]');
                         const doc = getDocFromElementSync(target);
-                        return doc?.isOwner && target.dataset.itemType !== 'beastform';
+                        return doc?.isOwner !== false && target.dataset.itemType !== 'beastform';
                     },
                     callback: async (target, event) => {
                         const doc = await getDocFromElement(target);


### PR DESCRIPTION
Fixed so that the delete option is available in the compendium.

The other instances of `doc?.isOwner` are fine as is, since they end up blocking things that should not be done in the compendium, such as trying to roll damage.