### PR TITLE
[Fix] Weapon Spellcasting Active Effects

### DIFF
--- a/module/applications/sheets/api/application-mixin.mjs
+++ b/module/applications/sheets/api/application-mixin.mjs
@@ -517,7 +517,7 @@ export default function DHApplicationMixin(Base) {
                         const doc = await getDocFromElement(target),
                             action = doc?.system?.attack ?? doc;
                         const config = action.prepareConfig(event);
-                        config.effects = await game.system.api.data.actions.actionsTypes.base.getEffects(
+                        config.effects = await game.system.api.data.actions.actionsTypes.base.getActionRelevantEffects(
                             this.document,
                             doc
                         );

--- a/module/applications/sheets/api/base-actor.mjs
+++ b/module/applications/sheets/api/base-actor.mjs
@@ -212,7 +212,7 @@ export default class DHBaseActorSheet extends DHApplicationMixin(ActorSheetV2) {
                     const doc = await getDocFromElement(target),
                         action = doc?.system?.attack ?? doc;
                     const config = action.prepareConfig(event);
-                    config.effects = await game.system.api.data.actions.actionsTypes.base.getEffects(
+                    config.effects = await game.system.api.data.actions.actionsTypes.base.getActionRelevantEffects(
                         this.document,
                         doc
                     );

--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -228,7 +228,8 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
         let config = this.prepareConfig(event, configOptions);
         if (!config) return;
 
-        config.effects = await game.system.api.data.actions.actionsTypes.base.getEffects(this.actor, this.item);
+        config.effects = 
+            await game.system.api.data.actions.actionsTypes.base.getActionRelevantEffects(this.actor, this.item);
 
         if (Hooks.call(`${CONFIG.DH.id}.preUseAction`, this, config) === false) return;
 
@@ -333,31 +334,36 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
     }
 
     /**
-     * Get the all potentially applicable effects on the actor
+     * Get the all potentially applicable effects on the actor for the action's RollDialog
      * @param {DHActor} actor The actor performing the action
      * @param {DHItem|DhActor} effectParent The parent of the effect
      * @returns {DhActiveEffect[]}
      */
-    static async getEffects(actor, effectParent) {
+    static async getActionRelevantEffects(actor, effectParent) {
         if (!actor) return [];
 
         // Changes on weapon effects are not typically only applicable to show in the roll dialog for the weapon itself 
         // The exemptions to this rule are listed below
-        const weaponTrasnferredEffectKeys = [
-            'system.bonuses.roll.spellcasting'
+        const weaponTransferredEffectKeys = [
+            'system.bonuses.roll.spellcast.bonus'
         ];
 
         return Array.from(await actor.allApplicableEffects({ noTransferArmor: true, noSelfArmor: true })).reduce(
             (acc, effect) => {
                 const effectData = effect.toObject();
-                /* Effects on weapons only ever apply for the weapon itself */
+                /* Effects on weapons only ever apply for the weapon itself, with a few defined exceptions */
                 if (effect.parent.type === 'weapon') {
                     /* Unless they're secondary - then they apply only to other primary weapons */
                     if (effect.parent.system.secondary) {
-                        if (effectParent?.type !== 'weapon' || effectParent?.system.secondary) 
-                            effectData.system.changes.filter(x => weaponTrasnferredEffectKeys.includes(x.key));
-                    } else if (effectParent?.id !== effect.parent.id) 
-                        effectData.system.changes.filter(x => weaponTrasnferredEffectKeys.includes(x.key));
+                        if (effectParent?.type !== 'weapon' || effectParent?.system.secondary) {
+                            effectData.system.changes = 
+                                effectData.system.changes.filter(x => weaponTransferredEffectKeys.includes(x.key));
+                        } 
+                    }
+                    else if (effectParent?.id !== effect.parent.id) {
+                        effectData.system.changes = 
+                            effectData.system.changes.filter(x => weaponTransferredEffectKeys.includes(x.key));
+                    }
                 }
 
                 if (!effect.isSuppressed) {

--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -341,19 +341,31 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
     static async getEffects(actor, effectParent) {
         if (!actor) return [];
 
-        return Array.from(await actor.allApplicableEffects({ noTransferArmor: true, noSelfArmor: true })).filter(
-            effect => {
+        // Changes on weapon effects are not typically only applicable to show in the roll dialog for the weapon itself 
+        // The exemptions to this rule are listed below
+        const weaponTrasnferredEffectKeys = [
+            'system.bonuses.roll.spellcasting'
+        ];
+
+        return Array.from(await actor.allApplicableEffects({ noTransferArmor: true, noSelfArmor: true })).reduce(
+            (acc, effect) => {
+                const effectData = effect.toObject();
                 /* Effects on weapons only ever apply for the weapon itself */
                 if (effect.parent.type === 'weapon') {
                     /* Unless they're secondary - then they apply only to other primary weapons */
                     if (effect.parent.system.secondary) {
-                        if (effectParent?.type !== 'weapon' || effectParent?.system.secondary) return false;
-                    } else if (effectParent?.id !== effect.parent.id) return false;
+                        if (effectParent?.type !== 'weapon' || effectParent?.system.secondary) 
+                            effectData.system.changes.filter(x => weaponTrasnferredEffectKeys.includes(x.key));
+                    } else if (effectParent?.id !== effect.parent.id) 
+                        effectData.system.changes.filter(x => weaponTrasnferredEffectKeys.includes(x.key));
                 }
 
-                return !effect.isSuppressed;
-            }
-        );
+                if (!effect.isSuppressed) {
+                    acc.push(effectData);
+                }
+
+                return acc;
+            }, []);
     }
 
     /**

--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -359,8 +359,7 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
                             effectData.system.changes = 
                                 effectData.system.changes.filter(x => weaponTransferredEffectKeys.includes(x.key));
                         } 
-                    }
-                    else if (effectParent?.id !== effect.parent.id) {
+                    } else if (effectParent?.id !== effect.parent.id) {
                         effectData.system.changes = 
                             effectData.system.changes.filter(x => weaponTransferredEffectKeys.includes(x.key));
                     }

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -549,7 +549,7 @@ export default class DhpActor extends Actor {
             headerTitle: game.i18n.format('DAGGERHEART.UI.Chat.dualityRoll.abilityCheckTitle', {
                 ability: abilityLabel
             }),
-            effects: await game.system.api.data.actions.actionsTypes.base.getEffects(this),
+            effects: await game.system.api.data.actions.actionsTypes.base.getActionRelevantEffects(this),
             roll: {
                 trait: trait,
                 type: 'trait'

--- a/module/documents/chatMessage.mjs
+++ b/module/documents/chatMessage.mjs
@@ -167,7 +167,7 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
         if (this.system.action) {
             const actor = await foundry.utils.fromUuid(config.source.actor);
             const item = actor?.items.get(config.source.item) ?? null;
-            config.effects = await game.system.api.data.actions.actionsTypes.base.getEffects(actor, item);
+            config.effects = await game.system.api.data.actions.actionsTypes.base.getActionRelevantEffects(actor, item);
             await this.system.action.workflow.get('damage')?.execute(config, this._id, true);
         }
     }


### PR DESCRIPTION
I made changes to `baseAction.getEffects` that is used to grab the toggleable effects shown in the d20RollDialog (such as +1 to attack rolls from `reliable`).

----
Weapons used to not return their effects at all for this unless the action being performed was from the weapon itself.
It will now return the effects, but all `changes` in the effects will be removed unless they're specifically allowed to be applied to things that isn't the weapon.
To do this, I changed so that we return a simple object version of the effect instead of the effect itself. I think this should be fine as we are essentially(maybe literally?) just using the changes array anyway.