### PR TITLE
[Fix] several issues with inline damage

### DIFF
--- a/module/data/actor/tierAdjustment.mjs
+++ b/module/data/actor/tierAdjustment.mjs
@@ -1,5 +1,6 @@
 import { calculateExpectedValue, parseTermsFromSimpleFormula } from '../../helpers/utils.mjs';
 import { adversaryExpectedDamage, adversaryScalingData } from '../../config/actorConfig.mjs';
+import { parseInlineParams } from '../../enrichers/parser.mjs';
 
 export function getTierAdjustedAdversary(source, tier) {
     const currentTier = source.tier ?? 1;
@@ -60,8 +61,8 @@ export function getTierAdjustedAdversary(source, tier) {
         const descriptionFormulas = [];
         for (const withDescription of [item.system, ...Object.values(item.system.actions)]) {
             withDescription.description = withDescription.description.replace(damageRegex, (match, inner) => {
-                const { value: formula } = parseInlineParams(inner);
-                if (!formula || !type) return match;
+                const { value: formula } = parseInlineParams(inner, { first: 'value' });
+                if (!formula) return match;
 
                 try {
                     const newFormula = calculateAdjustedDamage(formula, 'action', damageMeta)?.formula;

--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -37,6 +37,7 @@ export default class DHRoll extends Roll {
     static async buildConfigure(config = {}, message = {}) {
         config.hooks = [...this.getHooks(), ''];
         config.dialog ??= {};
+        config.damageOptions ??= {};
 
         for (const hook of config.hooks) {
             if (Hooks.call(`${CONFIG.DH.id}.preRoll${hook.capitalize()}`, config, message) === false) return null;

--- a/module/enrichers/DamageEnricher.mjs
+++ b/module/enrichers/DamageEnricher.mjs
@@ -1,7 +1,7 @@
 import { parseInlineParams } from './parser.mjs';
 
 export default function DhDamageEnricher(match, _options) {
-    const { value, type, inline } = parseInlineParams(match[1]);
+    const { value, type, inline } = parseInlineParams(match[1], { first: 'value' });
     if (!value || !type) return match[0];
     return getDamageMessage(value, type, inline, match[0]);
 }
@@ -59,7 +59,7 @@ export const renderDamageButton = async event => {
             {
                 formula: value,
                 applyTo: CONFIG.DH.GENERAL.healingTypes.hitPoints.id,
-                type: type
+                damageTypes: type
             }
         ]
     };

--- a/module/enrichers/parser.mjs
+++ b/module/enrichers/parser.mjs
@@ -8,7 +8,7 @@ export function parseInlineParams(paramString, { first } = {}) {
     const parts = paramString.split('|').map(x => x.trim());
     const params = {};
     for (const [idx, param] of parts.entries()) {
-        if (first && idx === 0) {
+        if (first && idx === 0 && !param.includes(':')) {
             params[first] = param;
         } else {
             const parts = param.split(':');


### PR DESCRIPTION
Fixes a few issues with inline damage rolls and does some quality of life

- Fix issue where clicking inline damage rolls didn't work
- Fix issue where scaling adversaries with inline damage didn't work
- Add QoL so that first param of damage roll is optional, and fix issue with optional first params. Now you can do `@Damage[3d6|type:physical]`