### PR TITLE
[Fix] Action Uses Not Spent

### DIFF
--- a/module/applications/dialogs/d20RollDialog.mjs
+++ b/module/applications/dialogs/d20RollDialog.mjs
@@ -226,6 +226,7 @@ export default class D20RollDialog extends HandlebarsApplicationMixin(Applicatio
 
     static async submitRoll(event) {
         event.preventDefault();
+        await this.submit();
         await this.close({ submitted: true });
     }
 

--- a/module/applications/dialogs/d20RollDialog.mjs
+++ b/module/applications/dialogs/d20RollDialog.mjs
@@ -160,7 +160,7 @@ export default class D20RollDialog extends HandlebarsApplicationMixin(Applicatio
         }
         if (rest.hasOwnProperty('trait')) {
             this.config.roll.trait = rest.trait;
-            if (!this.config.source.item)
+            if (!this.config.source.item && this.config.roll.trait)
                 this.config.title = game.i18n.format('DAGGERHEART.UI.Chat.dualityRoll.abilityCheckTitle', {
                     ability: game.i18n.localize(abilities[this.config.roll.trait]?.label)
                 });
@@ -225,8 +225,6 @@ export default class D20RollDialog extends HandlebarsApplicationMixin(Applicatio
     }
 
     static async submitRoll(event) {
-        event.preventDefault();
-        await this.submit();
         await this.close({ submitted: true });
     }
 


### PR DESCRIPTION
Fixes #2025 
Fixed so that action uses are automatically spent again. 

In `v2.2.3` I added `event.preventDefault` on submit in d20RollDialog, I did this to avoid the config.title being altered on Companion rolls. 
This wasn't a good fix as it had the side effect of not updating the config with uses and other things.
I removed it again so that the config update still happens (`updateRollConfiguration`) and fixed the changing Companion Roll message title directly.