### PR TITLE
[Fix] On Drop Compendium ActiveEffect

### DIFF
--- a/module/applications/sheets/api/application-mixin.mjs
+++ b/module/applications/sheets/api/application-mixin.mjs
@@ -381,9 +381,10 @@ export default function DHApplicationMixin(Base) {
          * @param {DragEvent} event
          * @protected
          */
-        _onDrop(event) {
+        async _onDrop(event) {
             event.stopPropagation();
-            const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
+            const baseData = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
+            const data = !baseData.name && baseData.uuid ? await foundry.utils.fromUuid(baseData.uuid) : baseData;
             if (data.type === 'ActiveEffect' && data.fromInternal !== this.document.uuid) {
                 this.document.createEmbeddedDocuments('ActiveEffect', [data.data]);
             } else {


### PR DESCRIPTION
Fixed so that it works to drop a compendium ActiveEffect on a sheet. 
Since it's form a compendium it wasn't the full data, just the UUID - now we fetch the data in that case.