### PR TITLE
[Feature] Show actor sheet when clicking actors in item browser

### DIFF
--- a/module/applications/ui/itemBrowser.mjs
+++ b/module/applications/ui/itemBrowser.mjs
@@ -1,3 +1,4 @@
+import { getDocFromElement } from '../../helpers/utils.mjs';
 import { RefreshType, socketEvent } from '../../systemRegistration/socket.mjs';
 
 const { HandlebarsApplicationMixin, ApplicationV2 } = foundry.applications.api;
@@ -47,7 +48,8 @@ export class ItemBrowser extends HandlebarsApplicationMixin(ApplicationV2) {
             expandContent: this.expandContent,
             resetFilters: this.resetFilters,
             sortList: this.sortList,
-            openSettings: this.openSettings
+            openSettings: this.openSettings,
+            viewSheet: this.#onViewSheet
         },
         position: {
             left: 100,
@@ -306,7 +308,8 @@ export class ItemBrowser extends HandlebarsApplicationMixin(ApplicationV2) {
                 {
                     items: this.items,
                     menu: this.selectedMenu,
-                    formatLabel: this.formatLabel
+                    formatLabel: this.formatLabel,
+                    viewSheet: this.items[0] instanceof Actor
                 }
             );
 
@@ -566,6 +569,11 @@ export class ItemBrowser extends HandlebarsApplicationMixin(ApplicationV2) {
                 }
             });
         }
+    }
+
+    static async #onViewSheet(_, target) {
+        const document = await getDocFromElement(target);
+        document?.sheet?.render(true);
     }
 
     _createDragProcess() {

--- a/styles/less/ui/item-browser/item-browser.less
+++ b/styles/less/ui/item-browser/item-browser.less
@@ -245,7 +245,7 @@
         }
 
         .item-list-header,
-        .item-list [data-action='expandContent'] {
+        .item-list .item-info[data-action] {
             display: flex;
 
             > * {

--- a/templates/ui/itemBrowser/itemContainer.hbs
+++ b/templates/ui/itemBrowser/itemContainer.hbs
@@ -1,7 +1,7 @@
 {{#each items}}
     <div class="item-container" data-item-uuid="{{uuid}}" draggable="true">
         <div class="item-header">
-            <div class="item-info" data-action="expandContent">
+            <div class="item-info" {{#if @root.viewSheet}}data-action="viewSheet"{{else}}data-action="expandContent"{{/if}}>
                 <img src="{{img}}" data-item-key="img" class="item-list-img">
                 <span data-item-key="name" class="item-list-name">{{name}}</span>
                 {{#each ../menu.data.columns}}
@@ -9,11 +9,13 @@
                 {{/each}}
             </div>
         </div>
-        <div class="item-desc extensible">
-            <span class="wrapper">
-                {{{system.enrichedTags}}}
-                {{{system.enrichedDescription}}}
-            </span>
-        </div>
+        {{#unless viewSheet}}
+            <div class="item-desc extensible">
+                <span class="wrapper">
+                    {{{system.enrichedTags}}}
+                    {{{system.enrichedDescription}}}
+                </span>
+            </div>
+        {{/unless}}
     </div>
 {{/each}}


### PR DESCRIPTION
Clicking on an actor in the browser now opens the sheet. There was nothing to expand for actors anyways. Should be easier to browse monsters and environments to throw against the party now.