### PR TITLE
[Fix] Companion Rolls

### DIFF
--- a/module/applications/dialogs/d20RollDialog.mjs
+++ b/module/applications/dialogs/d20RollDialog.mjs
@@ -224,7 +224,8 @@ export default class D20RollDialog extends HandlebarsApplicationMixin(Applicatio
         this.render();
     }
 
-    static async submitRoll() {
+    static async submitRoll(event) {
+        event.preventDefault();
         await this.close({ submitted: true });
     }
 

--- a/module/dice/d20Roll.mjs
+++ b/module/dice/d20Roll.mjs
@@ -100,16 +100,13 @@ export default class D20Roll extends DHRoll {
 
         this.options.roll.modifiers = this.applyBaseBonus();
 
-        const actorExperiences = this.options.roll.companionRoll
-            ? (this.options.data?.companion?.system?.experiences ?? {})
-            : (this.options.data.system?.experiences ?? {});
-        this.options.experiences?.forEach(m => {
-            if (actorExperiences[m])
-                this.options.roll.modifiers.push({
-                    label: actorExperiences[m].name,
-                    value: actorExperiences[m].value
-                });
-        });
+        let actorExperiences = this.options.data.system?.experiences ?? {};
+        if (this.options.roll.companionRoll) {
+            const companion = typeof this.options.data.companion === 'string' ? 
+                foundry.utils.fromUuidSync(this.options.data.companion) :
+                this.options.data.companion;
+            actorExperiences = companion?.system?.experiences ?? {};
+        }
 
         this.addModifiers();
         if (this.options.extraFormula) {

--- a/module/dice/d20Roll.mjs
+++ b/module/dice/d20Roll.mjs
@@ -101,7 +101,7 @@ export default class D20Roll extends DHRoll {
         this.options.roll.modifiers = this.applyBaseBonus();
 
         const actorExperiences = this.options.roll.companionRoll
-            ? (this.options.data?.companion?.system.experiences ?? {})
+            ? (this.options.data?.companion?.system?.experiences ?? {})
             : (this.options.data.system?.experiences ?? {});
         this.options.experiences?.forEach(m => {
             if (actorExperiences[m])


### PR DESCRIPTION
- Fixed so that companion rolls don't error. 
- Fixed title of companion action rolls. The formUpdate for `d20rollDialog` was being run onClose despite being flagged not to do so. Fixed by `event.preventDefault` - the update was changing the `config.title`.