### PR TITLE
[Fix] Message AutoExpand Selectors

### DIFF
--- a/module/documents/chatMessage.mjs
+++ b/module/documents/chatMessage.mjs
@@ -4,10 +4,10 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
     targetHook = null;
 
     static #EXPAND_SECTIONS = [
-        { selector: 'roll-section [data-action="expandRoll"]', key: 'roll' },
-        { selector: 'damage-section', key: 'damage' },
-        { selector: 'target-section', key: 'target' },
-        { selector: 'description-section', key: 'desc' }
+        { selector: '.roll-section [data-action="expandRoll"]', key: 'roll' },
+        { selector: '.damage-section', key: 'damage' },
+        { selector: '.target-section', key: 'target' },
+        { selector: '.description-section', key: 'desc' }
     ];
 
     async renderHTML() {


### PR DESCRIPTION
Fixed so that the Appearance setting for auto expanding message sections works. 
Selectors were just missing a dot 🙃 