### PR TITLE
[Feature] Configurable starting gold amounts in Homebrew settings

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2888,7 +2888,7 @@
                     "iconNameHint": "Icons are from fontawesome",
                     "bagName": "Bag Name",
                     "chestName": "Chest Name",
-                    "quantityName": "Quantity Name",
+                    "denomination": "Denomination",
                     "initialAmount": "Starting Amount"
                 },
                 "domains": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -2887,7 +2887,9 @@
                     "iconName": "Icon Name",
                     "iconNameHint": "Icons are from fontawesome",
                     "bagName": "Bag Name",
-                    "chestName": "Chest Name"
+                    "chestName": "Chest Name",
+                    "quantityName": "Quantity Name",
+                    "initialAmount": "Starting Amount"
                 },
                 "domains": {
                     "domainsTitle": "Base Domains",

--- a/module/config/resourceConfig.mjs
+++ b/module/config/resourceConfig.mjs
@@ -65,7 +65,6 @@ const companionBaseResources = Object.freeze({
 
 export const character = {
     base: characterBaseResources,
-    initialCurrency: { coins: 0, handfuls: 1, bags: 0, chests: 0 },
     custom: {}, // module stuff goes here
     all: { ...characterBaseResources }
 };

--- a/module/config/resourceConfig.mjs
+++ b/module/config/resourceConfig.mjs
@@ -65,6 +65,7 @@ const companionBaseResources = Object.freeze({
 
 export const character = {
     base: characterBaseResources,
+    initialCurrency: { coins: 0, handfuls: 1, bags: 0, chests: 0 },
     custom: {}, // module stuff goes here
     all: { ...characterBaseResources }
 };

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -3,7 +3,7 @@ import ForeignDocumentUUIDField from '../fields/foreignDocumentUUIDField.mjs';
 import DhLevelData from '../levelData.mjs';
 import { commonActorRules } from './base.mjs';
 import DhCreature from './creature.mjs';
-import { attributeField, stressDamageReductionRule, bonusField, GoldField } from '../fields/actorField.mjs';
+import { attributeField, stressDamageReductionRule, bonusField, CharacterGoldField } from '../fields/actorField.mjs';
 import { ActionField } from '../fields/actionField.mjs';
 import DHCharacterSettings from '../../applications/sheets-configs/character-settings.mjs';
 import { getArmorSources } from '../../helpers/utils.mjs';
@@ -64,7 +64,7 @@ export default class DhCharacter extends DhCreature {
                     core: new fields.BooleanField({ initial: false })
                 })
             ),
-            gold: new GoldField(),
+            gold: new CharacterGoldField(),
             scars: new fields.NumberField({ initial: 0, integer: true, label: 'DAGGERHEART.GENERAL.scars' }),
             biography: new fields.SchemaField({
                 background: new fields.HTMLField(),

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -3,7 +3,7 @@ import ForeignDocumentUUIDField from '../fields/foreignDocumentUUIDField.mjs';
 import DhLevelData from '../levelData.mjs';
 import { commonActorRules } from './base.mjs';
 import DhCreature from './creature.mjs';
-import { attributeField, stressDamageReductionRule, bonusField, CharacterGoldField } from '../fields/actorField.mjs';
+import { attributeField, stressDamageReductionRule, bonusField, GoldField } from '../fields/actorField.mjs';
 import { ActionField } from '../fields/actionField.mjs';
 import DHCharacterSettings from '../../applications/sheets-configs/character-settings.mjs';
 import { getArmorSources } from '../../helpers/utils.mjs';
@@ -64,7 +64,18 @@ export default class DhCharacter extends DhCreature {
                     core: new fields.BooleanField({ initial: false })
                 })
             ),
-            gold: new CharacterGoldField(),
+            gold: new GoldField({
+                initial: () => {
+                    const homebrew = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Homebrew);
+                    const { coins, handfuls, bags, chests } = homebrew.currency;
+                    return {
+                        coins: coins.enabled ? coins.initialAmount : 0,
+                        handfuls: handfuls.enabled ? handfuls.initialAmount : 0,
+                        bags: bags.enabled ? bags.initialAmount : 0,
+                        chests: chests.enabled ? chests.initialAmount : 0
+                    };
+                }
+            }),
             scars: new fields.NumberField({ initial: 0, integer: true, label: 'DAGGERHEART.GENERAL.scars' }),
             biography: new fields.SchemaField({
                 background: new fields.HTMLField(),

--- a/module/data/fields/actorField.mjs
+++ b/module/data/fields/actorField.mjs
@@ -126,4 +126,15 @@ class GoldField extends fields.SchemaField {
     }
 }
 
-export { attributeField, ResourcesField, GoldField, stressDamageReductionRule, bonusField };
+class CharacterGoldField extends GoldField {
+    getInitialValue(options) {
+        const base = super.getInitialValue(options);
+        const initialCurrency = CONFIG.DH.RESOURCE.character.initialCurrency;
+        for (const type of ['coins', 'handfuls', 'bags', 'chests']) {
+            base[type] = initialCurrency[type];
+        }
+        return base;
+    }
+}
+
+export { attributeField, ResourcesField, GoldField, CharacterGoldField, stressDamageReductionRule, bonusField };

--- a/module/data/fields/actorField.mjs
+++ b/module/data/fields/actorField.mjs
@@ -116,25 +116,29 @@ class ResourcesField extends fields.TypedObjectField {
 }
 
 class GoldField extends fields.SchemaField {
-    constructor() {
-        super({
-            coins: new fields.NumberField({ initial: 0, integer: true }),
-            handfuls: new fields.NumberField({ initial: 1, integer: true }),
-            bags: new fields.NumberField({ initial: 0, integer: true }),
-            chests: new fields.NumberField({ initial: 0, integer: true })
-        });
+    constructor({ initial, ...options } = {}) {
+        super(
+            {
+                coins: new fields.NumberField({ initial: 0, integer: true }),
+                handfuls: new fields.NumberField({ initial: 1, integer: true }),
+                bags: new fields.NumberField({ initial: 0, integer: true }),
+                chests: new fields.NumberField({ initial: 0, integer: true })
+            },
+            options
+        );
+        this._initialCallback = initial;
     }
-}
 
-class CharacterGoldField extends GoldField {
-    getInitialValue(options) {
-        const base = super.getInitialValue(options);
-        const initialCurrency = CONFIG.DH.RESOURCE.character.initialCurrency;
-        for (const type of ['coins', 'handfuls', 'bags', 'chests']) {
-            base[type] = initialCurrency[type];
+    getInitialValue(data) {
+        if (this._initialCallback) {
+            try {
+                return this._initialCallback(data);
+            } catch {
+                /* settings not yet available */
+            }
         }
-        return base;
+        return super.getInitialValue(data);
     }
 }
 
-export { attributeField, ResourcesField, GoldField, CharacterGoldField, stressDamageReductionRule, bonusField };
+export { attributeField, ResourcesField, GoldField, stressDamageReductionRule, bonusField };

--- a/module/data/fields/actorField.mjs
+++ b/module/data/fields/actorField.mjs
@@ -116,7 +116,7 @@ class ResourcesField extends fields.TypedObjectField {
 }
 
 class GoldField extends fields.SchemaField {
-    constructor({ initial, ...options } = {}) {
+    constructor(options = {}) {
         super(
             {
                 coins: new fields.NumberField({ initial: 0, integer: true }),
@@ -126,18 +126,6 @@ class GoldField extends fields.SchemaField {
             },
             options
         );
-        this._initialCallback = initial;
-    }
-
-    getInitialValue(data) {
-        if (this._initialCallback) {
-            try {
-                return this._initialCallback(data);
-            } catch {
-                /* settings not yet available */
-            }
-        }
-        return super.getInitialValue(data);
     }
 }
 

--- a/module/data/settings/Homebrew.mjs
+++ b/module/data/settings/Homebrew.mjs
@@ -239,11 +239,6 @@ export default class DhHomebrew extends foundry.abstract.DataModel {
                 ...config.base
             });
         }
-
-        const currencyInitial = CONFIG.DH.RESOURCE.character.initialCurrency;
-        for (const type of ['coins', 'handfuls', 'bags', 'chests']) {
-            currencyInitial[type] = this.currency[type].initialAmount;
-        }
     }
 }
 

--- a/module/data/settings/Homebrew.mjs
+++ b/module/data/settings/Homebrew.mjs
@@ -2,7 +2,7 @@ import { defaultRestOptions } from '../../config/generalConfig.mjs';
 import { resetAndRerenderActors } from '../../helpers/utils.mjs';
 import { ActionsField } from '../fields/actionField.mjs';
 
-const currencyField = (initial, label, icon) =>
+const currencyField = (initial, label, icon, initialAmount = 0) =>
     new foundry.data.fields.SchemaField({
         enabled: new foundry.data.fields.BooleanField({ required: true, initial: true }),
         label: new foundry.data.fields.StringField({
@@ -10,7 +10,14 @@ const currencyField = (initial, label, icon) =>
             initial,
             label
         }),
-        icon: new foundry.data.fields.StringField({ required: true, nullable: false, blank: true, initial: icon })
+        icon: new foundry.data.fields.StringField({ required: true, nullable: false, blank: true, initial: icon }),
+        initialAmount: new foundry.data.fields.NumberField({
+            required: true,
+            integer: true,
+            min: 0,
+            initial: initialAmount,
+            label: 'DAGGERHEART.SETTINGS.Homebrew.currency.initialAmount'
+        })
     });
 
 const restMoveField = () =>
@@ -108,7 +115,8 @@ export default class DhHomebrew extends foundry.abstract.DataModel {
                 handfuls: currencyField(
                     'Handfuls',
                     'DAGGERHEART.SETTINGS.Homebrew.currency.handfulName',
-                    'fa-solid fa-coins'
+                    'fa-solid fa-coins',
+                    1
                 ),
                 bags: currencyField('Bags', 'DAGGERHEART.SETTINGS.Homebrew.currency.bagName', 'fa-solid fa-sack'),
                 chests: currencyField(
@@ -193,6 +201,7 @@ export default class DhHomebrew extends foundry.abstract.DataModel {
         for (const type of ['coins', 'handfuls', 'bags', 'chests']) {
             const initial = this.schema.fields.currency.fields[type].getInitialValue();
             source.currency[type] = foundry.utils.mergeObject(initial, source.currency[type], { inplace: false });
+            source.currency[type].initialAmount ??= 0;
         }
         return source;
     }
@@ -229,6 +238,11 @@ export default class DhHomebrew extends foundry.abstract.DataModel {
                 ...config.custom,
                 ...config.base
             });
+        }
+
+        const currencyInitial = CONFIG.DH.RESOURCE.character.initialCurrency;
+        for (const type of ['coins', 'handfuls', 'bags', 'chests']) {
+            currencyInitial[type] = this.currency[type].initialAmount;
         }
     }
 }

--- a/styles/less/ui/settings/settings.less
+++ b/styles/less/ui/settings/settings.less
@@ -201,6 +201,23 @@
         }
     }
 
+    .currency-rows {
+        display: grid;
+        grid-template-columns: auto 1fr 1fr auto;
+        gap: 4px;
+        align-items: center;
+        width: 100%;
+
+        .currency-header-label {
+            text-align: center;
+            font-size: var(--font-size-14);
+        }
+
+        input[type='checkbox'] {
+            justify-self: center;
+        }
+    }
+
     .settings-hint {
         width: 100%;
         display: flex;

--- a/templates/settings/homebrew-settings/settings.hbs
+++ b/templates/settings/homebrew-settings/settings.hbs
@@ -49,27 +49,27 @@
             </div>
             <div class="currency-rows">
                 <span></span>
-                <span class="currency-header-label">{{localize "DAGGERHEART.SETTINGS.Homebrew.currency.quantityName"}}</span>
+                <span class="currency-header-label">{{localize "DAGGERHEART.SETTINGS.Homebrew.currency.denomination"}}</span>
                 <span class="currency-header-label">{{localize "DAGGERHEART.SETTINGS.Homebrew.currency.initialAmount"}}</span>
                 <span></span>
 
                 <button class="icon {{settingFields._source.currency.coins.icon}}" data-action="editCurrencyIcon" data-currency="coins" data-tooltip="DAGGERHEART.SETTINGS.Homebrew.currency.changeIcon"></button>
-                <input type="text" name="currency.coins.label" value="{{settingFields._source.currency.coins.label}}" />
+                {{formInput settingFields.schema.fields.currency.fields.coins.fields.label value=settingFields._source.currency.coins.label name="currency.coins.label"}}
                 <input type="number" name="currency.coins.initialAmount" value="{{settingFields._source.currency.coins.initialAmount}}" min="0" step="1" />
                 <input type="checkbox" name="currency.coins.enabled" {{checked settingFields._source.currency.coins.enabled}} />
 
                 <button class="icon {{settingFields._source.currency.handfuls.icon}}" data-action="editCurrencyIcon" data-currency="handfuls" data-tooltip="DAGGERHEART.SETTINGS.Homebrew.currency.changeIcon"></button>
-                <input type="text" name="currency.handfuls.label" value="{{settingFields._source.currency.handfuls.label}}" />
+                {{formInput settingFields.schema.fields.currency.fields.handfuls.fields.label value=settingFields._source.currency.handfuls.label name="currency.handfuls.label"}}
                 <input type="number" name="currency.handfuls.initialAmount" value="{{settingFields._source.currency.handfuls.initialAmount}}" min="0" step="1" />
                 <input type="checkbox" name="currency.handfuls.enabled" {{checked settingFields._source.currency.handfuls.enabled}} />
 
                 <button class="icon {{settingFields._source.currency.bags.icon}}" data-action="editCurrencyIcon" data-currency="bags" data-tooltip="DAGGERHEART.SETTINGS.Homebrew.currency.changeIcon"></button>
-                <input type="text" name="currency.bags.label" value="{{settingFields._source.currency.bags.label}}" />
+                {{formInput settingFields.schema.fields.currency.fields.bags.fields.label value=settingFields._source.currency.bags.label name="currency.bags.label"}}
                 <input type="number" name="currency.bags.initialAmount" value="{{settingFields._source.currency.bags.initialAmount}}" min="0" step="1" />
                 <input type="checkbox" name="currency.bags.enabled" {{checked settingFields._source.currency.bags.enabled}} />
 
                 <button class="icon {{settingFields._source.currency.chests.icon}}" data-action="editCurrencyIcon" data-currency="chests" data-tooltip="DAGGERHEART.SETTINGS.Homebrew.currency.changeIcon"></button>
-                <input type="text" name="currency.chests.label" value="{{settingFields._source.currency.chests.label}}" />
+                {{formInput settingFields.schema.fields.currency.fields.chests.fields.label value=settingFields._source.currency.chests.label name="currency.chests.label"}}
                 <input type="number" name="currency.chests.initialAmount" value="{{settingFields._source.currency.chests.initialAmount}}" min="0" step="1" />
                 <input type="checkbox" name="currency.chests.enabled" {{checked settingFields._source.currency.chests.enabled}} />
             </div>

--- a/templates/settings/homebrew-settings/settings.hbs
+++ b/templates/settings/homebrew-settings/settings.hbs
@@ -42,29 +42,35 @@
 
         <fieldset>
             <legend>
-                {{localize "DAGGERHEART.SETTINGS.Homebrew.currency.title"}} 
+                {{localize "DAGGERHEART.SETTINGS.Homebrew.currency.title"}}
             </legend>
             <div class="toggleable-row spaced">
                 {{formGroup settingFields.schema.fields.currency.fields.title value=settingFields._source.currency.title localize=true}}
             </div>
-            <div class="toggleable-row">
+            <div class="currency-rows">
+                <span></span>
+                <span class="currency-header-label">{{localize "DAGGERHEART.SETTINGS.Homebrew.currency.quantityName"}}</span>
+                <span class="currency-header-label">{{localize "DAGGERHEART.SETTINGS.Homebrew.currency.initialAmount"}}</span>
+                <span></span>
+
                 <button class="icon {{settingFields._source.currency.coins.icon}}" data-action="editCurrencyIcon" data-currency="coins" data-tooltip="DAGGERHEART.SETTINGS.Homebrew.currency.changeIcon"></button>
-                {{formGroup settingFields.schema.fields.currency.fields.coins.fields.label value=settingFields._source.currency.coins.label localize=true}}
+                <input type="text" name="currency.coins.label" value="{{settingFields._source.currency.coins.label}}" />
+                <input type="number" name="currency.coins.initialAmount" value="{{settingFields._source.currency.coins.initialAmount}}" min="0" step="1" />
                 <input type="checkbox" name="currency.coins.enabled" {{checked settingFields._source.currency.coins.enabled}} />
-            </div>
-            <div class="toggleable-row">
+
                 <button class="icon {{settingFields._source.currency.handfuls.icon}}" data-action="editCurrencyIcon" data-currency="handfuls" data-tooltip="DAGGERHEART.SETTINGS.Homebrew.currency.changeIcon"></button>
-                {{formGroup settingFields.schema.fields.currency.fields.handfuls.fields.label value=settingFields._source.currency.handfuls.label localize=true}}
+                <input type="text" name="currency.handfuls.label" value="{{settingFields._source.currency.handfuls.label}}" />
+                <input type="number" name="currency.handfuls.initialAmount" value="{{settingFields._source.currency.handfuls.initialAmount}}" min="0" step="1" />
                 <input type="checkbox" name="currency.handfuls.enabled" {{checked settingFields._source.currency.handfuls.enabled}} />
-            </div>
-            <div class="toggleable-row">
+
                 <button class="icon {{settingFields._source.currency.bags.icon}}" data-action="editCurrencyIcon" data-currency="bags" data-tooltip="DAGGERHEART.SETTINGS.Homebrew.currency.changeIcon"></button>
-                {{formGroup settingFields.schema.fields.currency.fields.bags.fields.label value=settingFields._source.currency.bags.label localize=true}}
+                <input type="text" name="currency.bags.label" value="{{settingFields._source.currency.bags.label}}" />
+                <input type="number" name="currency.bags.initialAmount" value="{{settingFields._source.currency.bags.initialAmount}}" min="0" step="1" />
                 <input type="checkbox" name="currency.bags.enabled" {{checked settingFields._source.currency.bags.enabled}} />
-            </div>
-            <div class="toggleable-row">
+
                 <button class="icon {{settingFields._source.currency.chests.icon}}" data-action="editCurrencyIcon" data-currency="chests" data-tooltip="DAGGERHEART.SETTINGS.Homebrew.currency.changeIcon"></button>
-                {{formGroup settingFields.schema.fields.currency.fields.chests.fields.label value=settingFields._source.currency.chests.label localize=true}}
+                <input type="text" name="currency.chests.label" value="{{settingFields._source.currency.chests.label}}" />
+                <input type="number" name="currency.chests.initialAmount" value="{{settingFields._source.currency.chests.initialAmount}}" min="0" step="1" />
                 <input type="checkbox" name="currency.chests.enabled" {{checked settingFields._source.currency.chests.enabled}} />
             </div>
         </fieldset>


### PR DESCRIPTION
Hi, guys! This is my first time contributing to a project; any feedback is appreciated.

This pull request aims to solve issue https://github.com/Foundryborne/daggerheart/issues/734

Added `initialAmount` field to each currency type (coins, handfuls, bags, chests) in the Homebrew settings schema. Defaults match book values (0, 1, 0, 0).

- Homebrew.mjs: added `initialAmount` NumberField per currency; `_initializeSource` coerces empty submissions to 0; `refreshConfig()` syncs values to `CONFIG.DH.RESOURCE.character.initialCurrency`
- resourceConfig.mjs: added mutable `initialCurrency` object on `character` export
- actorField.mjs: added `CharacterGoldField` subclass that reads initial values from config at actor creation time
- character.mjs: switched from `GoldField` to `CharacterGoldField`
- settings.hbs: restructured currency section to CSS Grid with column headers ("Quantity Name" / "Starting Amount") instead of per-field inline labels
- settings.less: added `.currency-rows` grid styles
- en.json: added `quantityName` and `initialAmount` localisation keys

<img width="595" height="839" alt="Screenshot from 2026-06-04 00-17-41" src="https://github.com/user-attachments/assets/7d15006c-86fc-4e32-9044-051bad6e3786" />