### PR TITLE
Swap order of thresholds and resources in actor editor

### DIFF
--- a/styles/less/sheets-settings/adversary-settings/sheet.less
+++ b/styles/less/sheets-settings/adversary-settings/sheet.less
@@ -7,7 +7,7 @@
         &.attack.active {
             display: flex;
             flex-direction: column;
-            gap: 16px;
+            gap: 12px;
         }
 
         .fieldsets-section {

--- a/templates/sheets-settings/adversary-settings/details.hbs
+++ b/templates/sheets-settings/adversary-settings/details.hbs
@@ -18,6 +18,12 @@
         {{formField systemFields.motivesAndTactics value=document._source.system.motivesAndTactics label=(localize "DAGGERHEART.ACTORS.Adversary.FIELDS.motivesAndTactics.label")}}
     </fieldset>
 
+    <fieldset class="flex">
+        <legend>{{localize "DAGGERHEART.GENERAL.DamageThresholds.title"}}</legend>
+        {{formGroup systemFields.damageThresholds.fields.major value=document._source.system.damageThresholds.major label=(localize "DAGGERHEART.GENERAL.DamageThresholds.majorThreshold")}}
+        {{formGroup systemFields.damageThresholds.fields.severe value=document._source.system.damageThresholds.severe label=(localize "DAGGERHEART.GENERAL.DamageThresholds.severeThreshold")}}
+    </fieldset>
+    
     <div class="fieldsets-section">
         <fieldset class="flex">
             <legend>{{localize "DAGGERHEART.GENERAL.Resource.plural"}}</legend>
@@ -26,10 +32,4 @@
             {{/each}}
          </fieldset>
     </div>
-
-    <fieldset class="flex">
-        <legend>{{localize "DAGGERHEART.GENERAL.DamageThresholds.title"}}</legend>
-        {{formGroup systemFields.damageThresholds.fields.major value=document._source.system.damageThresholds.major label=(localize "DAGGERHEART.GENERAL.DamageThresholds.majorThreshold")}}
-        {{formGroup systemFields.damageThresholds.fields.severe value=document._source.system.damageThresholds.severe label=(localize "DAGGERHEART.GENERAL.DamageThresholds.severeThreshold")}}
-    </fieldset>
 </section>


### PR DESCRIPTION
Minor thing that probably isn't worth a mention in the patch notes, but I tried to better match the statblock ordering to make it easier to data enter. Difficulty isn't as easy to move: there isn't space to put the token size where difficulty was. But something is better than nothing.

I was motivated from copying over homebrew statblocks and tripping over myself a bit.

<img width="464" height="749" alt="image" src="https://github.com/user-attachments/assets/41957e42-b601-481e-adc1-8ab562b34a24" />

<img width="325" height="172" alt="image" src="https://github.com/user-attachments/assets/35c3479a-6dab-42c0-8f42-057f01860068" />

Book ordering is 
tier -> type -> description -> motives -> difficulty -> thresholds -> hp/stress > attack -> experiences -> features

Current adversary order after this PR is
tier -> type -> difficulty -> description -> motives -> thresholds -> hp/stress -> attack -> experiences -> features