### PR TITLE
[Fix] 1898 - Reaction Roll Message Look

### DIFF
--- a/templates/ui/chat/parts/roll-part.hbs
+++ b/templates/ui/chat/parts/roll-part.hbs
@@ -6,7 +6,7 @@
                 {{#if roll.isCritical}}
                     <span>{{localize "DAGGERHEART.GENERAL.criticalShort"}}</span>
                 {{else}}
-                    {{#if (and roll.dHope (not (eq roll.type "reaction")))}}
+                    {{#if (and roll.dHope (not (eq roll.options.roll.type "reaction")))}}
                         <span>{{localize "DAGGERHEART.GENERAL.withThing" thing=roll.totalLabel}}</span>
                     {{/if}}
                 {{/if}}


### PR DESCRIPTION
Fixes #1898 
Fixed so that Reaction roll chat messages do not mention 'withHope'/'withFear'. The logic was already there, it was just looking at the wrong variable path now.