### PR TITLE
[UI/UX] Add minor visual tweaks to daggerheart setting dialogs

### DIFF
--- a/styles/less/global/elements.less
+++ b/styles/less/global/elements.less
@@ -7,12 +7,12 @@
     input[type='text'],
     input[type='number'],
     textarea,
+    file-picker,
     .input[contenteditable] {
         background: light-dark(transparent, transparent);
         border-radius: 6px;
         box-shadow: 0 4px 30px @soft-shadow;
         backdrop-filter: blur(9.5px);
-        -webkit-backdrop-filter: blur(9.5px);
         outline: 2px solid transparent;
         color: light-dark(@dark-blue, @golden);
         border: 1px solid light-dark(@dark, @beige);
@@ -98,7 +98,7 @@
         color: light-dark(@dark, @beige);
     }
 
-    button:where(:not(.plain)) {
+    button:where(:not(.plain, color-picker *, file-picker *)) {
         background: light-dark(transparent, @golden);
         border: 1px solid light-dark(@dark-blue, @dark-blue);
         color: light-dark(@dark-blue, @dark-blue);
@@ -250,6 +250,15 @@
     a:hover,
     a.active {
         text-shadow: 0 0 1px currentColor, 0 0 1px currentColor, 0 0 8px light-dark(@dark-blue, @golden);
+    }
+
+    file-picker, color-picker {
+        > input[type=text] {
+            background: transparent;
+            border: none;
+            outline: none;        
+            backdrop-filter: unset;
+        }
     }
 
     fieldset {
@@ -594,59 +603,6 @@
         color: light-dark(#14142599, #efe6d850);
         font-size: var(--font-size-12);
         padding-left: 3px;
-    }
-}
-
-.application.setting.dh-style {
-    h2,
-    h3,
-    h4 {
-        margin: 8px 0 4px;
-        text-align: center;
-    }
-
-    footer {
-        margin-top: 8px;
-        display: flex;
-        gap: 8px;
-
-        button {
-            flex: 1;
-        }
-    }
-
-    .form-group {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        gap: 0.25rem 0.5rem;
-        flex-wrap: wrap;
-
-        label {
-            font-size: var(--font-size-14);
-            font-weight: normal;
-        }
-
-        .form-fields {
-            display: flex;
-            gap: 4px;
-            align-items: center;
-        }
-
-        &.setting-two-values {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 0.25rem 0.5rem;
-
-            .form-group {
-                justify-content: end;
-                flex-wrap: nowrap;
-            }
-
-            .hint {
-                grid-column: 1 / -1;
-            }
-        }
     }
 }
 

--- a/styles/less/ui/settings/homebrew-settings/resources.less
+++ b/styles/less/ui/settings/homebrew-settings/resources.less
@@ -24,7 +24,7 @@
                     .resource-icons-container {
                         display: flex;
                         justify-content: space-between;
-                        gap: 8px;
+                        gap: 10px;
                         width: 100%;
 
                         .resource-icon-container {

--- a/styles/less/ui/settings/settings.less
+++ b/styles/less/ui/settings/settings.less
@@ -1,6 +1,67 @@
 @import '../../utils/colors.less';
 
 .daggerheart.dh-style.setting {
+    --color-form-label: var(--color-text-primary);
+
+    h2,
+    h3,
+    h4 {
+        margin: 8px 0 4px;
+        text-align: center;
+    }
+
+    footer {
+        margin-top: 8px;
+        display: flex;
+        gap: 8px;
+
+        button {
+            flex: 1;
+        }
+    }
+
+    .standard-form {
+        gap: var(--spacer-8);
+        .form-group .form-fields {
+            width: unset;
+        }
+    }
+
+    .form-group {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 0.25rem 0.5rem;
+        flex-wrap: wrap;
+
+        label {
+            font-size: var(--font-size-14);
+            font-weight: normal;
+            line-height: var(--input-height);
+        }
+
+        .form-fields {
+            display: flex;
+            gap: 4px;
+            align-items: center;
+        }
+
+        &.setting-two-values {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 0.25rem 0.5rem;
+
+            .form-group {
+                justify-content: end;
+                flex-wrap: nowrap;
+            }
+
+            .hint {
+                grid-column: 1 / -1;
+            }
+        }
+    }
+
     fieldset {
         display: flex;
         flex-direction: column;
@@ -19,7 +80,10 @@
         &.three-columns {
             display: grid;
             grid-template-columns: 1fr 1fr 1fr;
-            gap: 2px;
+            gap: 4px;
+            .form-group label {
+                line-height: unset;
+            }
         }
 
         &.six-columns {

--- a/templates/settings/metagaming-settings/general.hbs
+++ b/templates/settings/metagaming-settings/general.hbs
@@ -1,4 +1,4 @@
-<div>
+<div class="standard-form">
     {{formGroup settingFields.schema.fields.hideObserverPermissionInChat value=settingFields._source.hideObserverPermissionInChat localize=true}}
-     {{formGroup settingFields.schema.fields.hidePartyStats value=settingFields._source.hidePartyStats localize=true}}
+    {{formGroup settingFields.schema.fields.hidePartyStats value=settingFields._source.hidePartyStats localize=true}}
 </div>


### PR DESCRIPTION
This only impacts stuff like the homebrew/metagame/variant rule settings, not everything in general.

Does the following minor tweaks (and moves some CSS to the proper place):
- Fixes file-picker styles
- Gave a height to form group labels, leading to consistent height between select rows and checkbox rows
- Styled standard-form and applied to metagame, including a padding on top level labels similar to how fieldset does. I am 50/50 on removing the "gap" from fieldset and making that fieldset a standard-form.

<img width="1208" height="549" alt="image" src="https://github.com/user-attachments/assets/19ade3d9-1772-4148-8177-d5410c8ea55d" />

<img width="611" height="744" alt="image" src="https://github.com/user-attachments/assets/14789fc3-6f11-4624-b90e-fb84d388c366" />
