### PR TITLE
[Fix] Allow removing empty string domains

### DIFF
--- a/module/applications/settings/homebrewSettings.mjs
+++ b/module/applications/settings/homebrewSettings.mjs
@@ -111,7 +111,7 @@ export default class DhHomebrewSettings extends HandlebarsApplicationMixin(Appli
 
         switch (partId) {
             case 'domains':
-                const selectedDomain = this.selected.domain ? this.settings.domains[this.selected.domain] : null;
+                const selectedDomain = this.settings.domains[this.selected.domain] ?? null;
                 const enrichedDescription = selectedDomain
                     ? await foundry.applications.ux.TextEditor.implementation.enrichHTML(selectedDomain.description)
                     : null;


### PR DESCRIPTION
Doesn't need a changelog mention. This allows removal of erroneous domains added programmatically, like what I accidentally did while testing domain additions once upon a time.