### PR TITLE
Fix retrieving parent documents when the model is null

### DIFF
--- a/module/documents/activeEffect.mjs
+++ b/module/documents/activeEffect.mjs
@@ -171,6 +171,7 @@ export default class DhActiveEffect extends foundry.documents.ActiveEffect {
 
     /** Recursively finds the first parent document of the given object */
     static #resolveParentDocument(model, documentClass) {
+        if (!model) return null;
         return model instanceof documentClass
             ? model
             : model.parent


### PR DESCRIPTION
Supercedes https://github.com/Foundryborne/daggerheart/pull/1848
Fixes whatever that fixes and also fixes bonuses leading to erroring chat messages