### PR TITLE
[Fix] Countdown Fixes

### DIFF
--- a/module/data/action/countdownAction.mjs
+++ b/module/data/action/countdownAction.mjs
@@ -36,7 +36,7 @@ export default class DhCountdownAction extends DHBaseAction {
 
     /** @inheritDoc */
     static migrateData(source) {
-        for (const countdown of source.countdown) {
+        for (const countdown of Object.values(source.countdown)) {
             if (countdown.progress.max) {
                 countdown.progress.startFormula = countdown.progress.max;
                 countdown.progress.start = 1;


### PR DESCRIPTION
Fixed Countdown.migrationData assuming an array when it's actually an object. This was throwing a warning when you changed values in a Countdown Action.