### PR TITLE
[Fix] Resorting features to other feature types

### DIFF
--- a/module/applications/sheets-configs/adversary-settings.mjs
+++ b/module/applications/sheets-configs/adversary-settings.mjs
@@ -54,7 +54,7 @@ export default class DHAdversarySettings extends DHBaseActorSettings {
     async _prepareContext(options) {
         const context = await super._prepareContext(options);
 
-        const featureForms = ['passive', 'action', 'reaction'];
+        const featureForms = Object.keys(CONFIG.DH.ITEM.featureForm);
         context.features = context.document.system.features.sort((a, b) =>
             a.system.featureForm !== b.system.featureForm
                 ? featureForms.indexOf(a.system.featureForm) - featureForms.indexOf(b.system.featureForm)

--- a/module/applications/sheets/actors/adversary.mjs
+++ b/module/applications/sheets/actors/adversary.mjs
@@ -103,7 +103,7 @@ export default class AdversarySheet extends DHBaseActorSheet {
         context.resources.stress.emptyPips =
             context.resources.stress.max < maxResource ? maxResource - context.resources.stress.max : 0;
 
-        const featureForms = ['passive', 'action', 'reaction'];
+        const featureForms = Object.keys(CONFIG.DH.ITEM.featureForm);
         context.features = this.document.system.features.sort((a, b) =>
             a.system.featureForm !== b.system.featureForm
                 ? featureForms.indexOf(a.system.featureForm) - featureForms.indexOf(b.system.featureForm)

--- a/module/applications/sheets/api/application-mixin.mjs
+++ b/module/applications/sheets/api/application-mixin.mjs
@@ -387,6 +387,30 @@ export default function DHApplicationMixin(Base) {
             return super._onDrop?.(event);
         }
 
+        /** @inheritdoc */
+        _onSortItem(event, item) {
+            // If we are dragging a feature past its allowed feature form, put it in the front or in the back
+            const doc = this.actor.items.get(item.id);
+            const dropTargetEl = event.target.closest('[data-item-id]');
+            const dropTarget = this.actor.items.get(dropTargetEl?.dataset.itemId);
+            if (doc?.type === 'feature' && dropTarget?.type === 'feature' && doc.system.featureForm !== dropTarget.system.featureForm) {
+                const siblings = this.actor.itemTypes.feature
+                    .filter(f => f.system.featureForm === doc.system.featureForm)
+                    .sort((a, b) => a.sort - b.sort);
+                if (siblings.length > 1) {
+                    const featureForms = Object.keys(CONFIG.DH.ITEM.featureForm);
+                    const thisFeatureIdx = featureForms.indexOf(doc.system.featureForm);
+                    const targetFeatureIdx = featureForms.indexOf(dropTarget.system.featureForm);
+                    const target = targetFeatureIdx < thisFeatureIdx ? siblings[0] : siblings.at(-1);
+                    const sortUpdates = foundry.utils.performIntegerSort(doc, { target, siblings });
+                    const updateData = sortUpdates.map(u => ({ ...u.update, _id: u.target._id }));
+                    return this.actor.updateEmbeddedDocuments('Item', updateData);
+                }
+            }
+
+            return super._onSortItem?.(event, item);
+        }
+
         /* -------------------------------------------- */
         /*  Context Menu                                */
         /* -------------------------------------------- */


### PR DESCRIPTION
Leads to more predictable behavior when drag dropping adversary and environment features. Its a bit tricky to understand, so just in case I'll break it down.

Right now features are grouped together into passives -> actions -> reactions. This takes priority over sort order, so it is possible for a passive to internally have a higher sort order than an action even if it is actually displayed first.

<img width="517" height="765" alt="image" src="https://github.com/user-attachments/assets/c7a4d75c-9ae0-41d8-9bfe-12065b40b7b4" />

In this situation, if overgrown battlefield was actually created last (and had the highest sort order), dragging "You are not welcome here" to "Overgrown Battlefield" would actually cause "You are not welcome here" to move towards the end (after defiler). Now, it goes to the front, before "Barbed Vines". 

Resorting items is not implemented in setting sheets, so this only affects the non-edit sheets at this time. Later on though it will also support the edit sheets once those allow resorting.