### PR TITLE
[Fix] Status HUD Styling

### DIFF
--- a/styles/less/hud/token-hud/token-hud.less
+++ b/styles/less/hud/token-hud/token-hud.less
@@ -38,6 +38,9 @@
     }
 
     .status-effects {
+        // TODO: Remove when the issue https://github.com/foundryvtt/foundryvtt/issues/14410 is resolved and Foundry handles it cleanly themselves.
+        grid-template-rows: min-content;
+
         .effect-control-container {
             position: relative;
 


### PR DESCRIPTION
Added a temp fix for status effect rows
<img width="210" height="249" alt="image" src="https://github.com/user-attachments/assets/8a82d73b-ff53-448c-a4ef-65bfeaf2d926" />
