### PR TITLE
[Fix] 2094 - Critical Damage

### DIFF
--- a/module/applications/dialogs/damageDialog.mjs
+++ b/module/applications/dialogs/damageDialog.mjs
@@ -121,7 +121,14 @@ export default class DamageDialog extends HandlebarsApplicationMixin(Application
     }
 
     static async submitRoll() {
+        const isCritical = this.config.isCritical;
         const { damageFormula, resourceFormulas } = this.roll.constructFormulas({ ...this.config, isCritical: false }); 
+        /* Sideeffect occuring in constructFormulas that sets this.config.isCritical to the false value. Can remove the below if it can be prevented */
+        this.config.isCritical = isCritical;
+        damageFormula.roll.options.isCritical = isCritical;
+        for (const formula of resourceFormulas)
+            formula.roll.options.isCritical = isCritical;
+
         this.config.damageFormula = damageFormula;
         this.config.resourceFormulas = resourceFormulas;
         await this.close({ submitted: true });

--- a/module/applications/dialogs/damageDialog.mjs
+++ b/module/applications/dialogs/damageDialog.mjs
@@ -6,6 +6,7 @@ export default class DamageDialog extends HandlebarsApplicationMixin(Application
 
         this.roll = roll;
         this.config = config;
+        this.originalIsCritical = config.isCritical;
         this.selectedEffects = this.config.bonusEffects;
     }
 
@@ -121,13 +122,16 @@ export default class DamageDialog extends HandlebarsApplicationMixin(Application
     }
 
     static async submitRoll() {
-        const isCritical = this.config.isCritical;
         const { damageFormula, resourceFormulas } = this.roll.constructFormulas({ ...this.config, isCritical: false }); 
         /* Sideeffect occuring in constructFormulas that sets this.config.isCritical to the false value. Can remove the below if it can be prevented */
-        this.config.isCritical = isCritical;
-        damageFormula.roll.options.isCritical = isCritical;
-        for (const formula of resourceFormulas)
-            formula.roll.options.isCritical = isCritical;
+        this.config.isCritical = this.originalIsCritical;
+
+        /* If a critical has been forced in the Dialog, save that forced state to the damage roll */
+        if (this.config.isCritical && !this.originalIsCritical) {
+            damageFormula.roll.options.isCritical = true;
+            for (const formula of resourceFormulas)
+                formula.roll.options.isCritical = true;
+        }
 
         this.config.damageFormula = damageFormula;
         this.config.resourceFormulas = resourceFormulas;

--- a/module/applications/dialogs/damageDialog.mjs
+++ b/module/applications/dialogs/damageDialog.mjs
@@ -6,6 +6,10 @@ export default class DamageDialog extends HandlebarsApplicationMixin(Application
 
         this.roll = roll;
         this.config = config;
+        
+        /** The original isCritical state before any alterations in the dialog. 
+         * Used for checking if the state has been altered 
+         */  
         this.originalIsCritical = config.isCritical;
         this.selectedEffects = this.config.bonusEffects;
     }
@@ -122,15 +126,18 @@ export default class DamageDialog extends HandlebarsApplicationMixin(Application
     }
 
     static async submitRoll() {
-        const { damageFormula, resourceFormulas } = this.roll.constructFormulas({ ...this.config, isCritical: false }); 
         /* Sideeffect occuring in constructFormulas that sets this.config.isCritical to the false value. Can remove the below if it can be prevented */
-        this.config.isCritical = this.originalIsCritical;
+        const sideEffectSafeIsCritical = this.config.isCritical;
+        const { damageFormula, resourceFormulas } = this.roll.constructFormulas({ ...this.config, isCritical: false }); 
 
-        /* If a critical has been forced in the Dialog, save that forced state to the damage roll */
-        if (this.config.isCritical && !this.originalIsCritical) {
-            damageFormula.roll.options.isCritical = true;
+        this.config.isCritical = sideEffectSafeIsCritical;
+
+        /* If the isCritical state has been altered in the dialog, we update the roll options */
+        if (this.config.isCritical !== this.originalIsCritical) {
+            damageFormula.roll.options.isCritical = this.config.isCritical;
+
             for (const formula of resourceFormulas)
-                formula.roll.options.isCritical = true;
+                formula.roll.optionsisCritical = this.config.isCritical;
         }
 
         this.config.damageFormula = damageFormula;

--- a/module/applications/dialogs/damageDialog.mjs
+++ b/module/applications/dialogs/damageDialog.mjs
@@ -121,6 +121,9 @@ export default class DamageDialog extends HandlebarsApplicationMixin(Application
     }
 
     static async submitRoll() {
+        const { damageFormula, resourceFormulas } = this.roll.constructFormulas({ ...this.config, isCritical: false }); 
+        this.config.damageFormula = damageFormula;
+        this.config.resourceFormulas = resourceFormulas;
         await this.close({ submitted: true });
     }
 

--- a/module/applications/dialogs/tagTeamDialog.mjs
+++ b/module/applications/dialogs/tagTeamDialog.mjs
@@ -184,8 +184,8 @@ export default class TagTeamDialog extends HandlebarsApplicationMixin(Applicatio
                     ? undefined
                     : (selectedRoll?.roll?.isCritical ?? false);
 
-                partContext.hintText = await this.getInfoTexts(this.party.system.tagTeam.members);
-                partContext.joinedRoll = await this.getJoinedRoll({
+                partContext.hintText = this.getInfoTexts(this.party.system.tagTeam.members);
+                partContext.joinedRoll = this.getJoinedRoll({
                     overrideIsCritical: critSelected,
                     displayVersion: true
                 });
@@ -194,7 +194,7 @@ export default class TagTeamDialog extends HandlebarsApplicationMixin(Applicatio
         }
 
         if (Object.keys(this.party.system.tagTeam.members).includes(partId)) {
-            const data = await this.#prepareMemberContext(partId);
+            const data = this.#prepareMemberContext(partId);
             partContext.hasDamage |= Boolean(data?.damage);
             partContext.members[partId] = data;
         }
@@ -202,7 +202,7 @@ export default class TagTeamDialog extends HandlebarsApplicationMixin(Applicatio
         return partContext;
     }
 
-    async #prepareMemberContext(partId) {
+    #prepareMemberContext(partId) {
         const data = this.party.system.tagTeam.members[partId] ?? {};
         const actor = game.actors.get(partId);
         if (!actor) console.error(`Failed to get actor ${partId}`);
@@ -248,7 +248,7 @@ export default class TagTeamDialog extends HandlebarsApplicationMixin(Applicatio
             rollOptions,
             damageRollOptions,
             damage: data.damageRollData,
-            critDamage: await this.getCriticalDamage(data.damageRollData),
+            critDamage: this.getCriticalDamage(data.damageRollData),
             useCritDamage: critSelected || (critSelected === undefined && data.roll?.isCritical)
         };
     }
@@ -374,7 +374,7 @@ export default class TagTeamDialog extends HandlebarsApplicationMixin(Applicatio
     //#endregion
     //#region Tag Team Roll
 
-    async getInfoTexts(members) {
+    getInfoTexts(members) {
         let rollsAreFinished = true;
         let rollIsSelected = false;
         for (const member of Object.values(members)) {
@@ -579,14 +579,14 @@ export default class TagTeamDialog extends HandlebarsApplicationMixin(Applicatio
         );
     }
 
-    async getCriticalDamage(origDamage) {
+    getCriticalDamage(origDamage) {
         const newDamage = origDamage ? ChatDamageData.fromJSON(JSON.stringify(origDamage)) : null;
         if (newDamage?.main) {
-            const criticalDamage = await getCritDamageBonus(newDamage.main.formula);
+            const criticalDamage = getCritDamageBonus(newDamage.main.terms);
             if (criticalDamage) {
                 const criticalTerm = new foundry.dice.terms.NumericTerm({ number: criticalDamage, evaluated: true });
                 criticalTerm.evaluate();
-                newDamage.main = await Roll.fromTerms([
+                newDamage.main = Roll.fromTerms([
                     ...origDamage.main.terms,
                     new foundry.dice.terms.OperatorTerm({ operator: '+' }),
                     criticalTerm
@@ -620,7 +620,7 @@ export default class TagTeamDialog extends HandlebarsApplicationMixin(Applicatio
         );
     }
 
-    async getJoinedRoll({ overrideIsCritical, displayVersion } = {}) {
+    getJoinedRoll({ overrideIsCritical, displayVersion } = {}) {
         try {
             const memberValues = Object.values(this.party.system.tagTeam.members);
             const selectedRoll = memberValues.find(x => x.selected);
@@ -641,11 +641,11 @@ export default class TagTeamDialog extends HandlebarsApplicationMixin(Applicatio
                 ChatDamageData.fromJSON(JSON.stringify(baseSecondaryRoll.damageRollData)) : null;
 
             const isCritical = overrideIsCritical ?? mainRoll.roll.isCritical;
-            if (isCritical) mainRoll.damageRollData = await this.getCriticalDamage(mainRoll.damageRollData);
+            if (isCritical) mainRoll.damageRollData = this.getCriticalDamage(mainRoll.damageRollData);
 
             if (secondaryRoll.damageRollData) {
                 const secondaryDamage = (displayVersion ? overrideIsCritical : isCritical)
-                    ? await this.getCriticalDamage(secondaryRoll.damageRollData)
+                    ? this.getCriticalDamage(secondaryRoll.damageRollData)
                     : secondaryRoll.damageRollData;
                 if (mainRoll.damageRollData) {
                     if (secondaryDamage.main) {
@@ -741,7 +741,7 @@ export default class TagTeamDialog extends HandlebarsApplicationMixin(Applicatio
         const error = this.checkInitiatorHopeError(this.party.system.tagTeam.initiator);
         if (error) return error;
 
-        const joinedRoll = await this.getJoinedRoll();
+        const joinedRoll = this.getJoinedRoll();
         const mainRoll = joinedRoll.rollData;
         const finalRoll = foundry.utils.deepClone(joinedRoll.roll);
 

--- a/module/applications/dialogs/tagTeamDialog.mjs
+++ b/module/applications/dialogs/tagTeamDialog.mjs
@@ -2,7 +2,7 @@ import { ResourceUpdateMap } from '../../data/action/baseAction.mjs';
 import { ChatDamageData } from '../../data/chat-message/chatDamageData.mjs';
 import { MemberData } from '../../data/tagTeamData.mjs';
 import DamageRoll from '../../dice/damageRoll.mjs';
-import { getCritDamageBonus, shouldUseHopeFearAutomation } from '../../helpers/utils.mjs';
+import { shouldUseHopeFearAutomation } from '../../helpers/utils.mjs';
 import { emitGMUpdate, GMUpdateEvent, RefreshType, socketEvent } from '../../systemRegistration/socket.mjs';
 import PartySheet from '../sheets/actors/party.mjs';
 
@@ -581,25 +581,6 @@ export default class TagTeamDialog extends HandlebarsApplicationMixin(Applicatio
             },
             this.getUpdatingParts(button)
         );
-    }
-
-    getCriticalDamage(origDamage) {
-        const newDamage = origDamage ? ChatDamageData.fromJSON(JSON.stringify(origDamage)) : null;
-        if (newDamage?.main) {
-            const criticalDamage = getCritDamageBonus(newDamage.main.terms);
-            if (criticalDamage) {
-                const criticalTerm = new foundry.dice.terms.NumericTerm({ number: criticalDamage, evaluated: true });
-                criticalTerm.evaluate();
-                newDamage.main = Roll.fromTerms([
-                    ...origDamage.main.terms,
-                    new foundry.dice.terms.OperatorTerm({ operator: '+' }),
-                    criticalTerm
-                ]);
-                newDamage.main.options = foundry.utils.deepClone(origDamage.main.options);
-            }
-        } 
-
-        return newDamage;
     }
 
     static async #selectRoll(_, button) {

--- a/module/applications/dialogs/tagTeamDialog.mjs
+++ b/module/applications/dialogs/tagTeamDialog.mjs
@@ -682,7 +682,6 @@ export default class TagTeamDialog extends HandlebarsApplicationMixin(Applicatio
                 mainRoll.damageRollData.main.options.isCritical = isCritical;
             }
 
-
             return mainRoll;
         } catch (err) {
             console.error(err);

--- a/module/applications/dialogs/tagTeamDialog.mjs
+++ b/module/applications/dialogs/tagTeamDialog.mjs
@@ -1,6 +1,7 @@
 import { ResourceUpdateMap } from '../../data/action/baseAction.mjs';
 import { ChatDamageData } from '../../data/chat-message/chatDamageData.mjs';
 import { MemberData } from '../../data/tagTeamData.mjs';
+import DamageRoll from '../../dice/damageRoll.mjs';
 import { getCritDamageBonus, shouldUseHopeFearAutomation } from '../../helpers/utils.mjs';
 import { emitGMUpdate, GMUpdateEvent, RefreshType, socketEvent } from '../../systemRegistration/socket.mjs';
 import PartySheet from '../sheets/actors/party.mjs';
@@ -235,8 +236,12 @@ export default class TagTeamDialog extends HandlebarsApplicationMixin(Applicatio
             }
         }
 
-        const selectedRoll = Object.values(this.party.system.tagTeam.members).find(member => member.selected);
-        const critSelected = !selectedRoll ? undefined : (selectedRoll?.roll?.isCritical ?? false);
+        if (data.damageRollData.main) {
+            const selectedRoll = Object.values(this.party.system.tagTeam.members).find(member => member.selected);
+            const critSelected = !selectedRoll ? undefined : (selectedRoll?.roll?.isCritical ?? false);
+            const useCritDamage = critSelected || (critSelected === undefined && data.roll?.isCritical);
+            data.damageRollData.main.options.isCritical = useCritDamage;
+        }
 
         return {
             ...data,
@@ -249,7 +254,7 @@ export default class TagTeamDialog extends HandlebarsApplicationMixin(Applicatio
             damageRollOptions,
             damage: data.damageRollData,
             critDamage: this.getCriticalDamage(data.damageRollData),
-            useCritDamage: critSelected || (critSelected === undefined && data.roll?.isCritical)
+            useCritDamage: false
         };
     }
 
@@ -640,17 +645,13 @@ export default class TagTeamDialog extends HandlebarsApplicationMixin(Applicatio
             secondaryRoll.damageRollData = baseSecondaryRoll.damageRollData ? 
                 ChatDamageData.fromJSON(JSON.stringify(baseSecondaryRoll.damageRollData)) : null;
 
-            const isCritical = overrideIsCritical ?? mainRoll.roll.isCritical;
-            if (isCritical) mainRoll.damageRollData = this.getCriticalDamage(mainRoll.damageRollData);
-
             if (secondaryRoll.damageRollData) {
-                const secondaryDamage = (displayVersion ? overrideIsCritical : isCritical)
-                    ? this.getCriticalDamage(secondaryRoll.damageRollData)
-                    : secondaryRoll.damageRollData;
+                const secondaryDamage = secondaryRoll.damageRollData;
+
                 if (mainRoll.damageRollData) {
                     if (secondaryDamage.main) {
                         if (mainRoll.damageRollData.main) {
-                            mainRoll.damageRollData.main = Roll.fromTerms([
+                            mainRoll.damageRollData.main = DamageRoll.fromTerms([
                                 ...baseMainRoll.damageRollData.main.terms,
                                 new foundry.dice.terms.OperatorTerm({ operator: '+' }),
                                 ...baseSecondaryRoll.damageRollData.main.terms
@@ -672,7 +673,7 @@ export default class TagTeamDialog extends HandlebarsApplicationMixin(Applicatio
 
                     for (const [key, damage] of Object.entries(secondaryDamage.resources ?? {})) {
                         if (key in mainRoll.damageRollData.resources) {
-                            mainRoll.damageRollData.resources[key] = Roll.fromTerms([
+                            mainRoll.damageRollData.resources[key] = DamageRoll.fromTerms([
                                 ...baseMainRoll.damageRollData.resources[key].terms,
                                 new foundry.dice.terms.OperatorTerm({ operator: '+' }),
                                 ...baseSecondaryRoll.damageRollData.resources[key].terms
@@ -695,6 +696,12 @@ export default class TagTeamDialog extends HandlebarsApplicationMixin(Applicatio
                     mainRoll.damageRollData = secondaryDamage;
                 }
             }
+
+            if (mainRoll.damageRollData.main) {
+                const isCritical = overrideIsCritical ?? mainRoll.roll.isCritical;
+                mainRoll.damageRollData.main.options.isCritical = isCritical;
+            }
+
 
             return mainRoll;
         } catch (err) {
@@ -755,7 +762,11 @@ export default class TagTeamDialog extends HandlebarsApplicationMixin(Applicatio
         };
 
         if (joinedRoll.damageRollData.main) {
-            systemData.damage.main = joinedRoll.damageRollData.toJSON();
+            systemData.damage.main = joinedRoll.damageRollData.main.toJSON();
+            // isCritical is used internally in TagTeamDialog to force-flip damage from normal to critical and vice versa. 
+            // It's deleted here to avoid interupting normal critical damage logic in the chatMessage.
+            // If someone explicitly set their own damage roll to be a forced critical, then I think it's fine that isn't transmitted to the final joined roll.
+            delete systemData.damage.main.options.isCritical;
         }
         for (const type of Object.keys(joinedRoll.damageRollData?.resources ?? {})) {
             systemData.damage.resources[type] = joinedRoll.damageRollData.resources[type].toJSON();

--- a/module/applications/dialogs/tagTeamDialog.mjs
+++ b/module/applications/dialogs/tagTeamDialog.mjs
@@ -236,11 +236,11 @@ export default class TagTeamDialog extends HandlebarsApplicationMixin(Applicatio
             }
         }
 
+        const selectedRoll = Object.values(this.party.system.tagTeam.members).find(member => member.selected);
+        const critSelected = !selectedRoll ? undefined : (selectedRoll?.roll?.isCritical ?? false);
+        const isCritical = critSelected || (critSelected === undefined && data.roll?.isCritical);
         if (data.damageRollData.main) {
-            const selectedRoll = Object.values(this.party.system.tagTeam.members).find(member => member.selected);
-            const critSelected = !selectedRoll ? undefined : (selectedRoll?.roll?.isCritical ?? false);
-            const useCritDamage = critSelected || (critSelected === undefined && data.roll?.isCritical);
-            data.damageRollData.main.options.isCritical = useCritDamage;
+            data.damageRollData.main.options.isCritical = isCritical;
         }
 
         return {
@@ -253,8 +253,7 @@ export default class TagTeamDialog extends HandlebarsApplicationMixin(Applicatio
             rollOptions,
             damageRollOptions,
             damage: data.damageRollData,
-            critDamage: this.getCriticalDamage(data.damageRollData),
-            useCritDamage: false
+            isCritical
         };
     }
 

--- a/module/data/chat-message/actorRoll.mjs
+++ b/module/data/chat-message/actorRoll.mjs
@@ -203,7 +203,7 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
                 const oldRoll = damageData.parts[0]?.roll;
                 return oldRoll ? JSON.stringify({
                     ...oldRoll,
-                    class: 'BaseRoll',
+                    class: 'DamageRoll',
                     options: {
                         ...oldRoll.options,
                         damageTypes: damageData.parts[0].damageTypes ?? []

--- a/module/data/chat-message/chatDamageData.mjs
+++ b/module/data/chat-message/chatDamageData.mjs
@@ -41,11 +41,12 @@ export class ChatDamageData extends foundry.abstract.DataModel {
     }
 
     _prepareRolls() {
-        this.main &&= Roll.fromData({ 
+        this.main &&= Roll.fromData({
             ...this.main, 
             options: { 
                 ...this.main.options, 
-                isCritical: this.main.options.isCritical || this.isCritical 
+                isCritical: 
+                    this.main.options.isCritical === false ? false : (this.main.options.isCritical || this.isCritical) 
             } 
         });
 

--- a/module/data/chat-message/chatDamageData.mjs
+++ b/module/data/chat-message/chatDamageData.mjs
@@ -1,4 +1,6 @@
 import { triggerChatRollFx } from '../../helpers/utils.mjs';
+import { MemberData } from '../tagTeamData.mjs';
+import DHActorRoll from './actorRoll.mjs';
 
 export class ChatDamageData extends foundry.abstract.DataModel {
     constructor(data = {}, options = {}) {
@@ -8,10 +10,14 @@ export class ChatDamageData extends foundry.abstract.DataModel {
     }
 
     get isCritical() {
-        if (!this.parent?.parent) return false;
+        if (this.parent && this.parent instanceof MemberData) {
+            return this.parent.roll.isCritical;
+        }
+        if (this.parent && this.parent instanceof DHActorRoll && this.parent.parent) {
+            return Roll.fromJSON(this.parent.parent._source.rolls[0]).isCritical;
+        }
 
-        const roll = Roll.fromJSON(this.parent.parent._source.rolls[0]);
-        return roll.isCritical;
+        return false;
     }
 
     static defineSchema() {

--- a/module/data/chat-message/chatDamageData.mjs
+++ b/module/data/chat-message/chatDamageData.mjs
@@ -28,7 +28,7 @@ export class ChatDamageData extends foundry.abstract.DataModel {
     }
 
     _prepareRolls() {
-        this.main &&= Roll.fromData(this.main);
+        this.main &&= Roll.fromData({ ...this.main, class: 'DamageRoll' }); // Temp overriding to DamageRoll. Should be properly saved on creation instead
         for (const key of Object.keys(this.resources)) {
             this.resources[key] = Roll.fromData(this.resources[key]);
         }

--- a/module/data/chat-message/chatDamageData.mjs
+++ b/module/data/chat-message/chatDamageData.mjs
@@ -8,6 +8,8 @@ export class ChatDamageData extends foundry.abstract.DataModel {
     }
 
     get isCritical() {
+        if (!this.parent?.parent) return false;
+
         const roll = Roll.fromJSON(this.parent.parent._source.rolls[0]);
         return roll.isCritical;
     }
@@ -33,7 +35,14 @@ export class ChatDamageData extends foundry.abstract.DataModel {
     }
 
     _prepareRolls() {
-        this.main &&= Roll.fromData({ ...this.main, options: { ...this.main.options, isCritical: this.isCritical } });
+        this.main &&= Roll.fromData({ 
+            ...this.main, 
+            options: { 
+                ...this.main.options, 
+                isCritical: this.main.options.isCritical || this.isCritical 
+            } 
+        });
+
         for (const key of Object.keys(this.resources)) {
             this.resources[key] = Roll.fromData(this.resources[key]);
         }

--- a/module/data/chat-message/chatDamageData.mjs
+++ b/module/data/chat-message/chatDamageData.mjs
@@ -28,7 +28,7 @@ export class ChatDamageData extends foundry.abstract.DataModel {
     }
 
     _prepareRolls() {
-        this.main &&= Roll.fromData({ ...this.main, class: 'DamageRoll' }); // Temp overriding to DamageRoll. Should be properly saved on creation instead
+        this.main &&= Roll.fromData(this.main);
         for (const key of Object.keys(this.resources)) {
             this.resources[key] = Roll.fromData(this.resources[key]);
         }

--- a/module/data/chat-message/chatDamageData.mjs
+++ b/module/data/chat-message/chatDamageData.mjs
@@ -7,6 +7,11 @@ export class ChatDamageData extends foundry.abstract.DataModel {
         this._prepareRolls();
     }
 
+    get isCritical() {
+        const roll = Roll.fromJSON(this.parent.parent._source.rolls[0]);
+        return roll.isCritical;
+    }
+
     static defineSchema() {
         const fields = foundry.data.fields;
         
@@ -28,7 +33,7 @@ export class ChatDamageData extends foundry.abstract.DataModel {
     }
 
     _prepareRolls() {
-        this.main &&= Roll.fromData(this.main);
+        this.main &&= Roll.fromData({ ...this.main, options: { ...this.main.options, isCritical: this.isCritical } });
         for (const key of Object.keys(this.resources)) {
             this.resources[key] = Roll.fromData(this.resources[key]);
         }

--- a/module/data/fields/action/damageField.mjs
+++ b/module/data/fields/action/damageField.mjs
@@ -107,7 +107,7 @@ export default class DamageField extends fields.SchemaField {
                 if (configDamage.main) {
                     const multiplier = config.actionActor?.system.rules?.attack?.damage?.hpDamageMultiplier ?? 1;
                     const takenMultiplier = actor.system.rules?.attack?.damage?.hpDamageTakenMultiplier;
-                    configDamage.main.total = Math.ceil(configDamage.main.total * multiplier * takenMultiplier);
+                    configDamage.main.total = Math.ceil(config.damage.main.total * multiplier * takenMultiplier);
                 }
 
                 damagePromises.push(

--- a/module/dice/damageRoll.mjs
+++ b/module/dice/damageRoll.mjs
@@ -1,5 +1,5 @@
 import DamageDialog from '../applications/dialogs/damageDialog.mjs';
-import { parseRallyDice, triggerChatRollFx } from '../helpers/utils.mjs';
+import { getCritDamageBonus, parseRallyDice, triggerChatRollFx } from '../helpers/utils.mjs';
 import DHRoll from './dhRoll.mjs';
 
 export default class DamageRoll extends DHRoll {
@@ -8,7 +8,12 @@ export default class DamageRoll extends DHRoll {
     }
 
     get isCritical() {
-        return !!this.options.isCritical;
+        return true;
+    }
+
+    get modifierTotal() {
+        const criticalDamageBonus = this.isCritical ? getCritDamageBonus(this.terms) : 0;
+        return super.modifierTotal + criticalDamageBonus;
     }
 
     static DefaultDialog = DamageDialog;

--- a/module/dice/damageRoll.mjs
+++ b/module/dice/damageRoll.mjs
@@ -156,7 +156,7 @@ export default class DamageRoll extends DHRoll {
         if (!formulaData) return null;
         this.options.isCritical = config.isCritical;
 
-        formulaData.roll = new Roll(Roll.replaceFormulaData(formulaData.formula, config.data));
+        formulaData.roll = new this.constructor(Roll.replaceFormulaData(formulaData.formula, config.data));
         formulaData.roll.terms = Roll.parse(formulaData.roll.formula, config.data);
 
         if (formulaData.extraFormula) {

--- a/module/dice/damageRoll.mjs
+++ b/module/dice/damageRoll.mjs
@@ -8,12 +8,17 @@ export default class DamageRoll extends DHRoll {
     }
 
     get isCritical() {
-        return true;
+        return this.options.isCritical;
     }
 
     get modifierTotal() {
         const criticalDamageBonus = this.isCritical ? getCritDamageBonus(this.terms) : 0;
         return super.modifierTotal + criticalDamageBonus;
+    }
+
+    get total() {
+        const criticalDamageBonus = this.isCritical ? getCritDamageBonus(this.terms) : 0;
+        return super.total + criticalDamageBonus;
     }
 
     static DefaultDialog = DamageDialog;

--- a/module/dice/damageRoll.mjs
+++ b/module/dice/damageRoll.mjs
@@ -33,7 +33,7 @@ export default class DamageRoll extends DHRoll {
         
         const evaluateRoll = async roll => {
             await roll.roll.evaluate();
-            roll.roll.options = { damageTypes: roll.damageTypes ? [...roll.damageTypes] : [] };
+            roll.roll.options = { ...roll.roll.options, damageTypes: roll.damageTypes ? [...roll.damageTypes] : [] };
             return roll.roll;
         }
 
@@ -41,8 +41,10 @@ export default class DamageRoll extends DHRoll {
 
         if (config.damageFormula) {
             config.damage.main = await evaluateRoll(config.damageFormula);
-            config.damage.main.options = { damageTypes: 
-                config.damageFormula.damageTypes ? [...config.damageFormula.damageTypes] : []
+            config.damage.main.options = { 
+                ...config.damage.main.options,
+                damageTypes: 
+                    config.damageFormula.damageTypes ? [...config.damageFormula.damageTypes] : []
             };
         }
         

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -495,9 +495,8 @@ export function expireActiveEffects(actor, allowedTypes = null) {
     actor.deleteEmbeddedDocuments('ActiveEffect', effectsToExpire);
 }
 
-export async function getCritDamageBonus(formula) {
-    const critRoll = new Roll(formula);
-    await critRoll.evaluate();
+export function getCritDamageBonus(terms) {
+    const critRoll = Roll.fromTerms(terms);
     return critRoll.dice.reduce((acc, dice) => acc + dice.faces * dice.results.filter(r => r.active).length, 0);
 }
 

--- a/styles/less/dialog/tag-team-dialog/sheet.less
+++ b/styles/less/dialog/tag-team-dialog/sheet.less
@@ -252,11 +252,8 @@
                     width: 100%;
                     text-align: center;
 
-                    .result-info {
-                        display: flex;
-                        gap: 4px;
-                        align-items: center;
-                        justify-content: center;
+                    .damage-info {
+                        text-decoration: underline;
                     }
                 }
             }

--- a/templates/dialogs/tagTeamDialog/parts/tagTeamDamageParts.hbs
+++ b/templates/dialogs/tagTeamDialog/parts/tagTeamDamageParts.hbs
@@ -1,5 +1,5 @@
 {{#if damage.main}}
-    {{> damage roll=damage.main label=(localize "DAGGERHEART.GENERAL.damage") memberKey=key}}
+    {{> damage roll=damage.main label=(localize "DAGGERHEART.GENERAL.damage") memberKey=key isCritical=isCritical}}
 {{/if}}
 
 {{#each damage.resources as |roll key|}}

--- a/templates/dialogs/tagTeamDialog/result.hbs
+++ b/templates/dialogs/tagTeamDialog/result.hbs
@@ -6,18 +6,9 @@
                 {{#if hintText}}
                     <div class="hint">{{localize hintText}}</div>
                 {{else}}
-                    {{#if joinedRoll.rollData}}
-                        <div class="result-container">
-                            <span class="result-section-label">{{localize "DAGGERHEART.GENERAL.dualityRoll"}}</span>
-                            <div class="result-info">
-                                <div class="damage-info">{{joinedRoll.rollData.total}}</div>
-                                <div>{{localize "DAGGERHEART.GENERAL.withThing" thing=joinedRoll.roll.totalLabel}}</div>
-                            </div>
-                        </div>
-                    {{/if}}
                     {{#if joinedRoll.damageRollData}}
                         <div class="result-container">
-                            <span class="result-section-label">{{localize "DAGGERHEART.GENERAL.damage"}}</span>
+                            <div class="damage-info">{{joinedRoll.rollData.total}} {{localize "DAGGERHEART.GENERAL.withThing" thing=joinedRoll.roll.totalLabel}}</div>
                             {{#if joinedRoll.damageRollData.main}}
                                 {{> damageSummary roll=joinedRoll.damageRollData.main label=(localize "DAGGERHEART.GENERAL.damage")}}
                             {{/if}}
@@ -41,8 +32,5 @@
 </section>
 
 {{#*inline "damageSummary"}}
-    <div class="result-info">
-        <div>{{label}}</div>
-        <div class="damage-info">{{roll.total}}</div>
-    </div>
+    <div>{{label}} {{roll.total}}</div>
 {{/inline}}

--- a/templates/dialogs/tagTeamDialog/result.hbs
+++ b/templates/dialogs/tagTeamDialog/result.hbs
@@ -18,11 +18,11 @@
                     {{#if joinedRoll.damageRollData}}
                         <div class="result-container">
                             <span class="result-section-label">{{localize "DAGGERHEART.GENERAL.damage"}}</span>
-                            {{#each joinedRoll.damageRollData.types as |damage key|}}
-                                <div class="result-info">
-                                    <div>{{localize (concat "DAGGERHEART.CONFIG.HealingType." key ".name")}}</div>
-                                    <div class="damage-info">{{damage.total}}</div>
-                                </div>
+                            {{#if joinedRoll.damageRollData.main}}
+                                {{> damageSummary roll=joinedRoll.damageRollData.main label=(localize "DAGGERHEART.GENERAL.damage")}}
+                            {{/if}}
+                            {{#each joinedRoll.damageRollData.resources as |roll key|}}
+                                {{> damageSummary roll=roll label=(localize (concat "DAGGERHEART.CONFIG.HealingType." key ".name"))}}
                             {{/each}}
                         </div>
                     {{/if}}
@@ -39,3 +39,10 @@
         </div>
     </div>
 </section>
+
+{{#*inline "damageSummary"}}
+    <div class="result-info">
+        <div>{{label}}</div>
+        <div class="damage-info">{{roll.total}}</div>
+    </div>
+{{/inline}}

--- a/templates/dialogs/tagTeamDialog/tagTeamMember.hbs
+++ b/templates/dialogs/tagTeamDialog/tagTeamMember.hbs
@@ -109,11 +109,7 @@
                             </div>
                         </span>
                         {{#if damage.active}}
-                            {{#if useCritDamage}}
-                                {{> "systems/daggerheart/templates/dialogs/tagTeamDialog/parts/tagTeamDamageParts.hbs" damage=critDamage isCritical=true }}
-                            {{else}}
-                                {{> "systems/daggerheart/templates/dialogs/tagTeamDialog/parts/tagTeamDamageParts.hbs" damage=damage }}
-                            {{/if}}
+                            {{> "systems/daggerheart/templates/dialogs/tagTeamDialog/parts/tagTeamDamageParts.hbs" damage=damage isCritical=isCritical }}
                         {{else}}
                             <span class="hint">{{localize "DAGGERHEART.APPLICATIONS.TagTeamSelect.makeYourRoll"}}</span>
                         {{/if}}

--- a/templates/ui/chat/parts/damage-part.hbs
+++ b/templates/ui/chat/parts/damage-part.hbs
@@ -4,7 +4,7 @@
             {{#if hasHealing}}
                 <span>{{localize "DAGGERHEART.ACTIONS.TYPES.healing.name"}}</span>
             {{else}}
-                <span>{{localize (ifThen roll.isCritical "DAGGERHEART.ACTIONS.TYPES.damage.critical" "DAGGERHEART.ACTIONS.TYPES.damage.name")}}</span>
+                <span>{{localize (ifThen damage.main.isCritical "DAGGERHEART.ACTIONS.TYPES.damage.critical" "DAGGERHEART.ACTIONS.TYPES.damage.name")}}</span>
             {{/if}}
         </div>
     </div>


### PR DESCRIPTION
Fixes #2093 

- Fixed so that DamageRolls are actualy with class='Damage Roll' in the chatmessage. Previously they stored 'BaseRoll', and therefore got instantiated as that, giving us no access to DamageRoll methods.
- Fixed so that DamageRolls do not get saved with a formula including the crit damage. I opted to just redo the formulas when the DamageDialog submits. I think this is the most stable so that the formula shown while in the dialog will be showing crit damage.
<img width="1140" height="153" alt="image" src="https://github.com/user-attachments/assets/6f844684-d2c8-4a1d-bf15-da958a20c329" />
- DamageRoll now overrides the `total` and `modifierTotal` getters to retrieve critical damage when appropriate. The formula and terms are never changed. 
- Changed the utility method GetCritDamageBonus to not be async. Led to some `await` removals.