### PR TITLE
[Fix] selecting multiclass and multiple sheet issues

### DIFF
--- a/module/applications/levelup/characterLevelup.mjs
+++ b/module/applications/levelup/characterLevelup.mjs
@@ -156,6 +156,7 @@ export default class DhCharacterLevelUp extends LevelUpBase {
                 if (multiclasses?.[0]) {
                     const data = multiclasses[0];
                     const multiclass = data.data.length > 0 ? await foundry.utils.fromUuid(data.data[0]) : {};
+                    const subclasses = (await multiclass?.system?.fetchSubclasses()) ?? [];
 
                     context.multiclass = {
                         ...data,
@@ -175,13 +176,12 @@ export default class DhCharacterLevelUp extends LevelUpBase {
                                         alreadySelected
                                 };
                             }) ?? [],
-                        subclasses:
-                            multiclass?.system?.subclasses.map(subclass => ({
-                                ...subclass,
-                                uuid: subclass.uuid,
-                                selected: data.secondaryData.subclass === subclass.uuid,
-                                disabled: data.secondaryData.subclass && data.secondaryData.subclass !== subclass.uuid
-                            })) ?? [],
+                        subclasses: subclasses.map(subclass => ({
+                            ...subclass,
+                            uuid: subclass.uuid,
+                            selected: data.secondaryData.subclass === subclass.uuid,
+                            disabled: data.secondaryData.subclass && data.secondaryData.subclass !== subclass.uuid
+                        })),
                         compendium: 'classes',
                         limit: 1
                     };

--- a/styles/less/dialog/character-creation/selections-container.less
+++ b/styles/less/dialog/character-creation/selections-container.less
@@ -114,9 +114,6 @@
 
             .card-preview-container {
                 flex: 1;
-            }
-
-            .card-preview-container {
                 border-color: light-dark(@dark-blue, @golden);
             }
 

--- a/styles/less/dialog/index.less
+++ b/styles/less/dialog/index.less
@@ -1,10 +1,5 @@
 @import './attribution/sheet.less';
-@import './level-up/navigation-container.less';
-@import './level-up/selections-container.less';
-@import './level-up/sheet.less';
-@import './level-up/summary-container.less';
-@import './level-up/tiers-container.less';
-@import './level-up/footer.less';
+@import './level-up/index.less';
 
 @import './resource-dice/sheet.less';
 

--- a/styles/less/dialog/level-up/index.less
+++ b/styles/less/dialog/level-up/index.less
@@ -1,0 +1,6 @@
+@import './navigation-container.less';
+@import './selections-container.less';
+@import './summary-container.less';
+@import './tiers-container.less';
+@import './footer.less';
+@import './sheet.less';

--- a/styles/less/dialog/level-up/selections-container.less
+++ b/styles/less/dialog/level-up/selections-container.less
@@ -3,11 +3,7 @@
 
 .daggerheart.levelup {
     .levelup-selections-container {
-        overflow: auto;
         padding: 10px 0;
-        scrollbar-width: thin;
-        scrollbar-color: light-dark(@dark-blue, @golden) transparent;
-        mask-image: linear-gradient(0deg, transparent 0%, black 5%, black 95%, transparent 100%);
 
         .achievement-experience-cards {
             display: flex;

--- a/styles/less/dialog/level-up/selections-container.less
+++ b/styles/less/dialog/level-up/selections-container.less
@@ -45,20 +45,22 @@
 
         .levelup-card-selection {
             display: flex;
-            flex-wrap: wrap;
             justify-content: center;
             gap: 40px;
             height: 190px;
+            align-items: stretch;
 
             .card-preview-container {
-                height: 100%;
+                height: 190px;
                 max-width: 200px;
             }
 
             .levelup-domains-selection-container {
-                display: flex;
-                flex-direction: column;
-                gap: 8px;
+                display: grid;
+                grid-auto-flow: column;
+                grid-template-rows: repeat(2, minmax(0, 1fr));
+                height: 100%;
+                gap: 4px;
 
                 .levelup-domain-selection-container {
                     display: flex;
@@ -66,6 +68,8 @@
                     align-items: center;
                     position: relative;
                     cursor: pointer;
+                    overflow: hidden;
+                    width: 93px;
 
                     &.disabled {
                         pointer-events: none;
@@ -83,7 +87,9 @@
                     }
 
                     img {
-                        height: 124px;
+                        object-fit: cover;
+                        width: auto;
+                        height: auto;
 
                         &.svg {
                             filter: @beige-filter;
@@ -92,17 +98,18 @@
 
                     .levelup-domain-selected {
                         position: absolute;
-                        height: 54px;
-                        width: 54px;
+                        height: 48px;
+                        width: 48px;
                         border-radius: 50%;
-                        border: 2px solid;
-                        font-size: var(--font-size-48);
+                        border: 2px solid @golden;
+                        font-size: var(--font-size-28);
                         display: flex;
                         align-items: center;
                         justify-content: center;
-                        background-image: url(../assets/parchments/dh-parchment-light.png);
-                        color: var(--color-dark-5);
-                        top: calc(50% - 29px);
+                        background: @dark-golden;
+                        color: @golden;
+                        top: calc(50% - 10px);
+                        z-index: 2;
 
                         i {
                             position: relative;

--- a/styles/less/dialog/level-up/selections-container.less
+++ b/styles/less/dialog/level-up/selections-container.less
@@ -7,7 +7,6 @@
         padding: 10px 0;
         scrollbar-width: thin;
         scrollbar-color: light-dark(@dark-blue, @golden) transparent;
-        max-height: 500px;
         mask-image: linear-gradient(0deg, transparent 0%, black 5%, black 95%, transparent 100%);
 
         .achievement-experience-cards {

--- a/styles/less/dialog/level-up/selections-container.less
+++ b/styles/less/dialog/level-up/selections-container.less
@@ -78,12 +78,14 @@
 
                     .levelup-domain-label {
                         position: absolute;
+                        left: 0;
+                        right: 0;
+                        bottom: 0;
                         text-align: center;
-                        top: 4px;
                         background: grey;
-                        padding: 0 12px;
-                        border-radius: 6px;
+                        padding: 2px 12px;
                         z-index: 2;
+                        line-height: 1;
                     }
 
                     img {
@@ -98,17 +100,17 @@
 
                     .levelup-domain-selected {
                         position: absolute;
-                        height: 48px;
-                        width: 48px;
+                        height: 40px;
+                        width: 40px;
                         border-radius: 50%;
                         border: 2px solid @golden;
-                        font-size: var(--font-size-28);
+                        font-size: var(--font-size-24);
                         display: flex;
                         align-items: center;
                         justify-content: center;
                         background: @dark-golden;
                         color: @golden;
-                        top: calc(50% - 10px);
+                        top: 10px;
                         z-index: 2;
 
                         i {

--- a/styles/less/dialog/level-up/sheet.less
+++ b/styles/less/dialog/level-up/sheet.less
@@ -11,8 +11,8 @@
 });
 
 .daggerheart.levelup {
-    .window-content {
-        max-height: 960px;
+    .tab.active {
+        flex: 1;
         overflow: auto;
     }
 
@@ -22,15 +22,13 @@
         gap: 8px;
     }
 
-    section {
-        .section-container {
-            display: flex;
-            flex-direction: row;
-            justify-content: center;
-            gap: 20px 8px;
-            margin-top: 8px;
-            flex-wrap: wrap;
-        }
+    .section-container {
+        display: flex;
+        flex-direction: row;
+        justify-content: center;
+        gap: 20px 8px;
+        margin-top: 8px;
+        flex-wrap: wrap;
     }
 
     .levelup-footer {

--- a/styles/less/dialog/level-up/sheet.less
+++ b/styles/less/dialog/level-up/sheet.less
@@ -14,6 +14,8 @@
     .tab.active {
         flex: 1;
         overflow: auto;
+        scrollbar-width: thin;
+        scrollbar-color: light-dark(@dark-blue, @golden) transparent;
     }
 
     div[data-application-part='form'] {

--- a/styles/less/global/elements.less
+++ b/styles/less/global/elements.less
@@ -804,6 +804,7 @@
 
         .preview-image-container {
             width: 100%;
+            min-height: 0;
             flex-grow: 1;
             object-fit: cover;
             border-radius: 4px 4px 0 0;

--- a/templates/levelup/tabs/selections.hbs
+++ b/templates/levelup/tabs/selections.hbs
@@ -43,45 +43,6 @@
             </fieldset>
         {{/if}}
 
-        {{#if (gt this.domainCards.length 0)}}
-            <div class="card-section">
-                <div class="card-section-header">
-                    <side-line-div class="invert"></side-line-div>
-                    <h3>{{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.domainCards"}}</h3>
-                    <side-line-div></side-line-div>
-                </div>
-                <div class="tip">
-
-                </div>
-
-                <div class="levelup-card-selection domain-cards">
-                    {{#each this.domainCards}}
-                        {{#> "systems/daggerheart/templates/components/card-preview.hbs" this }}
-                            {{#each this.emptySubtexts}}
-                                <div class="">{{this}}</div>
-                            {{/each}}
-                        {{/"systems/daggerheart/templates/components/card-preview.hbs"}}
-                    {{/each}}
-                </div>
-            </div>
-        {{/if}}
-
-        {{#if (gt this.subclassCards.length 0)}}
-            <div class="card-section">
-                <div class="card-section-header">
-                    <side-line-div class="invert"></side-line-div>
-                    <h3>{{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.subclass"}}</h3>
-                    <side-line-div></side-line-div>
-                </div>
-
-                <div class="levelup-card-selection subclass-cards">
-                    {{#each this.subclassCards}}
-                        {{> "systems/daggerheart/templates/levelup/parts/selectable-card-preview.hbs" img=this.img header=this.featureLabel name=this.name path=this.path selected=this.selected uuid=this.uuid isMulticlass=this.isMulticlass featureState=this.featureState disabled=this.disabled }}
-                    {{/each}}
-                </div>
-            </div>
-        {{/if}}
-
         {{#if this.multiclass}}
             <div class="card-section">
                 <div class="card-section-header">
@@ -124,6 +85,45 @@
                             {{/each}}
                         </div>
                     {{/if}}
+                </div>
+            </div>
+        {{/if}}
+
+        {{#if (gt this.domainCards.length 0)}}
+            <div class="card-section">
+                <div class="card-section-header">
+                    <side-line-div class="invert"></side-line-div>
+                    <h3>{{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.domainCards"}}</h3>
+                    <side-line-div></side-line-div>
+                </div>
+                <div class="tip">
+
+                </div>
+
+                <div class="levelup-card-selection domain-cards">
+                    {{#each this.domainCards}}
+                        {{#> "systems/daggerheart/templates/components/card-preview.hbs" this }}
+                            {{#each this.emptySubtexts}}
+                                <div class="">{{this}}</div>
+                            {{/each}}
+                        {{/"systems/daggerheart/templates/components/card-preview.hbs"}}
+                    {{/each}}
+                </div>
+            </div>
+        {{/if}}
+
+        {{#if (gt this.subclassCards.length 0)}}
+            <div class="card-section">
+                <div class="card-section-header">
+                    <side-line-div class="invert"></side-line-div>
+                    <h3>{{localize "DAGGERHEART.APPLICATIONS.Levelup.summary.subclass"}}</h3>
+                    <side-line-div></side-line-div>
+                </div>
+
+                <div class="levelup-card-selection subclass-cards">
+                    {{#each this.subclassCards}}
+                        {{> "systems/daggerheart/templates/levelup/parts/selectable-card-preview.hbs" img=this.img header=this.featureLabel name=this.name path=this.path selected=this.selected uuid=this.uuid isMulticlass=this.isMulticlass featureState=this.featureState disabled=this.disabled }}
+                    {{/each}}
                 </div>
             </div>
         {{/if}}


### PR DESCRIPTION
Fixes a few things. Feel free to omit anything that seems minor from patch notes, or condense stuff

* Multiclass items causing an error when selected. We missed a spot in the previous release for subclass link stuff
* Moved multiclass selection before domain card selection
* Fixed height of multiclass selection row, and handle 3 or more domains and subclasses. Updating styling as well.
* Fixed responsiveness of tab when resized, removed max size rules
* Fixed card rendering when multiple lines (image should now resize appropriately)

Here's an example of most style fixes happening all at the same time.

<img width="1204" height="1023" alt="image" src="https://github.com/user-attachments/assets/003db4ec-2180-4cb3-a411-8a52b8dc2997" />
