### PR TITLE
[UI] Adjust prosemirror menu padding

### DIFF
--- a/styles/less/global/prose-mirror.less
+++ b/styles/less/global/prose-mirror.less
@@ -3,6 +3,8 @@
 
 .application.daggerheart {
     prose-mirror {
+        --menu-padding: 4px 0px;
+        --menu-height: calc(var(--menu-button-height) + 8px);
         height: 100% !important;
         width: 100%;
 


### PR DESCRIPTION
Adjusts the padding around the prosemirror menu bar

Before

<img width="1097" height="783" alt="image" src="https://github.com/user-attachments/assets/32cfc55f-ebd4-4ea7-bcde-bde889f89c98" />

After

<img width="1096" height="778" alt="image" src="https://github.com/user-attachments/assets/34f32e55-227c-415c-b69f-709f96297295" />
