### PR TITLE
[UI] Make prosemirror button nicer

### DIFF
--- a/styles/less/global/prose-mirror.less
+++ b/styles/less/global/prose-mirror.less
@@ -40,6 +40,11 @@
             ul {
                 list-style: disc;
             }
+        }       
+        // Fixes centering and makes it not render over scrollbar
+        &:hover button.toggle:enabled {
+            display: flex;
+            right: 12px;
         }
     }
 }


### PR DESCRIPTION
Buttons are normally display flex, but foundry makes the styling block when hovered

Before
<img width="514" height="345" alt="image" src="https://github.com/user-attachments/assets/82c1b6b2-77d3-414f-9fc4-03d56be25b04" />

After
<img width="514" height="351" alt="image" src="https://github.com/user-attachments/assets/c70da28f-8a5a-4507-b8c6-eba921255dd2" />
