### PR TITLE
[Fix] TemplateEnricher Shape Data

### DIFF
--- a/module/enrichers/TemplateEnricher.mjs
+++ b/module/enrichers/TemplateEnricher.mjs
@@ -58,7 +58,7 @@ export const renderMeasuredTemplate = async event => {
     if (!type || !range || !game.canvas.scene) return;
 
     const shapeData = CONFIG.Canvas.layers.regions.layerClass.getTemplateShape({
-        shapetype: type,
+        shapeType: type,
         angle,
         range,
         direction,

--- a/module/enrichers/_module.mjs
+++ b/module/enrichers/_module.mjs
@@ -35,23 +35,24 @@ export const enricherConfig = [
 ];
 
 export const enricherRenderSetup = element => {
+    const clickWrapper = func => event => {
+        event.stopPropagation();
+        func(event);
+    };   
+
     element
         .querySelectorAll('.enriched-damage-button')
-        .forEach(element => element.addEventListener('click', renderDamageButton));
+        .forEach(element => element.addEventListener('click', clickWrapper(renderDamageButton)));
 
     element
         .querySelectorAll('.duality-roll-button')
-        .forEach(element => element.addEventListener('click', renderDualityButton));
+        .forEach(element => element.addEventListener('click', clickWrapper(renderDualityButton)));
 
     element
         .querySelectorAll('.fate-roll-button')
-        .forEach(element => element.addEventListener('click', renderFateButton));
+        .forEach(element => element.addEventListener('click', clickWrapper(renderFateButton)));
 
     element
         .querySelectorAll('.measured-template-button')
-        .forEach(element => element.addEventListener('click', renderMeasuredTemplate));
-
-    // element
-    //     .querySelectorAll('.enriched-effect')
-    //     .forEach(element => element.addEventListener('dragstart', dragEnrichedEffect));
+        .forEach(element => element.addEventListener('click', clickWrapper(renderMeasuredTemplate)));
 };


### PR DESCRIPTION
- Fixed a typo in getTemplateShape that was causing TemplateEnricher buttons to error. 
- Added stopPropagaton when clicking enriched buttons. This stops the description in chat messages from closing when clicking on one.