### PR TITLE
[Refactor] Sidebar resources styling

### DIFF
--- a/module/applications/sheets/actors/adversary.mjs
+++ b/module/applications/sheets/actors/adversary.mjs
@@ -58,12 +58,13 @@ export default class AdversarySheet extends DHBaseActorSheet {
             template: 'systems/daggerheart/templates/sheets/actors/adversary/features.hbs',
             scrollable: ['.feature-section']
         },
-        notes: {
-            template: 'systems/daggerheart/templates/sheets/actors/adversary/notes.hbs'
-        },
         effects: {
             template: 'systems/daggerheart/templates/sheets/actors/adversary/effects.hbs',
             scrollable: ['.effects-sections']
+        },
+        notes: {
+            template: 'systems/daggerheart/templates/sheets/actors/adversary/notes.hbs',
+            scrollable: ['.editor-content']
         }
     };
 

--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -1057,7 +1057,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
             direction: 'DOWN'
         });
 
-        html.querySelectorAll('.armor-slot').forEach(element => {
+        html.querySelectorAll('.armor .slot').forEach(element => {
             element.addEventListener('click', CharacterSheet.armorSourcePipUpdate);
         });
     }
@@ -1072,7 +1072,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
 
     /** Update specific armor source */
     static async armorSourcePipUpdate(event) {
-        const target = event.target.closest('.armor-slot');
+        const target = event.target.closest('.slot');
         const { uuid, value } = target.dataset;
         const document = await foundry.utils.fromUuid(uuid);
 
@@ -1100,7 +1100,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
         }
 
         const container = target.closest('.slot-bar');
-        for (const armorSlot of container.querySelectorAll('.armor-slot i')) {
+        for (const armorSlot of container.querySelectorAll('.armor .slot i')) {
             const index = Number.parseInt(armorSlot.dataset.index);
             if (decreasing && index >= newCurrent) {
                 armorSlot.classList.remove('fa-shield');

--- a/styles/less/global/resource-bar.less
+++ b/styles/less/global/resource-bar.less
@@ -9,110 +9,108 @@
     }   
 });
 
+/** Pips styling, can exist standalone even without a slot-value */
+.slot-bar {
+    display: flex;
+    gap: 4px;
+    padding: 5px;
+    border: 1px solid @color-border;
+    border-radius: 6px;
+    z-index: 1;
+    color: @color-text-emphatic;
+    width: fit-content;
+    min-height: 22px;
+    flex-wrap: wrap;
+
+    .slot {
+        transition: all 0.3s ease;
+        cursor: pointer;
+    }
+
+    .slot:not(:has(i)) {
+        width: 15px;
+        height: 10px;
+        border: 1px solid @color-border;
+        background: light-dark(@dark-blue-10, @golden-10);
+        border-radius: 3px;
+
+        &.large {
+            width: 20px;
+        }
+
+        &.filled {
+            background: light-dark(@dark-blue, @golden);
+        }
+    }
+
+    &.armor .slot {
+        font-size: var(--font-size-12);
+        .fa-shield-halved {
+            color: light-dark(@dark-blue-40, @golden-40);
+        }
+    }
+
+    .empty-slot {
+        width: 15px;
+        height: 10px;
+    }
+}
+
+.slot-value {
+    display: flex;
+    flex-direction: column;
+    padding: 0 5px;
+    font-size: 1.5rem;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    z-index: 2;
+    color: @beige;
+
+    .slot-label {
+        display: flex;
+        align-items: center;
+        color: light-dark(@beige, @dark-blue);
+        background: light-dark(@dark-blue, @golden);
+        padding: 0 5px;
+        width: fit-content;
+        font-weight: bold;
+        border-radius: 0px 0px 5px 5px;
+        font-size: var(--font-size-12);
+
+        .label {
+            padding-right: 5px;
+        }
+
+        .value {
+            padding-left: 6px;
+            border-left: 1px solid light-dark(@beige, @dark-golden);
+        }
+    }
+}
+
 .status-bar {
     display: flex;
-    justify-content: center;
+    flex-direction: column;
+    align-items: center;
     position: relative;
-    width: 120px;
-    height: 40px;
-
-    .status-label {
-        position: relative;
-        top: 40px;
-        height: 22px;
-        width: 79px;
-        clip-path: path('M0 0H79L74 16.5L39 22L4 16.5L0 0Z');
-        background: light-dark(@dark-blue, @golden);
-
-        h4 {
-            font-weight: bold;
-            text-align: center;
-            line-height: 18px;
-            color: light-dark(@beige, @dark-blue);
-        }
-    }
-    .slot-value {
-        position: absolute;
-        display: flex;
-        flex-direction: column;
-        padding: 0 5px;
-        font-size: 1.5rem;
-        align-items: center;
-        width: 140px;
-        height: 40px;
-        justify-content: center;
-        text-align: center;
-        z-index: 2;
-        color: @beige;
-
-        .slot-bar {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 5px;
-            padding: 5px;
-            border: 1px solid @color-border;
-            border-radius: 6px;
-            z-index: 1;
-            color: @color-text-emphatic;
-            width: fit-content;
-
-            .slot {
-                width: 15px;
-                height: 10px;
-                border: 1px solid @color-border;
-                background: light-dark(@dark-blue-10, @golden-10);
-                border-radius: 3px;
-                transition: all 0.3s ease;
-                cursor: pointer;
-
-                &.large {
-                    width: 20px;
-                }
-
-                &.filled {
-                    background: light-dark(@dark-blue, @golden);
-                }
-            }
-
-            .empty-slot {
-                width: 15px;
-                height: 10px;
-            }
-        }
-        .slot-label {
-            display: flex;
-            align-items: center;
-            color: light-dark(@beige, @dark-blue);
-            background: light-dark(@dark-blue, @golden);
-            padding: 0 5px;
-            width: fit-content;
-            font-weight: bold;
-            border-radius: 0px 0px 5px 5px;
-            font-size: var(--font-size-12);
-
-            .label {
-                padding-right: 5px;
-            }
-
-            .value {
-                padding-left: 6px;
-                border-left: 1px solid light-dark(@beige, @dark-golden);
-            }
-        }
-    }
 
     .status-value {
-        position: absolute;
+        position: relative;
         display: flex;
         padding: 0 5px;
         font-size: 1.5rem;
         align-items: center;
-        width: 140px;
+        width: 100px;
         height: 40px;
         justify-content: center;
         text-align: center;
         z-index: 2;
         color: @beige;
+
+        > * {
+            z-index: 1;
+        }
 
         input[type='number'] {
             background: transparent;
@@ -146,11 +144,11 @@
     .progress-bar {
         position: absolute;
         appearance: none;
-        width: 100px;
-        height: 40px;
+        width: 100%;
+        height: 100%;
         border: 1px solid @color-border;
         border-radius: 6px;
-        z-index: 1;
+        z-index: 0;
         background: @dark-blue;
 
         &::-webkit-progress-bar {
@@ -175,4 +173,29 @@
             border-radius: 6px;
         }
     }
+    .status-label {
+        position: relative;
+        height: 22px;
+        width: 79px;
+        background: light-dark(@dark-blue, @golden);
+
+        &.pointy {
+            clip-path: path('M0 0H79L74 16.5L39 22L4 16.5L0 0Z');
+            margin-bottom: -2px; // compensate for pointy bottom so spacing feels more "right"
+        }
+
+        h4 {
+            font-weight: bold;
+            text-align: center;
+            line-height: 18px;
+            color: light-dark(@beige, @dark-blue);
+        }
+    }
+}
+
+// Overrides for sidebar usage.
+aside[data-application-part="sidebar"] .resources-section .slot-bar {
+    display: grid;
+    grid-template-columns: repeat(6, min-content);
+    grid-auto-flow: row;
 }

--- a/styles/less/sheets/actors/adversary/sidebar.less
+++ b/styles/less/sheets/actors/adversary/sidebar.less
@@ -106,7 +106,7 @@
             display: flex;
             flex-direction: column;
             top: -20px;
-            gap: 16px;
+            gap: 10px;
             margin-bottom: -10px;
 
             &.pip-display {
@@ -120,105 +120,6 @@
             .resources-section {
                 display: flex;
                 justify-content: space-evenly;
-                margin-bottom: 16px;
-
-                .status-bar {
-                    display: flex;
-                    justify-content: center;
-                    position: relative;
-                    width: 100px;
-                    height: 40px;
-
-                    .status-label {
-                        position: relative;
-                        top: 40px;
-                        height: 22px;
-                        width: 79px;
-                        clip-path: path('M0 0H79L74 16.5L39 22L4 16.5L0 0Z');
-                        background: light-dark(@dark-blue, @golden);
-
-                        h4 {
-                            font-weight: bold;
-                            text-align: center;
-                            line-height: 18px;
-                            color: light-dark(@beige, @dark-blue);
-                        }
-                    }
-                    .status-value {
-                        position: absolute;
-                        display: flex;
-                        padding: 0 6px;
-                        font-size: 1.5rem;
-                        align-items: center;
-                        width: 100px;
-                        height: 40px;
-                        justify-content: center;
-                        text-align: center;
-                        z-index: 2;
-                        color: @beige;
-
-                        input[type='number'] {
-                            background: transparent;
-                            font-size: 1.5rem;
-                            width: 40px;
-                            height: 30px;
-                            text-align: center;
-                            border: none;
-                            outline: 2px solid transparent;
-                            color: @beige;
-
-                            &.bar-input {
-                                padding: 0;
-                                color: @beige;
-                                backdrop-filter: none;
-                                background: transparent;
-                                transition: all 0.3s ease;
-
-                                &:hover,
-                                &:focus {
-                                    background: @semi-transparent-dark-blue;
-                                    backdrop-filter: blur(9.5px);
-                                }
-                            }
-                        }
-
-                        .bar-label {
-                            width: 40px;
-                        }
-                    }
-                    .progress-bar {
-                        position: absolute;
-                        appearance: none;
-                        width: 100px;
-                        height: 40px;
-                        border: 1px solid @color-border;
-                        border-radius: 6px;
-                        z-index: 1;
-                        background: @dark-blue;
-
-                        &::-webkit-progress-bar {
-                            border: none;
-                            background: @dark-blue;
-                            border-radius: 6px;
-                        }
-                        &::-webkit-progress-value {
-                            background: @gradient-hp;
-                            border-radius: 6px;
-                        }
-                        &.stress-color::-webkit-progress-value {
-                            background: @gradient-stress;
-                            border-radius: 6px;
-                        }
-                        &::-moz-progress-bar {
-                            background: @gradient-hp;
-                            border-radius: 6px;
-                        }
-                        &.stress-color::-moz-progress-bar {
-                            background: @gradient-stress;
-                            border-radius: 6px;
-                        }
-                    }
-                }
             }
 
             .status-section {
@@ -256,7 +157,7 @@
                     .status-label {
                         padding: 2px 10px;
                         width: 100%;
-                        border-radius: 3px;
+                        border-radius: 0 0 3px 3px;
                         background: light-dark(@dark-blue, @golden);
 
                         h4 {

--- a/styles/less/sheets/actors/character/sidebar.less
+++ b/styles/less/sheets/actors/character/sidebar.less
@@ -89,113 +89,13 @@
 
             .resources-section {
                 justify-content: space-around;
-                margin: 8px 2px 8px 2px;
+                margin: 8px 2px 0 2px;
             }
         }
 
         .resources-section {
             display: flex;
             justify-content: space-evenly;
-            margin-bottom: 20px;
-
-            .status-bar {
-                display: flex;
-                justify-content: center;
-                position: relative;
-                width: 120px;
-                height: 40px;
-
-                .status-label {
-                    position: relative;
-                    top: 40px;
-                    height: 22px;
-                    width: 79px;
-                    clip-path: path('M0 0H79L74 16.5L39 22L4 16.5L0 0Z');
-                    background: light-dark(@dark-blue, @golden);
-
-                    h4 {
-                        font-weight: bold;
-                        text-align: center;
-                        line-height: 18px;
-                        color: light-dark(@beige, @dark-blue);
-                    }
-                }
-
-                .status-value {
-                    position: absolute;
-                    display: flex;
-                    padding: 0 5px;
-                    font-size: 1.5rem;
-                    align-items: center;
-                    width: 140px;
-                    height: 40px;
-                    justify-content: center;
-                    text-align: center;
-                    z-index: 2;
-                    color: @beige;
-
-                    input[type='number'] {
-                        background: transparent;
-                        font-size: 1.5rem;
-                        width: 40px;
-                        height: 30px;
-                        text-align: center;
-                        border: none;
-                        outline: 2px solid transparent;
-                        color: @beige;
-
-                        &.bar-input {
-                            padding: 0;
-                            color: @beige;
-                            backdrop-filter: none;
-                            background: transparent;
-                            transition: all 0.3s ease;
-
-                            &:hover,
-                            &:focus {
-                                background: @semi-transparent-dark-blue;
-                                backdrop-filter: blur(9.5px);
-                            }
-                        }
-                    }
-
-                    .bar-label {
-                        width: 40px;
-                    }
-                }
-                .progress-bar {
-                    position: absolute;
-                    appearance: none;
-                    width: 100px;
-                    height: 40px;
-                    border: 1px solid @color-border;
-                    border-radius: 6px;
-                    z-index: 1;
-                    background: @dark-blue;
-
-                    &::-webkit-progress-bar {
-                        border: none;
-                        background: @dark-blue;
-                        border-radius: 6px;
-                    }
-                    &::-webkit-progress-value {
-                        background: @gradient-hp;
-                        border-radius: 6px;
-                    }
-                    &.stress-color::-webkit-progress-value {
-                        background: @gradient-stress;
-                        border-radius: 6px;
-                    }
-                    &::-moz-progress-bar {
-                        background: @gradient-hp;
-                        border-radius: 6px;
-                    }
-                    &.stress-color::-moz-progress-bar {
-                        background: @gradient-stress;
-                        border-radius: 6px;
-                    }
-                }
-            }
         }
 
         .status-section {
@@ -245,21 +145,21 @@
 
             .status-bar.armor-slots {
                 display: flex;
-                justify-content: center;
-                position: relative;
                 width: 95px;
-                height: 30px;
                 white-space: nowrap;
+
+                .status-label {
+                    height: 30px;
+                }
 
                 .status-label {
                     padding: 2px 2px;
                     position: relative;
-                    top: 30px;
                     height: 22px;
                     width: 95px;
                     border-radius: 3px;
                     background: light-dark(@dark-blue, @golden);
-                    clip-path: none;
+
                     display: flex;
                     align-items: center;
                     justify-content: center;
@@ -291,40 +191,16 @@
                     }
                 }
                 .slot-value {
-                    position: absolute;
-                    display: flex;
-                    padding: 0 5px;
                     font-size: 1.2rem;
-                    align-items: center;
                     width: 80px;
                     height: 30px;
-                    justify-content: center;
-                    text-align: center;
-                    z-index: 2;
                     color: light-dark(@dark-blue, @beige);
                     flex-direction: column;
 
                     .slot-bar {
-                        display: flex;
-                        flex-wrap: wrap;
-                        gap: 4px;
-                        padding: 5px;
-                        border: 1px solid @color-border;
-                        border-radius: 6px;
-                        z-index: 1;
                         background: @dark-blue;
                         justify-content: center;
-                        color: @color-text-emphatic;
-
-                        .armor-slot {
-                            cursor: pointer;
-                            transition: all 0.3s ease;
-                            font-size: var(--font-size-12);
-
-                            .fa-shield-halved {
-                                color: light-dark(@dark-blue-40, @golden-40);
-                            }
-                        }
+                        border-bottom: none;
                     }
                     .slot-label {
                         display: flex;
@@ -364,41 +240,21 @@
                     }
                 }
                 .status-value {
-                    position: absolute;
-                    display: flex;
                     padding: 0 6px;
                     font-size: 1.2rem;
-                    align-items: center;
                     width: 80px;
                     height: 30px;
                     justify-content: center;
-                    text-align: center;
-                    z-index: 2;
                     color: light-dark(@dark-blue, @beige);
-                    border: 1px solid @color-border;
-                    border-bottom: none;
-                    border-radius: 6px 6px 0 0;
 
                     input[type='number'] {
-                        background: transparent;
                         font-size: 1.2rem;
                         width: 30px;
                         height: 20px;
-                        text-align: center;
-                        border: none;
-                        outline: 2px solid transparent;
                         color: light-dark(@dark-blue, @beige);
 
                         &.bar-input {
-                            padding: 0;
                             color: light-dark(@dark-blue, @beige);
-                            backdrop-filter: none;
-                            background: transparent;
-                            &:hover,
-                            &:focus {
-                                background: @semi-transparent-dark-blue;
-                                backdrop-filter: blur(9.5px);
-                            }
                         }
                     }
 
@@ -407,32 +263,9 @@
                     }
                 }
                 .progress-bar {
-                    position: absolute;
-                    appearance: none;
-                    width: 80px;
-                    height: 30px;
-                    border: 1px solid @color-border;
-                    border-radius: 6px;
-                    z-index: 1;
                     background: light-dark(transparent, @dark-blue);
                     border-bottom: none;
                     border-radius: 6px 6px 0 0;
-                    &::-webkit-progress-bar {
-                        border: none;
-                        background: light-dark(transparent, @dark-blue);
-                    }
-                    &::-webkit-progress-value {
-                        background: @gradient-stress;
-                    }
-                    &.stress-color::-webkit-progress-value {
-                        background: @gradient-stress;
-                    }
-                    &::-moz-progress-bar {
-                        background: @gradient-stress;
-                    }
-                    &.stress-color::-moz-progress-bar {
-                        background: @gradient-stress;
-                    }
                 }
             }
 

--- a/styles/less/sheets/actors/party/party-members.less
+++ b/styles/less/sheets/actors/party/party-members.less
@@ -206,42 +206,12 @@
                     }
 
                     .slot-bar {
-                        display: flex;
                         align-items: center;
                         flex-wrap: wrap;
-                        gap: 4px;
-
                         background-color: light-dark(@dark-blue-10, @dark-blue);
-                        color: @color-text-emphatic;
                         padding: 2px 5px;
-                        border: 1px solid @color-border;
                         border-radius: 0 6px 6px 0;
                         width: fit-content;
-                        min-height: 22px;
-
-                        .armor-slot {
-                            cursor: pointer;
-                            transition: all 0.3s ease;
-                            font-size: var(--font-size-12);
-
-                            .fa-shield-halved {
-                                color: light-dark(@dark-blue-40, @golden-40);
-                            }
-                        }
-
-                        .slot {
-                            width: 16px;
-                            height: 10px;
-                            border: 1px solid @color-border;
-                            background: light-dark(@dark-blue-10, @golden-10);
-                            border-radius: 3px;
-                            transition: all 0.3s ease;
-                            cursor: pointer;
-
-                            &.filled {
-                                background: light-dark(@dark-blue, @golden);
-                            }
-                        }
                     }
                 }
             }

--- a/templates/sheets/actors/character/sidebar.hbs
+++ b/templates/sheets/actors/character/sidebar.hbs
@@ -23,9 +23,9 @@
                 <div class="status-bar armor-slots">
                     {{#if useResourcePips}}
                     <div class='slot-value'>
-                        <div class="slot-bar">
+                        <div class="slot-bar armor">
                         {{#times document.system.armorScore.max}}
-                            <a class='armor-slot' data-action='toggleArmor' data-value="{{add this 1}}">
+                            <a class="slot" data-action="toggleArmor" data-value="{{add this 1}}">
                                 {{#if (gte ../document.system.armorScore.value (add this 1))}}
                                     <i class="fa-solid fa-shield"></i>
                                 {{else}}
@@ -44,15 +44,15 @@
                     </div>
                     {{else}}
                     <div class='status-value'>
+                        <progress
+                            class='progress-bar stress-color'
+                            value='{{document.system.armorScore.value}}'
+                            max='{{document.system.armorScore.max}}'
+                        ></progress>
                         <input class="bar-input armor-marks-input" value="{{document.system.armorScore.value}}" type="number" id="{{document.uuid}}-armor-slots">
                         <span>/</span>
                         <span class="bar-label">{{document.system.armorScore.max}}</span>
                     </div>
-                    <progress
-                        class='progress-bar stress-color'
-                        value='{{document.system.armorScore.value}}'
-                        max='{{document.system.armorScore.max}}'
-                    ></progress>
                     <a class="status-label" data-action="toggleArmorMangement" {{disabled (not @root.editable)}}>
                         <h4>{{localize "DAGGERHEART.GENERAL.armorSlots"}}</h4>
                         {{#if @root.editable}}<i class="fa-solid fa-gear" inert></i>{{/if}}

--- a/templates/sheets/actors/party/party-members.hbs
+++ b/templates/sheets/actors/party/party-members.hbs
@@ -135,9 +135,9 @@
                                             <span class="max">{{member.armorScore.max}}</span>
                                         </span>
                                     </div>
-                                    <div class="slot-bar">
+                                    <div class="slot-bar armor">
                                         {{#times member.armorScore.max}}
-                                            <a class='armor-slot' data-action='toggleArmorSlot' data-actor-id="{{member.uuid}}" data-value="{{add this 1}}">
+                                            <a class="slot" data-action="toggleArmorSlot" data-actor-id="{{member.uuid}}" data-value="{{add this 1}}">
                                             {{#if (gte member.armorScore.value (add this 1))}}
                                                 <i class="fa-solid fa-shield"></i>
                                             {{else}}

--- a/templates/sheets/global/partials/resource-bar.hbs
+++ b/templates/sheets/global/partials/resource-bar.hbs
@@ -1,35 +1,35 @@
-<div class="status-bar">
-    {{#if useResourcePips}}
-        <div class='slot-value'>
-            <div class="slot-bar">
-                {{#times resource.max}}
-                    <span class='slot {{#if (gte ../resource.value (add this 1))}}filled{{/if}} {{#if ../largePips}}large{{/if}}' data-action="{{../action}}" data-value="{{add this 1}}">
-                    </span>
-                {{/times}}
-            
-                {{#times resource.emptyPips}}
-                    <span class="empty-slot"></span>
-                {{/times}}
-            </div>
-            <div class="slot-label">
-                <span class="label">{{localize label}}</span>
-                <span class="value">{{resource.value}} / {{resource.max}}</span>
-            </div> 
+{{#if useResourcePips}}
+    <div class="slot-value">
+        <div class="slot-bar">
+            {{#times resource.max}}
+                <span class='slot {{#if (gte ../resource.value (add this 1))}}filled{{/if}} {{#if ../largePips}}large{{/if}}' data-action="{{../action}}" data-value="{{add this 1}}">
+                </span>
+            {{/times}}
+        
+            {{#times resource.emptyPips}}
+                <span class="empty-slot"></span>
+            {{/times}}
         </div>
-    {{else}}
+        <div class="slot-label">
+            <span class="label">{{localize label}}</span>
+            <span class="value">{{resource.value}} / {{resource.max}}</span>
+        </div> 
+    </div>
+{{else}}
+    <div class="status-bar">
         <div class='status-value'>
+            <progress
+                class='progress-bar'
+                max='{{resource.max}}'
+                value='{{resource.value}}'
+            ></progress>
             <input class="bar-input" name="{{key}}" min="0" max='{{resource.max}}'
                     value="{{resource.value}}" type="number">
             <span>/</span>
             <span class="bar-label">{{resource.max}}</span>
         </div>
-        <progress
-            class='progress-bar'
-            max='{{resource.max}}'
-            value='{{resource.value}}'
-        ></progress>
-        <div class="status-label">
+        <div class="status-label pointy">
             <h4>{{localize label}}</h4>
         </div>
-    {{/if}}
-</div>
+    </div>
+ {{/if}}

--- a/templates/ui/tooltip/armorManagement.hbs
+++ b/templates/ui/tooltip/armorManagement.hbs
@@ -3,9 +3,9 @@
     {{#each sources as |source|}}
         <div class="armor-source-container">
             <p class="armor-source-label">{{source.name}}</p>
-            <div class="slot-bar">
+            <div class="slot-bar armor">
                 {{#times source.max}}
-                    <a class='armor-slot' data-value="{{add this 1}}" data-uuid="{{source.uuid}}">
+                    <a class="slot" data-value="{{add this 1}}" data-uuid="{{source.uuid}}">
                         {{#if (gte ../current (add this 1))}}
                             <i class="fa-solid fa-shield" data-index="{{this}}"></i>
                         {{else}}


### PR DESCRIPTION
Reduces a lot of extraneous styling and reduces reliance on position absolute for spacing, allowing things to be a bit more responsive and easier to resize and tweak. For example, if I were to hypothetically reduce the width of the adversary sidebar. I also made the pips styling slightly more general than before and removed an unnecessary wrapping element.

There are likely more improvements that could be done, including renaming some of the class names (slot-bar isn't really informative, and slot-value for slot + value is strange) but perhaps that might be better saved for an actual pips rework.

Most things should look the same, however there are a few visual tweaks. Most of them involve borders, but for example this changed:

Before
<img width="303" height="209" alt="image" src="https://github.com/user-attachments/assets/6bb6c032-6a21-472a-91f5-11f8f5999320" />
After
<img width="294" height="174" alt="image" src="https://github.com/user-attachments/assets/16b856e8-9cf2-4d56-a6d8-d72fd4b5b215" />

Files that changed completely are mostly because of carriage returns getting removed automatically by gitattributes (which were not in place when the project was started). If you disable whitespace changes when viewing the diff, they should be easier to read.

This is highly likely to break some UI modules, so it might be worth making a mention in patch notes?