### PR TITLE
[Fix] Levelup Experience Increase Display

### DIFF
--- a/module/applications/levelup/levelup.mjs
+++ b/module/applications/levelup/levelup.mjs
@@ -358,14 +358,14 @@ export default class DhlevelUp extends HandlebarsApplicationMixin(ApplicationV2)
         const experienceIncreaseTagify = htmlElement.querySelector('.levelup-experience-increases');
         if (experienceIncreaseTagify) {
             const allExperiences = {
-                ...this.actor.system.experiences,
                 ...Object.values(this.levelup.levels).reduce((acc, level) => {
                     for (const key of Object.keys(level.achievements.experiences)) {
                         acc[key] = level.achievements.experiences[key];
                     }
 
                     return acc;
-                }, {})
+                }, {}),
+                ...this.actor.system.experiences
             };
             tagifyElement(
                 experienceIncreaseTagify,


### PR DESCRIPTION
Fixed so that the saved data for an experience that is in the character data is used over that in the levelup data if available.

Previously we were fetching the stored experience data from the levelup data. But a player can change the label of the experience which didn't get reflected. Now that character data is used on identical keys it works.