### PR TITLE
[Feature] V14 Cleanup

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -778,7 +778,9 @@
                 "title": "Group Roll"
             },
             "TokenConfig": {
-                "actorSizeUsed": "Actor size is set, determining the dimensions"
+                "actorSizeUsed": "Actor size is set, determining the dimensions",
+                "tokenSize": "Token Size",
+                "sizeCategory": "Size Category"
             }
         },
         "CLASS": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -2567,10 +2567,11 @@
                     "tokenImg": { "label": "Token Image" },
                     "tokenRingImg": { "label": "Subject Texture" },
                     "tokenSize": {
-                        "placeholder": "Using character dimensions",
-                        "disabledPlaceholder": "Set by character size",
+                        "placeholder": "Token Size",
+                        "disabledPlaceholder": "Token Size",
                         "height": { "label": "Height" },
                         "width": { "label": "Width" },
+                        "depth": { "label": "Depth" },
                         "scale": { "label": "Token Scale" }
                     },
                     "evolved": {

--- a/module/data/activeEffect/beastformEffect.mjs
+++ b/module/data/activeEffect/beastformEffect.mjs
@@ -35,6 +35,7 @@ export default class BeastformEffect extends BaseEffect {
     static migrateData(source) {
         if (!source.characterTokenData.tokenSize.height) source.characterTokenData.tokenSize.height = 1;
         if (!source.characterTokenData.tokenSize.width) source.characterTokenData.tokenSize.width = 1;
+        if (!source.characterTokenData.tokenSize.depth) source.characterTokenData.tokenSize.depth = 1;
 
         return super.migrateData(source);
     }
@@ -52,7 +53,8 @@ export default class BeastformEffect extends BaseEffect {
         if (this.parent.parent.type === 'character') {
             const baseUpdate = {
                 height: this.characterTokenData.tokenSize.height,
-                width: this.characterTokenData.tokenSize.width
+                width: this.characterTokenData.tokenSize.width,
+                depth: this.characterTokenData.tokenSize.depth
             };
             const update = {
                 ...baseUpdate,

--- a/module/data/item/beastform.mjs
+++ b/module/data/item/beastform.mjs
@@ -51,7 +51,8 @@ export default class DHBeastform extends BaseDataItem {
                 }),
                 scale: new fields.NumberField({ nullable: false, min: 0.2, max: 3, step: 0.05, initial: 1 }),
                 height: new fields.NumberField({ integer: true, min: 1, initial: null, nullable: true }),
-                width: new fields.NumberField({ integer: true, min: 1, initial: null, nullable: true })
+                width: new fields.NumberField({ integer: true, min: 1, initial: null, nullable: true }),
+                depth: new fields.NumberField({ integer: true, min: 1, initial: null, nullable: true })
             }),
             mainTrait: new fields.StringField({
                 required: true,
@@ -192,7 +193,8 @@ export default class DHBeastform extends BaseDataItem {
                     tokenSize: {
                         scale: this.parent.parent.prototypeToken.texture.scaleX,
                         height: this.parent.parent.prototypeToken.height,
-                        width: this.parent.parent.prototypeToken.width
+                        width: this.parent.parent.prototypeToken.width,
+                        depth: this.parent.parent.prototypeToken.depth
                     }
                 },
                 advantageOn: this.advantageOn,
@@ -211,10 +213,12 @@ export default class DHBeastform extends BaseDataItem {
                 : null;
         const width = autoTokenSize ?? this.tokenSize.width;
         const height = autoTokenSize ?? this.tokenSize.height;
+        const depth = autoTokenSize ?? this.tokenSize.depth;
 
         const prototypeTokenUpdate = {
             height,
             width,
+            depth,
             texture: {
                 src: this.tokenImg,
                 scaleX: this.tokenSize.scale,

--- a/module/documents/scene.mjs
+++ b/module/documents/scene.mjs
@@ -20,7 +20,7 @@ export default class DhScene extends Scene {
         const prototype = tokenDoc.actor?.prototypeToken ?? tokenDoc;
         this.#sizeSyncBatch.set(tokenDoc.id, {
             size: tokenSize,
-            prototypeSize: { width: prototype.width, height: prototype.height },
+            prototypeSize: { width: prototype.width, height: prototype.height, depth: prototype.depth },
             position: { x: tokenDoc.x, y: tokenDoc.y, elevation: tokenDoc.elevation }
         });
         this.#processSyncBatch();
@@ -36,11 +36,13 @@ export default class DhScene extends Scene {
                 const tokenSize = tokenSizes[size];
                 const width = size !== CONFIG.DH.ACTOR.tokenSize.custom.id ? tokenSize : prototypeSize.width;
                 const height = size !== CONFIG.DH.ACTOR.tokenSize.custom.id ? tokenSize : prototypeSize.height;
+                const depth = size !== CONFIG.DH.ACTOR.tokenSize.custom.id ? tokenSize : prototypeSize.depth;
                 const updatedPosition = DHToken.getSnappedPositionInSquareGrid(this.grid, position, width, height);
                 return {
                     _id,
                     width,
                     height,
+                    depth,
                     ...updatedPosition
                 };
             });

--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -66,7 +66,8 @@ export default class DHToken extends CONFIG.Token.documentClass {
                 if (tokenSize && actor.system.size !== CONFIG.DH.ACTOR.tokenSize.custom.id) {
                     document.updateSource({
                         width: tokenSize,
-                        height: tokenSize
+                        height: tokenSize,
+                        depth: tokenSize
                     });
                 }
             }
@@ -90,7 +91,7 @@ export default class DHToken extends CONFIG.Token.documentClass {
             ) {
                 const tokenSizes = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Homebrew).tokenSizes;
                 const tokenSize = tokenSizes[update.system.size];
-                if (tokenSize !== this.width || tokenSize !== this.height) {
+                if (tokenSize !== this.width || tokenSize !== this.height || tokenSize !== this.depth) {
                     this.parent?.syncTokenDimensions(this, update.system.size);
                 }
             }

--- a/module/documents/tokenManager.mjs
+++ b/module/documents/tokenManager.mjs
@@ -15,6 +15,7 @@ export default class DhTokenManager {
             if (tokenSize && actor.system.size !== CONFIG.DH.ACTOR.tokenSize.custom.id) {
                 tokenData.width = tokenSize;
                 tokenData.height = tokenSize;
+                tokenData.depth = tokenSize;
             }
         }
 

--- a/system.json
+++ b/system.json
@@ -5,7 +5,7 @@
     "version": "2.2.6",
     "compatibility": {
         "minimum": "14.361",
-        "verified": "14.362",
+        "verified": "14.363",
         "maximum": "14"
     },
     "url": "https://github.com/Foundryborne/daggerheart",

--- a/templates/hud/tokenHUD.hbs
+++ b/templates/hud/tokenHUD.hbs
@@ -17,12 +17,19 @@
     {{/if}}
 
     <button type="button" class="control-icon" data-action="sort" data-tooltip aria-label="HUD.ToFrontOrBack">
-        <i class="fa-solid fa-arrow-down-arrow-up" inert></i>
+        <i class="fa-solid fa-bring-forward" inert></i>
     </button>
 
     {{#if hasCompanion}}
         <button type="button" class="control-icon clown-car" data-action="toggleCompanions" data-tooltip="{{#if companionOnCanvas}}{{localize "DAGGERHEART.APPLICATIONS.HUD.tokenHUD.retrieveCompanionTokens"}}{{else}}{{localize "DAGGERHEART.APPLICATIONS.HUD.tokenHUD.depositCompanionTokens"}}{{/if}}">
             <img {{#if companionOnCanvas}}class="flipped"{{/if}} src="{{icons.toggleClowncar}}">
+        </button>
+    {{/if}}
+
+    {{#if isGM}}
+        <button type="button" class="control-icon {{lockedClass}}" data-action="locked"
+            data-tooltip aria-label="{{localize (ifThen lockedClass "HUD.Unlock" "HUD.Lock")}}">
+            <i class="fa-solid {{ifThen lockedClass "fa-lock" "fa-lock-open"}}" inert></i>
         </button>
     {{/if}}
 

--- a/templates/sheets-settings/token-config/appearance.hbs
+++ b/templates/sheets-settings/token-config/appearance.hbs
@@ -36,7 +36,7 @@
     <fieldset>
         <legend>{{localize "DAGGERHEART.APPLICATIONS.TokenConfig.tokenSize"}}</legend>
         {{#if usesActorSize}}
-            <div class="form-group lim">
+            <div class="form-group slim">
                 <label>{{localize "DAGGERHEART.APPLICATIONS.TokenConfig.sizeCategory"}}</label>
 
                 <select id="dhTokenSize">
@@ -50,11 +50,13 @@
                 {{localize "TOKEN.Size"}}
                 <span class="units">({{localize "MEASUREMENT.GridSpaces"}})</span>
             </span>
-            <div class="form-fields">
+            <div class="form-group slim">
                 <label for="{{rootId}}-width">{{localize "DOCUMENT.FIELDS.width.label"}}</label>
                 {{formInput fields.width value=source.width id=(concat rootId "-width") disabled=actorSizeDisable}}
                 <label for="{{rootId}}-height">{{localize "DOCUMENT.FIELDS.height.label"}}</label>
                 {{formInput fields.height value=source.height id=(concat rootId "-height") disabled=actorSizeDisable}}
+                <label for="{{rootId}}-depth">Z</label>
+                {{formInput fields.depth value=source.depth id=(concat rootId "-depth") disabled=actorSizeDisable}}
             </div>
         </div>
     </fieldset>

--- a/templates/sheets-settings/token-config/appearance.hbs
+++ b/templates/sheets-settings/token-config/appearance.hbs
@@ -1,15 +1,38 @@
 <div class="tab scrollable{{#if tab.active}} active{{/if}}" data-group="{{tab.group}}" data-tab="{{tab.id}}">
-    {{formGroup fields.texture.fields.src value=source.texture.src rootId=rootId}}
-    {{#if randomImgEnabled}}
-    {{formGroup fields.randomImg value=source.randomImg classes="slim" rootId=rootId}}
-    {{else if hasAlternates}}
-    <div class="form-group">
-        <label for="{{rootId}}-alternateImages">{{localize "TOKEN.ImageAlts"}}</label>
-        <select id="{{rootId}}-alternateImages" class="alternate-images" name="alternateImages">
-            {{selectOptions alternateImages selected=source.texture.src blank=""}}
-        </select>
+    <div class="token-image-group">
+        {{formGroup fields.texture.fields.src value=source.texture.src rootId=rootId}}
+        {{#if randomImgEnabled}}
+        {{formGroup fields.randomImg value=source.randomImg classes="slim" rootId=rootId}}
+        {{else if hasAlternates}}
+        <div class="form-group">
+            <label for="{{rootId}}-alternateImages">{{localize "TOKEN.ImageAlts"}}</label>
+            <select id="{{rootId}}-alternateImages" class="alternate-images" name="alternateImages">
+                {{selectOptions alternateImages selected=source.texture.src blank=""}}
+            </select>
+        </div>
+        {{/if}}
+
+        {{#if imagePreview}}
+            <div class="{{imagePreview.cls}}">
+                {{#if imagePreview.isVideo}}
+                <video class="token-image-thumb" src="{{imagePreview.src}}" autoplay muted loop playsinline
+                    disablepictureinpicture></video>
+                {{else}}
+                <img class="token-image-thumb" src="{{imagePreview.src}}" alt="{{localize "TOKEN.ImagePreview"}}">
+                {{/if}}
+                <div class="token-image-controls">
+                    <button type="button" class="cycle-prev icon fa-solid fa-chevron-left" data-action="cycleImage"
+                            data-delta="-1" aria-label="{{localize "TOKEN.ImageCyclePrev"}}"
+                            {{#unless imagePreview.hasPrev}} disabled{{/unless}}></button>
+                    <span class="counter">{{imagePreview.current}} / {{imagePreview.total}}</span>
+                    <button type="button" class="cycle-next icon fa-solid fa-chevron-right" data-action="cycleImage"
+                            data-delta="1" aria-label="{{localize "TOKEN.ImageCycleNext"}}"
+                            {{#unless imagePreview.hasNext}} disabled{{/unless}}></button>
+                </div>
+            </div>
+        {{/if}}
     </div>
-    {{/if}}
+
     <fieldset>
         <legend>{{localize "Token Size"}}</legend>
         {{#if usesActorSize}}
@@ -23,10 +46,10 @@
         {{/if}}
 
         <div id="tokenSizeDimensions" class="form-group slim" {{#if actorSizeDisable}}data-tooltip="{{localize "DAGGERHEART.APPLICATIONS.TokenConfig.actorSizeUsed"}}"{{/if}}>
-            <label>
-                {{localize "TOKEN.Dimensions"}} <span class="units">({{localize "GridSpaces"}})</span>
-                <i class="fa-solid fa-lock" {{#unless actorSizeDisable}}style="opacity: 0%;"{{/unless}}></i>
-            </label>
+            <span class="label">
+                {{localize "TOKEN.Size"}}
+                <span class="units">({{localize "MEASUREMENT.GridSpaces"}})</span>
+            </span>
             <div class="form-fields">
                 <label for="{{rootId}}-width">{{localize "DOCUMENT.FIELDS.width.label"}}</label>
                 {{formInput fields.width value=source.width id=(concat rootId "-width") disabled=actorSizeDisable}}

--- a/templates/sheets-settings/token-config/appearance.hbs
+++ b/templates/sheets-settings/token-config/appearance.hbs
@@ -34,10 +34,10 @@
     </div>
 
     <fieldset>
-        <legend>{{localize "Token Size"}}</legend>
+        <legend>{{localize "DAGGERHEART.APPLICATIONS.TokenConfig.tokenSize"}}</legend>
         {{#if usesActorSize}}
             <div class="form-group lim">
-                <label>{{localize "Size Category"}}</label>
+                <label>{{localize "DAGGERHEART.APPLICATIONS.TokenConfig.sizeCategory"}}</label>
 
                 <select id="dhTokenSize">
                     {{selectOptions tokenSizes selected=tokenSize valueAttr="id" labelAttr="label" localize=true}}

--- a/templates/sheets/items/beastform/settings.hbs
+++ b/templates/sheets/items/beastform/settings.hbs
@@ -46,6 +46,13 @@
                     placeholder=(localize (ifThen dimensionsDisabled "DAGGERHEART.ITEMS.Beastform.FIELDS.tokenSize.disabledPlaceholder" "DAGGERHEART.ITEMS.Beastform.FIELDS.tokenSize.placeholder")) 
                     disabled=dimensionsDisabled 
                 }}
+                {{formGroup 
+                    systemFields.tokenSize.fields.depth 
+                    value=source.system.tokenSize.depth 
+                    localize=true 
+                    placeholder=(localize (ifThen dimensionsDisabled "DAGGERHEART.ITEMS.Beastform.FIELDS.tokenSize.disabledPlaceholder" "DAGGERHEART.ITEMS.Beastform.FIELDS.tokenSize.placeholder")) 
+                    disabled=dimensionsDisabled 
+                }}
             </div>
             <div class="full-width">
                 {{formGroup systemFields.tokenSize.fields.scale value=source.system.tokenSize.scale localize=true }}

--- a/templates/ui/combatTracker/combatTrackerSection.hbs
+++ b/templates/ui/combatTracker/combatTrackerSection.hbs
@@ -13,20 +13,20 @@
                         <div class="combatant-controls flex-0">
                             {{#if @root.user.isGM}}
                             <button type="button" class="inline-control combatant-control icon fa-solid fa-eye-slash {{#if hidden}}active{{/if}}"
-                                    data-action="toggleHidden" data-tooltip aria-label="{{ localize "COMBAT.ToggleVis" }}"></button>
+                                    data-action="toggleHidden" data-tooltip aria-label="{{ localize (ifThen hidden "COMBATANT.Show" "COMBATANT.Hide") }}"></button>
                             <button type="button" class="inline-control combatant-control icon fa-solid fa-skull {{#if isDefeated}}active{{/if}}"
                                     data-action="toggleDefeated" data-tooltip
-                                    aria-label="{{ localize "COMBAT.ToggleDead" }}"></button>
+                                    aria-label="{{ localize (ifThen isDefeated "COMBATANT.UnmarkDefeated" "COMBATANT.MarkDefeated") }}"></button>
                             {{/if}}
                             {{#if canPing}}
                             <button type="button" class="inline-control combatant-control icon fa-solid fa-bullseye-arrow"
                                     data-action="pingCombatant" data-tooltip
-                                    aria-label="{{ localize "COMBAT.PingCombatant" }}"></button>
+                                    aria-label="{{ localize "COMBATANT.Ping" }}"></button>
                             {{/if}}
                             {{#unless @root.user.isGM}}
                             <button type="button" class="inline-control combatant-control icon fa-solid fa-arrows-to-eye"
                                     data-action="panToCombatant" data-tooltip
-                                    aria-label="{{ localize "COMBAT.PanToCombatant" }}"></button>
+                                    aria-label="{{ localize "COMBATANT.PanTo" }}"></button>
                             {{/unless}}
                         </div>
 


### PR DESCRIPTION
- (TokenHUD) Changed to the updated Front/Back button icon. Added a new tokenHUD button from v14 we were missing: `LockToken`
- Fixed in the PrototypeTokenConfig token image preview added in v14
<img width="700" height="214" alt="image" src="https://github.com/user-attachments/assets/3282abc4-37f3-4327-9c1f-61101cd18dff" />

- Fixed translations in the combat tracker that had been moved
- Fixed so that our TokenSizes also set and sync the `token.depth` property
- Fixed so that our beastforms set `token.depth` when transforming and restores the tokens default depth when transforming back, same as it does for width/height.