### PR TITLE
[Feature] In setting sheets, split by feature type and include descriptions

### DIFF
--- a/module/applications/sheets-configs/adversary-settings.mjs
+++ b/module/applications/sheets-configs/adversary-settings.mjs
@@ -10,11 +10,7 @@ export default class DHAdversarySettings extends DHBaseActorSettings {
         actions: {
             addExperience: DHAdversarySettings.#addExperience,
             removeExperience: DHAdversarySettings.#removeExperience
-        },
-        dragDrop: [
-            { dragSelector: null, dropSelector: '.tab.features' },
-            { dragSelector: '.feature-item', dropSelector: null }
-        ]
+        }
     };
 
     /**@override */
@@ -38,7 +34,8 @@ export default class DHAdversarySettings extends DHBaseActorSettings {
         },
         features: {
             id: 'features',
-            template: 'systems/daggerheart/templates/sheets-settings/adversary-settings/features.hbs'
+            template: 'systems/daggerheart/templates/sheets-settings/adversary-settings/features.hbs',
+            scrollable: ['']
         }
     };
 
@@ -54,12 +51,16 @@ export default class DHAdversarySettings extends DHBaseActorSettings {
     async _prepareContext(options) {
         const context = await super._prepareContext(options);
 
-        const featureForms = Object.keys(CONFIG.DH.ITEM.featureForm);
-        context.features = context.document.system.features.sort((a, b) =>
-            a.system.featureForm !== b.system.featureForm
-                ? featureForms.indexOf(a.system.featureForm) - featureForms.indexOf(b.system.featureForm)
-                : a.sort - b.sort
-        );
+        // Get feature groups. Uncategorized go to actions
+        const featureFormsTypes = ['passive', 'action', 'reaction'];
+        const features = this.document.system.features.sort((a, b) => a.sort - b.sort);
+        const featureGroups = featureFormsTypes.map(t => ({
+            featureForm: t,
+            label: _loc(CONFIG.DH.ITEM.featureForm[t]),
+            features: features.filter(f => f.system.featureForm === t)
+        }));
+        featureGroups[1].features.push(...features.filter(f => !featureFormsTypes.includes(f.system.featureForm)));
+        context.featureGroups = featureGroups;
 
         return context;
     }

--- a/module/applications/sheets-configs/environment-settings.mjs
+++ b/module/applications/sheets-configs/environment-settings.mjs
@@ -32,11 +32,13 @@ export default class DHEnvironmentSettings extends DHBaseActorSettings {
         },
         features: {
             id: 'features',
-            template: 'systems/daggerheart/templates/sheets-settings/environment-settings/features.hbs'
+            template: 'systems/daggerheart/templates/sheets-settings/environment-settings/features.hbs',
+            scrollable: ['']
         },
         adversaries: {
             id: 'adversaries',
-            template: 'systems/daggerheart/templates/sheets-settings/environment-settings/adversaries.hbs'
+            template: 'systems/daggerheart/templates/sheets-settings/environment-settings/adversaries.hbs',
+            scrollable: ['']
         }
     };
 
@@ -52,12 +54,16 @@ export default class DHEnvironmentSettings extends DHBaseActorSettings {
     async _prepareContext(options) {
         const context = await super._prepareContext(options);
 
-        const featureForms = ['passive', 'action', 'reaction'];
-        context.features = context.document.system.features.sort((a, b) =>
-            a.system.featureForm !== b.system.featureForm
-                ? featureForms.indexOf(a.system.featureForm) - featureForms.indexOf(b.system.featureForm)
-                : a.sort - b.sort
-        );
+        // Get feature groups. Uncategorized go to actions
+        const featureFormsTypes = ['passive', 'action', 'reaction'];
+        const features = this.document.system.features.sort((a, b) => a.sort - b.sort);
+        const featureGroups = featureFormsTypes.map(t => ({
+            featureForm: t,
+            label: _loc(CONFIG.DH.ITEM.featureForm[t]),
+            features: features.filter(f => f.system.featureForm === t)
+        }));
+        featureGroups[1].features.push(...features.filter(f => !featureFormsTypes.includes(f.system.featureForm)));
+        context.featureGroups = featureGroups;
 
         return context;
     }

--- a/module/applications/sheets-configs/npc-settings.mjs
+++ b/module/applications/sheets-configs/npc-settings.mjs
@@ -27,7 +27,8 @@ export default class DHNPCSettings extends DHBaseActorSettings {
         },
         features: {
             id: 'features',
-            template: 'systems/daggerheart/templates/sheets-settings/npc-settings/features.hbs'
+            template: 'systems/daggerheart/templates/sheets-settings/npc-settings/features.hbs',
+            scrollable: ['']
         }
     };
 
@@ -43,12 +44,16 @@ export default class DHNPCSettings extends DHBaseActorSettings {
     async _prepareContext(options) {
         const context = await super._prepareContext(options);
 
-        const featureForms = ['passive', 'action', 'reaction'];
-        context.features = context.document.system.features.sort((a, b) =>
-            a.system.featureForm !== b.system.featureForm
-                ? featureForms.indexOf(a.system.featureForm) - featureForms.indexOf(b.system.featureForm)
-                : a.sort - b.sort
-        );
+        // Get feature groups. Uncategorized go to actions
+        const featureFormsTypes = ['passive', 'action', 'reaction'];
+        const features = this.document.system.features.sort((a, b) => a.sort - b.sort);
+        const featureGroups = featureFormsTypes.map(t => ({
+            featureForm: t,
+            label: _loc(CONFIG.DH.ITEM.featureForm[t]),
+            features: features.filter(f => f.system.featureForm === t)
+        }));
+        featureGroups[1].features.push(...features.filter(f => !featureFormsTypes.includes(f.system.featureForm)));
+        context.featureGroups = featureGroups;
 
         return context;
     }

--- a/module/applications/sheets/api/actor-setting.mjs
+++ b/module/applications/sheets/api/actor-setting.mjs
@@ -25,7 +25,7 @@ export default class DHBaseActorSettings extends DHApplicationMixin(ActorSheetV2
         },
         dragDrop: [
             { dragSelector: null, dropSelector: '.tab.features' },
-            { dragSelector: '.feature-item', dropSelector: null }
+            { dragSelector: '.feature-item, .inventory-item[data-type="feature"]', dropSelector: null }
         ]
     };
 
@@ -77,7 +77,7 @@ export default class DHBaseActorSettings extends DHApplicationMixin(ActorSheetV2
     }
 
     async _onDragStart(event) {
-        const featureItemEl = event.currentTarget.closest('.feature-item');
+        const featureItemEl = event.currentTarget.closest('.feature-item, .inventory-item[data-type="feature"]');
         const feature = this.actor.items.get(featureItemEl?.dataset.itemId);
         if (feature && event.target.closest('.tab.features')) {
             const featureData = { ...feature.toDragData(), fromInternal: true };

--- a/module/applications/sheets/api/actor-setting.mjs
+++ b/module/applications/sheets/api/actor-setting.mjs
@@ -100,4 +100,7 @@ export default class DHBaseActorSettings extends DHApplicationMixin(ActorSheetV2
             await this.actor.createEmbeddedDocuments('Item', [itemData]);
         }
     }
+
+    /** Setting sheets do not auto extend */
+    async _autoExpandDescriptions() {}
 }

--- a/module/applications/sheets/api/application-mixin.mjs
+++ b/module/applications/sheets/api/application-mixin.mjs
@@ -734,7 +734,7 @@ export default function DHApplicationMixin(Base) {
          * @type {ApplicationClickAction}
          */
         static async #onCreateDoc(event, target) {
-            const { documentClass, type, inVault, disabled } = target.dataset;
+            const { documentClass, type, inVault, disabled, featureForm } = target.dataset;
             const parentIsItem = this.document.documentName === 'Item';
             const featureOnCharacter = this.document.parent?.type === 'character' && type === 'feature';
             const parent = featureOnCharacter
@@ -752,6 +752,7 @@ export default function DHApplicationMixin(Base) {
                     identifier: this.document.system.isMulticlass ? 'multiclass' : null
                 };
             }
+            if (featureForm) systemData.featureForm = featureForm;
 
             const cls =
                 type === 'action' ? game.system.api.models.actions.actionsTypes.base : getDocumentClass(documentClass);

--- a/module/applications/sheets/api/application-mixin.mjs
+++ b/module/applications/sheets/api/application-mixin.mjs
@@ -4,6 +4,7 @@ import { getDocFromElement, getDocFromElementSync, tagifyElement } from '../../.
 const typeSettingsMap = {
     character: 'extendCharacterDescriptions',
     adversary: 'extendAdversaryDescriptions',
+    npc: 'extendAdversaryDescriptions',
     environment: 'extendEnvironmentDescriptions',
     ancestry: 'extendItemDescriptions',
     community: 'extendItemDescriptions',
@@ -262,7 +263,7 @@ export default function DHApplicationMixin(Base) {
 
             if (!!this.options.contextMenus.length) this._createContextMenus();
 
-            this.#autoExtendDescriptions(context);
+            this._autoExpandDescriptions(context);
         }
 
         /** @inheritDoc */
@@ -630,8 +631,9 @@ export default function DHApplicationMixin(Base) {
         /**
          * Extend inventory description when enabled in settings.
          * @returns {Promise<void>}
+         * @protected
          */
-        async #autoExtendDescriptions(context) {
+        async _autoExpandDescriptions(context) {
             const inventoryItems = this.element.querySelectorAll('.inventory-item[data-item-uuid]');
             for (const el of inventoryItems) {
                 // Get the doc uuid from the element

--- a/templates/sheets-settings/adversary-settings/features.hbs
+++ b/templates/sheets-settings/adversary-settings/features.hbs
@@ -21,6 +21,7 @@
                         hideContextMenu=true
                         hideResources=true
                         showActions=false
+                        hideTooltip=true
                     }}
                 {{/each}}
             </ul>

--- a/templates/sheets-settings/adversary-settings/features.hbs
+++ b/templates/sheets-settings/adversary-settings/features.hbs
@@ -3,27 +3,30 @@
     data-tab='{{tabs.features.id}}'
     data-group='{{tabs.features.group}}'
 >
-    <button type="button" class="add-feature-btn" data-action="createDoc" data-document-class="Item" data-type="feature">
-        {{localize "DOCUMENT.New" type=(localize "TYPES.Item.feature")}}
-    </button>
-    <fieldset>
-        <legend>{{localize tabs.features.label}}</legend>
-        <ul class="feature-list">
-            {{#each @root.features as |feature|}}
-                <li class="feature-item" data-item-id="{{feature.id}}" draggable="true">
-                    <img src="{{feature.img}}" alt="">
-                    <div class="label">
-                        <span>{{feature.name}}</span>
-                    </div>
-                    <div class="controls">
-                        <a data-action="editDoc" data-item-uuid="{{feature.uuid}}" data-tooltip="{{localize 'CONTROLS.CommonEdit'}}"><i class="fa-solid fa-pen-to-square"></i></a>
-                        <a data-action="deleteDoc"  data-item-uuid="{{feature.uuid}}" data-tooltip="{{localize 'CONTROLS.CommonDelete'}}"><i class="fa-solid fa-trash"></i></a>
-                    </div>
-                </li>
-            {{/each}}
-        </ul>
-        <div class="features-dragger">
-            <span>{{localize "DAGGERHEART.GENERAL.dropFeaturesHere"}}</span>
-        </div>
-    </fieldset>
+    {{#each featureGroups as |group|}}
+        <fieldset>
+            <legend>
+                {{group.label}}
+                <a data-action="createDoc" data-document-class="Item" data-type="feature" data-tooltip="{{localize 'DOCUMENT.Create' type=(localize "TYPES.Item.feature")}}" data-feature-form="{{group.featureForm}}">
+                    <i class="fa-solid fa-plus icon-button"></i>
+                </a>
+            </legend>
+            <ul class="feature-list">
+                {{#each group.features as |feature|}}
+                    {{> 'daggerheart.inventory-item'
+                        item=feature
+                        type='feature'
+                        actorType=@root.document.type
+                        hideTags=true
+                        hideContextMenu=true
+                        hideResources=true
+                        showActions=false
+                    }}
+                {{/each}}
+            </ul>
+        </fieldset>
+    {{/each}}
+    <div class="features-dragger">
+        <span>{{localize "DAGGERHEART.GENERAL.dropFeaturesHere"}}</span>
+    </div>
 </section>

--- a/templates/sheets-settings/environment-settings/features.hbs
+++ b/templates/sheets-settings/environment-settings/features.hbs
@@ -21,6 +21,7 @@
                         hideContextMenu=true
                         hideResources=true
                         showActions=false
+                        hideTooltip=true
                     }}
                 {{/each}}
             </ul>

--- a/templates/sheets-settings/environment-settings/features.hbs
+++ b/templates/sheets-settings/environment-settings/features.hbs
@@ -3,24 +3,30 @@
     data-tab='{{tabs.features.id}}'
     data-group='{{tabs.features.group}}'
 >
-    <button type="button" class="add-feature-btn" data-action="createDoc" data-document-class="Item" data-type="feature">
-        {{localize "DOCUMENT.New" type=(localize "TYPES.Item.feature")}}
-    </button>
-    <fieldset>
-        <legend>{{localize tabs.features.label}}</legend>
-        <ul class="feature-list">
-            {{#each @root.features as |feature|}}
-                <li class="feature-item" data-item-id="{{feature.id}}">
-                    <img src="{{feature.img}}" alt="">
-                    <div class="label">
-                        <span>{{feature.name}}</span>
-                    </div>
-                    <div class="controls">
-                        <a data-action="editDoc" data-item-uuid="{{feature.uuid}}" data-tooltip="{{localize 'CONTROLS.CommonEdit'}}"><i class="fa-solid fa-pen-to-square"></i></a>
-                        <a data-action="deleteDoc"  data-item-uuid="{{feature.uuid}}" data-tooltip="{{localize 'CONTROLS.CommonDelete'}}"><i class="fa-solid fa-trash"></i></a>
-                    </div>
-                </li>
-            {{/each}}
-        </ul>
-    </fieldset>
+    {{#each featureGroups as |group|}}
+        <fieldset>
+            <legend>
+                {{group.label}}
+                <a data-action="createDoc" data-document-class="Item" data-type="feature" data-tooltip="{{localize 'DOCUMENT.Create' type=(localize "TYPES.Item.feature")}}" data-feature-form="{{group.featureForm}}">
+                    <i class="fa-solid fa-plus icon-button"></i>
+                </a>
+            </legend>
+            <ul class="feature-list">
+                {{#each group.features as |feature|}}
+                    {{> 'daggerheart.inventory-item'
+                        item=feature
+                        type='feature'
+                        actorType=@root.document.type
+                        hideTags=true
+                        hideContextMenu=true
+                        hideResources=true
+                        showActions=false
+                    }}
+                {{/each}}
+            </ul>
+        </fieldset>
+    {{/each}}
+    <div class="features-dragger">
+        <span>{{localize "DAGGERHEART.GENERAL.dropFeaturesHere"}}</span>
+    </div>
 </section>

--- a/templates/sheets-settings/npc-settings/features.hbs
+++ b/templates/sheets-settings/npc-settings/features.hbs
@@ -21,6 +21,7 @@
                         hideContextMenu=true
                         hideResources=true
                         showActions=false
+                        hideTooltip=true
                     }}
                 {{/each}}
             </ul>

--- a/templates/sheets-settings/npc-settings/features.hbs
+++ b/templates/sheets-settings/npc-settings/features.hbs
@@ -3,27 +3,30 @@
     data-tab='{{tabs.features.id}}'
     data-group='{{tabs.features.group}}'
 >
-    <button type="button" class="add-feature-btn" data-action="createDoc" data-document-class="Item" data-type="feature">
-        {{localize "DOCUMENT.New" type=(localize "TYPES.Item.feature")}}
-    </button>
-    <fieldset>
-        <legend>{{localize tabs.features.label}}</legend>
-        <ul class="feature-list">
-            {{#each @root.features as |feature|}}
-                <li class="feature-item" data-item-id="{{feature.id}}" draggable="true">
-                    <img src="{{feature.img}}" alt="">
-                    <div class="label">
-                        <span>{{feature.name}}</span>
-                    </div>
-                    <div class="controls">
-                        <a data-action="editDoc" data-item-uuid="{{feature.uuid}}" data-tooltip="{{localize 'CONTROLS.CommonEdit'}}"><i class="fa-solid fa-pen-to-square"></i></a>
-                        <a data-action="deleteDoc"  data-item-uuid="{{feature.uuid}}" data-tooltip="{{localize 'CONTROLS.CommonDelete'}}"><i class="fa-solid fa-trash"></i></a>
-                    </div>
-                </li>
-            {{/each}}
-        </ul>
-        <div class="features-dragger">
-            <span>{{localize "DAGGERHEART.GENERAL.dropFeaturesHere"}}</span>
-        </div>
-    </fieldset>
+    {{#each featureGroups as |group|}}
+        <fieldset>
+            <legend>
+                {{group.label}}
+                <a data-action="createDoc" data-document-class="Item" data-type="feature" data-tooltip="{{localize 'DOCUMENT.Create' type=(localize "TYPES.Item.feature")}}" data-feature-form="{{group.featureForm}}">
+                    <i class="fa-solid fa-plus icon-button"></i>
+                </a>
+            </legend>
+            <ul class="feature-list">
+                {{#each group.features as |feature|}}
+                    {{> 'daggerheart.inventory-item'
+                        item=feature
+                        type='feature'
+                        actorType=@root.document.type
+                        hideTags=true
+                        hideContextMenu=true
+                        hideResources=true
+                        showActions=false
+                    }}
+                {{/each}}
+            </ul>
+        </fieldset>
+    {{/each}}
+    <div class="features-dragger">
+        <span>{{localize "DAGGERHEART.GENERAL.dropFeaturesHere"}}</span>
+    </div>
 </section>

--- a/templates/sheets/global/partials/inventory-item-V2.hbs
+++ b/templates/sheets/global/partials/inventory-item-V2.hbs
@@ -27,17 +27,17 @@ Parameters:
 >
   <div class="inventory-item-header {{#if hideContextMenu}}padded{{/if}}" {{#unless noExtensible}}data-action="toggleExtended" {{/unless}}>
     {{!-- Image --}}
-    <div class="img-portait" 
+    <div class="img-portait" draggable="true"
         {{#unless (eq showActions false)}}data-action='{{ifThen item.usable "useItem" (ifThen (hasProperty item "toChat" ) "toChat" "editDoc" ) }}'{{/unless}}
-        {{#unless hideTooltip}} {{#if (eq type 'attack' )}} data-tooltip="#attack#{{item.actor.uuid}}" {{else}} data-tooltip="#item#{{item.uuid}}" {{/if}} {{/unless}} draggable="true">
-      <img src="{{item.img}}" class="item-img {{#if isActor}}actor-img{{/if}}" />
-      {{#if (and item.usable (ne showActions false))}}
-        {{#if @root.isNPC}}
-          <img class="roll-img d20" src="systems/daggerheart/assets/icons/dice/default/d20.svg" alt="d20">
-        {{else}}
-          <img class="roll-img duality" src="systems/daggerheart/assets/icons/dice/duality/DualityBW.svg" alt="2d12">
+        {{#unless hideTooltip}} {{#if (eq type 'attack' )}} data-tooltip="#attack#{{item.actor.uuid}}" {{else}} data-tooltip="#item#{{item.uuid}}" {{/if}} {{/unless}}>
+        <img src="{{item.img}}" class="item-img {{#if isActor}}actor-img{{/if}}" />
+        {{#if (and item.usable (ne showActions false))}}
+            {{#if @root.isNPC}}
+                <img class="roll-img d20" src="systems/daggerheart/assets/icons/dice/default/d20.svg" alt="d20">
+            {{else}}
+                <img class="roll-img duality" src="systems/daggerheart/assets/icons/dice/duality/DualityBW.svg" alt="2d12">
+            {{/if}}
         {{/if}}
-      {{/if}}
     </div>
 
     {{!-- Name & Tags --}}

--- a/templates/sheets/global/partials/inventory-item-V2.hbs
+++ b/templates/sheets/global/partials/inventory-item-V2.hbs
@@ -27,11 +27,11 @@ Parameters:
 >
   <div class="inventory-item-header {{#if hideContextMenu}}padded{{/if}}" {{#unless noExtensible}}data-action="toggleExtended" {{/unless}}>
     {{!-- Image --}}
-    <div class="img-portait" data-action='{{ifThen item.usable "useItem" (ifThen
-      (hasProperty item "toChat" ) "toChat" "editDoc" ) }}' {{#unless hideTooltip}} {{#if (eq type 'attack' )}}
-      data-tooltip="#attack#{{item.actor.uuid}}" {{else}} data-tooltip="#item#{{item.uuid}}" {{/if}} {{/unless}} draggable="true">
+    <div class="img-portait" 
+        {{#unless (eq showActions false)}}data-action='{{ifThen item.usable "useItem" (ifThen (hasProperty item "toChat" ) "toChat" "editDoc" ) }}'{{/unless}}
+        {{#unless hideTooltip}} {{#if (eq type 'attack' )}} data-tooltip="#attack#{{item.actor.uuid}}" {{else}} data-tooltip="#item#{{item.uuid}}" {{/if}} {{/unless}} draggable="true">
       <img src="{{item.img}}" class="item-img {{#if isActor}}actor-img{{/if}}" />
-      {{#if item.usable}}
+      {{#if (and item.usable (ne showActions false))}}
         {{#if @root.isNPC}}
           <img class="roll-img d20" src="systems/daggerheart/assets/icons/dice/default/d20.svg" alt="d20">
         {{else}}

--- a/templates/sheets/global/partials/inventory-item-V2.hbs
+++ b/templates/sheets/global/partials/inventory-item-V2.hbs
@@ -46,10 +46,10 @@ Parameters:
         <span class="item-name">{{localize item.name}} {{#unless (or noExtensible (not item.system.description))}}<span class="expanded-icon"><i class="fa-solid fa-expand"></i></span>{{/unless}}</span>
 
         {{!-- Tags Start --}}
-        {{#if (not ../hideTags)}}
+        {{#if (not hideTags)}}
             {{#> "systems/daggerheart/templates/sheets/global/partials/item-tags.hbs" item}}
                 {{#if (eq ../type 'feature')}}
-                    {{#if (and system.featureForm (or (eq @root.document.type "adversary") (eq @root.document.type "environment")))}}
+                    {{#if (and system.featureForm (ne @root.document.type "character"))}}
                         <div class="tag feature-form">
                             <span class="recall-value">{{localize (concat "DAGGERHEART.CONFIG.FeatureForm." system.featureForm)}}</span>
                         </div>


### PR DESCRIPTION
Splits them up into these groups, and gives separate create buttons that makes a feature for that type. Added to adversary, environment, and npcs.

Also does a few extra things:
- show feature type on npc view sheet
- fix tags showing in companion limited sheet
- fixes scroll restoration for setting sheet features and potential adversaries 