### PR TITLE
[Fix] Weapon Effects Rules Correction

### DIFF
--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -343,13 +343,11 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
 
         return Array.from(await actor.allApplicableEffects({ noTransferArmor: true, noSelfArmor: true })).filter(
             effect => {
-                /* Effects on weapons only ever apply for the weapon itself */
-                if (effect.parent.type === 'weapon') {
-                    /* Unless they're secondary - then they apply only to other primary weapons */
-                    if (effect.parent.system.secondary) {
-                        if (effectParent?.type !== 'weapon' || effectParent?.system.secondary) return false;
-                    } else if (effectParent?.id !== effect.parent.id) return false;
-                }
+                /* Effects on secondary weapons only ever apply for the primary weapon */
+                const isSecondaryWeaponEffect = effect.parent.type === 'weapon' && effect.parent.system.secondary;
+                const parentIsNotPrimaryWeapon = effectParent?.type !== 'weapon' || effectParent?.system.secondary;
+                if (isSecondaryWeaponEffect && parentIsNotPrimaryWeapon)
+                    return false;
 
                 return !effect.isSuppressed;
             }


### PR DESCRIPTION
Changed so that weapon effects are not just applied to attack/damage of the weapon itself

I think I had missunderstood the following rule
<img width="622" height="107" alt="image" src="https://github.com/user-attachments/assets/25ebd0d9-34a6-4b42-9809-9ab1222a94dc" />
I thought they meant that the rules of a feature only applies to the weapon. 
Now I think they mean that the rules on the weapon (that can be whatever) are unique for that weapon (IE, read the rules on the weapon and apply them, you won't find them in any general rules section)

- This solves the issue that a weapon couldn't have a homebrew effect giving you +1 to spellcasting.
- It also means that something like `Reliable` on a rapier or `Powerfull` on a Greatstaff will apply the bonus to hit and damage respectively to spells being cast and such.