### PR TITLE
Simplify ActiveEffect sheet tags

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2010,7 +2010,8 @@
             "Attachments": {
                 "attachHint": "Drop items here to attach them",
                 "transferHint": "If checked, this effect will be applied to any actor that owns this Effect's parent Item. The effect is always applied if this Item is attached to another one."
-            }
+            },
+            "OriginTag": "Origin: {name}"
         },
         "GENERAL": {
             "Ability": {

--- a/module/documents/activeEffect.mjs
+++ b/module/documents/activeEffect.mjs
@@ -223,12 +223,14 @@ export default class DhActiveEffect extends foundry.documents.ActiveEffect {
      * Generates a list of localized tags based on this item's type-specific properties.
      * @returns {string[]} An array of localized tag strings.
      */
-    _getTags(rootDocument) {
-        const tags = [
-            rootDocument && rootDocument === this.parent 
-                ? _loc(`DOCUMENT.${rootDocument.documentName}`) 
-                : `${_loc(this.parent.system.metadata.label)}: ${this.parent.name}`
-        ];
+    _getTags() {
+        const tags = [];
+        const originActor = DhActiveEffect.#resolveParentDocument(fromUuidSync(this.origin), Actor);
+        if (originActor && originActor !== this.actor) {
+            tags.push(_loc('DAGGERHEART.EFFECTS.OriginTag', { name: originActor.name }));
+        } else if (!(this.parent instanceof Actor)) {
+            tags.push(`${_loc(this.parent.system.metadata.label)}: ${this.parent.name}`);
+        }
 
         for (const statusId of this.statuses) {
             const status = CONFIG.statusEffects.find(s => s.id === statusId);

--- a/module/documents/activeEffect.mjs
+++ b/module/documents/activeEffect.mjs
@@ -223,12 +223,11 @@ export default class DhActiveEffect extends foundry.documents.ActiveEffect {
      * Generates a list of localized tags based on this item's type-specific properties.
      * @returns {string[]} An array of localized tag strings.
      */
-    _getTags() {
+    _getTags(rootDocument) {
         const tags = [
-            `${game.i18n.localize(this.parent.system.metadata.label)}: ${this.parent.name}`,
-            game.i18n.localize(
-                this.isTemporary ? 'DAGGERHEART.EFFECTS.Duration.temporary' : 'DAGGERHEART.EFFECTS.Duration.passive'
-            )
+            rootDocument && rootDocument === this.parent 
+                ? _loc(`DOCUMENT.${rootDocument.documentName}`) 
+                : `${_loc(this.parent.system.metadata.label)}: ${this.parent.name}`
         ];
 
         for (const statusId of this.statuses) {

--- a/templates/sheets/global/partials/item-tags.hbs
+++ b/templates/sheets/global/partials/item-tags.hbs
@@ -1,5 +1,5 @@
 <div class="item-tags">
-    {{#each _getTags as |tag|}}
+    {{#each (_getTags @root.document) as |tag|}}
          <div class="tag">
             {{tag}}
         </div>

--- a/templates/sheets/global/partials/item-tags.hbs
+++ b/templates/sheets/global/partials/item-tags.hbs
@@ -1,5 +1,5 @@
 <div class="item-tags">
-    {{#each (_getTags @root.document) as |tag|}}
+    {{#each _getTags as |tag|}}
          <div class="tag">
             {{tag}}
         </div>


### PR DESCRIPTION
Removes the Passive/Temporary tag that is currently unused. Also, when the effect parent is the sheet's document, it will display the document name (Actor/Item) instead of `Adversary: X`

<img width="370" height="250" alt="image" src="https://github.com/user-attachments/assets/625b0339-5677-4a98-b463-ed01d7e125e3" />

Granted effects don't show the origin in the tags. This was the previous behavior as well.