### PR TITLE
[UI/UX] Remove item type line from domain cards

### DIFF
--- a/module/applications/sheets/items/domainCard.mjs
+++ b/module/applications/sheets/items/domainCard.mjs
@@ -4,7 +4,7 @@ export default class DomainCardSheet extends DHBaseItemSheet {
     /**@inheritdoc */
     static DEFAULT_OPTIONS = {
         classes: ['domain-card'],
-        position: { width: 450, height: 700 }
+        position: { width: 450, height: 680 }
     };
 
     /** @override */

--- a/styles/less/global/item-header.less
+++ b/styles/less/global/item-header.less
@@ -72,7 +72,7 @@
             height: 300px;
             width: 100%;
             object-fit: cover;
-            mask-image: linear-gradient(0deg, transparent 0%, black 10%);
+            mask-image: linear-gradient(0deg, transparent 0%, black 6.25%);
             cursor: pointer;
         }
 
@@ -142,7 +142,6 @@
             .item-name {
                 input[type='text'] {
                     font-size: var(--font-size-32);
-                    height: 42px;
                     text-align: center;
                     width: 90%;
                     transition: all 0.3s ease;

--- a/styles/less/sheets/items/domain-card.less
+++ b/styles/less/sheets/items/domain-card.less
@@ -3,7 +3,6 @@
 
 .application.sheet.daggerheart.dh-style.domain-card {
     section.tab {
-        height: 400px;
         overflow-y: auto;
     }
 }

--- a/styles/less/sheets/items/item-sheet-shared.less
+++ b/styles/less/sheets/items/item-sheet-shared.less
@@ -8,7 +8,7 @@
     .attribution-header-label {
         font-style: italic;
         font-family: @font-body;
-        color: light-dark(@chat-blue-bg, @beige-50);
+        color: @color-text-subtle;
     }
 
     button.plain.inline-control {

--- a/templates/sheets/items/domainCard/header.hbs
+++ b/templates/sheets/items/domainCard/header.hbs
@@ -14,7 +14,6 @@
     <div class='item-info'>
         <h1 class='item-name'><input type='text' name='name' value='{{source.name}}' /></h1>
         <div class='item-description'>
-            <h3>{{localize 'TYPES.Item.domainCard'}}</h3>
             <h3>
                 {{localize (concat 'DAGGERHEART.CONFIG.DomainCardTypes.' source.system.type)}}
                 <span>-</span>


### PR DESCRIPTION
Removes the "Domain Card" label from the item, reducing the total height. I was originally gonna reduce the image height, but then I found out I mathed out the aspect ratios from the book wrong, we are actually correct.

We can reject this or redirect the change if we think this will make it harder on newbies.

<img width="462" height="710" alt="image" src="https://github.com/user-attachments/assets/d977a9e3-7e72-47c4-bb45-7db6142c3e08" />

