### PR TITLE
Quality: Missing sem declarations in gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,16 +1,15 @@
 // Less configuration
-var gulp = require('gulp');
-var less = require('gulp-less');
-var sourcemaps = require('gulp-sourcemaps');
+const gulp = require('gulp');
+const less = require('gulp-less');
+const sourcemaps = require('gulp-sourcemaps');
 
-gulp.task('less', function (cb) {
-    gulp.src('styles/daggerheart.less')
+gulp.task('less', function () {
+    return gulp.src('styles/daggerheart.less')
         .pipe(sourcemaps.init())
         .pipe(less())
         .on('error', console.error.bind(console))
         .pipe(sourcemaps.write('.'))
         .pipe(gulp.dest('styles'));
-    cb();
 });
 
 gulp.task(


### PR DESCRIPTION
## Summary

Quality: Missing sem declarations in gulpfile.js

## Problem

**Severity**: `Medium` | **File**: `gulpfile.js:L2`

The gulpfile.js uses `var` instead of `const` or `let` for variable declarations, which is an outdated practice. Additionally, the callback `cb` in the 'less' task is called before the asynchronous gulp stream operations complete, which can lead to race conditions where the task reports completion before the Less compilation finishes.

## Solution

Replace `var` with `const` for gulp, less, and sourcemaps. Return the gulp stream from the task instead of calling `cb()`, or properly handle stream completion by calling `cb()` in the `.on('end')` callback. Alternatively, use an async function and return a promise.

## Changes

- `gulpfile.js` (modified)