### PR TITLE
[Fix] TokenHUD Movement Palette

### DIFF
--- a/templates/hud/tokenHUD.hbs
+++ b/templates/hud/tokenHUD.hbs
@@ -103,7 +103,7 @@
     {{/if}}
 
     <button type="button" class="control-icon" data-action="togglePalette" data-palette="movementActions"
-            aria-label="{{ localize "HUD.SelectMovementAction" }}" data-tooltip>
+            data-tooltip aria-label="{{ localize "HUD.SelectMovementAction" }}">
         {{#with movementActionsConfig}}
         {{#if img}}
         <img src="{{ img }}" alt="{{ localize "HUD.SelectMovementAction" }}">
@@ -112,9 +112,9 @@
         {{/if}}
         {{/with}}
     </button>
-    <div class="palette movement-actions" data-palette="movementActions">
+    <div class="palette palette-list" data-palette="movementActions">
         {{#each movementActions as |action|}}
-        <a class="movement-action-control {{action.cssClass}}" data-action="movementAction" data-movement-action="{{action.id}}">
+        <a class="palette-list-entry {{action.cssClass}}" data-action="movementAction" data-movement-action="{{action.id}}">
             <span>
                 {{#if action.img}}
                 <img src="{{ action.img }}" alt="{{ action.label }}">


### PR DESCRIPTION
Fixed the styling for the TokenHUD movement palette. Just copied over the updated v14.X foundry style. They had changed the name of a class.

**Previously**
<img width="553" height="1068" alt="image" src="https://github.com/user-attachments/assets/1bbc4cbf-6057-4c12-b715-e39d6b7b195e" />

**Updated**
<img width="792" height="622" alt="image" src="https://github.com/user-attachments/assets/4a71f847-5d13-4bc6-ad7a-4d688e93f436" />