### PR TITLE
[Refactor] remove postEvaluate static method

### DIFF
--- a/module/dice/d20Roll.mjs
+++ b/module/dice/d20Roll.mjs
@@ -185,8 +185,10 @@ export default class D20Roll extends DHRoll {
         return changeKeys;
     }
 
-    static postEvaluate(roll, config = {}) {
-        const data = super.postEvaluate(roll, config);
+    static async buildEvaluate(roll, config = {}, message = {}) {
+        await super.buildEvaluate(roll, config, message);
+
+        const data = config.roll;
         data.type = config.actionType;
         data.difficulty = config.roll.difficulty;
         if (config.targets?.length) {
@@ -222,7 +224,6 @@ export default class D20Roll extends DHRoll {
                 };
             });
         data.modifierTotal = roll.modifierTotal;
-        return data;
     }
 
     resetFormula() {

--- a/module/dice/damageRoll.mjs
+++ b/module/dice/damageRoll.mjs
@@ -13,30 +13,36 @@ export default class DamageRoll extends DHRoll {
 
     static DefaultDialog = DamageDialog;
 
+    /** @inheritdoc */
     static async buildEvaluate(roll, config = {}, message = {}) {
         if (config.dialog.configure === false) roll.constructFormula(config);
-        if (config.evaluate !== false) for (const roll of config.roll) await roll.roll.evaluate();
+        for (const roll of config.roll) await roll.roll.evaluate();
 
         roll._evaluated = true;
 
         const parts = [];
-        for (const roll of config.roll) {
-            parts.push(this.postEvaluate(roll));
-            roll.roll = JSON.stringify(roll.roll.toJSON());
+        for (const rollData of config.roll) {
+            const roll = rollData.roll;
+            parts.push({
+                ...rollData,
+                ...roll.options.roll,
+                total: roll.total,
+                formula: roll.formula,
+                dice: roll.dice.map(d => ({
+                    dice: d.denomination,
+                    total: d.total,
+                    formula: d.formula,
+                    results: d.results
+                })),
+                damageTypes: [...(rollData.damageTypes ?? [])],
+                roll,
+                type: config.type,
+                modifierTotal: this.calculateTotalModifiers(roll)
+            });
+            rollData.roll = JSON.stringify(roll.toJSON());
         }
 
         config.damage = this.unifyDamageRoll(parts);
-    }
-
-    static postEvaluate(roll, config = {}) {
-        return {
-            ...roll,
-            ...super.postEvaluate(roll.roll, config),
-            damageTypes: [...(roll.damageTypes ?? [])],
-            roll: roll.roll,
-            type: config.type,
-            modifierTotal: this.calculateTotalModifiers(roll.roll)
-        };
     }
 
     static async buildPost(roll, config, message) {

--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -33,7 +33,9 @@ export default class DHRoll extends Roll {
 
         if (config.skips?.createMessage) config.messageRoll = roll;
 
-        await this.buildEvaluate(roll, config, (message = {}));
+        if (config.evaluate !== false) {
+            await this.buildEvaluate(roll, config, (message = {}));
+        }
         await this.buildPost(roll, config, (message = {}));
         return config;
     }
@@ -72,27 +74,14 @@ export default class DHRoll extends Roll {
         return roll;
     }
 
+    /** 
+     * Evaluates the roll and assigns roll data into the config. 
+     * This is only called if config.evaluate is not set to false
+     * @protected
+     */
     static async buildEvaluate(roll, config = {}, message = {}) {
-        if (config.evaluate !== false) {
-            await roll.evaluate();
-            config.roll = this.postEvaluate(roll, config);
-        }
-    }
-
-    static async buildPost(roll, config, message) {
-        for (const hook of config.hooks) {
-            if (Hooks.call(`${CONFIG.DH.id}.postRoll${hook.capitalize()}`, config, message) === false) return null;
-        }
-
-        if (config.skips?.createMessage) {
-            await triggerChatRollFx([roll]);
-        } else if (!config.source?.message) {
-            config.message = await this.toMessage(roll, config);
-        }
-    }
-
-    static postEvaluate(roll, config = {}) {
-        return {
+        await roll.evaluate();
+        config.roll = {
             ...roll.options.roll,
             total: roll.total,
             formula: roll.formula,
@@ -103,6 +92,22 @@ export default class DHRoll extends Roll {
                 results: d.results
             }))
         };
+    }
+
+    /** 
+     * Runs any post configuration events that need to happen towards the end, such as hooks and dice so nice 
+     * @protected
+     */
+    static async buildPost(roll, config, message) {
+        for (const hook of config.hooks) {
+            if (Hooks.call(`${CONFIG.DH.id}.postRoll${hook.capitalize()}`, config, message) === false) return null;
+        }
+
+        if (config.skips?.createMessage) {
+            await triggerChatRollFx([roll]);
+        } else if (!config.source?.message) {
+            config.message = await this.toMessage(roll, config);
+        }
     }
 
     static async toMessage(roll, config) {

--- a/module/dice/dualityRoll.mjs
+++ b/module/dice/dualityRoll.mjs
@@ -232,22 +232,10 @@ export default class DualityRoll extends D20Roll {
         return changeKeys;
     }
 
+    /** @inheritdoc */
     static async buildEvaluate(roll, config = {}, message = {}) {
         await super.buildEvaluate(roll, config, message);
-
-        await setDiceSoNiceForDualityRoll(
-            roll,
-            config.roll.advantage.type,
-            config.roll.hope.dice,
-            config.roll.fear.dice,
-            config.roll.advantage.dice
-        );
-    }
-
-    static postEvaluate(roll, config = {}) {
-        const data = super.postEvaluate(roll, config);
-
-        data.hope = {
+        config.roll.hope = {
             dice: roll.dHope.denomination,
             value: this.guaranteedCritical ? 0 : roll.dHope.total,
             rerolled: {
@@ -255,7 +243,7 @@ export default class DualityRoll extends D20Roll {
                 rerolls: roll.dHope.results.filter(x => x.rerolled)
             }
         };
-        data.fear = {
+        config.roll.fear = {
             dice: roll.dFear.denomination,
             value: this.guaranteedCritical ? 0 : roll.dFear.total,
             rerolled: {
@@ -263,11 +251,11 @@ export default class DualityRoll extends D20Roll {
                 rerolls: roll.dFear.results.filter(x => x.rerolled)
             }
         };
-        data.rally = {
+        config.roll.rally = {
             dice: roll.dRally?.denomination,
             value: roll.dRally?.total
         };
-        data.result = {
+        config.roll.result = {
             duality: roll.withHope ? 1 : roll.withFear ? -1 : 0,
             total: this.guaranteedCritical ? 0 : roll.dHope.total + roll.dFear.total,
             label: roll.totalLabel
@@ -275,11 +263,18 @@ export default class DualityRoll extends D20Roll {
 
         if (roll._rallyIndex && roll.data?.parent)
             roll.data.parent.deleteEmbeddedDocuments('ActiveEffect', [roll._rallyIndex]);
-
-        return data;
     }
-
+    
+    /** @inheritdoc */
     static async buildPost(roll, config, message) {
+        await setDiceSoNiceForDualityRoll(
+            roll,
+            config.roll.advantage.type,
+            config.roll.hope.dice,
+            config.roll.fear.dice,
+            config.roll.advantage.dice
+        );
+
         await super.buildPost(roll, config, message);
 
         await DualityRoll.dualityUpdate(config);

--- a/module/dice/fateRoll.mjs
+++ b/module/dice/fateRoll.mjs
@@ -75,25 +75,23 @@ export default class FateRoll extends D20Roll {
         this.terms[0] = new foundry.dice.terms.Die({ faces: 12 });
     }
 
+    /** @inheritdoc */
     static async buildEvaluate(roll, config = {}, message = {}) {
         await super.buildEvaluate(roll, config, message);
+        config.roll.fate = {
+            dice: roll.fateDie === 'Hope' ? roll.dHope.denomination : roll.dFear.denomination,
+            value: roll.fateDie === 'Hope' ? roll.dHope.total : roll.dFear.total,
+            fateDie: roll.fateDie
+        };
+    }
 
+    /** @inheritdoc */
+    static async buildPost(roll, config, message) {
         if (roll.fateDie === 'Hope') {
             await setDiceSoNiceForHopeFateRoll(roll, config.roll.fate.dice);
         } else {
             await setDiceSoNiceForFearFateRoll(roll, config.roll.fate.dice);
         }
-    }
-
-    static postEvaluate(roll, config = {}) {
-        const data = super.postEvaluate(roll, config);
-
-        data.fate = {
-            dice: roll.fateDie === 'Hope' ? roll.dHope.denomination : roll.dFear.denomination,
-            value: roll.fateDie === 'Hope' ? roll.dHope.total : roll.dFear.total,
-            fateDie: roll.fateDie
-        };
-
-        return data;
+        return super.buildPost(roll, config, message);
     }
 }


### PR DESCRIPTION
Needs some heavy testing, so far it seems fine tho,. but I might have missed a spot.

Attempts to remove one of the protected methods of the build pipeline to simplify matters, letting that task be performed by buildEvaluate(). There is one bit of duplication as a result (in damage), but I think in this case the duplication is easier to follow than what was there before.

It would be nice if there is a way to remove buildPost() (leaving the overrides to build()) and/or buildConfigure() but I don't quite know how to do those yet.