### PR TITLE
[Fix] Advantage Dice Duplication

### DIFF
--- a/module/applications/dialogs/d20RollDialog.mjs
+++ b/module/applications/dialogs/d20RollDialog.mjs
@@ -175,14 +175,14 @@ export default class D20RollDialog extends HandlebarsApplicationMixin(Applicatio
         this.disadvantage = advantage === -1;
 
         this.config.roll.advantage = this.config.roll.advantage === advantage ? 0 : advantage;
+        if (this.config.roll.advantage === 0) return this.render();
 
-        if (this.config.roll.advantage === 1 && this.config.data.rules.roll.defaultAdvantageDice) {
-            const faces = Number.parseInt(this.config.data.rules.roll.defaultAdvantageDice);
-            this.roll.advantageFaces = Number.isNaN(faces) ? this.roll.advantageFaces : faces;
-        } else if (this.config.roll.advantage === -1 && this.config.data.rules.roll.defaultDisadvantageDice) {
-            const faces = Number.parseInt(this.config.data.rules.roll.defaultDisadvantageDice);
-            this.roll.advantageFaces = Number.isNaN(faces) ? this.roll.advantageFaces : faces;
-        }
+        const defaultFaces =
+            this.config.roll.advantage === 1
+                ? this.config.data.rules.roll.defaultAdvantageDice
+                : this.config.data.rules.roll.defaultDisadvantageDice;
+        const faces = Number.parseInt(defaultFaces);
+        this.roll.advantageFaces = Number.isNaN(faces) ? this.roll.advantageFaces : faces;
 
         this.render();
     }

--- a/module/dice/dualityRoll.mjs
+++ b/module/dice/dualityRoll.mjs
@@ -148,14 +148,22 @@ export default class DualityRoll extends D20Roll {
     }
 
     applyAdvantage() {
-        if (this.hasAdvantage || this.hasDisadvantage) {
-            const dieFaces = this.advantageFaces,
-                advDie = new foundry.dice.terms.Die({ faces: dieFaces, number: this.advantageNumber });
-            if (this.advantageNumber > 1) advDie.modifiers = ['kh'];
-            this.terms.push(
-                new foundry.dice.terms.OperatorTerm({ operator: this.hasDisadvantage ? '-' : '+' }),
-                advDie
-            );
+        const advDieClass = this.hasAdvantage
+            ? game.system.api.dice.diceTypes.AdvantageDie
+            : this.hasDisadvantage
+              ? game.system.api.dice.diceTypes.DisadvantageDie
+              : null;
+        if (advDieClass) {
+            const advDie = new advDieClass({ faces: this.advantageFaces, number: this.advantageNumber });
+            if (this.terms.length < 4) {
+                if (this.advantageNumber > 1) advDie.modifiers = ['kh'];
+                this.terms.push(
+                    new foundry.dice.terms.OperatorTerm({ operator: this.hasDisadvantage ? '-' : '+' }),
+                    advDie
+                );
+            } else {
+                this.terms[4] = advDie;
+            }
         }
         if (this.rallyFaces)
             this.terms.push(


### PR DESCRIPTION
I found an issue where adding an Advantage or Disadvantage dice has the AdvantageDice term in that `DhRoll` get duplicated upon rerolling.
It hasn't been an issue since advantage dice have never been possible to reroll before, but since that is about to get added, it's an issue beyond just technically being wrong.

- Fixed so that the Advantage/Disadvantage dice recieves the correct dice type, previously it ended up as just a `Die`.
- Changed `ApplyAdvantage` to work the same way as `ConstructBaseDice`, where the typing is corrected if the dice already exists, otherwise the dice are added to the `DhRoll` if it should be present. Previously it always added, even if the dice was already present.