### PR TITLE
[Fix] V13 - Downtime Use Reset RollData 

### DIFF
--- a/module/applications/dialogs/downtime.mjs
+++ b/module/applications/dialogs/downtime.mjs
@@ -259,7 +259,7 @@ export default class DhpDowntime extends HandlebarsApplicationMixin(ApplicationV
                 const resetValue = increasing
                     ? 0
                     : feature.system.resource.max
-                      ? new Roll(Roll.replaceFormulaData(feature.system.resource.max, this.actor)).evaluateSync().total
+                      ? new Roll(Roll.replaceFormulaData(feature.system.resource.max, this.actor.getRollData())).evaluateSync().total
                       : 0;
 
                 await feature.update({ 'system.resource.value': resetValue });


### PR DESCRIPTION
Fixed so that reseting Uses upon finishing downtime uses the actor's rollData and not just the actor data