### PR TITLE
[Feature] Enable sorting for Loadout domain cards

### DIFF
--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -411,8 +411,8 @@ export default class DhCharacter extends DhCreature {
 
     get domainCards() {
         const domainCards = this.parent.items.filter(x => x.type === 'domainCard');
-        const loadout = domainCards.filter(x => !x.system.inVault);
-        const vault = domainCards.filter(x => x.system.inVault);
+        const loadout = domainCards.filter(x => !x.system.inVault).sort((a, b) => a.sort - b.sort);
+        const vault = domainCards.filter(x => x.system.inVault).sort((a, b) => a.sort - b.sort);
 
         return {
             loadout: loadout,

--- a/templates/sheets/global/partials/domain-card-item.hbs
+++ b/templates/sheets/global/partials/domain-card-item.hbs
@@ -1,5 +1,5 @@
-<li class="card-item" data-item-uuid="{{item.uuid}}" data-type="domainCard">
-    <img src="{{item.img}}" data-action="useItem" class="card-img" />
+<li class="card-item" data-item-id="{{item.id}}" data-item-uuid="{{item.uuid}}" data-type="domainCard">
+    <img src="{{item.img}}" data-action="useItem" class="card-img" draggable="true" />
     <span class="item-icon recall-cost">
         <span class="recall-value">{{item.system.recallCost}}</span>
         <i class="fa-solid fa-bolt"></i>

--- a/templates/sheets/global/partials/domain-card-item.hbs
+++ b/templates/sheets/global/partials/domain-card-item.hbs
@@ -1,5 +1,5 @@
-<li class="card-item" data-item-id="{{item.id}}" data-item-uuid="{{item.uuid}}" data-type="domainCard">
-    <img src="{{item.img}}" data-action="useItem" class="card-img" draggable="true" />
+<li class="card-item" data-item-id="{{item.id}}" data-item-uuid="{{item.uuid}}" data-type="domainCard" draggable="true">
+    <img src="{{item.img}}" data-action="useItem" class="card-img" />
     <span class="item-icon recall-cost">
         <span class="recall-value">{{item.system.recallCost}}</span>
         <i class="fa-solid fa-bolt"></i>


### PR DESCRIPTION
## Summary

This PR aims to solve issue https://github.com/Foundryborne/daggerheart/issues/1981: 
Enable drag-and-drop sorting functionality for Domain Cards in the Loadout and Vault sections by reusing the exact pattern already implemented for Loot items.

## Changes

- Add \`data-item-id\` and \`draggable=\"true\"\` attributes to domain card template (\`domain-card-item.hbs\`)
- Add sorting by Foundry's \`sort\` property in the \`domainCards\` getter (\`character.mjs\`)

## Test plan

- [ ] Open character sheet with domain cards in Loadout
- [ ] Drag a card to reorder it — should move to new position
- [ ] Reload application — order should persist
- [ ] Move card to Vault and drag to reorder there too
- [ ] Verify Loot sorting still works (no regressions)