### PR TITLE
[Fix] chat messages with list items or weapon/armor features

### DIFF
--- a/module/data/item/base.mjs
+++ b/module/data/item/base.mjs
@@ -143,7 +143,7 @@ export default class BaseDataItem extends foundry.abstract.TypeDataModel {
     /**
      * Gets the enriched and augmented description for the item.
      * @param {object} [options] - Options that modify the styling of the rendered template. { headerStyle: undefined|'none'|'large' }
-     * @returns {string}
+     * @returns {Promise<string>}
      */
     async getEnrichedDescription() {
         if (!this.metadata.hasDescription) return '';

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -208,10 +208,7 @@ export default class DHItem extends foundry.documents.Item {
                 tags: this._getTags()
             },
             actions: item.system.actionsList,
-            description: await foundry.applications.ux.TextEditor.implementation.enrichHTML(this.system.description, {
-                relativeTo: this.parent,
-                rollData: this.parent?.getRollData() ?? {}
-            })
+            description: await this.system.getEnrichedDescription()
         };
 
         const msg = {

--- a/styles/less/global/inventory-item.less
+++ b/styles/less/global/inventory-item.less
@@ -163,37 +163,7 @@
                 }
                 .inventory-description {
                     overflow: hidden;
-
-                    h1 {
-                        font-size: var(--font-size-32);
-                    }
-                    h2 {
-                        font-size: var(--font-size-28);
-                        font-weight: 600;
-                    }
-                    h3 {
-                        font-size: var(--font-size-20);
-                        font-weight: 600;
-                    }
-                    h4 {
-                        font-size: var(--font-size-16);
-                        color: @beige;
-                        font-weight: 600;
-                    }
-
-                    ul,
-                    ol {
-                        margin: 1rem 0;
-                        padding: 0 0 0 1.25rem;
-
-                        li {
-                            margin-bottom: 0.25rem;
-                        }
-                    }
-
-                    ul {
-                        list-style: disc;
-                    }
+                    .typography();
                 }
             }
             .item-resources {

--- a/styles/less/global/prose-mirror.less
+++ b/styles/less/global/prose-mirror.less
@@ -14,36 +14,7 @@
         }
         .editor-content {
             .with-scroll-shadows();
-            h1 {
-                font-size: var(--font-size-32);
-            }
-            h2 {
-                font-size: var(--font-size-28);
-                font-weight: 600;
-            }
-            h3 {
-                font-size: var(--font-size-20);
-                font-weight: 600;
-            }
-            h4 {
-                font-size: var(--font-size-16);
-                color: light-dark(@dark, @beige);
-                font-weight: 600;
-            }
-
-            ul,
-            ol {
-                margin: 1rem 0;
-                padding: 0 0 0 1.25rem;
-
-                li {
-                    margin-bottom: 0.25rem;
-                }
-            }
-
-            ul {
-                list-style: disc;
-            }
+            .typography();
         }
         // Fixes centering and makes it not render over scrollbar
         &:hover button.toggle:enabled {

--- a/styles/less/ui/chat/ability-use.less
+++ b/styles/less/ui/chat/ability-use.less
@@ -117,7 +117,9 @@
         }
 
         .description {
-            padding: 8px;
+            padding: 0;
+            margin: 8px;
+            .typography();
         }
 
         .ability-card-footer {

--- a/styles/less/utils/mixin.less
+++ b/styles/less/utils/mixin.less
@@ -204,3 +204,37 @@
     scrollbar-gutter: stable;
     .with-scroll-shadows();
 }
+
+/** Typography stylings for most longform text, usually item descriptions */
+.typography() {
+    h1 {
+        font-size: var(--font-size-32);
+    }
+    h2 {
+        font-size: var(--font-size-28);
+        font-weight: 600;
+    }
+    h3 {
+        font-size: var(--font-size-20);
+        font-weight: 600;
+    }
+    h4 {
+        font-size: var(--font-size-16);
+        color: light-dark(@dark, @beige);
+        font-weight: 600;
+    }
+
+    ul,
+    ol {
+        margin: 1rem 0;
+        padding: 0 0 0 1.25rem;
+
+        li {
+            margin-bottom: 0.25rem;
+        }
+    }
+
+    ul {
+        list-style: disc;
+    }
+}


### PR DESCRIPTION
Fixes item chat descriptions for items that have list items (such as from some environments) or have addends or prepends (such as weapon/armor abilities). There's also a minor beneath notice styling change where descriptions now have a nicer gap from the header (margins overlap, paddings don't).

This is something I caught while testing gm notes (ongoing feature im working on)