### PR TITLE
[Feature] 1876 - Adversary Disposition Split

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -409,7 +409,7 @@
                 "openCountdowns": "Countdowns",
                 "adversaryCategories": {
                     "friendly": "Friendly",
-                    "neutral": "Neutral"
+                    "adversaries": "Adversaries"
                 }
             },
             "CompendiumBrowserSettings": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -406,7 +406,11 @@
                 "giveSpotlight": "Give The Spotlight",
                 "requestingSpotlight": "Requesting The Spotlight",
                 "requestSpotlight": "Request The Spotlight",
-                "openCountdowns": "Countdowns"
+                "openCountdowns": "Countdowns",
+                "adversaryCategories": {
+                    "friendly": "Friendly",
+                    "neutral": "Neutral"
+                }
             },
             "CompendiumBrowserSettings": {
                 "title": "Enable Compendiums",

--- a/module/applications/ui/combatTracker.mjs
+++ b/module/applications/ui/combatTracker.mjs
@@ -57,11 +57,8 @@ export default class DhCombatTracker extends foundry.applications.sidebar.tabs.C
         await super._prepareTrackerContext(context, options);
 
         const npcs = context.turns?.filter(x => x.isNPC) ?? [];
-        const adversaries = npcs.filter(x => x.disposition === CONST.TOKEN_DISPOSITIONS.HOSTILE);
+        const adversaries = npcs.filter(x => x.disposition !== CONST.TOKEN_DISPOSITIONS.FRIENDLY);
         const friendlies = npcs.filter(x => x.disposition === CONST.TOKEN_DISPOSITIONS.FRIENDLY);
-        const neutrals = npcs.filter(x =>
-            [CONST.TOKEN_DISPOSITIONS.SECRET, CONST.TOKEN_DISPOSITIONS.NEUTRAL].includes(x.disposition)
-        );
         const characters = context.turns?.filter(x => !x.isNPC) ?? [];
         const spotlightQueueEnabled = game.settings.get(
             CONFIG.DH.id,
@@ -81,7 +78,6 @@ export default class DhCombatTracker extends foundry.applications.sidebar.tabs.C
             actionTokens: game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.variantRules).actionTokens,
             adversaries,
             friendlies,
-            neutrals,
             allCharacters: characters,
             characters: characters.filter(x => !spotlightQueueEnabled || x.system.spotlight.requestOrderIndex == 0),
             spotlightRequests

--- a/module/applications/ui/combatTracker.mjs
+++ b/module/applications/ui/combatTracker.mjs
@@ -56,7 +56,12 @@ export default class DhCombatTracker extends foundry.applications.sidebar.tabs.C
     async _prepareTrackerContext(context, options) {
         await super._prepareTrackerContext(context, options);
 
-        const adversaries = context.turns?.filter(x => x.isNPC) ?? [];
+        const npcs = context.turns?.filter(x => x.isNPC) ?? [];
+        const adversaries = npcs.filter(x => x.disposition === CONST.TOKEN_DISPOSITIONS.HOSTILE);
+        const friendlies = npcs.filter(x => x.disposition === CONST.TOKEN_DISPOSITIONS.FRIENDLY);
+        const neutrals = npcs.filter(x =>
+            [CONST.TOKEN_DISPOSITIONS.SECRET, CONST.TOKEN_DISPOSITIONS.NEUTRAL].includes(x.disposition)
+        );
         const characters = context.turns?.filter(x => !x.isNPC) ?? [];
         const spotlightQueueEnabled = game.settings.get(
             CONFIG.DH.id,
@@ -75,6 +80,8 @@ export default class DhCombatTracker extends foundry.applications.sidebar.tabs.C
         Object.assign(context, {
             actionTokens: game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.variantRules).actionTokens,
             adversaries,
+            friendlies,
+            neutrals,
             allCharacters: characters,
             characters: characters.filter(x => !spotlightQueueEnabled || x.system.spotlight.requestOrderIndex == 0),
             spotlightRequests
@@ -129,7 +136,8 @@ export default class DhCombatTracker extends foundry.applications.sidebar.tabs.C
             active: index === combat.turn,
             canPing: combatant.sceneId === canvas.scene?.id && game.user.hasPermission('PING_CANVAS'),
             type: combatant.actor?.system?.type,
-            img: await this._getCombatantThumbnail(combatant)
+            img: await this._getCombatantThumbnail(combatant),
+            disposition: combatant.token.disposition
         };
 
         turn.css = [turn.active ? 'active' : null, hidden ? 'hide' : null, isDefeated ? 'defeated' : null].filterJoin(

--- a/module/documents/tooltipManager.mjs
+++ b/module/documents/tooltipManager.mjs
@@ -350,7 +350,9 @@ export default class DhTooltipManager extends foundry.helpers.interaction.Toolti
     async getBattlepointHTML(combatId) {
         const combat = game.combats.get(combatId);
         const adversaries =
-            combat.turns?.filter(x => x.actor?.isNPC)?.map(x => ({ ...x.actor, type: x.actor.system.type })) ?? [];
+            combat.turns
+                ?.filter(x => x.actor?.isNPC && x.token.disposition === CONST.TOKEN_DISPOSITIONS.HOSTILE)
+                ?.map(x => ({ ...x.actor, type: x.actor.system.type })) ?? [];
         const characters = combat.turns?.filter(x => !x.isNPC && x.actor) ?? [];
 
         const nrCharacters = characters.length;

--- a/templates/ui/combatTracker/combatTracker.hbs
+++ b/templates/ui/combatTracker/combatTracker.hbs
@@ -8,9 +8,6 @@
     {{#if (gt this.friendlies.length 0)}}
         {{> 'systems/daggerheart/templates/ui/combatTracker/combatTrackerSection.hbs' this title=(localize "DAGGERHEART.APPLICATIONS.CombatTracker.adversaryCategories.friendly") turns=this.friendlies}}
     {{/if}}
-    {{#if (gt this.neutrals.length 0)}}
-        {{> 'systems/daggerheart/templates/ui/combatTracker/combatTrackerSection.hbs' this title=(localize "DAGGERHEART.APPLICATIONS.CombatTracker.adversaryCategories.neutral") turns=this.neutrals}}
-    {{/if}}
     {{#if (gt this.adversaries.length 0)}}
         {{> 'systems/daggerheart/templates/ui/combatTracker/combatTrackerSection.hbs' this title=(localize "DAGGERHEART.GENERAL.Adversary.plural") turns=this.adversaries}}
     {{/if}}

--- a/templates/ui/combatTracker/combatTracker.hbs
+++ b/templates/ui/combatTracker/combatTracker.hbs
@@ -5,6 +5,12 @@
     {{#if (gt this.characters.length 0)}}
         {{> 'systems/daggerheart/templates/ui/combatTracker/combatTrackerSection.hbs' this title=(localize "DAGGERHEART.GENERAL.Character.plural") turns=this.characters}}
     {{/if}}
+    {{#if (gt this.friendlies.length 0)}}
+        {{> 'systems/daggerheart/templates/ui/combatTracker/combatTrackerSection.hbs' this title=(localize "DAGGERHEART.APPLICATIONS.CombatTracker.adversaryCategories.friendly") turns=this.friendlies}}
+    {{/if}}
+    {{#if (gt this.neutrals.length 0)}}
+        {{> 'systems/daggerheart/templates/ui/combatTracker/combatTrackerSection.hbs' this title=(localize "DAGGERHEART.APPLICATIONS.CombatTracker.adversaryCategories.neutral") turns=this.neutrals}}
+    {{/if}}
     {{#if (gt this.adversaries.length 0)}}
         {{> 'systems/daggerheart/templates/ui/combatTracker/combatTrackerSection.hbs' this title=(localize "DAGGERHEART.GENERAL.Adversary.plural") turns=this.adversaries}}
     {{/if}}

--- a/templates/ui/combatTracker/combatTracker.hbs
+++ b/templates/ui/combatTracker/combatTracker.hbs
@@ -9,6 +9,6 @@
         {{> 'systems/daggerheart/templates/ui/combatTracker/combatTrackerSection.hbs' this title=(localize "DAGGERHEART.APPLICATIONS.CombatTracker.adversaryCategories.friendly") turns=this.friendlies}}
     {{/if}}
     {{#if (gt this.adversaries.length 0)}}
-        {{> 'systems/daggerheart/templates/ui/combatTracker/combatTrackerSection.hbs' this title=(localize "DAGGERHEART.GENERAL.Adversary.plural") turns=this.adversaries}}
+        {{> 'systems/daggerheart/templates/ui/combatTracker/combatTrackerSection.hbs' this title=(localize "DAGGERHEART.APPLICATIONS.CombatTracker.adversaryCategories.adversaries") turns=this.adversaries}}
     {{/if}}
 </div>


### PR DESCRIPTION
Fixes #1876 
Introduced a adversary category split for BP calculation and CombatTracker display based on token disposition
<img width="373" height="636" alt="image" src="https://github.com/user-attachments/assets/d3c905bc-7781-4913-91cb-aa95df3ca150" />

----
The combat tracker isn't currently rerendering based on changes to tokenData related to the combatants. Not sure if that's something we want to delve into or not.

A possibility to enable quicker changes of disposition (thinking primarily neutral to hostile might be a usecase) could be to add a disposition change button in the combat tracker, since there's space there 🤷‍♂️ 
<img width="369" height="301" alt="image" src="https://github.com/user-attachments/assets/428165f7-34c2-4fba-88fc-1887388f9b50" />