### PR TITLE
[Fix] Trigger Error Info

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1451,7 +1451,7 @@
                 },
                 "triggerType": "Trigger Type",
                 "triggeringActorType": "Triggering Actor Type",
-                "triggerError": "{trigger} trigger on {item} failed for {actor}. It's probably configured wrong."
+                "triggerError": "{trigger} trigger on {item}({itemUuid}) failed for {actor}. It's probably configured wrong."
             },
             "WeaponFeature": {
                 "barrier": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -1451,7 +1451,7 @@
                 },
                 "triggerType": "Trigger Type",
                 "triggeringActorType": "Triggering Actor Type",
-                "triggerError": "{trigger} trigger failed for {actor}. It's probably configured wrong."
+                "triggerError": "{trigger} trigger on {item} failed for {actor}. It's probably configured wrong."
             },
             "WeaponFeature": {
                 "barrier": {

--- a/module/data/registeredTriggers.mjs
+++ b/module/data/registeredTriggers.mjs
@@ -156,7 +156,8 @@ export default class RegisteredTriggers extends Map {
                             game.i18n.format('DAGGERHEART.CONFIG.Triggers.triggerError', {
                                 trigger: triggerName,
                                 actor: currentActor?.name,
-                                item: item?.name ?? '<Missing Item>'
+                                item: item?.name ?? '<Missing Item>',
+                                itemUuid: item?.uuid ?? '<Missing UUID>'
                             })
                         );
                     }

--- a/module/data/registeredTriggers.mjs
+++ b/module/data/registeredTriggers.mjs
@@ -150,11 +150,13 @@ export default class RegisteredTriggers extends Map {
                         const result = await command(...args);
                         if (result?.updates?.length) updates.push(...result.updates);
                     } catch {
+                        const item = await foundry.utils.fromUuid(itemUuid);
                         const triggerName = game.i18n.localize(triggerData.label);
-                        ui.notifications.error(
+                        console.error(
                             game.i18n.format('DAGGERHEART.CONFIG.Triggers.triggerError', {
                                 trigger: triggerName,
-                                actor: currentActor?.name
+                                actor: currentActor?.name,
+                                item: item?.name ?? '<Missing Item>'
                             })
                         );
                     }


### PR DESCRIPTION
Fixes #2014

- Made trigger errors more informative by including the name of the Item the trigger is on (in this case `Strange Patterns`)
<img width="1167" height="37" alt="image" src="https://github.com/user-attachments/assets/458afc57-9977-40d7-bff7-31099644661e" />

- I changed so that the error is only printed to console, rather than showing via `ui.notifications`. This part I'm not sure on. It'll make it less annoying if you don't want to fix it, but it'll also mean most users will probably never notice a trigger is broken since they won't check the console 🤷‍♂️ 