### PR TITLE
Support vaulting and unvaulting domain cards via dragdrop

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3233,7 +3233,7 @@
                 "beastformToManyAdvantages": "You cannot select any more advantages.",
                 "beastformToManyFeatures": "You cannot select any more features.",
                 "beastformEquipWeapon": "You cannot use weapons while in a Beastform.",
-                "loadoutMaxReached": "You've reached maximum loadout. Move atleast one domain card to the vault, or increase the limit in homebrew settings if desired.",
+                "loadoutMaxReached": "You've reached the maximum loadout. Move at least one domain card to the vault, or increase the limit in homebrew settings if desired.",
                 "domainMaxReached": "You've reached the maximum domains for the class. Increase the limit in homebrew settings if desired.",
                 "insufficientResources": "You don't have enough resources to use that action.",
                 "actionNoUsesRemaining": "That action doesn't have remaining uses.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -3233,7 +3233,7 @@
                 "beastformToManyAdvantages": "You cannot select any more advantages.",
                 "beastformToManyFeatures": "You cannot select any more features.",
                 "beastformEquipWeapon": "You cannot use weapons while in a Beastform.",
-                "loadoutMaxReached": "You've reached the maximum loadout. Move at least one domain card to the vault, or increase the limit in homebrew settings if desired.",
+                "loadoutMaxReached": "You've reached the maximum loadout size. To add more, move at least one domain card to the vault.",
                 "domainMaxReached": "You've reached the maximum domains for the class. Increase the limit in homebrew settings if desired.",
                 "insufficientResources": "You don't have enough resources to use that action.",
                 "actionNoUsesRemaining": "That action doesn't have remaining uses.",

--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -914,7 +914,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
         const doc = await getDocFromElement(button);
         const { available } = this.document.system.loadoutSlot;
         if (doc.system.inVault && !available && !doc.system.loadoutIgnore) {
-            return ui.notifications.warn(game.i18n.localize('DAGGERHEART.UI.Notifications.loadoutMaxReached'));
+            return ui.notifications.warn('DAGGERHEART.UI.Notifications.loadoutMaxReached', { localize: true });
         }
 
         await doc?.update({ 'system.inVault': !doc.system.inVault });
@@ -1206,10 +1206,22 @@ export default class CharacterSheet extends DHBaseActorSheet {
             if (!confirmed) return;
         }
 
-        if (this.document.uuid === item.parent?.uuid) {
+        // Check for same actor drag/drop attempts
+        const isSameActor = this.document.uuid === item.parent?.uuid;
+        const loadoutFieldset = event.target.closest('[data-in-vault]');
+        const vaulting = loadoutFieldset?.dataset.inVault === 'true';
+        if (isSameActor && loadoutFieldset && item.type === 'domainCard' && vaulting !== item.system.inVault) {
+            // This is likely an attempt to vault or unvault an item
+            const { available } = this.document.system.loadoutSlot;
+            if (!vaulting && !available && !item.system.loadoutIgnore) {
+                return ui.notifications.warn('DAGGERHEART.UI.Notifications.loadoutMaxReached', { localize: true });
+            }
+            return item.update({ 'system.inVault': vaulting });
+        } else if (isSameActor) {
             return super._onDropItem(event, item);
         }
 
+        // Handle beastforms
         if (item.type === 'beastform') {
             if (this.document.effects.find(x => x.type === 'beastform')) {
                 return ui.notifications.warn(

--- a/templates/sheets/actors/character/loadout.hbs
+++ b/templates/sheets/actors/character/loadout.hbs
@@ -28,6 +28,7 @@
         cardView=cardView
         collection=document.system.domainCards.loadout
         canCreate=@root.editable
+        inVault=false
         }}
         {{> 'daggerheart.inventory-items'
         title='DAGGERHEART.GENERAL.Tabs.vault'

--- a/templates/sheets/actors/character/sidebar.hbs
+++ b/templates/sheets/actors/character/sidebar.hbs
@@ -110,7 +110,7 @@
                 {{/each}}
             </ul>
         </div>
-        <div class="loadout-section">
+        <div class="loadout-section" data-in-vault="false">
             <div class="title">
                 <side-line-div class="invert"></side-line-div>
                 <h3>{{localize "DAGGERHEART.GENERAL.loadout"}}</h3>
@@ -118,11 +118,10 @@
             </div>
             <ul class="items-sidebar-list">
                 {{#each document.system.domainCards.loadout as |card|}}
-                {{> 'daggerheart.inventory-item-compact'
-                    item=card
-                    type='domainCard'
-                }}
-
+                    {{> 'daggerheart.inventory-item-compact'
+                        item=card
+                        type='domainCard'
+                    }}
                 {{/each}}
             </ul>
         </div>

--- a/templates/sheets/global/partials/inventory-fieldset-items-V2.hbs
+++ b/templates/sheets/global/partials/inventory-fieldset-items-V2.hbs
@@ -26,7 +26,7 @@ Parameters:
 - showActions {boolean} : If true show feature's actions. 
 --}}
 
-<fieldset class="{{#if isGlassy}}glassy{{/if}} drop-section">
+<fieldset class="{{#if isGlassy}}glassy{{/if}} drop-section" {{#unless (isNullish inVault)}}data-in-vault="{{inVault}}"{{/unless}}>
   <legend>
     {{localize title}}
     {{#if canCreate}}


### PR DESCRIPTION
Hiding whitespace when reviewing makes the crln -> ln auto converted file (loadout.hbs) more readable.