### PR TITLE
[Fix] NPC Improvements

### DIFF
--- a/module/applications/sheets/actors/party.mjs
+++ b/module/applications/sheets/actors/party.mjs
@@ -47,11 +47,6 @@ export default class Party extends DHBaseActorSheet {
             template: 'systems/daggerheart/templates/sheets/actors/party/party-members.hbs',
             scrollable: ['']
         },
-        /* NOT YET IMPLEMENTED */
-        // projects: {
-        //     template: 'systems/daggerheart/templates/sheets/actors/party/projects.hbs',
-        //     scrollable: ['']
-        // },
         inventory: {
             template: 'systems/daggerheart/templates/sheets/actors/party/inventory.hbs',
             scrollable: ['.tab.inventory .items-section']
@@ -62,19 +57,13 @@ export default class Party extends DHBaseActorSheet {
     /** @inheritdoc */
     static TABS = {
         primary: {
-            tabs: [
-                { id: 'partyMembers' },
-                /* NOT YET IMPLEMENTED */
-                // { id: 'projects' },
-                { id: 'inventory' },
-                { id: 'notes' }
-            ],
+            tabs: [{ id: 'partyMembers' }, { id: 'inventory' }, { id: 'notes' }],
             initial: 'partyMembers',
             labelPrefix: 'DAGGERHEART.GENERAL.Tabs'
         }
     };
 
-    static ALLOWED_ACTOR_TYPES = ['character', 'companion', 'adversary'];
+    static ALLOWED_ACTOR_TYPES = ['character', 'companion', 'adversary', 'npc'];
     static DICE_ROLL_ACTOR_TYPES = ['character'];
 
     async _onRender(context, options) {

--- a/styles/less/sheets/actors/npc/header.less
+++ b/styles/less/sheets/actors/npc/header.less
@@ -5,7 +5,7 @@
 
         .portrait {
             cursor: pointer;
-            width: 275px;
+            max-width: 275px;
 
             img {
                 height: 275px;

--- a/templates/sheets/actors/npc/header.hbs
+++ b/templates/sheets/actors/npc/header.hbs
@@ -31,10 +31,12 @@
             <span class="description">
                 <i>{{{description}}}</i>
             </span>
-            <div class="motives-and-tactics">
-                <b>{{localize 'DAGGERHEART.ACTORS.NPC.FIELDS.motives.label'}}: </b>
-                {{source.system.motives}}
-            </div>
+            {{#if source.system.motives}}
+                <div class="motives-and-tactics">
+                    <b>{{localize 'DAGGERHEART.ACTORS.NPC.FIELDS.motives.label'}}: </b>
+                    {{source.system.motives}}
+                </div>
+            {{/if}}
         </div>
     </div>
 </header>

--- a/templates/sheets/actors/party/party-members.hbs
+++ b/templates/sheets/actors/party/party-members.hbs
@@ -42,7 +42,7 @@
                         {{#if member.difficulty includeZero=true}}
                             <div class="evasion" data-tooltip="DAGGERHEART.GENERAL.difficulty">{{member.difficulty}}</div>
                         {{/if}}
-                        {{#unless (eq member.type 'companion')}}
+                        {{#unless (or (eq member.type 'companion') (eq member.type 'npc'))}}
                             <div class="threshold-section">
                                 <h4 class="threshold-label">{{localize "DAGGERHEART.ACTORS.Party.Thresholds.minor"}}</h4>
                                 <h4 class="threshold-value">{{member.damageThresholds.major}}</h4>
@@ -58,7 +58,7 @@
                             <a class="delete-icon" data-action="deletePartyMember" data-uuid="{{member.uuid}}"><i class="fa-regular fa-times" inert></i></a>
                         </h2>
                         <div>
-                            {{#unless (or (eq member.type 'companion') (eq member.type 'adversary')) }}
+                            {{#unless (or (eq member.type 'companion') (eq member.type 'adversary') (eq member.type 'npc')) }}
                                 <div class="hope-section">
                                     <h4>{{localize "DAGGERHEART.GENERAL.hope"}}</h4>
                                     {{#times member.resources.hope.max}}
@@ -79,7 +79,7 @@
                     </header>
                     <section class="body">
                         <section class="resources">
-                            {{#unless (eq member.type 'companion') }}
+                            {{#unless (or (eq member.type 'companion') (eq member.type 'npc')) }}
                                 <div class="slot-section">
                                     <div class="slot-label" data-tooltip="DAGGERHEART.GENERAL.HitPoints.plural">
                                         <span class="label">
@@ -101,25 +101,27 @@
                                 </div>
                             {{/unless}}
 
-                            <div class="slot-section">
-                                <div class="slot-label" data-tooltip="DAGGERHEART.GENERAL.stress">
-                                    <span class="label">
-                                        <i class="fa-solid fa-bolt" inert></i>
-                                    </span>
-                                    <span class="value">
-                                        <span class="current">{{member.resources.stress.value}}</span>
-                                        / 
-                                        <span class="max">{{member.resources.stress.max}}</span>
-                                    </span>
-                                </div>
-                                <div class="slot-bar">
-                                    {{#times member.resources.stress.max}}
-                                        <span class='slot {{#if (gte member.resources.stress.value (add this 1))}}filled{{/if}}'
-                                        data-action='toggleStress' data-actor-id="{{member.uuid}}" data-value="{{add this 1}}">
+                            {{#unless (eq member.type 'npc')}}
+                                <div class="slot-section">
+                                    <div class="slot-label" data-tooltip="DAGGERHEART.GENERAL.stress">
+                                        <span class="label">
+                                            <i class="fa-solid fa-bolt" inert></i>
                                         </span>
-                                    {{/times}}
+                                        <span class="value">
+                                            <span class="current">{{member.resources.stress.value}}</span>
+                                            / 
+                                            <span class="max">{{member.resources.stress.max}}</span>
+                                        </span>
+                                    </div>
+                                    <div class="slot-bar">
+                                        {{#times member.resources.stress.max}}
+                                            <span class='slot {{#if (gte member.resources.stress.value (add this 1))}}filled{{/if}}'
+                                            data-action='toggleStress' data-actor-id="{{member.uuid}}" data-value="{{add this 1}}">
+                                            </span>
+                                        {{/times}}
+                                    </div>
                                 </div>
-                            </div>
+                            {{/unless}}
 
                             {{#if member.armorScore.max}}
                                 <div class="slot-section">


### PR DESCRIPTION
- NPC portrait styling changed from `width: 275px` to `max-width: 275px` to be better for thin potraits
- The `Motives:` label will now only be shown if there -is- actually stated motives for the NPC.
- NPCs can now be added to parties
<img width="759" height="1133" alt="image" src="https://github.com/user-attachments/assets/5202df79-d7c4-4b00-b6d0-5a5c0eb2a783" />