### PR TITLE
[Fix] ChatMessage Saves Pending Confirmation

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -711,9 +711,9 @@
             },
             "PendingReactionsDialog": {
                 "title": "Pending Reaction Rolls Found",
-                "unfinishedRolls": "Some Tokens still need to roll their Reaction Roll.",
-                "confirmation": "Are you sure you want to continue ?",
-                "warning": "Undone reaction rolls will be considered as failed"
+                "unfinishedRolls": "Some Tokens have not finished their Reaction Rolls.",
+                "warning": "Unfinished reaction rolls will be considered as failed.",
+                "confirmation": "Are you sure you want to continue?"
             },
             "ReactionRoll": {
                 "title": "Reaction Roll: {trait}"

--- a/module/documents/chatMessage.mjs
+++ b/module/documents/chatMessage.mjs
@@ -247,8 +247,20 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
         const targets = this.filterPermTargets(this.system.hitTargets),
             config = foundry.utils.deepClone(this.system);
         config.event = event;
+
         if (targets.length === 0)
-            ui.notifications.info(game.i18n.localize('DAGGERHEART.UI.Notifications.noTargetsSelectedOrPerm'));
+            return ui.notifications.info(game.i18n.localize('DAGGERHEART.UI.Notifications.noTargetsSelectedOrPerm'));
+        else if (config.hasSave) {
+            const pendingingSaves = targets.filter(t => t.saved.success === null);
+            if (pendingingSaves.length) {
+                const confirm = await foundry.applications.api.DialogV2.confirm({
+                    window: { title: game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.title') },
+                    content: `<p>${game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.unfinishedRolls')}</p><p>${game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.confirmation')}</p><p><i>${game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.warning')}</i></p>`
+                });
+                if (!confirm) return;
+            }
+        }
+
         this.consumeOnSuccess();
         this.system.action?.workflow.get('effects')?.execute(config, targets, true);
     }

--- a/module/documents/chatMessage.mjs
+++ b/module/documents/chatMessage.mjs
@@ -183,7 +183,11 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
             if (pendingingSaves.length) {
                 const confirm = await foundry.applications.api.DialogV2.confirm({
                     window: { title: game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.title') },
-                    content: `<p>${game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.unfinishedRolls')}</p><p>${game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.confirmation')}</p><p><i>${game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.warning')}</i></p>`
+                    content: `
+                        <p>${game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.unfinishedRolls')}</p>
+                        <p><i>${game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.warning')}</i></p>
+                        <p>${game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.confirmation')}</p>
+                    `
                 });
                 if (!confirm) return;
             }
@@ -255,7 +259,11 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
             if (pendingingSaves.length) {
                 const confirm = await foundry.applications.api.DialogV2.confirm({
                     window: { title: game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.title') },
-                    content: `<p>${game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.unfinishedRolls')}</p><p>${game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.confirmation')}</p><p><i>${game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.warning')}</i></p>`
+                    content: `
+                        <p>${game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.unfinishedRolls')}</p>
+                        <p><i>${game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.warning')}</i></p>
+                        <p>${game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.confirmation')}</p>
+                    `
                 });
                 if (!confirm) return;
             }


### PR DESCRIPTION
Changed so that a confirmation warning pops up when trying to apply effects to targets that haven't done their saves.
It's the same dialog shown when trying to apply damage to targets that haven't done their saves.

<img width="520" height="338" alt="image" src="https://github.com/user-attachments/assets/317df80d-1513-4afa-b979-f830001f2001" />

Possible we should look at prettying this one up, but that can always be done later 🤷‍♂️ 