### PR TITLE
[Fix] SRD Towering Stalk Fix

### DIFF
--- a/src/packs/domains/domainCard_Towering_Stalk_n0P3VS1WfxvmXbB6.json
+++ b/src/packs/domains/domainCard_Towering_Stalk_n0P3VS1WfxvmXbB6.json
@@ -25,14 +25,6 @@
             "scalable": false,
             "step": null,
             "consumeOnSuccess": false
-          },
-          {
-            "key": "resource",
-            "itemId": "n0P3VS1WfxvmXbB6",
-            "value": 1,
-            "scalable": false,
-            "step": null,
-            "consumeOnSuccess": false
           }
         ],
         "uses": {

--- a/src/packs/domains/domainCard_Towering_Stalk_n0P3VS1WfxvmXbB6.json
+++ b/src/packs/domains/domainCard_Towering_Stalk_n0P3VS1WfxvmXbB6.json
@@ -19,12 +19,20 @@
         "actionType": "action",
         "cost": [
           {
-            "key": "stress",
-            "itemId": null,
-            "value": 1,
+            "consumeOnSuccess": false,
             "scalable": false,
-            "step": null,
-            "consumeOnSuccess": false
+            "key": "stress",
+            "value": 1,
+            "itemId": null,
+            "step": null
+          },
+          {
+            "consumeOnSuccess": false,
+            "scalable": false,
+            "key": "resource",
+            "value": 1,
+            "itemId": "n0P3VS1WfxvmXbB6",
+            "step": null
           }
         ],
         "uses": {
@@ -111,16 +119,17 @@
         "cost": [
           {
             "scalable": false,
-            "key": "hitPoints",
+            "key": "resource",
             "value": 1,
+            "itemId": "n0P3VS1WfxvmXbB6",
             "step": null,
             "consumeOnSuccess": false
           }
         ],
         "uses": {
           "value": null,
-          "max": "1",
-          "recovery": "shortRest"
+          "max": "",
+          "recovery": null
         },
         "effects": [],
         "target": {
@@ -132,7 +141,15 @@
         "range": ""
       }
     },
-    "resource": null,
+    "resource": {
+      "type": "simple",
+      "value": 1,
+      "max": "1",
+      "recovery": "shortRest",
+      "progression": "decreasing",
+      "dieFaces": "d4",
+      "icon": "fa-solid fa-seedling"
+    },
     "attribution": {
       "source": "Daggerheart SRD",
       "page": 130,


### PR DESCRIPTION
Removed a faulty setup for the domain card Towering Stalk.

It's now set up so that it has a resource with a 1 max that refreshes every rest. That resource is needed for either action.