### PR TITLE
[Fix] Missing Class Subclass Filter

### DIFF
--- a/module/config/itemBrowserConfig.mjs
+++ b/module/config/itemBrowserConfig.mjs
@@ -443,10 +443,12 @@ export const typeConfig = {
                     const list = [];
                     for (const item of items.filter(item => item.system.linkedClass)) {
                         const linkedClass = await foundry.utils.fromUuid(item.system.linkedClass);
-                        list.push({
-                            value: linkedClass.uuid,
-                            label: linkedClass.name
-                        });
+                        if (linkedClass) {
+                            list.push({
+                                value: linkedClass.uuid,
+                                label: linkedClass.name
+                            });
+                        }
                     }
 
                     return list.reduce((a, c) => {


### PR DESCRIPTION
Fixed so that a non-existing class link uuid on a subclass doesn't make the subclass filter in the CompendiumBrowser error.