### PR TITLE
[Fix] finishing levelup with a multiclass

### DIFF
--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -718,7 +718,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
                     ? {
                           'system.linkedClass.uuid': {
                               key: 'system.linkedClass.uuid',
-                              value: this.document.system.class.value._stats.compendiumSource
+                              value: this.document.system.class.value?._stats.compendiumSource
                           }
                       }
                     : undefined,

--- a/module/data/item/subclass.mjs
+++ b/module/data/item/subclass.mjs
@@ -56,38 +56,30 @@ export default class DHSubclass extends BaseDataItem {
         if (allowed === false) return;
 
         if (this.actor?.type === 'character') {
-            const dataUuid = data.uuid ?? data._stats.compendiumSource ?? `Item.${data._id}`;
-            if (this.actor.system.class.subclass) {
-                if (this.actor.system.multiclass.subclass) {
-                    ui.notifications.warn(game.i18n.localize('DAGGERHEART.UI.Notifications.subclassesAlreadyPresent'));
-                    return false;
-                } else {
-                    const multiclass = this.actor.items.find(x => x.type === 'class' && x.system.isMulticlass);
-                    if (!multiclass) {
-                        ui.notifications.warn(game.i18n.localize('DAGGERHEART.UI.Notifications.missingMulticlass'));
-                        return false;
-                    }
+            const { value: actorClass, subclass: existingSubclass } = this.actor.system.class;
+            const { value: multiclass, subclass: existingMultisubclass } = this.actor.system.multiclass;
+            if (!actorClass && !multiclass) {
+                ui.notifications.warn('DAGGERHEART.UI.Notifications.missingClass', { localize: true });
+                return false;
+            }
+            if (existingSubclass && existingMultisubclass) {
+                ui.notifications.warn('DAGGERHEART.UI.Notifications.subclassesAlreadyPresent', { localize: true });
+                return false;
+            }
+            if (existingSubclass && !multiclass) {
+                ui.notifications.warn('DAGGERHEART.UI.Notifications.missingMulticlass', { localize: true });
+                return false;
+            }
 
-                    if (multiclass.system.subclasses.every(x => x.uuid !== dataUuid)) {
-                        ui.notifications.error(
-                            game.i18n.localize('DAGGERHEART.UI.Notifications.subclassNotInMulticlass')
-                        );
-                        return false;
-                    }
-
-                    await this.updateSource({ isMulticlass: true });
-                }
-            } else {
-                const actorClass = this.actor.items.find(x => x.type === 'class' && !x.system.isMulticlass);
-                if (!actorClass) {
-                    ui.notifications.warn(game.i18n.localize('DAGGERHEART.UI.Notifications.missingClass'));
-                    return false;
-                }
-
-                if ((await actorClass.system.fetchSubclasses()).every(x => x.uuid !== dataUuid)) {
-                    ui.notifications.error(game.i18n.localize('DAGGERHEART.UI.Notifications.subclassNotInClass'));
-                    return false;
-                }
+            const match = [multiclass, actorClass].find(
+                c => c && (c._stats.compendiumSource ?? c.uuid) === this.linkedClass
+            );
+            if (!match) {
+                const key = multiclass ? 'subclassNotInMulticlass' : 'subclassNotInClass';
+                ui.notifications.warn(`DAGGERHEART.UI.Notifications.${key}`, { localize: true });
+                return false;
+            } else if (match.system.isMulticlass) {
+                await this.updateSource({ isMulticlass: true });
             }
         }
     }

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -153,10 +153,13 @@ export default class DhpActor extends Actor {
     async updateLevel(newLevel) {
         if (!['character', 'companion'].includes(this.type) || newLevel === this.system.levelData.level.changed) return;
 
+        const tiers = Object.values(game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.LevelTiers).tiers);
+        const maxLevel = tiers.reduce((acc, tier) => Math.max(acc, tier.levels.end), 0);
+        const multiclassMinLevel = Math.min(
+            maxLevel,
+            ...tiers.filter(t => t.options.multiclass).map(t => t.levels.start)
+        );
         if (newLevel > this.system.levelData.level.current) {
-            const maxLevel = Object.values(
-                game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.LevelTiers).tiers
-            ).reduce((acc, tier) => Math.max(acc, tier.levels.end), 0);
             if (newLevel > maxLevel) {
                 ui.notifications.warn(game.i18n.localize('DAGGERHEART.UI.Notifications.tooHighLevel'));
             }
@@ -231,16 +234,19 @@ export default class DhpActor extends Actor {
                     this.system.multiclass.subclass.update({ 'system.featureState': subclassFeatureState.multiclass });
                 }
 
-                if (multiclass) {
-                    const multiclassItem = this.items.find(x => x.uuid === multiclass.itemUuid);
-                    const multiclassRelatedFeatures = this.items.filter(
-                        x => ['class', 'subclass'].includes(x.system.originItemType) && x.system.multiclassOrigin
+                // Remove multiclass if we're removing a multiclass feature or if we're below the multiclass minimum level
+                // Multclasses cannot be manually removed on the sheet, so this allows recovering in the case of errors
+                if (multiclass || newLevel < multiclassMinLevel) {
+                    const multiclassItems = this.items.filter(
+                        x =>
+                            x.uuid === multiclass?.itemUuid ||
+                            x.system.isMulticlass ||
+                            (['class', 'subclass'].includes(x.system.originItemType) && x.system.multiclassOrigin)
                     );
-                    if (!multiclassItem) console.error('Unexpected missing multiclass item to remove');
 
                     this.deleteEmbeddedDocuments(
                         'Item',
-                        [multiclassItem, ...multiclassRelatedFeatures].filter(i => !!i).map(x => x.id)
+                        multiclassItems.map(x => x.id)
                     );
 
                     this.update({

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -281,6 +281,7 @@ export default class DhpActor extends Actor {
 
     async levelUp(levelupData) {
         const levelupAuto = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Automation).levelupAuto;
+        const getStatsWithSource = document => ({ ...(document._stats ?? {}), compendiumSource: document.uuid });
 
         const levelups = {};
         for (var levelKey of Object.keys(levelupData)) {
@@ -393,8 +394,7 @@ export default class DhpActor extends Actor {
                     const embeddedItem = await this.createEmbeddedDocuments('Item', [
                         {
                             ...multiclassData,
-                            uuid: multiclassItem.uuid,
-                            _stats: multiclassItem._stats,
+                            _stats: getStatsWithSource(multiclassItem),
                             system: {
                                 ...multiclassData.system,
                                 features: multiclassData.system.features.filter(x => x.type !== 'hope'),
@@ -407,8 +407,7 @@ export default class DhpActor extends Actor {
                     await this.createEmbeddedDocuments('Item', [
                         {
                             ...subclassData,
-                            uuid: subclassItem.uuid,
-                            _stats: subclassItem._stats,
+                            _stats: getStatsWithSource(subclassItem),
                             system: {
                                 ...subclassData.system,
                                 isMulticlass: true
@@ -428,8 +427,7 @@ export default class DhpActor extends Actor {
                     const embeddedItem = await this.createEmbeddedDocuments('Item', [
                         {
                             ...cardData,
-                            uuid: cardItem.uuid,
-                            _stats: cardItem._stats,
+                            _stats: getStatsWithSource(cardItem),
                             system: {
                                 ...cardData.system,
                                 inVault: true
@@ -450,8 +448,7 @@ export default class DhpActor extends Actor {
                     const embeddedItem = await this.createEmbeddedDocuments('Item', [
                         {
                             ...cardData,
-                            uuid: cardItem.uuid,
-                            _stats: cardItem._stats,
+                            _stats: getStatsWithSource(cardItem),
                             system: {
                                 ...cardData.system,
                                 inVault: true

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -233,16 +233,14 @@ export default class DhpActor extends Actor {
 
                 if (multiclass) {
                     const multiclassItem = this.items.find(x => x.uuid === multiclass.itemUuid);
-                    const multiclassFeatures = this.items.filter(
-                        x => x.system.originItemType === 'class' && x.system.multiclassOrigin
+                    const multiclassRelatedFeatures = this.items.filter(
+                        x => ['class', 'subclass'].includes(x.system.originItemType) && x.system.multiclassOrigin
                     );
-                    const subclassFeatures = this.items.filter(
-                        x => x.system.originItemType === 'subclass' && x.system.multiclassOrigin
-                    );
+                    if (!multiclassItem) console.error('Unexpected missing multiclass item to remove');
 
                     this.deleteEmbeddedDocuments(
                         'Item',
-                        [multiclassItem, ...multiclassFeatures, ...subclassFeatures].map(x => x.id)
+                        [multiclassItem, ...multiclassRelatedFeatures].filter(i => !!i).map(x => x.id)
                     );
 
                     this.update({
@@ -394,6 +392,7 @@ export default class DhpActor extends Actor {
                     const embeddedItem = await this.createEmbeddedDocuments('Item', [
                         {
                             ...multiclassData,
+                            uuid: multiclassItem.uuid, // todo: replace with setting an id and using keepId
                             _stats: getStatsWithSource(multiclassItem),
                             system: {
                                 ...multiclassData.system,
@@ -407,6 +406,7 @@ export default class DhpActor extends Actor {
                     await this.createEmbeddedDocuments('Item', [
                         {
                             ...subclassData,
+                            uuid: subclassItem.uuid, // todo: replace with setting an id and using keepId
                             _stats: getStatsWithSource(subclassItem),
                             system: {
                                 ...subclassData.system,
@@ -427,6 +427,7 @@ export default class DhpActor extends Actor {
                     const embeddedItem = await this.createEmbeddedDocuments('Item', [
                         {
                             ...cardData,
+                            uuid: cardItem.uuid, // todo: replace with setting an id and using keepId
                             _stats: getStatsWithSource(cardItem),
                             system: {
                                 ...cardData.system,


### PR DESCRIPTION
Bit of a double trouble here:

* The multiclass logic wasn't updated to use linkedClass or fetchSubclasses. Either worked, but linkedClass is faster
* Items added via level up were not receiving a compendiumSource, making subclass belongs to checks not function

Also, when leveling below the minimum possible multiclass level (5), it also removes the multiclass item. This allows cleanup. There should probably be better ways to remove char creation stuff stuff if not "bound". Perhaps a context menu.