### PR TITLE
Fix adversary type not updating in actor directory

### DIFF
--- a/module/applications/sidebar/tabs/actorDirectory.mjs
+++ b/module/applications/sidebar/tabs/actorDirectory.mjs
@@ -1,6 +1,6 @@
 export default class DhActorDirectory extends foundry.applications.sidebar.tabs.ActorDirectory {
     static DEFAULT_OPTIONS = {
-        renderUpdateKeys: ['system.levelData.level.current', 'system.partner', 'system.tier']
+        renderUpdateKeys: ['system.levelData.level.current', 'system.partner', 'system.tier', 'system.type']
     };
 
     static _entryPartial = 'systems/daggerheart/templates/ui/sidebar/actor-document-partial.hbs';


### PR DESCRIPTION
Fixes #2007
Add system.type to renderUpdateKeys so the sidebar re-renders immediately when adversary or environment type changes.

[adversary_type_update.webm](https://github.com/user-attachments/assets/3aaf70f7-f8de-45bb-ad5f-bb13f7ca98bf)
