### PR TITLE
[Fix] party rerenders from shields and weapons

### DIFF
--- a/module/data/item/armor.mjs
+++ b/module/data/item/armor.mjs
@@ -141,16 +141,6 @@ export default class DHArmor extends AttachableItem {
         }
     }
 
-    _onUpdate(a, b, c) {
-        super._onUpdate(a, b, c);
-
-        if (this.actor?.type === 'character') {
-            for (const party of this.actor.parties) {
-                party.render();
-            }
-        }
-    }
-
     /** @inheritDoc */
     static migrateDocumentData(source) {
         if (!source.system.armor) {

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -112,10 +112,22 @@ export default class DhpActor extends Actor {
         this.updateSource(update);
     }
 
+    /** Perform a render, debounced in order to prevent overloading repeat render requests */
+    renderDebounced = foundry.utils.debounce(options => {
+        return this.render(options);
+    }, 10);
+
+    _onUpdateDescendantDocuments(parent, collection, documents, changes, options, userId) {
+        super._onUpdateDescendantDocuments(parent, collection, documents, changes, options, userId);
+        for (const party of this.parties) {
+            party.renderDebounced({ parts: ['partyMembers'] });
+        }
+    }
+
     _onUpdate(changes, options, userId) {
         super._onUpdate(changes, options, userId);
         for (const party of this.parties) {
-            party.render({ parts: ['partyMembers'] });
+            party.renderDebounced({ parts: ['partyMembers'] });
         }
     }
 
@@ -134,7 +146,7 @@ export default class DhpActor extends Actor {
     _onDelete(options, userId) {
         super._onDelete(options, userId);
         for (const party of this.parties) {
-            party.render({ parts: ['partyMembers'] });
+            party.renderDebounced({ parts: ['partyMembers'] });
         }
     }
 


### PR DESCRIPTION
Equips/unequips as well as updates in shields did not reflect in the party sheet. This extends it to all item updates, though there is a debounce to prevent overloading the render requests.