### PR TITLE
[Fix] SummonAction Actor Choice

### DIFF
--- a/module/data/fields/action/summonField.mjs
+++ b/module/data/fields/action/summonField.mjs
@@ -65,9 +65,16 @@ export default class DHSummonField extends fields.ArrayField {
     /* Check for any available instances of the actor present in the world if we're missing artwork in the compendium. If none exists, create one. */
     static async getWorldActor(baseActor) {
         const dataType = game.system.api.data.actors[`Dh${baseActor.type.capitalize()}`];
-        if (baseActor.inCompendium && dataType && baseActor.img === dataType.DEFAULT_ICON) {
+        if (baseActor.inCompendium) {
             const worldActorCopy = game.actors.find(x => x.name === baseActor.name);
-            if (worldActorCopy) return worldActorCopy;
+            if (
+                worldActorCopy && (
+                    baseActor.img === worldActorCopy.img || 
+                    (dataType && baseActor.img === dataType.DEFAULT_ICON)
+                )
+            ) {
+                return worldActorCopy;
+            } 
 
             return await game.system.api.documents.DhpActor.create(baseActor.toObject());
         }

--- a/module/data/fields/action/summonField.mjs
+++ b/module/data/fields/action/summonField.mjs
@@ -44,7 +44,7 @@ export default class DHSummonField extends fields.ArrayField {
 
             const actor = await getWorldActor(await foundry.utils.fromUuid(summon.actorUUID));
             /* Extending summon data in memory so it's available in actionField.toChat. Think it's harmless, but ugly. Could maybe find a better way. */
-            summon.actor = actor;
+            summon.actor = actor.toObject();
 
             const countNumber = Number.parseInt(count);
             for (let i = 0; i < countNumber; i++) {

--- a/module/data/fields/action/summonField.mjs
+++ b/module/data/fields/action/summonField.mjs
@@ -1,4 +1,4 @@
-import { itemAbleRollParse, triggerChatRollFx } from '../../../helpers/utils.mjs';
+import { getWorldActor, itemAbleRollParse, triggerChatRollFx } from '../../../helpers/utils.mjs';
 import FormulaField from '../formulaField.mjs';
 
 const fields = foundry.data.fields;
@@ -42,9 +42,9 @@ export default class DHSummonField extends fields.ArrayField {
             const count = roll.total;
             if (!roll.isDeterministic) rolls.push(roll);
 
-            const actor = await DHSummonField.getWorldActor(await foundry.utils.fromUuid(summon.actorUUID));
+            const actor = await getWorldActor(await foundry.utils.fromUuid(summon.actorUUID));
             /* Extending summon data in memory so it's available in actionField.toChat. Think it's harmless, but ugly. Could maybe find a better way. */
-            summon.actor = actor.toObject();
+            summon.actor = actor;
 
             const countNumber = Number.parseInt(count);
             for (let i = 0; i < countNumber; i++) {
@@ -60,26 +60,6 @@ export default class DHSummonField extends fields.ArrayField {
 
         this.actor.sheet?.minimize();
         DHSummonField.handleSummon(summonData, this.actor);
-    }
-
-    /* Check for any available instances of the actor present in the world if we're missing artwork in the compendium. If none exists, create one. */
-    static async getWorldActor(baseActor) {
-        const dataType = game.system.api.data.actors[`Dh${baseActor.type.capitalize()}`];
-        if (baseActor.inCompendium) {
-            const worldActorCopy = game.actors.find(x => x.name === baseActor.name);
-            if (
-                worldActorCopy && (
-                    baseActor.img === worldActorCopy.img || 
-                    (dataType && baseActor.img === dataType.DEFAULT_ICON)
-                )
-            ) {
-                return worldActorCopy;
-            } 
-
-            return await game.system.api.documents.DhpActor.create(baseActor.toObject());
-        }
-
-        return baseActor;
     }
 
     static async handleSummon(summonData, actionActor) {

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -897,7 +897,7 @@ export async function getWorldActor(baseActor) {
             game.actors.find(x => x._stats.compendiumSource === baseActor.uuid && x.name === baseActor.name);
 
         if (worldActorCopy)
-            return worldActorCopy;
+            return worldActorCopy.toObject();
 
         const baseActorData = baseActor.toObject();
         return await game.system.api.documents.DhpActor.create({ 

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -890,3 +890,24 @@ export function shouldUseHopeFearAutomation(options = { gmAsPlayer: true }) {
     const { hopeFear } = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Automation);
     return (!game.user.isGM || options.gmAsPlayer) ? hopeFear.players : hopeFear.gm; 
 }
+
+export async function getWorldActor(baseActor) {
+    if (baseActor.inCompendium) {
+        const worldActorCopy = 
+            game.actors.find(x => x._stats.compendiumSource === baseActor.uuid && x.name === baseActor.name);
+
+        if (worldActorCopy)
+            return worldActorCopy;
+
+        const baseActorData = baseActor.toObject();
+        return await game.system.api.documents.DhpActor.create({ 
+            ...baseActorData, 
+            _stats: { 
+                ...baseActorData._stats, 
+                compendiumSource: baseActor.uuid 
+            } 
+        });
+    }
+
+    return baseActor.toObject();
+}

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -893,13 +893,15 @@ export function shouldUseHopeFearAutomation(options = { gmAsPlayer: true }) {
 
 export async function getWorldActor(baseActor) {
     if (baseActor.inCompendium) {
-        const worldActorCopy = 
-            game.actors.find(x => x._stats.compendiumSource === baseActor.uuid && x.name === baseActor.name);
+        const worldActorCopy = game.actors.find(x => 
+            x._stats.compendiumSource === baseActor.uuid && 
+            (!x.prototypeToken.actorLink || x.name === baseActor.name)
+        );
 
         if (worldActorCopy)
-            return worldActorCopy.toObject();
+            return worldActorCopy;
 
-        const baseActorData = baseActor.toObject();
+        const baseActorData = baseActor;
         return await game.system.api.documents.DhpActor.create({ 
             ...baseActorData, 
             _stats: { 
@@ -909,5 +911,5 @@ export async function getWorldActor(baseActor) {
         });
     }
 
-    return baseActor.toObject();
+    return baseActor;
 }


### PR DESCRIPTION
Fixed logic for picking which actor to summon. The previous logic didn't work correctly if the actors in the compendium had artwork - which they might have with certain modules that map art onto them.

The new logic is as such:
**1)** The actor to be summoned is stored in a compendium
    **a)** There exists a an actor in the world with the same name as the one to be summoned
        a1) Use the in-world actor if: They both have the same artwork, or the compendium actor has the default artwork.
        a2) Goto `b`
    **b)** No in-world actor, so we create a new actor.
   
----
**2)** Not a compendium actor, so just use the actor straight up.