### PR TITLE
[Fix] item expand state not being retained across rerenders

### DIFF
--- a/module/applications/sheets/api/application-mixin.mjs
+++ b/module/applications/sheets/api/application-mixin.mjs
@@ -305,7 +305,7 @@ export default function DHApplicationMixin(Base) {
         _preSyncPartState(partId, newElement, priorElement, state) {
             super._preSyncPartState(partId, newElement, priorElement, state);
             for (const el of priorElement.querySelectorAll('.extensible.extended')) {
-                const { actionId, itemUuid } = el.parentElement.dataset;
+                const { actionId, itemUuid } = el.closest('[data-item-uuid], [data-action-id]').dataset;
                 const selector = `${actionId ? `[data-action-id="${actionId}"]` : `[data-item-uuid="${itemUuid}"]`} .extensible`;
                 const newExtensible = newElement.querySelector(selector);
                 newExtensible?.classList.add('extended');


### PR DESCRIPTION
This occured last release when I wraped the header and summary in an item main for styling reasons.