### PR TITLE
[Fix] ApplyEffect Without GM

### DIFF
--- a/module/data/fields/action/effectsField.mjs
+++ b/module/data/fields/action/effectsField.mjs
@@ -1,5 +1,3 @@
-import { emitGMUpdate, GMUpdateEvent } from '../../../systemRegistration/socket.mjs';
-
 const fields = foundry.data.fields;
 
 export default class EffectsField extends fields.ArrayField {
@@ -34,8 +32,7 @@ export default class EffectsField extends fields.ArrayField {
         }
         if (EffectsField.getAutomation() || force) {
             targets ??= (message.system?.targets ?? config.targets).filter(t => !config.hasRoll || t.hit);
-            await emitGMUpdate(GMUpdateEvent.UpdateEffect, EffectsField.applyEffects.bind(this), targets, this.uuid);
-            // EffectsField.applyEffects.call(this, config.targets.filter(t => !config.hasRoll || t.hit));
+            EffectsField.applyEffects.call(this, targets);
         }
     }
 


### PR DESCRIPTION
Changed so that EffectField applyEffect doesn't run EmitAsGM.

We -could- keep EmitAsGM if the user doesn't have permission for the targets, but I'm not convinced we should. At the moment we are running by the principle that the GM applies damage and other things to Adversaries after all 🤔 