### PR TITLE
[Fix] Uses of font awesome and adjust browser filter spacing

### DIFF
--- a/styles/less/global/global.less
+++ b/styles/less/global/global.less
@@ -38,7 +38,7 @@
         }
 
         &:before {
-            font-family: 'Font Awesome 6 Pro';
+            font-family: var(--font-awesome);
             content: '\f110';
             position: absolute;
             height: 100%;

--- a/styles/less/ui/chat/sheet.less
+++ b/styles/less/ui/chat/sheet.less
@@ -195,7 +195,7 @@ fieldset.daggerheart.chat {
         &:before,
         &:after {
             content: '\f0d8';
-            font-family: 'Font Awesome 6 Pro';
+            font-family: var(--font-awesome);
         }
     }
     &.expanded {

--- a/styles/less/ui/item-browser/item-browser.less
+++ b/styles/less/ui/item-browser/item-browser.less
@@ -125,6 +125,7 @@
 
             .form-group {
                 white-space: nowrap;
+                gap: 0;
             }
 
             .filter-header {
@@ -167,6 +168,10 @@
                         color: light-dark(@dark-blue-50, @beige-50);
                     }
                 }
+            }
+
+            .filter-content {            
+                margin-top: 8px;
             }
         }
 
@@ -272,7 +277,7 @@
 
             div[data-sort-key] {
                 &:after {
-                    font-family: 'Font Awesome 6 Pro';
+                    font-family: var(--font-awesome);
                     margin-left: 5px;
                 }
 


### PR DESCRIPTION
I don't know what the other uses are, but it does fix the header icons in the browser. I also adjusted the spacing of the filter elements to hopefully flow a bit better.

<img width="661" height="308" alt="image" src="https://github.com/user-attachments/assets/7ff2af89-72ac-4443-a64a-dcc442d320bd" />
