### PR TITLE
[Fix] Combat Modifier Toggle Fix

### DIFF
--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -46,7 +46,9 @@ export default class DhpCombat extends Combat {
             for (let actor of actors) {
                 await actor.createEmbeddedDocuments(
                     'ActiveEffect',
-                    effects.filter(x => x.effectTargetTypes.includes(actor.type))
+                    effects
+                        .filter(x => x.effectTargetTypes.includes(actor.type))
+                        .map(x => foundry.utils.deepClone(x))
                 );
             }
         } else {


### PR DESCRIPTION
Fixes #2040
Appearantly foundy's `createEmbeddedDocuments` method is mutating.

Toggling the combat modifier in the BP menu was using the same effectData to create an effect on each adversary, and it failed if there were many adversaries in the loop because our `effectTargetTypes` property was stripped out during `createEmbeddedDocuments` because it's not part of the data saved to the DB.