### PR TITLE
[Fix] Clowncar Lingering Destroyed Tokens

### DIFF
--- a/module/applications/hud/tokenHUD.mjs
+++ b/module/applications/hud/tokenHUD.mjs
@@ -124,7 +124,9 @@ export default class DHTokenHUD extends foundry.applications.hud.TokenHUD {
         const animationDuration = 500;
         const scene = game.scenes.get(game.user.viewedScene);
         /* getDependentTokens returns already removed tokens with id = null. Need to filter that until it's potentially fixed from Foundry */
-        const activeTokens = actors.flatMap(member => member.getDependentTokens({ scenes: scene }).filter(x => x._id));
+        const activeTokens = actors.flatMap(member =>
+            member.getDependentTokens({ scenes: scene }).filter(x => x._id && !x._destroyed)
+        );
         const { x: actorX, y: actorY } = this.document;
         if (activeTokens.length > 0) {
             for (let token of activeTokens) {


### PR DESCRIPTION
Fixed so that already destroyed tokens that foundry still lists in `getDependentTokens` are not considered for the Party/Companion clowncar functionality.
Currently we end up with trying to run an update on a token that doesn't actually exist, and therefore it errors out.