### PR TITLE
[Fix] DamageReductionDialog Conditions

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -622,22 +622,30 @@ export default class DhpActor extends Actor {
         return rollData;
     }
 
-    #canReduceDamage(hpDamage, type) {
-        const { stressDamageReduction, disabledArmor } = this.system.rules.damageReduction;
+    #canReduceDamage(hpDamage, types) {
+        const { stressDamageReduction, disabledArmor, reduceSeverity, thresholdImmunities } = 
+            this.system.rules.damageReduction;
         if (disabledArmor) return false;
 
         const availableStress = this.system.resources.stress.max - this.system.resources.stress.value;
 
         const canUseArmor =
             this.system.armorScore.value < this.system.armorScore.max &&
-            type.every(t => this.system.armorApplicableDamageTypes[t] === true);
+            types.every(t => this.system.armorApplicableDamageTypes[t] === true);
+
         const canUseStress = Object.keys(stressDamageReduction).reduce((acc, x) => {
             const rule = stressDamageReduction[x];
             if (damageKeyToNumber(x) <= hpDamage) return acc || (rule.enabled && availableStress >= rule.cost);
             return acc;
         }, false);
 
-        return canUseArmor || canUseStress;
+        const hasReduceSeverity = types.some(t => reduceSeverity[t]);
+        
+        const hasThresholdImmunity = Object.entries(thresholdImmunities)
+            .filter(([key, value]) => Boolean(value) && damageKeyToNumber(key) === hpDamage)
+            .length;
+
+        return canUseArmor || canUseStress || hasReduceSeverity || hasThresholdImmunity;
     }
 
     async takeDamage(damages, isDirect = false) {


### PR DESCRIPTION
Fixed so that a character having ReduceSeverity or ThresholdImmunity rules are considered for popping the DamageReductionDialog.

Those rules are only used within the dialog, so because it was only opened if armor or stress was available for use, you could be out of armor and not get the benefit of those rules.
We -could- just apply them automatically in that case without a dialog since no choices are to be made - but I think it makes it a lot more clear what's happening to still pop the dialog so they can see that the severity is reduced etc.