### PR TITLE
[Fix] Homebrew ActiveEffect Transfer

### DIFF
--- a/module/applications/sheets-configs/activeEffectConfig.mjs
+++ b/module/applications/sheets-configs/activeEffectConfig.mjs
@@ -175,6 +175,7 @@ export default class DhActiveEffectConfig extends foundry.applications.sheets.Ac
         const partContext = await super._preparePartContext(partId, context);
         switch (partId) {
             case 'details':
+                partContext.isItemEffect = partContext.isItemEffect || this.options.isSetting;
                 const useGeneric = game.settings.get(
                     CONFIG.DH.id,
                     CONFIG.DH.SETTINGS.gameSettings.appearance

--- a/templates/sheets/activeEffect/details.hbs
+++ b/templates/sheets/activeEffect/details.hbs
@@ -5,16 +5,9 @@
     {{formGroup systemFields.targetDispositions value=source.system.targetDispositions name=(concat "system.targetDispositions") localize=true}}
 
     {{#if isActorEffect}}
-        <div class="form-group">
-            <label>{{localize "EFFECT.FIELDS.origin.label"}}</label>
-            <div class="form-fields">
-                <input type="text" value="{{source.origin}}" disabled />
-            </div>
-        </div>
-    {{/if}}
-    
-    {{#if isItemEffect}}
-        {{formGroup fields.transfer value=source.transfer rootId=rootId label=legacyTransfer.label hint=(localize "DAGGERHEART.EFFECTS.Attachments.transferHint")}}
+        {{formGroup fields.origin value=source.origin rootId=rootId disabled=true}}
+    {{else if isItemEffect}}
+        {{formGroup fields.transfer value=source.transfer rootId=rootId}}
     {{/if}}
 
     {{formGroup fields.statuses value=source.statuses options=statuses rootId=rootId classes="statuses"}}


### PR DESCRIPTION
- Fixed so that ActiveEffects on homebrew features can set 'Transfer To Actor'
- Replaced the `ActiveEffect.Details` template part with a v14 updated more succinct version