### PR TITLE
[Feature] Exclude unusable non-weapons in character sidebar

### DIFF
--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -227,7 +227,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
             context.resources.stress.max < maxResource ? maxResource - context.resources.stress.max : 0;
 
         context.equippedItems = sortBy(
-            this.document.items.filter(i => i.system.equipped),
+            this.document.items.filter(i => i.system.equipped && (i.type === 'weapon' || i.usable)),
             i => (i.type === 'weapon' ? (i.system.secondary ? 1 : 0) : 2)
         );
 


### PR DESCRIPTION
Mostly just hides armor unless its special usable armor

<img width="291" height="366" alt="image" src="https://github.com/user-attachments/assets/379a7000-e49e-41e3-9bf1-ae3800ed604c" />
