### PR TITLE
[UI] Increase size of pause image and text

### DIFF
--- a/styles/less/ui/game-pause/game-pause.less
+++ b/styles/less/ui/game-pause/game-pause.less
@@ -1,23 +1,34 @@
 @import '../../utils/mixin.less';
 
 #pause.dh-style {
+    animation: none;
+
+    img {
+        width: 125px;
+        height: 125px;
+    }
+    
     figcaption {
+        --base-shadow: drop-shadow(2px 2px 2px black);
         position: absolute;
         margin-top: 24px;
         animation: pause-pulse 3s ease-in-out infinite;
+        font-size: var(--font-size-30);
+        letter-spacing: 0.18em;
+        filter: var(--base-shadow);
     }
 
     @keyframes pause-pulse {
         0% {
-            filter: drop-shadow(0 0 5px @secondary-blue);    
+            filter: var(--base-shadow) drop-shadow(0 0 5px @secondary-blue);    
         }
 
         50% {
-            filter: drop-shadow(0 0 5px @golden);
+            filter: var(--base-shadow) drop-shadow(0 0 5px @golden-secondary);
         }
 
         100% {
-            filter: drop-shadow(0 0 5px @secondary-blue);   
+            filter: var(--base-shadow) drop-shadow(0 0 5px @secondary-blue);   
         }
     }
 }

--- a/styles/less/utils/fonts.less
+++ b/styles/less/utils/fonts.less
@@ -10,6 +10,7 @@
     --font-size-8: 0.5rem;
     --font-size-9: 0.5625rem;
     --font-size-22: 1.375rem;
+    --font-size-30: 1.875rem;
 }
 
 @font-title: ~"var(--dh-font-title, 'Cinzel Decorative'), serif";


### PR DESCRIPTION
Removes the size pulse, makes the image and font larger, and slightly reduces the relative spacing between letters. It also introduces a secondary black text shadow for contrast.

https://github.com/user-attachments/assets/5aa75da4-d7fc-4ed8-bc4c-31661f383cb7

