### PR TITLE
[Fix] CompendiumBrowser Pack Toggling

### DIFF
--- a/module/applications/dialogs/CompendiumBrowserSettings.mjs
+++ b/module/applications/dialogs/CompendiumBrowserSettings.mjs
@@ -50,12 +50,11 @@ export default class CompendiumBrowserSettings extends HandlebarsApplicationMixi
         const excludedSourceData = this.browserSettings.excludedSources;
         const excludedPackData = this.browserSettings.excludedPacks;
         context.typePackCollections = game.packs.reduce((acc, pack) => {
-            const { type, label, packageType, packageName: basePackageName, id: baseId } = pack.metadata;
+            const { type, label, packageType, packageName: basePackageName, name, id } = pack.metadata;
             if (!CompendiumBrowserSettings.#browserPackTypes.includes(type)) return acc;
 
-            const id = baseId.slugify();
             const isWorldPack = packageType === 'world';
-            const packageName = isWorldPack ? 'world' : basePackageName.slugify();
+            const packageName = isWorldPack ? 'world' : basePackageName;
             const sourceChecked =
                 !excludedSourceData[packageName] ||
                 !excludedSourceData[packageName].excludedDocumentTypes.includes(type);
@@ -69,10 +68,12 @@ export default class CompendiumBrowserSettings extends HandlebarsApplicationMixi
             if (!acc[type].sources[packageName])
                 acc[type].sources[packageName] = { label: sourceLabel, checked: sourceChecked, packs: [] };
 
-            const checked = !excludedPackData[id] || !excludedPackData[id].excludedDocumentTypes.includes(type);
+            const checked =
+                !excludedPackData[packageName] ||
+                !excludedPackData[packageName][name]?.excludedDocumentTypes.includes(type);
 
             acc[type].sources[packageName].packs.push({
-                pack: id,
+                name,
                 type,
                 label: id === game.system.id ? game.system.title : game.i18n.localize(label),
                 checked: checked
@@ -107,16 +108,20 @@ export default class CompendiumBrowserSettings extends HandlebarsApplicationMixi
     toggleTypedPack(event) {
         event.stopPropagation();
 
-        const { type, pack } = event.target.dataset;
-        const currentlyExcluded = this.browserSettings.excludedPacks[pack]
-            ? this.browserSettings.excludedPacks[pack].excludedDocumentTypes.includes(type)
+        const { type, source, packName } = event.target.dataset;
+        const currentlyExcluded = this.browserSettings.excludedPacks[source]?.[packName]
+            ? this.browserSettings.excludedPacks[source][packName].excludedDocumentTypes.includes(type)
             : false;
 
-        if (!this.browserSettings.excludedPacks[pack])
-            this.browserSettings.excludedPacks[pack] = { excludedDocumentTypes: [] };
-        this.browserSettings.excludedPacks[pack].excludedDocumentTypes = currentlyExcluded
-            ? this.browserSettings.excludedPacks[pack].excludedDocumentTypes.filter(x => x !== type)
-            : [...(this.browserSettings.excludedPacks[pack]?.excludedDocumentTypes ?? []), type];
+        if (!this.browserSettings.excludedPacks[source]?.[packName]) {
+            if (!this.browserSettings.excludedPacks[source]) this.browserSettings.excludedPacks[source] = {};
+
+            this.browserSettings.excludedPacks[source][packName] = { excludedDocumentTypes: [] };
+        }
+
+        this.browserSettings.excludedPacks[source][packName].excludedDocumentTypes = currentlyExcluded
+            ? this.browserSettings.excludedPacks[source][packName].excludedDocumentTypes.filter(x => x !== type)
+            : [...(this.browserSettings.excludedPacks[source][packName]?.excludedDocumentTypes ?? []), type];
 
         this.render();
     }

--- a/module/applications/dialogs/CompendiumBrowserSettings.mjs
+++ b/module/applications/dialogs/CompendiumBrowserSettings.mjs
@@ -113,12 +113,8 @@ export default class CompendiumBrowserSettings extends HandlebarsApplicationMixi
             ? this.browserSettings.excludedPacks[source][packName].excludedDocumentTypes.includes(type)
             : false;
 
-        if (!this.browserSettings.excludedPacks[source]?.[packName]) {
-            if (!this.browserSettings.excludedPacks[source]) this.browserSettings.excludedPacks[source] = {};
-
-            this.browserSettings.excludedPacks[source][packName] = { excludedDocumentTypes: [] };
-        }
-
+        this.browserSettings.excludedPacks[source] ??= {};
+        this.browserSettings.excludedPacks[source][packName] ??= { excludedDocumentTypes: [] };
         this.browserSettings.excludedPacks[source][packName].excludedDocumentTypes = currentlyExcluded
             ? this.browserSettings.excludedPacks[source][packName].excludedDocumentTypes.filter(x => x !== type)
             : [...(this.browserSettings.excludedPacks[source][packName]?.excludedDocumentTypes ?? []), type];

--- a/module/applications/dialogs/CompendiumBrowserSettings.mjs
+++ b/module/applications/dialogs/CompendiumBrowserSettings.mjs
@@ -1,3 +1,5 @@
+import { slugify } from '../../helpers/utils.mjs';
+
 const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
 export default class CompendiumBrowserSettings extends HandlebarsApplicationMixin(ApplicationV2) {
@@ -50,11 +52,12 @@ export default class CompendiumBrowserSettings extends HandlebarsApplicationMixi
         const excludedSourceData = this.browserSettings.excludedSources;
         const excludedPackData = this.browserSettings.excludedPacks;
         context.typePackCollections = game.packs.reduce((acc, pack) => {
-            const { type, label, packageType, packageName: basePackageName, id } = pack.metadata;
+            const { type, label, packageType, packageName: basePackageName, id: baseId } = pack.metadata;
             if (!CompendiumBrowserSettings.#browserPackTypes.includes(type)) return acc;
 
+            const id = slugify(baseId);
             const isWorldPack = packageType === 'world';
-            const packageName = isWorldPack ? 'world' : basePackageName;
+            const packageName = isWorldPack ? 'world' : slugify(basePackageName);
             const sourceChecked =
                 !excludedSourceData[packageName] ||
                 !excludedSourceData[packageName].excludedDocumentTypes.includes(type);

--- a/module/applications/dialogs/CompendiumBrowserSettings.mjs
+++ b/module/applications/dialogs/CompendiumBrowserSettings.mjs
@@ -68,7 +68,7 @@ export default class CompendiumBrowserSettings extends HandlebarsApplicationMixi
             if (!acc[type].sources[packageName])
                 acc[type].sources[packageName] = { label: sourceLabel, checked: sourceChecked, packs: [] };
 
-            const checked =
+            const included =
                 !excludedPackData[packageName] ||
                 !excludedPackData[packageName][name]?.excludedDocumentTypes.includes(type);
 
@@ -76,7 +76,7 @@ export default class CompendiumBrowserSettings extends HandlebarsApplicationMixi
                 name,
                 type,
                 label: id === game.system.id ? game.system.title : game.i18n.localize(label),
-                checked: checked
+                checked: included
             });
 
             return acc;

--- a/module/data/compendiumBrowserSettings.mjs
+++ b/module/data/compendiumBrowserSettings.mjs
@@ -11,11 +11,13 @@ export default class CompendiumBrowserSettings extends foundry.abstract.DataMode
                 })
             ),
             excludedPacks: new fields.TypedObjectField(
-                new fields.SchemaField({
-                    excludedDocumentTypes: new fields.ArrayField(
-                        new fields.StringField({ required: true, choices: CONST.SYSTEM_SPECIFIC_COMPENDIUM_TYPES })
-                    )
-                })
+                new fields.TypedObjectField(
+                    new fields.SchemaField({
+                        excludedDocumentTypes: new fields.ArrayField(
+                            new fields.StringField({ required: true, choices: CONST.SYSTEM_SPECIFIC_COMPENDIUM_TYPES })
+                        )
+                    })
+                )
             )
         };
     }
@@ -24,12 +26,11 @@ export default class CompendiumBrowserSettings extends foundry.abstract.DataMode
         const pack = game.packs.get(item.pack);
         if (!pack) return false;
 
-        const packageName = pack.metadata.packageType === 'world' ? 'world' : pack.metadata.packageName.slugify();
+        const packageName = pack.metadata.packageType === 'world' ? 'world' : pack.metadata.packageName;
         const excludedSourceData = this.excludedSources[packageName];
         if (excludedSourceData && excludedSourceData.excludedDocumentTypes.includes(pack.metadata.type)) return true;
 
-        const packName = item.pack.slugify();
-        const excludedPackData = this.excludedPacks[packName];
+        const excludedPackData = this.excludedPacks[packageName]?.[pack.metadata.name];
         if (excludedPackData && excludedPackData.excludedDocumentTypes.includes(pack.metadata.type)) return true;
 
         return false;

--- a/module/data/compendiumBrowserSettings.mjs
+++ b/module/data/compendiumBrowserSettings.mjs
@@ -1,3 +1,5 @@
+import { slugify } from '../helpers/utils.mjs';
+
 export default class CompendiumBrowserSettings extends foundry.abstract.DataModel {
     static defineSchema() {
         const fields = foundry.data.fields;
@@ -24,11 +26,12 @@ export default class CompendiumBrowserSettings extends foundry.abstract.DataMode
         const pack = game.packs.get(item.pack);
         if (!pack) return false;
 
-        const packageName = pack.metadata.packageType === 'world' ? 'world' : pack.metadata.packageName;
+        const packageName = pack.metadata.packageType === 'world' ? 'world' : slugify(pack.metadata.packageName);
         const excludedSourceData = this.excludedSources[packageName];
         if (excludedSourceData && excludedSourceData.excludedDocumentTypes.includes(pack.metadata.type)) return true;
 
-        const excludedPackData = this.excludedPacks[item.pack];
+        const packName = slugify(item.pack);
+        const excludedPackData = this.excludedPacks[packName];
         if (excludedPackData && excludedPackData.excludedDocumentTypes.includes(pack.metadata.type)) return true;
 
         return false;

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -449,12 +449,11 @@ export async function createEmbeddedItemsWithEffects(actor, baseData) {
             effects: data.effects?.map(effect => effect.toObject())
         });
     }
-
     await actor.createEmbeddedDocuments('Item', effectData);
 }
 
 export const slugify = name => {
-    return name.toLowerCase().replaceAll(' ', '-').replaceAll('.', '');
+    return name.toLowerCase().replaceAll(' ', '-').replaceAll('.', '_');
 };
 
 export function shuffleArray(array) {

--- a/templates/dialogs/compendiumBrowserSettingsDialog/packs.hbs
+++ b/templates/dialogs/compendiumBrowserSettingsDialog/packs.hbs
@@ -22,7 +22,7 @@
                             <div class="checks-container {{#unless source.checked}}collapsed{{/unless}}">
                                 {{#each source.packs as |pack|}}
                                     <div class="check-container">
-                                        <input type="checkbox" class="pack-checkbox" data-type="{{pack.type}}" data-pack="{{pack.pack}}" {{checked pack.checked}} />
+                                        <input type="checkbox" class="pack-checkbox" data-type="{{pack.type}}" data-source="{{@../key}}" data-pack-name="{{pack.name}}" {{checked pack.checked}} />
                                         <label>{{pack.label}}</label>
                                     </div>
                                 {{/each}}


### PR DESCRIPTION
Fixed so that CompendiumBrowserSettings saves source/pack names as sllgified version to avoid foundry not saving names with dots in the middle.
EX: The pack `daggerheart.classes` and any such were not saved as the updates were discarded.