### PR TITLE
[Fix] companion effects not being scrollable when overflowing

### DIFF
--- a/styles/less/sheets/actors/companion/sheet.less
+++ b/styles/less/sheets/actors/companion/sheet.less
@@ -10,3 +10,16 @@
         background: url('../assets/parchments/dh-parchment-light.png');
     }
 });
+
+.application.sheet.daggerheart.actor.dh-style.companion {
+    .window-content {
+        display: flex;
+    }
+
+    .tab.active {
+        flex: 1;
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+    }
+}


### PR DESCRIPTION
<img width="382" height="890" alt="image" src="https://github.com/user-attachments/assets/8f2c5630-9bfb-408c-b989-48d6d6af46ed" />
