### PR TITLE
Support drag resort on features in actor setting sheets

### DIFF
--- a/module/applications/sheets-configs/adversary-settings.mjs
+++ b/module/applications/sheets-configs/adversary-settings.mjs
@@ -97,32 +97,4 @@ export default class DHAdversarySettings extends DHBaseActorSettings {
 
         await this.actor.update({ [`system.experiences.${target.dataset.experience}`]: _del });
     }
-
-    async _onDragStart(event) {
-        const featureItem = event.currentTarget.closest('.feature-item');
-
-        if (featureItem) {
-            const feature = this.actor.items.get(featureItem.id);
-            const featureData = { type: 'Item', uuid: feature.uuid, fromInternal: true };
-            event.dataTransfer.setData('text/plain', JSON.stringify(featureData));
-            event.dataTransfer.setDragImage(featureItem.querySelector('img'), 60, 0);
-        }
-    }
-
-    async _onDrop(event) {
-        event.stopPropagation();
-        const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
-
-        const item = await fromUuid(data.uuid);
-        if (item?.type === 'feature') {
-            if (data.fromInternal && item.parent?.uuid === this.actor.uuid) {
-                return;
-            }
-
-            const itemData = item.toObject();
-            delete itemData._id;
-
-            await this.actor.createEmbeddedDocuments('Item', [itemData]);
-        }
-    }
 }

--- a/module/applications/sheets-configs/environment-settings.mjs
+++ b/module/applications/sheets-configs/environment-settings.mjs
@@ -15,7 +15,7 @@ export default class DHEnvironmentSettings extends DHBaseActorSettings {
         dragDrop: [
             { dragSelector: null, dropSelector: '.category-container' },
             { dragSelector: null, dropSelector: '.tab.features' },
-            { dragSelector: '.feature-item', dropSelector: null }
+            { dragSelector: '.feature-item, .inventory-item[data-type="adversary"]', dropSelector: null }
         ]
     };
 
@@ -110,33 +110,30 @@ export default class DHEnvironmentSettings extends DHBaseActorSettings {
     }
 
     async _onDragStart(event) {
-        const featureItem = event.currentTarget.closest('.feature-item');
-
-        if (featureItem) {
-            const feature = this.actor.items.get(featureItem.id);
-            const featureData = { type: 'Item', uuid: feature.uuid, fromInternal: true };
-            event.dataTransfer.setData('text/plain', JSON.stringify(featureData));
-            event.dataTransfer.setDragImage(featureItem.querySelector('img'), 60, 0);
+        const element = event.currentTarget.closest('.inventory-item[data-type=adversary]');
+        if (element) {
+            const adversaryData = { type: 'Actor', uuid: element.dataset.itemUuid };
+            event.dataTransfer.setData('text/plain', JSON.stringify(adversaryData));
+            event.dataTransfer.setDragImage(element, 60, 0);
+        } else {
+            return super._onDragStart(event);
         }
     }
 
     async _onDrop(event) {
         event.stopPropagation();
         const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
-        const item = await fromUuid(data.uuid);
-        if (data.fromInternal && item?.parent?.uuid === this.actor.uuid) return;
-
-        if (item.type === 'adversary' && event.target.closest('.category-container')) {
+        const doc = await fromUuid(data.uuid);
+        if (doc?.type === 'adversary' && event.target.closest('.category-container')) {
             const target = event.target.closest('.category-container');
             const path = `system.potentialAdversaries.${target.dataset.potentialAdversary}.adversaries`;
             const current = foundry.utils.getProperty(this.actor, path).map(x => x.uuid);
-            await this.actor.update({
-                [path]: [...current, item.uuid]
-            });
-            this.render();
-        } else if (item.type === 'feature' && event.target.closest('.tab.features')) {
-            await this.actor.createEmbeddedDocuments('Item', [item]);
-            this.render();
+            if (!current.includes(doc.uuid)) {
+                await this.actor.update({ [path]: [...current, doc.uuid] });
+            }
+            return;
         }
+        
+        return super._onDrop(event);
     }
 }

--- a/module/applications/sheets-configs/npc-settings.mjs
+++ b/module/applications/sheets-configs/npc-settings.mjs
@@ -52,34 +52,4 @@ export default class DHNPCSettings extends DHBaseActorSettings {
 
         return context;
     }
-
-    /* -------------------------------------------- */
-
-    async _onDragStart(event) {
-        const featureItem = event.currentTarget.closest('.feature-item');
-
-        if (featureItem) {
-            const feature = this.actor.items.get(featureItem.id);
-            const featureData = { type: 'Item', uuid: feature.uuid, fromInternal: true };
-            event.dataTransfer.setData('text/plain', JSON.stringify(featureData));
-            event.dataTransfer.setDragImage(featureItem.querySelector('img'), 60, 0);
-        }
-    }
-
-    async _onDrop(event) {
-        event.stopPropagation();
-        const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
-
-        const item = await fromUuid(data.uuid);
-        if (item?.type === 'feature') {
-            if (data.fromInternal && item.parent?.uuid === this.actor.uuid) {
-                return;
-            }
-
-            const itemData = item.toObject();
-            delete itemData._id;
-
-            await this.actor.createEmbeddedDocuments('Item', [itemData]);
-        }
-    }
 }

--- a/module/applications/sheets/actors/environment.mjs
+++ b/module/applications/sheets/actors/environment.mjs
@@ -78,7 +78,6 @@ export default class DhpEnvironment extends DHBaseActorSheet {
         switch (partId) {
             case 'header':
                 await this._prepareHeaderContext(context, options);
-
                 break;
             case 'features':
                 await this._prepareFeaturesContext(context, options);

--- a/module/applications/sheets/api/actor-setting.mjs
+++ b/module/applications/sheets/api/actor-setting.mjs
@@ -1,13 +1,15 @@
 import DHApplicationMixin from './application-mixin.mjs';
-const { DocumentSheetV2 } = foundry.applications.api;
+const { ActorSheetV2 } = foundry.applications.sheets;
 
-/**@typedef {import('@client/applications/_types.mjs').ApplicationClickAction} ApplicationClickAction */
+/**
+ * @typedef {import('@client/applications/_types.mjs').ApplicationClickAction} ApplicationClickAction
+ */
 
 /**
  * Base settings sheet for Daggerheart actors.
- * @extends {DHApplicationMixin<DocumentSheetV2>}
+ * @extends {DHApplicationMixin<ActorSheetV2>}
  */
-export default class DHBaseActorSettings extends DHApplicationMixin(DocumentSheetV2) {
+export default class DHBaseActorSettings extends DHApplicationMixin(ActorSheetV2) {
     /**@inheritdoc */
     static DEFAULT_OPTIONS = {
         classes: ['dialog'],
@@ -34,7 +36,7 @@ export default class DHBaseActorSettings extends DHApplicationMixin(DocumentShee
         return options;
     }
 
-    /**@returns {foundry.documents.Actor} */
+    /** @returns {foundry.documents.Actor} */
     get actor() {
         return this.document;
     }
@@ -72,5 +74,30 @@ export default class DHBaseActorSettings extends DHApplicationMixin(DocumentShee
         }
 
         return context;
+    }
+
+    async _onDragStart(event) {
+        const featureItemEl = event.currentTarget.closest('.feature-item');
+        const feature = this.actor.items.get(featureItemEl?.dataset.itemId);
+        if (feature && event.target.closest('.tab.features')) {
+            const featureData = { ...feature.toDragData(), fromInternal: true };
+            event.dataTransfer.setData('text/plain', JSON.stringify(featureData));
+            event.dataTransfer.setDragImage(featureItemEl.querySelector('img'), 60, 0);
+        }
+    }
+
+    async _onDrop(event) {
+        event.stopPropagation();
+        const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
+        const item = await fromUuid(data.uuid);
+        if (item?.type === 'feature') {
+            if (data.fromInternal && item.parent?.uuid === this.actor.uuid) {
+                return super._onDrop(event);
+            }
+
+            const itemData = item.toObject();
+            delete itemData._id;
+            await this.actor.createEmbeddedDocuments('Item', [itemData]);
+        }
     }
 }

--- a/module/applications/sheets/api/application-mixin.mjs
+++ b/module/applications/sheets/api/application-mixin.mjs
@@ -381,8 +381,7 @@ export default function DHApplicationMixin(Base) {
          * @protected
          */
         _onDrop(event) {
-            // Fallback to super, but note that config sheets don't have this option
-            // We still need this to avoid setting apps having issues
+            // Potentially handle subclasses that dont descend from actor/item sheet.
             event.stopPropagation();
             return super._onDrop?.(event);
         }

--- a/templates/sheets-settings/adversary-settings/features.hbs
+++ b/templates/sheets-settings/adversary-settings/features.hbs
@@ -10,7 +10,7 @@
         <legend>{{localize tabs.features.label}}</legend>
         <ul class="feature-list">
             {{#each @root.features as |feature|}}
-                <li class="feature-item" id="{{feature.id}}" draggable="true">
+                <li class="feature-item" data-item-id="{{feature.id}}" draggable="true">
                     <img src="{{feature.img}}" alt="">
                     <div class="label">
                         <span>{{feature.name}}</span>

--- a/templates/sheets-settings/environment-settings/features.hbs
+++ b/templates/sheets-settings/environment-settings/features.hbs
@@ -10,7 +10,7 @@
         <legend>{{localize tabs.features.label}}</legend>
         <ul class="feature-list">
             {{#each @root.features as |feature|}}
-                <li class="feature-item" id="{{feature.id}}">
+                <li class="feature-item" data-item-id="{{feature.id}}">
                     <img src="{{feature.img}}" alt="">
                     <div class="label">
                         <span>{{feature.name}}</span>

--- a/templates/sheets-settings/npc-settings/features.hbs
+++ b/templates/sheets-settings/npc-settings/features.hbs
@@ -10,7 +10,7 @@
         <legend>{{localize tabs.features.label}}</legend>
         <ul class="feature-list">
             {{#each @root.features as |feature|}}
-                <li class="feature-item" id="{{feature.id}}" draggable="true">
+                <li class="feature-item" data-item-id="{{feature.id}}" draggable="true">
                     <img src="{{feature.img}}" alt="">
                     <div class="label">
                         <span>{{feature.name}}</span>


### PR DESCRIPTION
This should make the features sections in the sheet one step more usable. Its still not quite there yet, as feature forms barriors are not visible yet, and dragging across feature forms leads to weird behaviors (separately solved by https://github.com/Foundryborne/daggerheart/pull/2016).

This fixes an issue where dragging adversaries in the environment sheet caused errors, however it does not support drag/drop resorting there. You can drag/drop an adversary from there into a different category though.