### PR TITLE
Start supporting flat damage without custom formulas

### DIFF
--- a/module/data/fields/action/damageField.mjs
+++ b/module/data/fields/action/damageField.mjs
@@ -275,10 +275,18 @@ export class DHActionDiceData extends foundry.abstract.DataModel {
         };
     }
 
+    /**
+     * @returns {string} the formula associated with this damage field
+     */
     getFormula() {
-        const multiplier = this.multiplier === 'flat' ? this.flatMultiplier : `@${this.multiplier}`,
-            bonus = this.bonus ? (this.bonus < 0 ? ` - ${Math.abs(this.bonus)}` : ` + ${this.bonus}`) : '';
-        return this.custom.enabled ? this.custom.formula : `${multiplier ?? 1}${this.dice}${bonus}`;
+        if (this.custom.enabled) return this.custom.formula;
+
+        const multiplier = this.multiplier === 'flat' ? this.flatMultiplier : `@${this.multiplier}`;
+        if (!multiplier) return String(this.bonus || 0);
+
+        const dice = `${multiplier ?? 1}${this.dice}`;
+        const sign = this.bonus < 0 ? ' - ' : ' + ';
+        return this.bonus ? `${dice} ${sign} ${Math.abs(this.bonus)}` : dice;
     }
 }
 


### PR DESCRIPTION
This allows a flat modifier of 0 and a bonus of 5 to print `5` instead of `0d6 + 5` in something like an adversary attack's damage formula.

This may be insufficiently exhaustive to be the new way of doing things for minions, but its a start.