### PR TITLE
[Fix] setting dialogs created from overriden light sheet actors

### DIFF
--- a/styles/less/sheets-settings/character-settings/sheet.less
+++ b/styles/less/sheets-settings/character-settings/sheet.less
@@ -1,17 +1,19 @@
 @import '../../utils/colors.less';
 
-.theme-light .application.daggerheart.dh-style.dialog {
-    .tab.details {
-        .traits-inner-container .trait-container {
-            background: url('../assets/svg/trait-shield-light.svg') no-repeat;
+.appTheme({}, {
+    &.dialog.character-settings {
+        .tab.details {
+            .traits-inner-container .trait-container {
+                background: url('../assets/svg/trait-shield-light.svg') no-repeat;
 
-            div {
-                filter: drop-shadow(0 0 3px @beige);
-                text-shadow: 0 0 3px @beige;
+                div {
+                    filter: drop-shadow(0 0 3px @beige);
+                    text-shadow: 0 0 3px @beige;
+                }
             }
         }
     }
-}
+});
 
 .application.daggerheart.dh-style.dialog {
     .tab.details {

--- a/styles/less/utils/mixin.less
+++ b/styles/less/utils/mixin.less
@@ -5,16 +5,16 @@
  */
 .appTheme(@darkRules, @lightRules) {
     // Dark theme selectors
-    .themed.theme-dark .application.daggerheart.sheet.dh-style,
-    .themed.theme-dark.application.daggerheart.sheet.dh-style,
+    .themed.theme-dark .application.daggerheart.dh-style,
+    .themed.theme-dark.application.daggerheart.dh-style,
     body.theme-dark .application.daggerheart,
     body.theme-dark.application.daggerheart {
         @darkRules();
     }
 
     // Light theme selectors
-    .themed.theme-light .application.daggerheart.sheet.dh-style,
-    .themed.theme-light.application.daggerheart.sheet.dh-style,
+    .themed.theme-light .application.daggerheart.dh-style,
+    .themed.theme-light.application.daggerheart.dh-style,
     body.theme-light .application.daggerheart,
     body.theme-light.application.daggerheart {
         @lightRules();


### PR DESCRIPTION
Not a new bug. This occurs when the world is set to dark mode, you set a character to light mode, then open the character settings.