### PR TITLE
[Fix] Compendium browser sometimes spawning behind other windows

### DIFF
--- a/module/applications/ui/itemBrowser.mjs
+++ b/module/applications/ui/itemBrowser.mjs
@@ -109,8 +109,8 @@ export class ItemBrowser extends HandlebarsApplicationMixin(ApplicationV2) {
             CONFIG.DH.id,
             CONFIG.DH.FLAGS[`${this.compendiumBrowserTypeKey}`].position
         );
-
         options.position = userPresetPosition ?? ItemBrowser.DEFAULT_OPTIONS.position;
+        delete options.position.zIndex;
 
         if (!userPresetPosition) {
             const width = noFolder === true || lite === true ? 600 : 850;


### PR DESCRIPTION
Internally foundry uses a combination of zIndex and frontApp to handle bring to front. Us persisting and setting the zIndex caused the two to go out of sync starting in v14, which is why sometimes compendium browsers when spawning behind will not go back to front when you click them, forcing you to click on a tertiary window.