### PR TITLE
[Fix] old armorscore AEs clobbering data

### DIFF
--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -315,7 +315,12 @@ export default class DhCharacter extends DhCreature {
                         label: 'DAGGERHEART.ACTORS.Character.defaultDisadvantageDice'
                     })
                 })
-            })
+            }),
+            /** Accumulated armor score from all sources */
+            armorScore: new fields.SchemaField({
+                value: new fields.NumberField(),
+                max: new fields.NumberField()
+            }, { persisted: false })
         };
     }
 


### PR DESCRIPTION
This causes the AE to run through field changes rather than unguided changes, making the invalid AEs usually no-op rather than corrupt data.