### PR TITLE
Adjust styling of secret blocks

### DIFF
--- a/styles/less/global/elements.less
+++ b/styles/less/global/elements.less
@@ -603,7 +603,7 @@
         section.secret {
             background-color: @red-10;
             padding: 0;
-            margin-top: var(--spacer-4);
+            margin-top: 0.375rem;
             &.revealed {
                 background-color: @green-10;
             }
@@ -627,6 +627,12 @@
             font-size: var(--font-size-10);
             user-select: none;
             text-transform: uppercase;
+
+            visibility: hidden;
+        }
+
+        &:hover button.reveal {
+            visibility: visible;
         }
     }
 }

--- a/styles/less/global/elements.less
+++ b/styles/less/global/elements.less
@@ -597,6 +597,38 @@
         font-size: var(--font-size-12);
         padding-left: 3px;
     }
+
+    secret-block {
+        position: relative;
+        section.secret {
+            background-color: @red-10;
+            padding: 0;
+            margin-top: var(--spacer-4);
+            &.revealed {
+                background-color: @green-10;
+            }
+            p {
+                margin: 0.5rem 0;
+            }
+        }
+        button.reveal {
+            --button-size: 0.875rem;
+            position: absolute;
+            margin: auto;
+            left: 0;
+            right: 0;
+            width: min-content;
+            padding: 1px 8px 0 8px;
+            bottom: calc(100% - 0.4375rem - 2px);
+            
+            background-color: var(--dh-window-button-color-bg); // todo: find a better var name
+            border-color: var(--color-secret-border);
+            color: var(--dh-window-button-color-text);
+            font-size: var(--font-size-10);
+            user-select: none;
+            text-transform: uppercase;
+        }
+    }
 }
 
 .system-daggerheart {

--- a/styles/less/global/sheet.less
+++ b/styles/less/global/sheet.less
@@ -36,8 +36,8 @@ body.game:is(.performance-low, .noblur) {
         }
 
         button {
-            background: light-dark(#e8e6e3, @deep-black);
-            color: light-dark(@dark-blue, @beige);
+            background: var(--dh-window-button-color-bg);
+            color: var(--dh-window-button-color-text);
             border: 1px solid light-dark(@dark-blue, transparent);
             padding: 0;
 

--- a/styles/less/utils/colors.less
+++ b/styles/less/utils/colors.less
@@ -107,6 +107,8 @@
         --dh-input-color-text: @dark;
         --dh-trait-color-bg: #b1afb6;
         --dh-trait-color-border: #8e8d96;
+        --dh-window-button-color-bg: #e8e6e3;
+        --dh-window-button-color-text: @dark-blue;
     }
 }
 @scope (.theme-dark) to (.themed) {  
@@ -124,6 +126,8 @@
         --dh-input-color-text: @beige;
         --dh-trait-color-bg: #50433F;
         --dh-trait-color-border: #927952;
+        --dh-window-button-color-bg: @deep-black;
+        --dh-window-button-color-text: @beige;
     }
 }
 


### PR DESCRIPTION
Attempts to clean up the styling of secret blocks. This isn't my preference long term for environment feature notes, but it is a start. Generally pretty similar to the 5e one, though I also made the button only render when hovering.

<img width="1125" height="456" alt="image" src="https://github.com/user-attachments/assets/cc1703df-b009-4867-ac37-33603572ec5e" />

Note that toggling reveal/hide doesn't work from the actor sheet. Given this also happens in 5e, I suspect its a foundry bug.