### PR TITLE
[Fix] usable checks on adversary features and locked compendium actors

### DIFF
--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -148,10 +148,14 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
               : null;
     }
 
-    /** Returns true if the action is usable */
+    /**
+     * Returns true if the action is usable.
+     * An action is usable on any actor type. For example, an adversary might have a base attack action.
+     */
     get usable() {
         const actor = this.actor;
-        return this.isOwner && actor?.type === 'character';
+        const pack = actor?.pack ? game.packs.get(actor.pack) : null;
+        return !pack?.locked && this.isOwner;
     }
 
     static getRollType(parent) {

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -73,8 +73,10 @@ export default class DHItem extends foundry.documents.Item {
     /** Returns true if the item can be used */
     get usable() {
         const actor = this.actor;
-        const actionsList = this.system.actionsList;
-        return this.isOwner && actor?.type === 'character' && (actionsList?.size || actionsList?.length);
+        const pack = actor?.pack ? game.packs.get(actor.pack) : null;
+        const hasActions = this.system.actionsList?.size || this.system.actionsList?.length;
+        const isValidType = actor?.type === 'character' || this.type === 'feature';
+        return !pack?.locked && this.isOwner && isValidType && hasActions;
     }
 
     /** @inheritdoc */

--- a/templates/sheets/global/partials/inventory-item-compact.hbs
+++ b/templates/sheets/global/partials/inventory-item-compact.hbs
@@ -5,7 +5,7 @@
     (hasProperty item "toChat" ) "toChat" "editDoc" ) }}' {{#unless hideTooltip}} {{#if (eq type 'attack' )}}
     data-tooltip="#attack#{{item.actor.uuid}}" {{else}} data-tooltip="#item#{{item.uuid}}" {{/if}} {{/unless}}>
         <img src="{{item.img}}" class="item-img {{#if isActor}}actor-img{{/if}}" />
-        {{#if (or item.system.actionsList.size item.system.actionsList.length item.actionType)}}
+        {{#if item.usable}}
             {{#if @root.isNPC}}
                 <img class="roll-img d20" src="systems/daggerheart/assets/icons/dice/default/d20.svg" alt="d20">
             {{else}}


### PR DESCRIPTION
This fixes something i broke in v14 that works fine in v13.

<img width="424" height="182" alt="image" src="https://github.com/user-attachments/assets/adedb39f-ebbd-4c90-9a5e-e79d321a4dde" />

This also makes all actions and items flagged as unusable (which means don't show roll icons) if inside of a locked compendium.