### PR TITLE
[Fix] Disable character and adversary name inputs when read only

### DIFF
--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -184,6 +184,9 @@ export default class CharacterSheet extends DHBaseActorSheet {
         for (const input of form.querySelectorAll('input:not([type=search]), .editor.prosemirror')) {
             input.disabled = disabled;
         }
+        for (const element of form.querySelectorAll('.input[contenteditable]')) {
+            element.classList.toggle('disabled', disabled);
+        }
     }
 
     /** @inheritDoc */

--- a/module/applications/sheets/api/base-actor.mjs
+++ b/module/applications/sheets/api/base-actor.mjs
@@ -166,6 +166,15 @@ export default class DHBaseActorSheet extends DHApplicationMixin(ActorSheetV2) {
         }
     }
 
+    /** Add support for input content editables */
+    _toggleDisabled(disabled) {
+        super._toggleDisabled(disabled);
+        const form = this.form;
+        for (const element of form.querySelectorAll('.input[contenteditable]')) {
+            element.classList.toggle('disabled', disabled);
+        }
+    }
+
     /* -------------------------------------------- */
     /*  Context Menu                                */
     /* -------------------------------------------- */


### PR DESCRIPTION
Fixes adversary and characters names having editable inputs (and then throwing errors) in locked compendiums, and probably also fixes a similar issue for observers.