### PR TITLE
[Fix] Include more item types when viewing compendium browser from item tab

### DIFF
--- a/module/applications/ui/itemBrowser.mjs
+++ b/module/applications/ui/itemBrowser.mjs
@@ -606,7 +606,16 @@ export class ItemBrowser extends HandlebarsApplicationMixin(ApplicationV2) {
                 items: {
                     folder: 'equipments',
                     render: {
-                        noFolder: true
+                        folders: [
+                            'equipments',
+                            'ancestries',
+                            'classes',
+                            'subclasses',
+                            'domains',
+                            'communities',
+                            'beastforms'
+                            // excluded: features
+                        ]
                     }
                 },
                 compendium: {}


### PR DESCRIPTION
<img width="361" height="331" alt="image" src="https://github.com/user-attachments/assets/680091dd-6078-4818-9abe-cd962a0d3d65" />

<img width="865" height="620" alt="image" src="https://github.com/user-attachments/assets/bd0915f6-5814-4775-9761-83e19fe99eda" />
