### PR TITLE
[Fix] ActiveEffect Non Existant Origin

### DIFF
--- a/module/documents/activeEffect.mjs
+++ b/module/documents/activeEffect.mjs
@@ -185,9 +185,8 @@ export default class DhActiveEffect extends foundry.documents.ActiveEffect {
         if (effect.origin) {
             if (useOrigin) value = value.replaceAll(/origin\.@/gi, '@');
             const originEffect = foundry.utils.fromUuidSync(effect.origin);
-            
-            if (originEffect)
-                origin = this.#resolveParentDocument(originEffect, Item);
+
+            if (originEffect) origin = this.#resolveParentDocument(originEffect, Item);
         }
 
         // Get the actor and item documents. Note that actor roll data is inclusive of system roll data

--- a/module/documents/activeEffect.mjs
+++ b/module/documents/activeEffect.mjs
@@ -185,7 +185,9 @@ export default class DhActiveEffect extends foundry.documents.ActiveEffect {
         if (effect.origin) {
             if (useOrigin) value = value.replaceAll(/origin\.@/gi, '@');
             const originEffect = foundry.utils.fromUuidSync(effect.origin);
-            origin = this.#resolveParentDocument(originEffect, Item);
+            
+            if (originEffect)
+                origin = this.#resolveParentDocument(originEffect, Item);
         }
 
         // Get the actor and item documents. Note that actor roll data is inclusive of system roll data


### PR DESCRIPTION
Made sure a non-existant origin doesn't cause ActiveEffect application to break.

An error would be produced any time you applied an effect via an Action's ChatMessage to a character, and then you deleted the origin actor the effect came from. The error would break the chain of ActiveEffect application, so unrelated other effects would not get applied.

---
Looking at this, I realised that the origin atm is always the most synthetic version of the actor, IE UUUID is `scene.<id>.actor.<id>`.
It could be more ideal to try and find any non-synthetic actors in the world that it came from and using that as the origin - but I didn't figure it the path at this time. Doing so would make it work if some persistent adversary puts an effect on a character that depends on it's `@tier`, and then the scene actor is deleted, but the effect is expected to still work.
It would in that case be done at `ActiveEffect.applyEffect`, altering what the origin is.

(Although I suppose this would instead make it have a non-value if a player deletes the actor in the tab and keeps only the synthetic actor on the canvas, so IDK, it may just be best to only do this simple change 🤷 )