### PR TITLE
[UI] Adjust spacing of character hope

### DIFF
--- a/styles/less/sheets/actors/character/header.less
+++ b/styles/less/sheets/actors/character/header.less
@@ -168,7 +168,7 @@
             .domains-section {
                 position: relative;
                 display: flex;
-                gap: 10px;
+                gap: 4px;
                 background-color: light-dark(transparent, @dark-blue);
                 color: light-dark(@dark-blue, @golden);
                 padding: 5px 10px;
@@ -183,6 +183,7 @@
                     font-weight: bold;
                     text-transform: uppercase;
                     color: light-dark(@dark-blue, @golden);
+                    margin-right: 4px;
                 }
 
                 .domain {


### PR DESCRIPTION
Minor UI change. The hope section feels too wide, and I think that might be because all font awesome icons became fixed width in v14. 

Before
<img width="295" height="115" alt="image" src="https://github.com/user-attachments/assets/f0c04b0a-99ec-45e2-a9ca-20c7433bd586" />

After
<img width="305" height="115" alt="image" src="https://github.com/user-attachments/assets/140d114b-ac93-4171-87cb-aebfde6f2b8a" />
