### PR TITLE
[Fix] dragging AE from compendium or within same actor

### DIFF
--- a/module/applications/sheets/actors/adversary.mjs
+++ b/module/applications/sheets/actors/adversary.mjs
@@ -186,15 +186,6 @@ export default class AdversarySheet extends DHBaseActorSheet {
         });
     }
 
-    /** @inheritdoc */
-    async _onDragStart(event) {
-        const inventoryItem = event.currentTarget.closest('.inventory-item');
-        if (inventoryItem) {
-            event.dataTransfer.setDragImage(inventoryItem.querySelector('img'), 60, 0);
-        }
-        super._onDragStart(event);
-    }
-
     /* -------------------------------------------- */
     /*  Application Clicks Actions                  */
     /* -------------------------------------------- */

--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -1193,15 +1193,6 @@ export default class CharacterSheet extends DHBaseActorSheet {
         });
     }
 
-    /** @inheritdoc */
-    async _onDragStart(event) {
-        const inventoryItem = event.currentTarget.closest('.inventory-item');
-        if (inventoryItem) {
-            event.dataTransfer.setDragImage(inventoryItem.querySelector('img'), 60, 0);
-        }
-        super._onDragStart(event);
-    }
-
     async _onDropItem(event, item) {
         const setupCriticalItemTypes = ['class', 'subclass', 'ancestry', 'community'];
         if (this.document.system.needsCharacterSetup && setupCriticalItemTypes.includes(item.type)) {

--- a/module/applications/sheets/api/application-mixin.mjs
+++ b/module/applications/sheets/api/application-mixin.mjs
@@ -361,18 +361,17 @@ export default function DHApplicationMixin(Base) {
          */
         async _onDragStart(event) {
             const inventoryItem = event.currentTarget.closest('.inventory-item');
-            if (inventoryItem) {
-                const { type, itemUuid } = inventoryItem.dataset;
-                if (type === 'effect') {
-                    const effect = await foundry.utils.fromUuid(itemUuid);
-                    const effectData = {
-                        type: 'ActiveEffect',
-                        data: { ...effect.toObject(), _id: null },
-                        fromInternal: this.document.uuid
-                    };
-                    event.dataTransfer.setData('text/plain', JSON.stringify(effectData));
-                    event.dataTransfer.setDragImage(inventoryItem.querySelector('img'), 60, 0);
-                }
+            if (!inventoryItem) return;
+            
+            const { type, itemUuid } = inventoryItem.dataset;
+            const effect = type === 'effect' ? await foundry.utils.fromUuid(itemUuid) : null;
+            if (effect) {
+                const effectData = {
+                    ...effect.toDragData(),
+                    fromInternal: this.document.uuid
+                };
+                event.dataTransfer.setData('text/plain', JSON.stringify(effectData));
+                event.dataTransfer.setDragImage(inventoryItem.querySelector('img'), 60, 0);
             }
         }
 
@@ -382,14 +381,10 @@ export default function DHApplicationMixin(Base) {
          * @protected
          */
         _onDrop(event) {
+            // Fallback to super, but note that config sheets don't have this option
+            // We still need this to avoid setting apps having issues
             event.stopPropagation();
-            const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
-            if (data.type === 'ActiveEffect' && data.fromInternal !== this.document.uuid) {
-                this.document.createEmbeddedDocuments('ActiveEffect', [data.data]);
-            } else {
-                // Fallback to super, but note that item sheets do not have this function
-                return super._onDrop?.(event);
-            }
+            return super._onDrop?.(event);
         }
 
         /* -------------------------------------------- */

--- a/module/applications/sheets/api/base-actor.mjs
+++ b/module/applications/sheets/api/base-actor.mjs
@@ -447,13 +447,15 @@ export default class DHBaseActorSheet extends DHApplicationMixin(ActorSheetV2) {
 
         const item = await getDocFromElement(event.target);
         if (item) {
+            const inventoryItem = event.currentTarget.closest('.inventory-item');
             const dragData = {
+                ...item.toDragData(),
                 originActor: this.document.uuid,
-                originId: item.id,
-                type: item.documentName,
-                uuid: item.uuid
+                originId: item.id
             };
             event.dataTransfer.setData('text/plain', JSON.stringify(dragData));
+            if (inventoryItem) event.dataTransfer.setDragImage(inventoryItem.querySelector('img'), 60, 0);
+            return;
         }
 
         super._onDragStart(event);


### PR DESCRIPTION
Supercedes https://github.com/Foundryborne/daggerheart/pull/1996 and fixes drag dropping AEs within the same sheet.

As of v14, item's now support drag/drop events, and `_onDropActiveEffect` checks for same actor. Using item.toDragData() handles pretty much most of the checks, though we may need to use `Document.fromDropData()` in some places I'm not aware of yet.

This won't work for dropping AEs on non-actor-item sheets. Actor/item setting apps don't accept AEs anyways, and action sheets don't support drag dropped AEs regardless of this change (but perhaps they should?).