### PR TITLE
[Fix] Summon Wildcard Handling

### DIFF
--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -256,7 +256,8 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
 
         if (Hooks.call(`${CONFIG.DH.id}.postUseAction`, this, config) === false) return;
 
-        if (this.chatDisplay && !config.skips.createMessage && !config.actionChatMessageHandled) await this.toChat();
+        if (this.chatDisplay && !config.skips.createMessage && !config.actionChatMessageHandled) 
+            await this.toChat(null, config);
 
         return config;
     }

--- a/module/data/fields/action/summonField.mjs
+++ b/module/data/fields/action/summonField.mjs
@@ -23,7 +23,7 @@ export default class DHSummonField extends fields.ArrayField {
         super(summonFields, options, context);
     }
 
-    static async execute() {
+    static async execute(config) {
         if (!canvas.scene) {
             ui.notifications.warn(game.i18n.localize('DAGGERHEART.ACTIONS.TYPES.summon.error'));
             return;
@@ -36,6 +36,7 @@ export default class DHSummonField extends fields.ArrayField {
 
         const rolls = [];
         const summonData = [];
+        const chatMessageData = [];
         for (const summon of this.summon) {
             const roll = new Roll(itemAbleRollParse(summon.count, this.actor, this.item));
             await roll.evaluate();
@@ -54,17 +55,18 @@ export default class DHSummonField extends fields.ArrayField {
                     tokenPreviewName: `${actor.prototypeToken.name}${remaining > 1 ? ` (${remaining}x)` : ''}`
                 });
             }
+
+            chatMessageData.push({
+                data: actor,
+                quantity: countNumber
+            });
         }
 
         if (rolls.length) await triggerChatRollFx(rolls);
 
         this.actor.sheet?.minimize();
-        DHSummonField.handleSummon(summonData, this.actor);
-    }
-
-    static async handleSummon(summonData, actionActor) {
-        await CONFIG.ux.TokenManager.createTokensWithPreview(summonData, { elevation: actionActor.token?.elevation });
-
-        return actionActor.sheet?.maximize();
+        await CONFIG.ux.TokenManager.createTokensWithPreview(summonData, { elevation: this.actor.token?.elevation });
+        this.actor.sheet?.maximize();
+        config.summonData = chatMessageData;
     }
 }

--- a/module/data/fields/actionField.mjs
+++ b/module/data/fields/actionField.mjs
@@ -269,7 +269,7 @@ export function ActionMixin(Base) {
             return this.delete();
         }
 
-        async toChat(origin) {
+        async toChat(origin, config) {
             const autoExpandDescription = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.appearance)
                 .expandRollMessage?.desc;
 
@@ -282,7 +282,7 @@ export function ActionMixin(Base) {
                     img: this.baseAction ? this.parent.parent.img : this.img,
                     tags: this.tags ? this.tags : ['Spell', 'Arcana', 'Lv 10'],
                     areas: this.areas,
-                    summon: this.summon
+                    summon: config?.summonData
                 },
                 source: {
                     actor: this.actor.uuid,

--- a/module/documents/tokenManager.mjs
+++ b/module/documents/tokenManager.mjs
@@ -22,7 +22,7 @@ export default class DhTokenManager {
         return await canvas.tokens.placeTokens(
             [
                 {
-                    ...actor.prototypeToken.toObject(),
+                    ...(await actor.getTokenDocument()).toObject(),
                     actorId: actor.id,
                     displayName: 50,
                     ...tokenData

--- a/module/documents/tokenManager.mjs
+++ b/module/documents/tokenManager.mjs
@@ -19,7 +19,7 @@ export default class DhTokenManager {
             }
         }
 
-        return await canvas.tokens.placeTokens(
+        const placedData = await canvas.tokens.placeTokens(
             [
                 {
                     ...(await actor.getTokenDocument()).toObject(),
@@ -30,6 +30,10 @@ export default class DhTokenManager {
             ],
             { create: false }
         );
+
+        if (!placedData.length) return null;
+
+        return placedData[0];
     }
 
     /**
@@ -46,22 +50,24 @@ export default class DhTokenManager {
 
         const createElevation = elevation ?? level.elevation.bottom;
         for (const tokenData of tokensData) {
-            const previewTokens = await this.createPreview(tokenData.actor, {
+            const previewToken = await this.createPreview(tokenData.actor, {
                 name: tokenData.tokenPreviewName,
                 level: game.user.viewedLevel,
                 elevation: createElevation,
                 flags: { daggerheart: { createPlacement: true } }
             });
-            if (!previewTokens?.length) return null;
+            if (!previewToken) return null;
+
+            const finalTokenData = {
+                ...previewToken.toObject(),
+                name: tokenData.actor.prototypeToken.name,
+                displayName: tokenData.actor.prototypeToken.displayName,
+                flags: tokenData.actor.prototypeToken.flags
+            };
 
             await canvas.scene.createEmbeddedDocuments(
                 'Token',
-                previewTokens.map(x => ({
-                    ...x.toObject(),
-                    name: tokenData.actor.prototypeToken.name,
-                    displayName: tokenData.actor.prototypeToken.displayName,
-                    flags: tokenData.actor.prototypeToken.flags
-                })),
+                [finalTokenData],
                 { controlObject: true, parent: canvas.scene }
             );
         }

--- a/module/documents/tokenManager.mjs
+++ b/module/documents/tokenManager.mjs
@@ -31,9 +31,7 @@ export default class DhTokenManager {
             { create: false }
         );
 
-        if (!placedData.length) return null;
-
-        return placedData[0];
+        return placedData[0] ?? null;
     }
 
     /**

--- a/templates/ui/chat/action.hbs
+++ b/templates/ui/chat/action.hbs
@@ -16,10 +16,10 @@
                     {{#each action.summon}}
                         <div class="summon-container">
                             <div class="summon-label-container">
-                                <img src="{{this.actor.img}}" />
-                                <label>{{this.actor.name}}</label>
+                                <img src="{{this.data.img}}" />
+                                <label>{{this.data.name}}</label>
                             </div>
-                            <span># {{this.rolledCount}}</span>
+                            <span># {{this.quantity}}</span>
                         </div>
                     {{/each}}
                 </div>


### PR DESCRIPTION
- Fixed to using Foundry's inbuilt tokenDocument data creator (`actor.getTokenDocument()`) so that wildcard token image paths get handled as expected. It was previously erroring out on wildcard paths since it was just trying to resolve an image on that exact path, which doesn't exist.
- Fixed ChatMessage data for summon actions. The summary text in the chat message for how many summons were created wasn't being passed along.
<img width="365" height="227" alt="image" src="https://github.com/user-attachments/assets/541600cd-ba29-423f-bf99-118477c96c4b" />
I fixed this by passing along the data in the config. Unsure if we could do it some other way.