### PR TITLE
[Feature] Class/Multiclass Feature Split

### DIFF
--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -588,11 +588,9 @@ export default class DhCharacter extends DhCreature {
             } else if (item.system.originItemType === CONFIG.DH.ITEM.featureTypes.community.id) {
                 communityFeatures.push(item);
             } else if (item.system.originItemType === CONFIG.DH.ITEM.featureTypes.class.id) {
-                if (item.system.multiclassOrigin) multiclassFeatures.push(item);
-                else classFeatures.push(item);
+                (item.system.multiclassOrigin ? multiclassFeatures : classFeatures).push(item);
             } else if (item.system.originItemType === CONFIG.DH.ITEM.featureTypes.subclass.id) {
-                if (item.system.multiclassOrigin) multiclassSubclassFeatures.push(item);
-                else subclassFeatures.push(item);
+                (item.system.multiclassOrigin ? multiclassSubclassFeatures : subclassFeatures).push(item);
             } else if (item.system.originItemType === CONFIG.DH.ITEM.featureTypes.companion.id) {
                 companionFeatures.push(item);
             } else if (item.type === 'feature' && !item.system.type) {

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -577,6 +577,8 @@ export default class DhCharacter extends DhCreature {
             communityFeatures = [],
             classFeatures = [],
             subclassFeatures = [],
+            multiclassFeatures = [],
+            multiclassSubclassFeatures = [],
             companionFeatures = [],
             features = [];
 
@@ -586,9 +588,11 @@ export default class DhCharacter extends DhCreature {
             } else if (item.system.originItemType === CONFIG.DH.ITEM.featureTypes.community.id) {
                 communityFeatures.push(item);
             } else if (item.system.originItemType === CONFIG.DH.ITEM.featureTypes.class.id) {
-                classFeatures.push(item);
+                if (item.system.multiclassOrigin) multiclassFeatures.push(item);
+                else classFeatures.push(item);
             } else if (item.system.originItemType === CONFIG.DH.ITEM.featureTypes.subclass.id) {
-                subclassFeatures.push(item);
+                if (item.system.multiclassOrigin) multiclassSubclassFeatures.push(item);
+                else subclassFeatures.push(item);
             } else if (item.system.originItemType === CONFIG.DH.ITEM.featureTypes.companion.id) {
                 companionFeatures.push(item);
             } else if (item.type === 'feature' && !item.system.type) {
@@ -617,6 +621,24 @@ export default class DhCharacter extends DhCreature {
                 type: 'subclass',
                 values: subclassFeatures
             },
+            ...(multiclassFeatures.length
+                ? {
+                      multiclassFeatures: {
+                          title: `${game.i18n.localize('DAGGERHEART.GENERAL.multiclass')} - ${this.multiclass.value?.name}`,
+                          type: 'multiclass',
+                          values: multiclassFeatures
+                      }
+                  }
+                : {}),
+            ...(multiclassSubclassFeatures.length
+                ? {
+                      multiclassSubclassFeatures: {
+                          title: `${game.i18n.localize('DAGGERHEART.GENERAL.multiclass')} ${game.i18n.localize('TYPES.Item.subclass')} - ${this.multiclass.subclass?.name}`,
+                          type: 'multiclassSubclass',
+                          values: multiclassSubclassFeatures
+                      }
+                  }
+                : {}),
             companionFeatures: {
                 title: game.i18n.localize('DAGGERHEART.ACTORS.Character.companionFeatures'),
                 type: 'companion',


### PR DESCRIPTION
Changed so that Multiclass features and MulticlassSubclass features are displayed in separate fieldsets from the base class features in the character sheet.
We could either order it:

1) Class|Multiclass|Subclass|MulticlassSubclass

2) Class|Subclass|Multiclass|MulticlassSubclass

I went with **2** at the moment.
<img width="708" height="1811" alt="image" src="https://github.com/user-attachments/assets/a421411b-61f7-492c-ac92-37320a5fcef0" />
