### PR TITLE
[Feature] Add way to delete unbound character creation items

### DIFF
--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -58,6 +58,14 @@ export default class CharacterSheet extends DHBaseActorSheet {
         ],
         contextMenus: [
             {
+                handler: CharacterSheet.#getCreationMainContextOptions,
+                selector: '.character-details [data-action="editDoc"]',
+                options: {
+                    parentClassHooks: false,
+                    fixed: true
+                }
+            },
+            {
                 handler: CharacterSheet.#getDomainCardContextOptions,
                 selector: '[data-item-uuid][data-type="domainCard"]',
                 options: {
@@ -318,6 +326,53 @@ export default class CharacterSheet extends DHBaseActorSheet {
     /* -------------------------------------------- */
     /*  Context Menu                                */
     /* -------------------------------------------- */
+
+    static #getCreationMainContextOptions() {
+        /** Returns true if the item is managed by the level up wizard. Such items shouldn't allow things like manual removal */
+        function isItemWizardManaged(item) {
+            const actor = item?.actor;
+            if (!actor) return false;
+            const levelupAuto = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Automation).levelupAuto;
+            if (!levelupAuto) return false;
+
+            // Core items aren't part of levelup data. TODO: add some way to flag a specific character as no auto leveling
+            const classPair = actor.system.class;
+            const coreItems = [actor.system.ancestry, actor.system.community, classPair?.value, classPair?.subclass];
+            if (coreItems.includes(item)) return true;
+
+            const levelups = Object.values(actor.system.levelData?.levelups) ?? [];
+            const uuid = item.uuid;
+            const sourceUuid = item._stats.compendiumSource; // on older characters this may be missing
+            return levelups.some(data => {
+                if (item.type === 'subclass') {
+                    const selectedSubclasses = data.selections.map(s => s.secondaryData?.subclass).filter(s => !!s);
+                    return sourceUuid
+                        ? selectedSubclasses.includes(sourceUuid)
+                        : selectedSubclasses.length && item.system.isMulticlass;
+                }
+
+                const matchesCard = data.achievements.domainCards.some(i => i.itemUuid === uuid);
+                const matchesSelection = data.selections.some(s => s.itemUuid === uuid);
+                return matchesCard || matchesSelection;
+            });
+        }
+
+        return [
+            {
+                label: 'CONTROLS.CommonDelete',
+                icon: 'fa-solid fa-trash',
+                visible: target => {
+                    const doc = getDocFromElementSync(target);
+                    return doc?.isOwner && !isItemWizardManaged(doc);
+                },
+                callback: async (target, event) => {
+                    const doc = await getDocFromElement(target);
+                    if (event.shiftKey) return doc.delete();
+                    else return doc.deleteDialog();
+                }
+            }
+        ];
+    }
 
     /**
      * Get the set of ContextMenu options for DomainCards.

--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -332,8 +332,11 @@ export default class CharacterSheet extends DHBaseActorSheet {
         function isItemWizardManaged(item) {
             const actor = item?.actor;
             if (!actor) return false;
-            const levelupAuto = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Automation).levelupAuto;
-            if (!levelupAuto) return false;
+
+            // If levelup automation is off in general or for this character, all items are unmanaged
+            // This is disabled until we have proper granted feature removal, for now this feature is to correct errors
+            // const levelupAuto = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Automation).levelupAuto;
+            // if (!levelupAuto) return false;
 
             // Core items aren't part of levelup data. TODO: add some way to flag a specific character as no auto leveling
             const classPair = actor.system.class;

--- a/module/data/item/subclass.mjs
+++ b/module/data/item/subclass.mjs
@@ -68,7 +68,7 @@ export default class DHSubclass extends BaseDataItem {
                         return false;
                     }
 
-                    if (multiclass.system.subclasses.every(x => x.uuid !== dataUuid)) {
+                    if ((await multiclass.system.fetchSubclasses()).every(x => x.uuid !== dataUuid)) {
                         ui.notifications.error(
                             game.i18n.localize('DAGGERHEART.UI.Notifications.subclassNotInMulticlass')
                         );

--- a/module/data/item/subclass.mjs
+++ b/module/data/item/subclass.mjs
@@ -68,7 +68,7 @@ export default class DHSubclass extends BaseDataItem {
                         return false;
                     }
 
-                    if ((await multiclass.system.fetchSubclasses()).every(x => x.uuid !== dataUuid)) {
+                    if (multiclass.system.subclasses.every(x => x.uuid !== dataUuid)) {
                         ui.notifications.error(
                             game.i18n.localize('DAGGERHEART.UI.Notifications.subclassNotInMulticlass')
                         );

--- a/templates/sheets/actors/character/header.hbs
+++ b/templates/sheets/actors/character/header.hbs
@@ -64,7 +64,7 @@
             {{/if}}
         </div>
 
-        {{#if document.system.multiclass.value}}
+        {{#if (or document.system.multiclass.value document.system.multiclass.subclass)}}
             <div class="multiclass">
                 {{#if document.system.multiclass.value}}
                     <span data-action="editDoc"data-item-uuid="{{document.system.multiclass.value.uuid}}">{{document.system.multiclass.value.name}}</span>


### PR DESCRIPTION
Currently this only works on worlds with auto levelup disabled as well as multiclass items that are "left behind" after a failed levelup. But given the errors in circulation starting the last release, this may be handy.

Once we have a way to flag individual characters as manual vs automatic, this will see more use.

<img width="185" height="78" alt="image" src="https://github.com/user-attachments/assets/58a62bf2-f370-47eb-9861-23d2e4bd38ca" />

<img width="237" height="93" alt="image" src="https://github.com/user-attachments/assets/12085169-14c5-4e7f-b1e6-ddfce8c942c3" />
