### PR TITLE
[Fix] Adversary Settings DragDrop

### DIFF
--- a/module/applications/sheets-configs/adversary-settings.mjs
+++ b/module/applications/sheets-configs/adversary-settings.mjs
@@ -110,6 +110,7 @@ export default class DHAdversarySettings extends DHBaseActorSettings {
     }
 
     async _onDrop(event) {
+        event.stopPropagation();
         const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
 
         const item = await fromUuid(data.uuid);

--- a/module/applications/sheets-configs/environment-settings.mjs
+++ b/module/applications/sheets-configs/environment-settings.mjs
@@ -121,6 +121,7 @@ export default class DHEnvironmentSettings extends DHBaseActorSettings {
     }
 
     async _onDrop(event) {
+        event.stopPropagation();
         const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
         const item = await fromUuid(data.uuid);
         if (data.fromInternal && item?.parent?.uuid === this.actor.uuid) return;
@@ -137,9 +138,5 @@ export default class DHEnvironmentSettings extends DHBaseActorSettings {
             await this.actor.createEmbeddedDocuments('Item', [item]);
             this.render();
         }
-    }
-
-    async _onDropItem(event, item) {
-        console.log(item);
     }
 }


### PR DESCRIPTION
Added event.stopPropagation to avoid double matches and therefore double drops on drag/drop.
(ATM drag/dropping an adversary feature onto another adversary sheet created an extra duplicate feature)