### PR TITLE
Security: Missing Error Handler in Gulp Watch Task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,8 +15,8 @@ gulp.task('less', function (cb) {
 
 gulp.task(
     'default',
-    gulp.series('less', function (cb) {
-        gulp.watch('styles/**/*.less', gulp.series('less'));
-        cb();
+    gulp.series('less', function () {
+        return gulp.watch('styles/**/*.less', gulp.series('less'))
+            .on('error', console.error.bind(console));
     })
 );


### PR DESCRIPTION
## Summary

Security: Missing Error Handler in Gulp Watch Task

## Problem

**Severity**: `Low` | **File**: `gulpfile.js:L16`

The gulp.watch task does not include error handling. If the 'less' task fails during watch mode, the watch process may crash or hang without clear indication, potentially leaving the build in an inconsistent state. Additionally, the callback `cb()` is called immediately after gulp.watch, not waiting for the watch to actually start or handle errors.

## Solution

Add error handling to the watch task and ensure proper callback management. Consider returning the stream or using a promise-based approach. Example: return gulp.watch('styles/**/*.less', gulp.series('less')) or add .on('error', ...) handler.

## Changes

- `gulpfile.js` (modified)