### PR TITLE
Fade adversary notes tab when notes are empty

### DIFF
--- a/module/applications/sheets/actors/adversary.mjs
+++ b/module/applications/sheets/actors/adversary.mjs
@@ -131,6 +131,15 @@ export default class AdversarySheet extends DHBaseActorSheet {
         return context;
     }
 
+    /** @inheritdoc */
+    _prepareTabs(group) {
+        const result = super._prepareTabs(group);
+        if (group === 'primary') {
+            result.notes.empty = !this.document.system.notes?.trim();
+        }
+        return result;
+    }
+
     /**@inheritdoc */
     _attachPartListeners(partId, htmlElement, options) {
         super._attachPartListeners(partId, htmlElement, options);


### PR DESCRIPTION
Should make it easier for the GM to see that the specific adversary has notes hopefully

<img width="685" height="783" alt="image" src="https://github.com/user-attachments/assets/0c719f3d-4981-4705-962f-e96d1d3523d3" />
