### PR TITLE
[Fix] Reload Fixes

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -126,7 +126,7 @@
                 "damageOnSave": "Damage on Save",
                 "useDefaultItemValues": "Use default Item values"
             },
-            "Reload": {
+            "Reload": { 
                 "checkReload": "Check Reload",
                 "reloadRequired": "Reload Required!"
             },
@@ -3274,7 +3274,9 @@
                 "lackingItemTransferPermission": "User {user} lacks owner permission needed to transfer items to {target}",
                 "noTokenTargeted": "No token is targeted",
                 "behaviorRegionRequiresGM": "Creating a Region with an attached Behavior requires an online GM",
-                "reloadRequired": "The {weapon} must be reloaded to be used!"
+                "reloadRequired": "The {weapon} must be reloaded to be used!",
+                "reloadRequiredRollResponse": "Reload Check: 1d6 -> {roll}. Reload required.",
+                "noReloadRequiredRollResponse": "Reload Check: 1d6 -> {roll}. No reload required."
             },
             "Progress": {
                 "migrationLabel": "Performing system migration. Please wait and do not close Foundry."
@@ -3329,7 +3331,8 @@
                 "immune": "Immune",
                 "middleClick": "[Middle Click] Keep tooltip view",
                 "tokenSize": "The token size used on the canvas",
-                "previewTokenHelp": "Left-click to place, right-click to cancel"
+                "previewTokenHelp": "Left-click to place, right-click to cancel",
+                "noReloadRequired": "No Reload Required!"
             }
         }
     }

--- a/lang/en.json
+++ b/lang/en.json
@@ -126,7 +126,7 @@
                 "damageOnSave": "Damage on Save",
                 "useDefaultItemValues": "Use default Item values"
             },
-            "Reload": { 
+            "Reload": {
                 "checkReload": "Check Reload",
                 "reloadRequired": "Reload Required!"
             },

--- a/lang/en.json
+++ b/lang/en.json
@@ -128,7 +128,12 @@
             },
             "Reload": {
                 "checkReload": "Check Reload",
-                "reloadRequired": "Reload Required!"
+                "reloadRequired": "Reload Required!",
+                "notRolled": "Not Rolled",
+                "checkFailed": "Check Failed",
+                "checkPassed": "Check Passed",
+                "rerollConfirmationTitle": "Reroll Reload Check",
+                "rerollConfirmationText": "Are you sure you want to reload the reload check?"
             },
             "RollField": {
                 "diceRolling": {
@@ -1328,7 +1333,7 @@
             },
             "ReloadChoices": {
                 "off": { "label": "Don't Use" },
-                "button": { "label": "Use button" },
+                "manual": { "label": "Manual" },
                 "auto": { "label": "Automatic" }
             },
             "RollTypes": {
@@ -2810,7 +2815,7 @@
                     },
                     "reload": {
                         "label": "Reload Checking",
-                        "hint": "If the system should present a button for checking if the character will need to reload or do it automatically"
+                        "hint": "If the system should automatically roll reload checks or wait for the manual press of a button in chat"
                     },
                     "resourceScrollTexts": {
                         "label": "Show Resource Change Scrolltexts",
@@ -3274,9 +3279,7 @@
                 "lackingItemTransferPermission": "User {user} lacks owner permission needed to transfer items to {target}",
                 "noTokenTargeted": "No token is targeted",
                 "behaviorRegionRequiresGM": "Creating a Region with an attached Behavior requires an online GM",
-                "reloadRequired": "The {weapon} must be reloaded to be used!",
-                "reloadRequiredRollResponse": "Reload Check: 1d6 -> {roll}. Reload required.",
-                "noReloadRequiredRollResponse": "Reload Check: 1d6 -> {roll}. No reload required."
+                "reloadRequired": "The {weapon} must be reloaded to be used!"
             },
             "Progress": {
                 "migrationLabel": "Performing system migration. Please wait and do not close Foundry."
@@ -3331,8 +3334,7 @@
                 "immune": "Immune",
                 "middleClick": "[Middle Click] Keep tooltip view",
                 "tokenSize": "The token size used on the canvas",
-                "previewTokenHelp": "Left-click to place, right-click to cancel",
-                "noReloadRequired": "No Reload Required!"
+                "previewTokenHelp": "Left-click to place, right-click to cancel"
             }
         }
     }

--- a/module/applications/ui/chatLog.mjs
+++ b/module/applications/ui/chatLog.mjs
@@ -281,7 +281,12 @@ export default class DhpChatLog extends foundry.applications.sidebar.tabs.ChatLo
 
     async onRollReloadCheck(_event, messageData) {
         const message = game.messages.get(messageData._id);
-        const needsReload = await message.system.action.handleReload?.({ awaitRoll: true });
-        await message.update({ 'system.needsReload': needsReload });
+        const { needsReload, rollValue } = await message.system.action.handleReload?.({ awaitRoll: true });
+        await message.update({ 'system.reloadCheckValue': rollValue });
+
+        if (needsReload) 
+            ui.notifications.info(_loc('DAGGERHEART.UI.Notifications.reloadRequiredRollResponse', { roll: rollValue }));
+        else
+            ui.notifications.info(_loc('DAGGERHEART.UI.Notifications.noReloadRequiredRollResponse', { roll: rollValue }));
     }
 }

--- a/module/applications/ui/chatLog.mjs
+++ b/module/applications/ui/chatLog.mjs
@@ -279,14 +279,21 @@ export default class DhpChatLog extends foundry.applications.sidebar.tabs.ChatLo
         new game.system.api.applications.dialogs.RiskItAllDialog(actor, resourceValue).render({ force: true });
     }
 
-    async onRollReloadCheck(_event, messageData) {
+    async onRollReloadCheck(event, messageData) {
         const message = game.messages.get(messageData._id);
-        const { needsReload, rollValue } = await message.system.action.handleReload?.({ awaitRoll: true });
-        await message.update({ 'system.reloadCheckValue': rollValue });
 
-        if (needsReload) 
-            ui.notifications.info(_loc('DAGGERHEART.UI.Notifications.reloadRequiredRollResponse', { roll: rollValue }));
-        else
-            ui.notifications.info(_loc('DAGGERHEART.UI.Notifications.noReloadRequiredRollResponse', { roll: rollValue }));
+        if (message.system.reloadCheckValue) {
+            const confirmed = await foundry.applications.api.DialogV2.confirm({
+                window: {
+                    title: _loc('DAGGERHEART.ACTIONS.Reload.rerollConfirmationTitle')
+                },
+                content: _loc('DAGGERHEART.ACTIONS.Reload.rerollConfirmationText')
+            });
+
+            if (!confirmed) return;
+        }
+
+        const { rollValue } = await message.system.action.handleReload?.({ awaitRoll: true });
+        await message.update({ 'system.reloadCheckValue': rollValue });
     }
 }

--- a/module/config/settingsConfig.mjs
+++ b/module/config/settingsConfig.mjs
@@ -68,9 +68,9 @@ export const reloadChoices = {
         id: 'off',
         label: 'DAGGERHEART.CONFIG.ReloadChoices.off.label'
     },
-    button: {
-        id: 'button',
-        label: 'DAGGERHEART.CONFIG.ReloadChoices.button.label'
+    manual: {
+        id: 'manual',
+        label: 'DAGGERHEART.CONFIG.ReloadChoices.manual.label'
     },
     auto: {
         id: 'auto',

--- a/module/data/action/attackAction.mjs
+++ b/module/data/action/attackAction.mjs
@@ -74,13 +74,13 @@ export default class DHAttackAction extends DHDamageAction {
             else
                 game.dice3d.showForRoll(roll, game.user, true);    
         }
-
-        const needsToReload = roll.total === 1;
-        if (needsToReload) {
+        
+        const needsReload = roll.total === 1;
+        if (needsReload) {
             this.item.update({ 'system.resource.value': 0 });
         }
 
-        return needsToReload;
+        return { needsReload, rollValue: roll.total };
     }
 
     /**

--- a/module/data/chat-message/actorRoll.mjs
+++ b/module/data/chat-message/actorRoll.mjs
@@ -42,7 +42,7 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
             hasEffect: new fields.BooleanField({ initial: false }),
             hasSave: new fields.BooleanField({ initial: false }),
             hasTarget: new fields.BooleanField({ initial: false }),
-            needsReload: new fields.BooleanField({ initial: false }),
+            reloadCheckValue: new fields.NumberField({ integer: true, nullable: true, initial: null }),
             isDirect: new fields.BooleanField({ initial: false }),
             onSave: new fields.StringField(),
             source: new fields.SchemaField({
@@ -97,6 +97,10 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
 
     get hasReload() {
         return this.item?.system.hasReload;
+    }
+
+    get needsReload() {
+        return this.reloadCheckValue === 1;
     }
 
     get action() {

--- a/module/data/chat-message/actorRoll.mjs
+++ b/module/data/chat-message/actorRoll.mjs
@@ -99,7 +99,7 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
         return this.item?.system.hasReload;
     }
 
-    get needsReload() {
+    get reloadCheckFailed() {
         return this.reloadCheckValue === 1;
     }
 

--- a/module/data/chat-message/actorRoll.mjs
+++ b/module/data/chat-message/actorRoll.mjs
@@ -76,10 +76,14 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
         return fromUuidSync(this.source.actor);
     }
 
-    get actionItem() {
+    get item() {
         const actionActor = this.actionActor;
         if (!actionActor || !this.source.item) return null;
+        
+        return actionActor.items.get(this.source.item);
+    }
 
+    get actionItem() {
         switch (this.source.originItem.type) {
             case CONFIG.DH.ITEM.originItemType.restMove:
                 const restMoves = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Homebrew).restMoves;
@@ -87,9 +91,12 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
                     this.source.originItem.actionIndex
                 ];
             default:
-                const item = actionActor.items.get(this.source.item);
-                return item ? item.system.actionsList?.find(a => a.id === this.source.action) : null;
+                return this.item?.system.actionsList?.find(a => a.id === this.source.action);
         }
+    }
+
+    get hasReload() {
+        return this.item?.system.hasReload;
     }
 
     get action() {

--- a/module/data/settings/Automation.mjs
+++ b/module/data/settings/Automation.mjs
@@ -199,7 +199,7 @@ export default class DhAutomation extends foundry.abstract.DataModel {
             reload: new fields.StringField({
                 required: true,
                 choices: CONFIG.DH.SETTINGS.reloadChoices,
-                initial: CONFIG.DH.SETTINGS.reloadChoices.button.id,
+                initial: CONFIG.DH.SETTINGS.reloadChoices.manual.id,
                 label: 'DAGGERHEART.SETTINGS.Automation.FIELDS.reload.label',
                 hint: 'DAGGERHEART.SETTINGS.Automation.FIELDS.reload.hint'
             }),

--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -139,7 +139,14 @@ export default class DHRoll extends BaseRoll {
             item?.system.hasReload && 
             action?.type === 'attack' && 
             reloadSetting === CONFIG.DH.SETTINGS.reloadChoices.auto.id;
-        const needsReload = useReload ? await action?.handleReload?.() : false;
+        const reloadResult = useReload ? await action?.handleReload?.() : {};
+        
+        if (useReload) {
+            if (reloadResult.needsReload) 
+                ui.notifications.info(_loc('DAGGERHEART.UI.Notifications.reloadRequiredRollResponse', { roll: reloadResult.rollValue }));
+            else
+                ui.notifications.info(_loc('DAGGERHEART.UI.Notifications.noReloadRequiredRollResponse', { roll: reloadResult.rollValue }));
+        }
         
         const cls = getDocumentClass('ChatMessage'),
             msgData = {
@@ -148,7 +155,11 @@ export default class DHRoll extends BaseRoll {
                 title: roll.title,
                 speaker: cls.getSpeaker({ actor: roll.data?.parent }),
                 sound: config.mute ? null : CONFIG.sounds.dice,
-                system: { ...config, actionDescription, needsReload },
+                system: { 
+                    ...config, 
+                    actionDescription,
+                    reloadCheckValue: reloadResult.rollValue 
+                },
                 rolls: [roll]
             };
 

--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -141,13 +141,6 @@ export default class DHRoll extends BaseRoll {
             reloadSetting === CONFIG.DH.SETTINGS.reloadChoices.auto.id;
         const reloadResult = useReload ? await action?.handleReload?.() : {};
         
-        if (useReload) {
-            if (reloadResult.needsReload) 
-                ui.notifications.info(_loc('DAGGERHEART.UI.Notifications.reloadRequiredRollResponse', { roll: reloadResult.rollValue }));
-            else
-                ui.notifications.info(_loc('DAGGERHEART.UI.Notifications.noReloadRequiredRollResponse', { roll: reloadResult.rollValue }));
-        }
-        
         const cls = getDocumentClass('ChatMessage'),
             msgData = {
                 type: this.messageType,

--- a/styles/less/ui/chat/chat.less
+++ b/styles/less/ui/chat/chat.less
@@ -271,28 +271,6 @@
                 }
             }
 
-            .roll-reload-container {
-                text-align: center;
-                display: flex;
-                align-items: center;
-                justify-content: center;
-                gap: 4px;
-
-                .reload-warning {
-                    display: flex;
-                    align-items: center;
-                    border-radius: 5px;
-                    width: fit-content;
-                    gap: 5px;
-                    cursor: pointer;
-                    padding: 5px;
-                    transition: all 0.3s ease;
-                    color: @beige;
-                    background: @red-40;
-                    outline: 1px solid @red;
-                }
-            }
-
             .roll-part-extra {
                 display: flex;
                 justify-content: center;
@@ -643,20 +621,74 @@
         }
 
         .roll-buttons {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 5px;
-            width: 100%;
             margin-top: 8px;
+            display: flex;
+            flex-direction: column;
+            gap: 5px;
 
             button {
-                height: 36px;
-                flex: 1 1 calc(50% - 5px);
-                font-family: @font-body;
-                font-weight: 700;
+                height: 32px;
+            }
 
-                &:nth-last-child(1):nth-child(odd) {
-                    flex-basis: 100%;
+            .main-buttons {
+                display: flex;
+                gap: 5px;
+            
+                button {
+                    flex: 1;
+
+                    &.end-button {
+                        flex: 0;
+                    }
+                }
+            }
+
+            .extra-button-row {
+                width: 100%;
+                display: flex;
+                gap: 5px;
+
+                .image-container {
+                    position: relative;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    
+                    img {
+                        height: 24px;
+                        filter: @dark-filter;
+                    }
+                    
+                    .dice-result {
+                        position: absolute;
+                        font-size: 18px;
+                        color: @beige;
+                        filter: drop-shadow(0 0 1px @light-white);
+                    }
+                }
+
+                .reload-data {
+                    flex: 1;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    border-radius: 5px;
+                    gap: 5px;
+                    cursor: pointer;
+                    padding: 5px;
+                    transition: all 0.3s ease;
+                    color: @golden;
+                    background: @golden-40;
+
+                    &.failed-check {
+                        background: @red-40;
+                        color: @red;
+                    }
+
+                    &.passed-check {
+                        background: @green-40;
+                        color: @green;
+                    }   
                 }
             }
         }

--- a/templates/ui/chat/parts/button-part.hbs
+++ b/templates/ui/chat/parts/button-part.hbs
@@ -1,23 +1,40 @@
 <div class="roll-buttons">
-    {{#if (and parent.system.hasReload (eq automationSettings.reload 'button'))}}
-        <button class="roll-reload-check" {{#if reloadCheckValue}}{{#unless parent.system.needsReload}}title="{{localize "DAGGERHEART.UI.Tooltip.noReloadRequired"}}"{{/unless}} disabled{{/if}}>
-            {{localize "DAGGERHEART.ACTIONS.Reload.checkReload"}}
-        </button>
-    {{/if}}
-    {{#if areas.length}}<button class="action-areas end-button"><i class="fa-solid fa-crosshairs"></i></button>{{/if}}
-    {{#if hasDamage}}
-        {{#if damage.active}}
-            <button class="duality-action damage-button">{{localize "DAGGERHEART.UI.Chat.damageRoll.dealDamage"}}</button>
-        {{else}}
-            <button class="duality-action duality-action-damage">{{localize "DAGGERHEART.UI.Chat.attackRoll.rollDamage"}}</button>
+    <div class="main-buttons">
+        {{#if areas.length}}<button class="action-areas end-button"><i class="fa-solid fa-crosshairs"></i></button>{{/if}}
+        {{#if hasDamage}}
+            {{#if damage.active}}
+                <button class="duality-action damage-button">{{localize "DAGGERHEART.UI.Chat.damageRoll.dealDamage"}}</button>
+            {{else}}
+                <button class="duality-action duality-action-damage">{{localize "DAGGERHEART.UI.Chat.attackRoll.rollDamage"}}</button>
+            {{/if}}
         {{/if}}
-    {{/if}}
-    {{#if hasHealing}}
-        {{#if damage.active}}
-            <button class="duality-action damage-button">{{localize "DAGGERHEART.UI.Chat.healingRoll.applyHealing"}}</button>
-        {{else}}
-            <button class="duality-action duality-action-damage">{{localize "DAGGERHEART.UI.Chat.attackRoll.rollHealing"}}</button>
+        {{#if hasHealing}}
+            {{#if damage.active}}
+                <button class="duality-action damage-button">{{localize "DAGGERHEART.UI.Chat.healingRoll.applyHealing"}}</button>
+            {{else}}
+                <button class="duality-action duality-action-damage">{{localize "DAGGERHEART.UI.Chat.attackRoll.rollHealing"}}</button>
+            {{/if}}
         {{/if}}
+        {{#if (and hasEffect)}}<button class="duality-action-effect">{{localize "DAGGERHEART.UI.Chat.attackRoll.applyEffect"}}</button>{{/if}}
+    </div>
+
+    {{#if parent.system.hasReload}}
+        <div class="extra-button-row">
+            <button class="roll-reload-check">
+                <div class="image-container">
+                    <img class="dice-icon normal" src="{{concat 'systems/daggerheart/assets/icons/dice/default/d20.svg'}}" alt="">
+                    {{#if reloadCheckValue}}<div class="dice-result">{{reloadCheckValue}}</div>{{/if}}
+                </div>
+
+                {{localize "DAGGERHEART.ACTIONS.Reload.checkReload"}}
+            </button>
+            <div class="reload-data {{#if reloadCheckValue}}{{ifThen parent.system.reloadCheckFailed 'failed-check' 'passed-check'}}{{/if}}">
+                {{#unless reloadCheckValue}}
+                    {{localize "DAGGERHEART.ACTIONS.Reload.notRolled"}}
+                {{else}}
+                    {{ifThen parent.system.reloadCheckFailed (localize "DAGGERHEART.ACTIONS.Reload.checkFailed") (localize "DAGGERHEART.ACTIONS.Reload.checkPassed")}}
+                {{/unless}}
+            </div>
+        </div>
     {{/if}}
-    {{#if (and hasEffect)}}<button class="duality-action-effect">{{localize "DAGGERHEART.UI.Chat.attackRoll.applyEffect"}}</button>{{/if}}
 </div>

--- a/templates/ui/chat/parts/button-part.hbs
+++ b/templates/ui/chat/parts/button-part.hbs
@@ -1,6 +1,8 @@
 <div class="roll-buttons">
     {{#if (and parent.system.hasReload (eq automationSettings.reload 'button'))}}
-        <button class="roll-reload-check" {{#if needsReload}}disabled{{/if}}>{{localize "DAGGERHEART.ACTIONS.Reload.checkReload"}}</button>
+        <button class="roll-reload-check" {{#if reloadCheckValue}}{{#unless parent.system.needsReload}}title="{{localize "DAGGERHEART.UI.Tooltip.noReloadRequired"}}"{{/unless}} disabled{{/if}}>
+            {{localize "DAGGERHEART.ACTIONS.Reload.checkReload"}}
+        </button>
     {{/if}}
     {{#if areas.length}}<button class="action-areas end-button"><i class="fa-solid fa-crosshairs"></i></button>{{/if}}
     {{#if hasDamage}}

--- a/templates/ui/chat/parts/button-part.hbs
+++ b/templates/ui/chat/parts/button-part.hbs
@@ -1,5 +1,5 @@
 <div class="roll-buttons">
-    {{#if (eq automationSettings.reload 'button')}}
+    {{#if (and parent.system.hasReload (eq automationSettings.reload 'button'))}}
         <button class="roll-reload-check" {{#if needsReload}}disabled{{/if}}>{{localize "DAGGERHEART.ACTIONS.Reload.checkReload"}}</button>
     {{/if}}
     {{#if areas.length}}<button class="action-areas end-button"><i class="fa-solid fa-crosshairs"></i></button>{{/if}}

--- a/templates/ui/chat/roll.hbs
+++ b/templates/ui/chat/roll.hbs
@@ -1,14 +1,10 @@
 <div class="chat-roll">
     <div class="roll-part-title"><span>{{title}}</span></div>
     
-    {{#if (eq action.type 'attack')}}
-        {{#if needsReload}}
-            <div class="roll-reload-container">
-                {{#if needsReload}}
-                    <p class='reload-warning'>{{localize "DAGGERHEART.ACTIONS.Reload.reloadRequired"}}</p>
-                {{/if}}
-            </div>
-        {{/if}}
+    {{#if (and (eq action.type 'attack') parent.system.needsReload)}}
+        <div class="roll-reload-container">
+            <p class='reload-warning'>{{localize "DAGGERHEART.ACTIONS.Reload.reloadRequired"}}</p>
+        </div>
     {{/if}}
 
     {{#if actionDescription}}{{> 'systems/daggerheart/templates/ui/chat/parts/description-part.hbs'}}{{/if}}

--- a/templates/ui/chat/roll.hbs
+++ b/templates/ui/chat/roll.hbs
@@ -1,11 +1,5 @@
 <div class="chat-roll">
     <div class="roll-part-title"><span>{{title}}</span></div>
-    
-    {{#if (and (eq action.type 'attack') parent.system.needsReload)}}
-        <div class="roll-reload-container">
-            <p class='reload-warning'>{{localize "DAGGERHEART.ACTIONS.Reload.reloadRequired"}}</p>
-        </div>
-    {{/if}}
 
     {{#if actionDescription}}{{> 'systems/daggerheart/templates/ui/chat/parts/description-part.hbs'}}{{/if}}
     {{#if hasRoll}}


### PR DESCRIPTION
Some errors and useability issues revealed themselves.

- The Reload Button was shown in all roll messages. I added a check for whether the `actorRoll` is using reload or not via `get hasReload`
- When the reload check is made, automatically or via the button, we now show a notification message stating the result and the roll.
- The Check Button in the chat message wasn't getting disabled if you rolled and didn't end up needing to reload, making it unclear if you had ever clicked it. It's now disabled and there's a tooltip. 
- Fixed missing translations