### PR TITLE
[Fix] TagTeamDialog Fixes

### DIFF
--- a/styles/less/dialog/tag-team-dialog/sheet.less
+++ b/styles/less/dialog/tag-team-dialog/sheet.less
@@ -194,6 +194,7 @@
 
         .roll-selection-container {
             display: flex;
+            gap: 16px;
 
             .select-roll-button {
                 margin-top: 8px;

--- a/templates/dialogs/tagTeamDialog/parts/tagTeamDamageParts.hbs
+++ b/templates/dialogs/tagTeamDialog/parts/tagTeamDamageParts.hbs
@@ -16,7 +16,7 @@
                     {{/unless}}
                 {{/each}}
                 {{#if part.modifierTotal}}
-                    <span class="roll-operator">{{#if (gte part.modifierTotal 0)}}+{{else}}-{{/if}}</span>
+                    {{#if part.dice.length}}<span class="roll-operator">{{#if (gte part.modifierTotal 0)}}+{{else}}-{{/if}}</span>{{/if}}
                     <span class="roll-value">{{positive part.modifierTotal}}</span>
                 {{/if}}
             </div>


### PR DESCRIPTION
- Fixed the centering of the Select-Roll circles in TagTeamDialog. 
- Fixed so that damage formulas that are just a modifier don't get a prefix '+' rendered.

**Previously:**
<img width="699" height="880" alt="image" src="https://github.com/user-attachments/assets/ba4ece11-befd-491f-9334-9d505fdfbab7" />

**After:**
<img width="699" height="873" alt="image" src="https://github.com/user-attachments/assets/90aed407-7d4e-4e8d-a49d-75e4e5cca01b" />