### PR TITLE
[Fix] Reroll Fixes

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3331,7 +3331,6 @@
                 "rangeAndTarget": "Range & Target",
                 "dragApplyEffect": "Drag effect to apply it to an actor",
                 "appliedEvenIfSuccessful": "Applied even if save succeeded",
-                "diceIsRerolled": "The dice has been rerolled (x{times})",
                 "pendingSaves": "Pending Reaction Rolls",
                 "openSheetSettings": "Open Settings",
                 "compendiumBrowser": "Compendium Browser",

--- a/module/applications/ui/chatLog.mjs
+++ b/module/applications/ui/chatLog.mjs
@@ -247,7 +247,7 @@ export default class DhpChatLog extends foundry.applications.sidebar.tabs.ChatLo
         }
 
         const message = game.messages.get(messageData._id);
-        const target = event.target.closest('[data-result]');
+        const target = event.target.closest('[data-type]');
 
         if (target.dataset.type === 'damage') {
             const { isResource, damageType, dice, result } = target.dataset;

--- a/module/applications/ui/chatLog.mjs
+++ b/module/applications/ui/chatLog.mjs
@@ -268,6 +268,8 @@ export default class DhpChatLog extends foundry.applications.sidebar.tabs.ChatLo
                     isReaction: message.system.roll.options.actionType === 'reaction'
                 }
             });
+            rerollDice.results[rerollDice.results.length - 1].rerolled = true;
+            
             await message.update({
                 rolls: [message.system.roll.toJSON()]
             });

--- a/module/data/chat-message/chatDamageData.mjs
+++ b/module/data/chat-message/chatDamageData.mjs
@@ -37,10 +37,9 @@ export class ChatDamageData extends foundry.abstract.DataModel {
     async rerollDamageDie(isResource, damageType, dice, resultIndex) {
         const reroll = isResource ? this.resources[damageType] : this.main;
         const rerollDice = reroll.dice[dice];
-        await rerollDice.rerollResult(resultIndex);
+        const rerolledResult = await rerollDice.rerollResult(resultIndex);
         await reroll._evaluate();
     
-        const rerolledResult = rerollDice.results[rerollDice.results.length - 1];
         if (rerolledResult) {
             const fakeRoll = {
                 _evaluated: true,

--- a/module/dice/die/baseDie.mjs
+++ b/module/dice/die/baseDie.mjs
@@ -21,7 +21,8 @@ export default class BaseDie extends foundry.dice.terms.Die {
         if (['c', 'cc'].some(x => this.modifiers.includes(x))) {
             await this.handleComboDiceReroll(resultIndex, result);
         }
-        
+
+        rerolledResult.rerolled = true;
         return rerolledResult;
     }
 

--- a/module/dice/die/baseDie.mjs
+++ b/module/dice/die/baseDie.mjs
@@ -20,7 +20,9 @@ export default class BaseDie extends foundry.dice.terms.Die {
 
         if (['c', 'cc'].some(x => this.modifiers.includes(x))) {
             await this.handleComboDiceReroll(resultIndex, result);
-        } 
+        }
+        
+        return rerolledResult;
     }
 
     /** @inheritDoc */

--- a/module/dice/die/dualityDie.mjs
+++ b/module/dice/die/dualityDie.mjs
@@ -8,6 +8,10 @@ export default class DualityDie extends BaseDie {
         this.modifiers = [];
     }
 
+    get isRerolled() {
+        return this.results.some(x => x.rerolled);
+    }
+
     #getDualityState(roll) {
         if (!roll) return null;
         return roll.withHope ? 1 : roll.withFear ? -1 : 0;

--- a/templates/ui/chat/parts/damage-part.hbs
+++ b/templates/ui/chat/parts/damage-part.hbs
@@ -65,7 +65,7 @@
                                     class="dice reroll-button {{coalesce dieResult.denomination dice.denomination}}" 
                                     data-type="damage" data-dice="{{diceKey}}" data-result="{{resultKey}}" {{#if ../../resource}}data-damage-type="{{../../resource}}" data-is-resource="true"{{/if}}
                                 >
-                                    {{#if hasRerolls}}<i class="fa-solid fa-dice dice-rerolled" data-tooltip="{{localize "DAGGERHEART.GENERAL.rerolled"}}"></i>{{/if}}
+                                    {{#if dieResult.rerolled}}<i class="fa-solid fa-dice dice-rerolled" data-tooltip="{{localize "DAGGERHEART.GENERAL.rerolled"}}"></i>{{/if}}
                                     {{result}}
                                 </div>
                             </div>

--- a/templates/ui/chat/parts/roll-part.hbs
+++ b/templates/ui/chat/parts/roll-part.hbs
@@ -47,14 +47,14 @@
                                 <div class="roll-die">
                                     <label>{{localize "DAGGERHEART.GENERAL.hope"}}</label>
                                     <div class="dice {{roll.dHope.denomination}} color-hope reroll-button" data-die-index="0" data-type="hope" data-tooltip="{{localize "DAGGERHEART.GENERAL.rerollThing" thing=(localize "DAGGERHEART.GENERAL.hope")}}">
-                                        {{#if roll.dHopehope.rerolled.any}}<i class="fa-solid fa-dice dice-rerolled" data-tooltip="{{localize "DAGGERHEART.UI.Tooltip.diceIsRerolled" times=roll.dHope.rerolled.rerolls.length}}"></i>{{/if}}
+                                        {{#if roll.dHope.isRerolled}}<i class="fa-solid fa-dice dice-rerolled" data-tooltip="{{localize "DAGGERHEART.GENERAL.rerolled"}}"></i>{{/if}}
                                         {{roll.dHope.total}}
                                     </div>
                                 </div>
                                 <div class="roll-die has-plus">
                                     <label>{{localize "DAGGERHEART.GENERAL.fear"}}</label>
                                     <div class="dice {{roll.dFear.denomination}} color-fear reroll-button" data-die-index="1" data-type="fear" style="--svg-folder: 'fear';" data-tooltip="{{localize "DAGGERHEART.GENERAL.rerollThing" thing=(localize "DAGGERHEART.GENERAL.fear")}}">
-                                        {{#if roll.dFear.rerolled.any}}<i class="fa-solid fa-dice dice-rerolled" data-tooltip="{{localize "DAGGERHEART.UI.Tooltip.diceIsRerolled" times=roll.dFear.rerolled.rerolls.length}}"></i>{{/if}}
+                                        {{#if roll.dFear.isRerolled}}<i class="fa-solid fa-dice dice-rerolled" data-tooltip="{{localize "DAGGERHEART.GENERAL.rerolled"}}"></i>{{/if}}
                                         {{roll.dFear.total}}
                                     </div>
                                 </div>


### PR DESCRIPTION
Fixed so rerollDamage grabs the right dice for DiceSoNice. Fixed so that non-damage rerolls work again

- baseDie.rerollResult shuffles around the results, and the rerollDamageDie method wasn't accounting for that. Fixed.
- the `rerollEvent` method wasn't using a universal enough selector for it's target, so non-damage rerolls errored out. 
- Fixed so the reroll marking visualisations show up again