### PR TITLE
[Fix] Damage Related Getters

### DIFF
--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -429,11 +429,11 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
     }
 
     get hasDamage() {
-        return this.type !== 'healing' && (Boolean(this.damage.main) || !foundry.utils.isEmpty(this.damage.resources));
+        return this.type !== 'healing' && (Boolean(this.damage?.main) || !foundry.utils.isEmpty(this.damage?.resources));
     }
 
     get hasHealing() {
-        return this.type === 'healing' && !foundry.utils.isEmpty(this.damage.resources);
+        return this.type === 'healing' && !foundry.utils.isEmpty(this.damage?.resources);
     }
 
     get hasSave() {


### PR DESCRIPTION
Fixed so that non attack/damage actions that don't have `this.damage` don't error out when used.

We could also opt to change the `get hasDamage` to check specifically that the type is in `['damage', 'attack']` or some such instead if preferable.