### PR TITLE
[Fix] Base Attack Context Menu

### DIFF
--- a/module/applications/sheets/actors/adversary.mjs
+++ b/module/applications/sheets/actors/adversary.mjs
@@ -34,7 +34,7 @@ export default class AdversarySheet extends DHBaseActorSheet {
         ],
         contextMenus: [
             {
-                handler: AdversarySheet.#getStandardAttackContextOptions,
+                handler: DHBaseActorSheet.getBaseAttackContextOptions,
                 selector: '[data-item-uuid][data-type="attack"]',
                 options: {
                     parentClassHooks: false,
@@ -272,43 +272,6 @@ export default class AdversarySheet extends DHBaseActorSheet {
                 return acc;
             }, {})
         });
-    }
-
-    /**
-     * Get the set of ContextMenu options for the standard attack.
-     * @returns {import('@client/applications/ux/context-menu.mjs').ContextMenuEntry[]} - The Array of context options passed to the ContextMenu instance
-     * @this {CharacterSheet}
-     * @protected
-     */
-    static #getStandardAttackContextOptions() {
-        /**@type {import('@client/applications/ux/context-menu.mjs').ContextMenuEntry[]} */
-        return [
-            {
-                label: 'DAGGERHEART.CONFIG.RollTypes.attack.name',
-                icon: 'fa-solid fa-burst',
-                onClick: async (event, target) => (await getDocFromElement(target)).use(event)
-            },
-            {
-                label: 'DAGGERHEART.GENERAL.damage',
-                icon: 'fa-solid fa-explosion',
-                onClick: async (event, target) => {
-                    const doc = await getDocFromElement(target),
-                        action = doc?.system?.attack ?? doc;
-                    const config = action.prepareConfig(event);
-                    config.effects = await game.system.api.data.actions.actionsTypes.base.getEffects(
-                        this.document,
-                        doc
-                    );
-                    config.hasRoll = false;
-                    return action && action.workflow.get('damage').execute(config, null, true);
-                }
-            },
-            {
-                label: 'DAGGERHEART.APPLICATIONS.ContextMenu.sendToChat',
-                icon: 'fa-solid fa-message',
-                onClick: async (_, target) => (await getDocFromElement(target)).toChat(this.document.uuid)
-            }
-        ];
     }
 
     /* -------------------------------------------- */

--- a/module/applications/sheets/actors/adversary.mjs
+++ b/module/applications/sheets/actors/adversary.mjs
@@ -31,6 +31,16 @@ export default class AdversarySheet extends DHBaseActorSheet {
                 dragSelector: '[data-item-id][draggable="true"], [data-item-id] [draggable="true"]',
                 dropSelector: null
             }
+        ],
+        contextMenus: [
+            {
+                handler: AdversarySheet.#getStandardAttackContextOptions,
+                selector: '[data-item-uuid][data-type="attack"]',
+                options: {
+                    parentClassHooks: false,
+                    fixed: true
+                }
+            }
         ]
     };
 
@@ -262,6 +272,43 @@ export default class AdversarySheet extends DHBaseActorSheet {
                 return acc;
             }, {})
         });
+    }
+
+    /**
+     * Get the set of ContextMenu options for the standard attack.
+     * @returns {import('@client/applications/ux/context-menu.mjs').ContextMenuEntry[]} - The Array of context options passed to the ContextMenu instance
+     * @this {CharacterSheet}
+     * @protected
+     */
+    static #getStandardAttackContextOptions() {
+        /**@type {import('@client/applications/ux/context-menu.mjs').ContextMenuEntry[]} */
+        return [
+            {
+                label: 'DAGGERHEART.CONFIG.RollTypes.attack.name',
+                icon: 'fa-solid fa-burst',
+                onClick: async (event, target) => (await getDocFromElement(target)).use(event)
+            },
+            {
+                label: 'DAGGERHEART.GENERAL.damage',
+                icon: 'fa-solid fa-explosion',
+                onClick: async (event, target) => {
+                    const doc = await getDocFromElement(target),
+                        action = doc?.system?.attack ?? doc;
+                    const config = action.prepareConfig(event);
+                    config.effects = await game.system.api.data.actions.actionsTypes.base.getEffects(
+                        this.document,
+                        doc
+                    );
+                    config.hasRoll = false;
+                    return action && action.workflow.get('damage').execute(config, null, true);
+                }
+            },
+            {
+                label: 'DAGGERHEART.APPLICATIONS.ContextMenu.sendToChat',
+                icon: 'fa-solid fa-message',
+                onClick: async (_, target) => (await getDocFromElement(target)).toChat(this.document.uuid)
+            }
+        ];
     }
 
     /* -------------------------------------------- */

--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -66,6 +66,14 @@ export default class CharacterSheet extends DHBaseActorSheet {
                 }
             },
             {
+                handler: CharacterSheet.#getBaseAttackContextOptions,
+                selector: '[data-item-uuid][data-type="attack"]',
+                options: {
+                    parentClassHooks: false,
+                    fixed: true
+                }
+            },
+            {
                 handler: CharacterSheet.#getDomainCardContextOptions,
                 selector: '[data-item-uuid][data-type="domainCard"]',
                 options: {
@@ -376,6 +384,43 @@ export default class CharacterSheet extends DHBaseActorSheet {
                     if (event.shiftKey) return doc.delete();
                     else return doc.deleteDialog();
                 }
+            }
+        ];
+    }
+
+    /**
+     * Get the set of ContextMenu options for the base attack.
+     * @returns {import('@client/applications/ux/context-menu.mjs').ContextMenuEntry[]} - The Array of context options passed to the ContextMenu instance
+     * @this {CharacterSheet}
+     * @protected
+     */
+    static #getBaseAttackContextOptions() {
+        /**@type {import('@client/applications/ux/context-menu.mjs').ContextMenuEntry[]} */
+        return [
+            {
+                label: 'DAGGERHEART.CONFIG.RollTypes.attack.name',
+                icon: 'fa-solid fa-burst',
+                onClick: async (event, target) => (await getDocFromElement(target)).use(event)
+            },
+            {
+                label: 'DAGGERHEART.GENERAL.damage',
+                icon: 'fa-solid fa-explosion',
+                onClick: async (event, target) => {
+                    const doc = await getDocFromElement(target),
+                        action = doc?.system?.attack ?? doc;
+                    const config = action.prepareConfig(event);
+                    config.effects = await game.system.api.data.actions.actionsTypes.base.getEffects(
+                        this.document,
+                        doc
+                    );
+                    config.hasRoll = false;
+                    return action && action.workflow.get('damage').execute(config, null, true);
+                }
+            },
+            {
+                label: 'DAGGERHEART.APPLICATIONS.ContextMenu.sendToChat',
+                icon: 'fa-solid fa-message',
+                onClick: async (_, target) => (await getDocFromElement(target)).toChat(this.document.uuid)
             }
         ];
     }

--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -66,7 +66,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
                 }
             },
             {
-                handler: CharacterSheet.#getBaseAttackContextOptions,
+                handler: DHBaseActorSheet.getBaseAttackContextOptions,
                 selector: '[data-item-uuid][data-type="attack"]',
                 options: {
                     parentClassHooks: false,
@@ -384,43 +384,6 @@ export default class CharacterSheet extends DHBaseActorSheet {
                     if (event.shiftKey) return doc.delete();
                     else return doc.deleteDialog();
                 }
-            }
-        ];
-    }
-
-    /**
-     * Get the set of ContextMenu options for the base attack.
-     * @returns {import('@client/applications/ux/context-menu.mjs').ContextMenuEntry[]} - The Array of context options passed to the ContextMenu instance
-     * @this {CharacterSheet}
-     * @protected
-     */
-    static #getBaseAttackContextOptions() {
-        /**@type {import('@client/applications/ux/context-menu.mjs').ContextMenuEntry[]} */
-        return [
-            {
-                label: 'DAGGERHEART.CONFIG.RollTypes.attack.name',
-                icon: 'fa-solid fa-burst',
-                onClick: async (event, target) => (await getDocFromElement(target)).use(event)
-            },
-            {
-                label: 'DAGGERHEART.GENERAL.damage',
-                icon: 'fa-solid fa-explosion',
-                onClick: async (event, target) => {
-                    const doc = await getDocFromElement(target),
-                        action = doc?.system?.attack ?? doc;
-                    const config = action.prepareConfig(event);
-                    config.effects = await game.system.api.data.actions.actionsTypes.base.getEffects(
-                        this.document,
-                        doc
-                    );
-                    config.hasRoll = false;
-                    return action && action.workflow.get('damage').execute(config, null, true);
-                }
-            },
-            {
-                label: 'DAGGERHEART.APPLICATIONS.ContextMenu.sendToChat',
-                icon: 'fa-solid fa-message',
-                onClick: async (_, target) => (await getDocFromElement(target)).toChat(this.document.uuid)
             }
         ];
     }

--- a/module/applications/sheets/actors/companion.mjs
+++ b/module/applications/sheets/actors/companion.mjs
@@ -15,7 +15,7 @@ export default class DhCompanionSheet extends DHBaseActorSheet {
         },
         contextMenus: [
             {
-                handler: DhCompanionSheet.#getAttackContextOptions,
+                handler: DHBaseActorSheet.getBaseAttackContextOptions,
                 selector: '[data-item-uuid][data-type="attack"]',
                 options: {
                     parentClassHooks: false,
@@ -48,47 +48,6 @@ export default class DhCompanionSheet extends DHBaseActorSheet {
             labelPrefix: 'DAGGERHEART.GENERAL.Tabs'
         }
     };
-
-    /* -------------------------------------------- */
-    /*  Context Menu                                */
-    /* -------------------------------------------- */
-
-    /**
-     * Get the set of ContextMenu options for the companion's attack.
-     * @returns {import('@client/applications/ux/context-menu.mjs').ContextMenuEntry[]} - The Array of context options passed to the ContextMenu instance
-     * @this {CharacterSheet}
-     * @protected
-     */
-    static #getAttackContextOptions() {
-        /**@type {import('@client/applications/ux/context-menu.mjs').ContextMenuEntry[]} */
-        return [
-            {
-                label: 'DAGGERHEART.CONFIG.RollTypes.attack.name',
-                icon: 'fa-solid fa-burst',
-                onClick: async (event, target) => (await getDocFromElement(target)).use(event)
-            },
-            {
-                label: 'DAGGERHEART.GENERAL.damage',
-                icon: 'fa-solid fa-explosion',
-                onClick: async (event, target) => {
-                    const doc = await getDocFromElement(target),
-                        action = doc?.system?.attack ?? doc;
-                    const config = action.prepareConfig(event);
-                    config.effects = await game.system.api.data.actions.actionsTypes.base.getEffects(
-                        this.document,
-                        doc
-                    );
-                    config.hasRoll = false;
-                    return action && action.workflow.get('damage').execute(config, null, true);
-                }
-            },
-            {
-                label: 'DAGGERHEART.APPLICATIONS.ContextMenu.sendToChat',
-                icon: 'fa-solid fa-message',
-                onClick: async (_, target) => (await getDocFromElement(target)).toChat(this.document.uuid)
-            }
-        ];
-    }
 
     /* -------------------------------------------- */
     /*  Application Clicks Actions                  */

--- a/module/applications/sheets/actors/companion.mjs
+++ b/module/applications/sheets/actors/companion.mjs
@@ -1,4 +1,3 @@
-import { getDocFromElement } from '../../../helpers/utils.mjs';
 import DhCompanionLevelUp from '../../levelup/companionLevelup.mjs';
 import DHBaseActorSheet from '../api/base-actor.mjs';
 

--- a/module/applications/sheets/actors/companion.mjs
+++ b/module/applications/sheets/actors/companion.mjs
@@ -1,3 +1,4 @@
+import { getDocFromElement } from '../../../helpers/utils.mjs';
 import DhCompanionLevelUp from '../../levelup/companionLevelup.mjs';
 import DHBaseActorSheet from '../api/base-actor.mjs';
 
@@ -11,7 +12,17 @@ export default class DhCompanionSheet extends DHBaseActorSheet {
             toggleStress: DhCompanionSheet.#toggleStress,
             actionRoll: DhCompanionSheet.#actionRoll,
             levelManagement: DhCompanionSheet.#levelManagement
-        }
+        },
+        contextMenus: [
+            {
+                handler: DhCompanionSheet.#getAttackContextOptions,
+                selector: '[data-item-uuid][data-type="attack"]',
+                options: {
+                    parentClassHooks: false,
+                    fixed: true
+                }
+            }
+        ]
     };
 
     static PARTS = {
@@ -37,6 +48,47 @@ export default class DhCompanionSheet extends DHBaseActorSheet {
             labelPrefix: 'DAGGERHEART.GENERAL.Tabs'
         }
     };
+
+    /* -------------------------------------------- */
+    /*  Context Menu                                */
+    /* -------------------------------------------- */
+
+    /**
+     * Get the set of ContextMenu options for the companion's attack.
+     * @returns {import('@client/applications/ux/context-menu.mjs').ContextMenuEntry[]} - The Array of context options passed to the ContextMenu instance
+     * @this {CharacterSheet}
+     * @protected
+     */
+    static #getAttackContextOptions() {
+        /**@type {import('@client/applications/ux/context-menu.mjs').ContextMenuEntry[]} */
+        return [
+            {
+                label: 'DAGGERHEART.CONFIG.RollTypes.attack.name',
+                icon: 'fa-solid fa-burst',
+                onClick: async (event, target) => (await getDocFromElement(target)).use(event)
+            },
+            {
+                label: 'DAGGERHEART.GENERAL.damage',
+                icon: 'fa-solid fa-explosion',
+                onClick: async (event, target) => {
+                    const doc = await getDocFromElement(target),
+                        action = doc?.system?.attack ?? doc;
+                    const config = action.prepareConfig(event);
+                    config.effects = await game.system.api.data.actions.actionsTypes.base.getEffects(
+                        this.document,
+                        doc
+                    );
+                    config.hasRoll = false;
+                    return action && action.workflow.get('damage').execute(config, null, true);
+                }
+            },
+            {
+                label: 'DAGGERHEART.APPLICATIONS.ContextMenu.sendToChat',
+                icon: 'fa-solid fa-message',
+                onClick: async (_, target) => (await getDocFromElement(target)).toChat(this.document.uuid)
+            }
+        ];
+    }
 
     /* -------------------------------------------- */
     /*  Application Clicks Actions                  */

--- a/module/applications/sheets/api/base-actor.mjs
+++ b/module/applications/sheets/api/base-actor.mjs
@@ -189,6 +189,43 @@ export default class DHBaseActorSheet extends DHApplicationMixin(ActorSheetV2) {
         return this._getContextMenuCommonOptions.call(this, { usable: true, toChat: true });
     }
 
+    /**
+     * Get the set of ContextMenu options for the base attack.
+     * @returns {import('@client/applications/ux/context-menu.mjs').ContextMenuEntry[]} - The Array of context options passed to the ContextMenu instance
+     * @this {CharacterSheet}
+     * @protected
+     */
+    static getBaseAttackContextOptions() {
+        /**@type {import('@client/applications/ux/context-menu.mjs').ContextMenuEntry[]} */
+        return [
+            {
+                label: 'DAGGERHEART.CONFIG.RollTypes.attack.name',
+                icon: 'fa-solid fa-burst',
+                onClick: async (event, target) => (await getDocFromElement(target)).use(event)
+            },
+            {
+                label: 'DAGGERHEART.GENERAL.damage',
+                icon: 'fa-solid fa-explosion',
+                onClick: async (event, target) => {
+                    const doc = await getDocFromElement(target),
+                        action = doc?.system?.attack ?? doc;
+                    const config = action.prepareConfig(event);
+                    config.effects = await game.system.api.data.actions.actionsTypes.base.getEffects(
+                        this.document,
+                        doc
+                    );
+                    config.hasRoll = false;
+                    return action && action.workflow.get('damage').execute(config, null, true);
+                }
+            },
+            {
+                label: 'DAGGERHEART.APPLICATIONS.ContextMenu.sendToChat',
+                icon: 'fa-solid fa-message',
+                onClick: async (_, target) => (await getDocFromElement(target)).toChat(this.document.uuid)
+            }
+        ];
+    }
+
     /* -------------------------------------------- */
     /*  Application Listener Actions                */
     /* -------------------------------------------- */

--- a/module/data/action/attackAction.mjs
+++ b/module/data/action/attackAction.mjs
@@ -75,7 +75,12 @@ export default class DHAttackAction extends DHDamageAction {
         const useAltDamage = this.actor?.effects?.find(x => x.type === 'horde')?.active;
         for (const { value, valueAlt, type } of damage.parts) {
             const usedValue = useAltDamage ? valueAlt : value;
-            const str = Roll.replaceFormulaData(usedValue.getFormula(), this.actor?.getRollData() ?? {});
+            const damageString = Roll.replaceFormulaData(usedValue.getFormula(), this.actor?.getRollData() ?? {});
+            const str = damageString
+                ? damageString
+                : game.i18n.format('DAGGERHEART.GENERAL.missingX', {
+                      x: game.i18n.localize('DAGGERHEART.GENERAL.damage')
+                  });
 
             const icons = Array.from(type)
                 .map(t => CONFIG.DH.GENERAL.damageTypes[t]?.icon)


### PR DESCRIPTION
Fixes #1924 
Fixes #1669 

- Fixed Adversary standard attack context menu
- Fixed Character base attack context menu
- Fixed Companion base attack context menu

I only added in attack/damage/show-message as these are not things to edit or delete. The main benefit is the `Damage` option being available now.
<img width="337" height="200" alt="image" src="https://github.com/user-attachments/assets/e480296c-127d-4696-be00-425271ab7410" />

Minor thing I also spotted - fixed so that adversaries do not display `Object Object` if the current Attack Damage is invalid
**Previous**
<img width="339" height="85" alt="image" src="https://github.com/user-attachments/assets/4bd52252-5bed-4096-a841-9dfcbde3da0f" />

**After**
<img width="338" height="92" alt="image" src="https://github.com/user-attachments/assets/3b74ff52-0788-4f6f-8595-b3edd29e06e8" />