### PR TITLE
[Fix] 1844 - Armor Source Names

### DIFF
--- a/module/applications/dialogs/damageReductionDialog.mjs
+++ b/module/applications/dialogs/damageReductionDialog.mjs
@@ -22,9 +22,10 @@ export default class DamageReductionDialog extends HandlebarsApplicationMixin(Ap
         );
 
         const orderedArmorSources = getArmorSources(actor).filter(s => !s.disabled);
-        const armor = orderedArmorSources.reduce((acc, { document }) => {
+        const armor = orderedArmorSources.reduce((acc, { name, document }) => {
             const { current, max } = document.type === 'armor' ? document.system.armor : document.system.armorData;
             acc.push({
+                name,
                 effect: document,
                 marks: [...Array(max).keys()].reduce((acc, _, index) => {
                     const spent = index < current;
@@ -152,14 +153,8 @@ export default class DamageReductionDialog extends HandlebarsApplicationMixin(Ap
 
         const armorSources = [];
         for (const source of this.marks.armor) {
-            const parent = source.effect.origin
-                ? await foundry.utils.fromUuid(source.effect.origin)
-                : source.effect.parent;
-
-            const useEffectName = parent.type === 'armor' || parent instanceof Actor;
-            const label = useEffectName ? source.effect.name : parent.name;
             armorSources.push({
-                label: label,
+                label: source.name,
                 uuid: source.effect.uuid,
                 marks: source.marks
             });

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -757,9 +757,12 @@ export function getArmorSources(actor) {
         // Get the origin item. Since the actor is already loaded, it should already be cached
         // Consider the relative function versions if this causes an issue
         const origin = doc.origin ? foundry.utils.fromUuidSync(doc.origin) : doc;
+        const useParentName = doc.parent && !(doc.parent instanceof Actor);
+        const name = doc.origin || !useParentName ? doc.name : doc.parent.name;
+
         return {
             origin,
-            name: origin.name,
+            name,
             document: doc,
             data: doc.system.armor ?? doc.system.armorData,
             disabled: !!doc.disabled || !!doc.isSuppressed


### PR DESCRIPTION
Fixes #1844 

DamageReductionDialog had it's own handling for the name that made it work.
I removed that and set up the names to be correct in the `utils.mjs` method that's used for both DamageReductionDialog and for the CharacterSheet armor tooltip.