### PR TITLE
[Fix] Tooltip Color Scope

### DIFF
--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -1045,7 +1045,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
         game.tooltip.activate(target, {
             html,
             locked: true,
-            cssClass: 'bordered-tooltip',
+            cssClass: 'bordered-tooltip dh-style',
             direction: 'DOWN'
         });
 
@@ -1141,7 +1141,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
         game.tooltip.activate(target, {
             html,
             locked: true,
-            cssClass: 'bordered-tooltip',
+            cssClass: 'bordered-tooltip dh-style',
             direction: 'DOWN',
             noOffset: true
         });

--- a/module/documents/tooltipManager.mjs
+++ b/module/documents/tooltipManager.mjs
@@ -3,7 +3,6 @@ import { AdversaryBPPerEncounter, BaseBPPerEncounter } from '../config/encounter
 export default class DhTooltipManager extends foundry.helpers.interaction.TooltipManager {
     #wide = false;
     #bordered = false;
-    #active = false;
 
     async activate(element, options = {}) {
         const { TextEditor } = foundry.applications.ux;
@@ -321,6 +320,7 @@ export default class DhTooltipManager extends foundry.helpers.interaction.Toolti
     /**@inheritdoc */
     _setStyle(position = {}) {
         super._setStyle(position);
+        this.tooltip.classList.add('dh-style');
 
         if (this.#wide) {
             this.tooltip.classList.add('wide');

--- a/module/documents/tooltipManager.mjs
+++ b/module/documents/tooltipManager.mjs
@@ -320,7 +320,6 @@ export default class DhTooltipManager extends foundry.helpers.interaction.Toolti
     /**@inheritdoc */
     _setStyle(position = {}) {
         super._setStyle(position);
-        this.tooltip.classList.add('dh-style');
 
         if (this.#wide) {
             this.tooltip.classList.add('wide');


### PR DESCRIPTION
Added DH style to tooltips to fix the coloring of ArmorManagement and ResourceManagement tooltip.
The new scoped color variables weren't hitting as it didn't match any of the rules.

**Prev**
<img width="325" height="219" alt="image" src="https://github.com/user-attachments/assets/0c475a0e-3ddb-470c-98b6-dd8a0b696225" />
<img width="308" height="117" alt="image" src="https://github.com/user-attachments/assets/304642f1-61e7-454c-ad54-e6201d5fd8fc" />

**Changed**
<img width="221" height="210" alt="image" src="https://github.com/user-attachments/assets/324b5831-d0ae-46cc-90a0-6505e16468d6" />
<img width="307" height="117" alt="image" src="https://github.com/user-attachments/assets/1ab7d2b1-f88e-4d9c-a6f0-fa09266f3252" />

Not 100% if it's right to tack it on in the `setStyle` method, but it doesn't seem to cause any trouble in other tooltips from what I've noticed.