### PR TITLE
[Fix] ContextMenu v14 Deprecation

### DIFF
--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -368,7 +368,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
                     const doc = getDocFromElementSync(target);
                     return doc?.isOwner && !isItemWizardManaged(doc);
                 },
-                callback: async (target, event) => {
+                onClick: async (event, target) => {
                     const doc = await getDocFromElement(target);
                     if (event.shiftKey) return doc.delete();
                     else return doc.deleteDialog();
@@ -393,7 +393,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
                     const doc = getDocFromElementSync(target);
                     return doc?.isOwner && doc.system.inVault;
                 },
-                callback: async target => {
+                onClick: async (_, target) => {
                     const doc = await getDocFromElement(target);
                     const actorLoadout = doc.actor.system.loadoutSlot;
                     if (actorLoadout.available) return doc.update({ 'system.inVault': false });
@@ -407,7 +407,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
                     const doc = getDocFromElementSync(target);
                     return doc?.isOwner && doc.system.inVault;
                 },
-                callback: async (target, event) => {
+                onClick: async (event, target) => {
                     const doc = await getDocFromElement(target);
                     const actorLoadout = doc.actor.system.loadoutSlot;
                     if (!actorLoadout.available) {
@@ -446,7 +446,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
                     const doc = getDocFromElementSync(target);
                     return doc?.isOwner && !doc.system.inVault;
                 },
-                callback: async target => (await getDocFromElement(target)).update({ 'system.inVault': true })
+                onClick: async (_, target) => (await getDocFromElement(target)).update({ 'system.inVault': true })
             }
         ].map(option => ({
             ...option,
@@ -472,7 +472,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
                     const doc = getDocFromElementSync(target);
                     return doc.isOwner && doc && !doc.system.equipped;
                 },
-                callback: (target, event) => CharacterSheet.#toggleEquipItem.call(this, event, target)
+                onClick: (event, target) => CharacterSheet.#toggleEquipItem.call(this, event, target)
             },
             {
                 label: 'unequip',
@@ -481,7 +481,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
                     const doc = getDocFromElementSync(target);
                     return doc.isOwner && doc && doc.system.equipped;
                 },
-                callback: (target, event) => CharacterSheet.#toggleEquipItem.call(this, event, target)
+                onClick: (event, target) => CharacterSheet.#toggleEquipItem.call(this, event, target)
             }
         ].map(option => ({
             ...option,

--- a/module/applications/sheets/api/application-mixin.mjs
+++ b/module/applications/sheets/api/application-mixin.mjs
@@ -424,7 +424,7 @@ export default function DHApplicationMixin(Base) {
                         const target = element.closest('[data-item-uuid]');
                         return !target.dataset.disabled && target.dataset.itemType !== 'beastform';
                     },
-                    callback: async target => (await getDocFromElement(target)).update({ disabled: true })
+                    onClick: async (_, target) => (await getDocFromElement(target)).update({ disabled: true })
                 },
                 {
                     label: 'enableEffect',
@@ -433,7 +433,7 @@ export default function DHApplicationMixin(Base) {
                         const target = element.closest('[data-item-uuid]');
                         return target.dataset.disabled && target.dataset.itemType !== 'beastform';
                     },
-                    callback: async target => (await getDocFromElement(target)).update({ disabled: false })
+                    onClick: async (_, target) => (await getDocFromElement(target)).update({ disabled: false })
                 }
             ].map(option => ({
                 ...option,
@@ -478,7 +478,9 @@ export default function DHApplicationMixin(Base) {
                             (doc?.isOwner && (!doc?.hasOwnProperty('systemPath') || doc?.inCollection))
                         );
                     },
-                    callback: async target => (await getDocFromElement(target)).sheet.render({ force: true })
+                    onClick: async (_, target) => {
+                        return (await getDocFromElement(target)).sheet.render({ force: true });
+                    }
                 }
             ];
 
@@ -493,7 +495,7 @@ export default function DHApplicationMixin(Base) {
                             !foundry.utils.isEmpty(doc?.damage?.parts);
                         return doc?.isOwner && hasDamage;
                     },
-                    callback: async (target, event) => {
+                    onClick: async (event, target) => {
                         const doc = await getDocFromElement(target),
                             action = doc?.system?.attack ?? doc;
                         const config = action.prepareConfig(event);
@@ -513,7 +515,7 @@ export default function DHApplicationMixin(Base) {
                         const doc = getDocFromElementSync(target);
                         return doc?.isOwner && !(doc.type === 'domainCard' && doc.system.inVault);
                     },
-                    callback: async (target, event) => (await getDocFromElement(target)).use(event)
+                    onClick: async (event, target) => (await getDocFromElement(target)).use(event)
                 });
             }
 
@@ -521,7 +523,7 @@ export default function DHApplicationMixin(Base) {
                 options.push({
                     label: 'DAGGERHEART.APPLICATIONS.ContextMenu.sendToChat',
                     icon: 'fa-solid fa-message',
-                    callback: async target => (await getDocFromElement(target)).toChat(this.document.uuid)
+                    onClick: async (_, target) => (await getDocFromElement(target)).toChat(this.document.uuid)
                 });
 
             if (deletable)
@@ -533,7 +535,7 @@ export default function DHApplicationMixin(Base) {
                         const doc = getDocFromElementSync(target);
                         return doc?.isOwner !== false && target.dataset.itemType !== 'beastform';
                     },
-                    callback: async (target, event) => {
+                    onClick: async (event, target) => {
                         const doc = await getDocFromElement(target);
                         if (event.shiftKey) return doc.delete();
                         else return doc.deleteDialog();

--- a/module/applications/sheets/api/base-item.mjs
+++ b/module/applications/sheets/api/base-item.mjs
@@ -126,7 +126,7 @@ export default class DHBaseItemSheet extends DHApplicationMixin(ItemSheetV2) {
         options.push({
             name: 'CONTROLS.CommonDelete',
             icon: '<i class="fa-solid fa-trash"></i>',
-            callback: async target => {
+            onClick: async target => {
                 const feature = await getDocFromElement(target);
                 if (!feature) return;
                 const confirmed = await foundry.applications.api.DialogV2.confirm({

--- a/module/applications/sheets/api/base-item.mjs
+++ b/module/applications/sheets/api/base-item.mjs
@@ -126,7 +126,7 @@ export default class DHBaseItemSheet extends DHApplicationMixin(ItemSheetV2) {
         options.push({
             name: 'CONTROLS.CommonDelete',
             icon: '<i class="fa-solid fa-trash"></i>',
-            onClick: async target => {
+            onClick: async (_, target) => {
                 const feature = await getDocFromElement(target);
                 if (!feature) return;
                 const confirmed = await foundry.applications.api.DialogV2.confirm({


### PR DESCRIPTION
Fixes #1925 
Updated from the deprecated 'callback' to 'onClick' for ContextMenu entries. It has legacy support up to v16, but doesn't hurt to get it done already 🤷 
