### PR TITLE
[Fix] Preserve description expand state on re-render

### DIFF
--- a/module/applications/dialogs/deathMove.mjs
+++ b/module/applications/dialogs/deathMove.mjs
@@ -185,8 +185,6 @@ export default class DhDeathMove extends HandlebarsApplicationMixin(ApplicationV
 
         if (result === undefined) return;
 
-        const autoExpandDescription = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.appearance)
-            .expandRollMessage?.desc;
         const cls = getDocumentClass('ChatMessage');
 
         const msg = {
@@ -202,7 +200,6 @@ export default class DhDeathMove extends HandlebarsApplicationMixin(ApplicationV
                     img: this.selectedMove.img,
                     description: game.i18n.localize(this.selectedMove.description),
                     result: result,
-                    open: autoExpandDescription ? 'open' : '',
                     showRiskItAllButton: this.showRiskItAllButton,
                     riskItAllButtonLabel: this.riskItAllButtonLabel,
                     riskItAllHope: this.riskItAllHope

--- a/module/applications/dialogs/downtime.mjs
+++ b/module/applications/dialogs/downtime.mjs
@@ -196,9 +196,6 @@ export default class DhpDowntime extends HandlebarsApplicationMixin(ApplicationV
             .filter(x => x.testUserPermission(game.user, 'LIMITED'))
             .filter(x => x.uuid !== this.actor.uuid);
 
-        const autoExpandDescription = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.appearance)
-            .expandRollMessage?.desc;
-
         const cls = getDocumentClass('ChatMessage');
         const msg = {
             user: game.user.id,
@@ -219,8 +216,7 @@ export default class DhpDowntime extends HandlebarsApplicationMixin(ApplicationV
                     actor: { name: this.actor.name, img: this.actor.img },
                     moves: moves,
                     characters: characters,
-                    selfId: this.actor.uuid,
-                    open: autoExpandDescription ? 'open' : ''
+                    selfId: this.actor.uuid
                 }
             ),
             flags: {

--- a/module/data/fields/actionField.mjs
+++ b/module/data/fields/actionField.mjs
@@ -270,9 +270,6 @@ export function ActionMixin(Base) {
         }
 
         async toChat(origin, config) {
-            const autoExpandDescription = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.appearance)
-                .expandRollMessage?.desc;
-
             const cls = getDocumentClass('ChatMessage');
             const systemData = {
                 title: game.i18n.localize('DAGGERHEART.CONFIG.FeatureForm.action'),
@@ -307,7 +304,7 @@ export function ActionMixin(Base) {
                 system: systemData,
                 content: await foundry.applications.handlebars.renderTemplate(
                     'systems/daggerheart/templates/ui/chat/action.hbs',
-                    { ...systemData, open: autoExpandDescription ? 'open' : '' }
+                    systemData
                 ),
                 flags: {
                     daggerheart: {

--- a/module/documents/chatMessage.mjs
+++ b/module/documents/chatMessage.mjs
@@ -3,6 +3,13 @@ import { emitGMUpdate, emitGMCreate, GMUpdateEvent } from '../systemRegistration
 export default class DhpChatMessage extends foundry.documents.ChatMessage {
     targetHook = null;
 
+    static #EXPAND_SECTIONS = [
+        { selector: 'roll-section [data-action="expandRoll"]', key: 'roll' },
+        { selector: 'damage-section', key: 'damage' },
+        { selector: 'target-section', key: 'target' },
+        { selector: 'description-section', key: 'desc' }
+    ];
+
     async renderHTML() {
         const actor = game.actors.get(this.speaker.actor);
         const actorData =
@@ -89,23 +96,26 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
                 }
             }
 
+            // Check registered selectors and the main item section for expanding
+            // Preserving during re-render is handled by core foundry on anything with [data-action=expandRoll]
             const autoExpandRoll = game.settings.get(
-                    CONFIG.DH.id,
-                    CONFIG.DH.SETTINGS.gameSettings.appearance
-                ).expandRollMessage,
-                rollSections = html.querySelectorAll('.roll-part'),
-                itemDesc = html.querySelector('.domain-card-move');
-            rollSections.forEach(s => {
-                if (s.classList.contains('roll-section')) {
-                    const toExpand = s.querySelector('[data-action="expandRoll"]');
-                    toExpand.classList.toggle('expanded', autoExpandRoll.roll);
-                } else if (s.classList.contains('damage-section'))
-                    s.classList.toggle('expanded', autoExpandRoll.damage);
-                else if (s.classList.contains('target-section')) s.classList.toggle('expanded', autoExpandRoll.target);
-                else if (s.classList.contains('description-section'))
-                    s.classList.toggle('expanded', autoExpandRoll.desc);
-            });
-            if (itemDesc && autoExpandRoll.desc) itemDesc.setAttribute('open', '');
+                CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.appearance
+            ).expandRollMessage;
+            for (const { selector, key } of DhpChatMessage.#EXPAND_SECTIONS) {
+                const elements = html.querySelectorAll(selector);
+                for (const element of elements) {
+                    element.classList.toggle('expanded', autoExpandRoll[key]);
+                }
+            }
+
+            // Auto expand the item description. These are not preserved by foundry during re-renders
+            const itemDesc = html.querySelector('details');
+            if (itemDesc) {
+                const existing = document.querySelector(`.chat-message[data-message-id="${this.id}"] details`);
+                if (existing?.hasAttribute('open') ?? autoExpandRoll.desc) {
+                    itemDesc.setAttribute('open', '');
+                }
+            }
         }
 
         if (!this.isAuthor && !this.speakerActor?.isOwner) {


### PR DESCRIPTION
any `<details>` elements are not preserved by foundry, and in general it was previously rejected: https://github.com/foundryvtt/foundryvtt/issues/12063

So we gotta do it ourselves.