### PR TITLE
[Fix] V13 Migration Fixes

### DIFF
--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -447,7 +447,15 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
 
     static migrateData(source) {
         if (source.damage?.parts && Array.isArray(source.damage.parts)) {
+            let hitPointsExists = source.damage.parts.some(x => x.applyTo === 'hitPoints');
             source.damage.parts = source.damage.parts.reduce((acc, part) => {
+                if (!part.applyTo && hitPointsExists) return acc;
+
+                if (!part.applyTo) {
+                    hitPointsExists = true;
+                    part.applyTo = 'hitPoints';
+                }
+
                 acc[part.applyTo] = part;
                 return acc;
             }, {});

--- a/module/data/actor/adversary.mjs
+++ b/module/data/actor/adversary.mjs
@@ -87,6 +87,7 @@ export default class DhpAdversary extends DhCreature {
                         parts: {
                             hitPoints: {
                                 type: ['physical'],
+                                applyTo: 'hitPoints',
                                 value: {
                                     multiplier: 'flat'
                                 }

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -107,6 +107,7 @@ export default class DhCharacter extends DhCreature {
                         parts: {
                             hitPoints: {
                                 type: ['physical'],
+                                applyTo: 'hitPoints',
                                 value: {
                                     custom: {
                                         enabled: true,

--- a/module/data/actor/companion.mjs
+++ b/module/data/actor/companion.mjs
@@ -102,6 +102,7 @@ export default class DhCompanion extends DhCreature {
                         parts: {
                             hitPoints: {
                                 type: ['physical'],
+                                applyTo: 'hitPoints',
                                 value: {
                                     dice: 'd6',
                                     multiplier: 'prof'

--- a/module/data/countdowns.mjs
+++ b/module/data/countdowns.mjs
@@ -28,6 +28,39 @@ export default class DhCountdowns extends foundry.abstract.DataModel {
         for (const countdownKey of changedCountdowns)
             foundry.ui.countdowns.changedCountdownsForAnimation.add(countdownKey);
     }
+
+    static migrateData(source) {
+        const migrateOldCountdowns = (data, type) => {
+            for (const key of Object.keys(data.countdowns)) {
+                const countdown = data.countdowns[key];
+                source.countdowns[key] = {
+                    ...countdown,
+                    type: type,
+                    ownership: Object.keys(countdown.ownership.players).reduce((acc, key) => {
+                        acc[key] =
+                            countdown.ownership.players[key].type === 1 ? 2 : countdown.ownership.players[key].type;
+                        return acc;
+                    }, {}),
+                    progress: {
+                        ...countdown.progress,
+                        type: countdown.progress.type.value
+                    }
+                };
+            }
+
+            source[type] = null;
+        };
+
+        if (source.narrative) {
+            migrateOldCountdowns(source.narrative, 'narrative');
+        }
+
+        if (source.encounter) {
+            migrateOldCountdowns(source.encounter, 'encounter');
+        }
+
+        return super.migrateData(source);
+    }
 }
 
 export class DhCountdown extends foundry.abstract.DataModel {

--- a/module/systemRegistration/migrations.mjs
+++ b/module/systemRegistration/migrations.mjs
@@ -1,5 +1,4 @@
 import { defaultRestOptions } from '../config/generalConfig.mjs';
-import { RefreshType, socketEvent } from './socket.mjs';
 
 export async function runMigrations() {
     let lastMigrationVersion = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.LastMigrationVersion);
@@ -152,43 +151,6 @@ export async function runMigrations() {
             const pack = game.packs.get(packId);
             await pack.configure({ locked: true });
         }
-
-        /* Migrate old countdown structure */
-        const countdownSettings = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Countdowns);
-        const getCountdowns = (data, type) => {
-            return Object.keys(data.countdowns).reduce((acc, key) => {
-                const countdown = data.countdowns[key];
-                acc[key] = {
-                    ...countdown,
-                    type: type,
-                    ownership: Object.keys(countdown.ownership.players).reduce((acc, key) => {
-                        acc[key] =
-                            countdown.ownership.players[key].type === 1 ? 2 : countdown.ownership.players[key].type;
-                        return acc;
-                    }, {}),
-                    progress: {
-                        ...countdown.progress,
-                        type: countdown.progress.type.value
-                    }
-                };
-
-                return acc;
-            }, {});
-        };
-
-        await countdownSettings.updateSource({
-            countdowns: {
-                ...getCountdowns(countdownSettings.narrative, 'narrative'),
-                ...getCountdowns(countdownSettings.encounter, 'encounter')
-            }
-        });
-        await game.settings.set(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Countdowns, countdownSettings);
-
-        game.socket.emit(`system.${CONFIG.DH.id}`, {
-            action: socketEvent.Refresh,
-            data: { refreshType: RefreshType.Countdown }
-        });
-        Hooks.callAll(socketEvent.Refresh, { refreshType: RefreshType.Countdown });
 
         lastMigrationVersion = '1.2.0';
     }

--- a/module/systemRegistration/migrations.mjs
+++ b/module/systemRegistration/migrations.mjs
@@ -303,6 +303,8 @@ export async function runMigrations() {
 
         /* Migrate existing effects modifying armor, creating new Armor Effects instead */
         const migrateEffects = async entity => {
+            if (!entity?.effects) return;
+
             for (const effect of entity.effects) {
                 if (effect.system.changes.every(x => x.key !== 'system.armorScore')) continue;
 

--- a/module/systemRegistration/migrations.mjs
+++ b/module/systemRegistration/migrations.mjs
@@ -155,61 +155,65 @@ export async function runMigrations() {
 
         /* Migrate old countdown structure */
         const countdownSettings = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Countdowns);
-        const getCountdowns = (data, type) => {
-            return Object.keys(data.countdowns).reduce((acc, key) => {
-                const countdown = data.countdowns[key];
-                acc[key] = {
-                    ...countdown,
-                    type: type,
-                    ownership: Object.keys(countdown.ownership.players).reduce((acc, key) => {
-                        acc[key] =
-                            countdown.ownership.players[key].type === 1 ? 2 : countdown.ownership.players[key].type;
-                        return acc;
-                    }, {}),
-                    progress: {
-                        ...countdown.progress,
-                        type: countdown.progress.type.value
-                    }
-                };
+        if (!countdownSettings.narrative || !countdownSettings.encounter) {
+            const getCountdowns = (data, type) => {
+                return Object.keys(data.countdowns).reduce((acc, key) => {
+                    const countdown = data.countdowns[key];
+                    acc[key] = {
+                        ...countdown,
+                        type: type,
+                        ownership: Object.keys(countdown.ownership.players).reduce((acc, key) => {
+                            acc[key] =
+                                countdown.ownership.players[key].type === 1 ? 2 : countdown.ownership.players[key].type;
+                            return acc;
+                        }, {}),
+                        progress: {
+                            ...countdown.progress,
+                            type: countdown.progress.type.value
+                        }
+                    };
 
-                return acc;
-            }, {});
-        };
+                    return acc;
+                }, {});
+            };
 
-        await countdownSettings.updateSource({
-            countdowns: {
-                ...getCountdowns(countdownSettings.narrative, 'narrative'),
-                ...getCountdowns(countdownSettings.encounter, 'encounter')
-            }
-        });
-        await game.settings.set(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Countdowns, countdownSettings);
+            await countdownSettings.updateSource({
+                countdowns: {
+                    ...getCountdowns(countdownSettings.narrative, 'narrative'),
+                    ...getCountdowns(countdownSettings.encounter, 'encounter')
+                }
+            });
+            await game.settings.set(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Countdowns, countdownSettings);
 
-        game.socket.emit(`system.${CONFIG.DH.id}`, {
-            action: socketEvent.Refresh,
-            data: { refreshType: RefreshType.Countdown }
-        });
-        Hooks.callAll(socketEvent.Refresh, { refreshType: RefreshType.Countdown });
-
+            game.socket.emit(`system.${CONFIG.DH.id}`, {
+                action: socketEvent.Refresh,
+                data: { refreshType: RefreshType.Countdown }
+            });
+            Hooks.callAll(socketEvent.Refresh, { refreshType: RefreshType.Countdown });
+        }
+        
         lastMigrationVersion = '1.2.0';
     }
 
     if (foundry.utils.isNewerVersion('1.2.7', lastMigrationVersion)) {
-        const tagTeam = game.settings.get(CONFIG.DH.id, 'TagTeamRoll');
-        const initatorMissing = tagTeam.initiator && !game.actors.some(actor => actor.id === tagTeam.initiator);
-        const missingMembers = Object.keys(tagTeam.members).reduce((acc, id) => {
-            if (!game.actors.some(actor => actor.id === id)) {
-                acc[id] = _del;
-            }
-            return acc;
-        }, {});
+        try {
+            const tagTeam = game.settings.get(CONFIG.DH.id, 'TagTeamRoll');
+            const initatorMissing = tagTeam.initiator && !game.actors.some(actor => actor.id === tagTeam.initiator);
+            const missingMembers = Object.keys(tagTeam.members).reduce((acc, id) => {
+                if (!game.actors.some(actor => actor.id === id)) {
+                    acc[id] = _del;
+                }
+                return acc;
+            }, {});
 
-        await tagTeam.updateSource({
-            initiator: initatorMissing ? null : tagTeam.initiator,
-            members: missingMembers
-        });
-        await game.settings.set(CONFIG.DH.id, 'TagTeamRoll', tagTeam);
-
-        lastMigrationVersion = '1.2.7';
+            await tagTeam.updateSource({
+                initiator: initatorMissing ? null : tagTeam.initiator,
+                members: missingMembers
+            });
+            await game.settings.set(CONFIG.DH.id, 'TagTeamRoll', tagTeam);
+        } finally {
+            lastMigrationVersion = '1.2.7';
+        }
     }
 
     if (foundry.utils.isNewerVersion('1.5.5', lastMigrationVersion)) {

--- a/module/systemRegistration/migrations.mjs
+++ b/module/systemRegistration/migrations.mjs
@@ -171,9 +171,9 @@ export async function runMigrations() {
                 members: missingMembers
             });
             await game.settings.set(CONFIG.DH.id, 'TagTeamRoll', tagTeam);
-        } finally {
-            lastMigrationVersion = '1.2.7';
-        }
+        } catch { }
+
+        lastMigrationVersion = '1.2.7';
     }
 
     if (foundry.utils.isNewerVersion('1.5.5', lastMigrationVersion)) {


### PR DESCRIPTION
- Fixed so that damageParts without an applyTo field is assumed to be hitPoints in migration.
This occurs on Character/Adversary basic attacks because the `applyTo` field wasn't set. Just in case there would be some freak case where there were -multiple- parts with the `undefined` key I made any instances beyond the first be tossed out during migrateData.
- Made a tentative fix to the migration script where one user noted that it error:ed for them with `entity` = null. I haven't been able to replicate it. This assumably fixes it, but it's a shot in the dark unless we get some more info and can actually test it.
- Added some extra safeties to the old V13 migrations. An issue happened because someone was updating from v1.2.0 from back in november all the way to latest V14. A few settings that were expected back in those V13 migrations no longer exist in V14 which caused errors.