### PR TITLE
[Fix] BaseAction Getter Fixes

### DIFF
--- a/module/data/action/_types.d.ts
+++ b/module/data/action/_types.d.ts
@@ -1,0 +1,23 @@
+import { DHDamageData, DHResourceData } from '../fields/action/damageField.mjs';
+
+declare module './baseAction.mjs' {
+    export default interface DHBaseAction {
+        _id: string;
+        systemPath: string;
+        type?: string;
+        baseAction: boolean;
+        name?: string;
+        description: string;
+        img?: string;
+        chatDisplay: boolean;
+        originItem: object;
+        actionType: string;
+        targetUuid?: string;
+        
+        damage: {
+            main: DHDamageData;
+            /** An iterable record of items (todo: type the iterable record) */
+            resources: Record<string, DHResourceData>;
+        }
+    }
+}

--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -429,11 +429,11 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
     }
 
     get hasDamage() {
-        return this.type !== 'healing' && (Boolean(this.damage?.main) || !foundry.utils.isEmpty(this.damage?.resources));
+        return this.type !== 'healing' && (Boolean(this.damage?.main) || Object.keys(this.damage?.resources ?? {}).length);
     }
 
     get hasHealing() {
-        return this.type === 'healing' && !foundry.utils.isEmpty(this.damage?.resources);
+        return this.type === 'healing' && Object.keys(this.damage?.resources ?? {}).length;
     }
 
     get hasSave() {

--- a/module/data/fields/iterableTypedObjectField.mjs
+++ b/module/data/fields/iterableTypedObjectField.mjs
@@ -27,5 +27,3 @@ export default class IterableTypedObjectField extends foundry.data.fields.TypedO
         return object;
     }
 }
-
-

--- a/module/data/fields/iterableTypedObjectField.mjs
+++ b/module/data/fields/iterableTypedObjectField.mjs
@@ -6,27 +6,26 @@ export default class IterableTypedObjectField extends foundry.data.fields.TypedO
 
     #elementClass;
 
-    /** Initializes an object with an iterator. This modifies the prototype instead of */
+    /** Initializes an object with an iterator, where foundry.utils.getType() returns "Object" */
     initialize(values) {
-        const object = Object.create(IterableObjectPrototype);
+        const object = {};
         for (const [key, value] of Object.entries(values)) {
             object[key] = new this.#elementClass(value);
         }
+        object[Symbol.iterator] = function* () {
+            for (const value of Object.values(this)) {
+                yield value;
+            }
+        }
+        Object.defineProperties(object, {
+            map: {
+                value: function (func) {
+                    return Array.from(this, func);
+                }
+            }
+        });
         return object;
     }
 }
 
-/**
- * The prototype of an iterable object.
- * This allows the functionality of a class but also allows foundry.utils.getType() to return "Object" instead of "Unknown".
- */
-const IterableObjectPrototype = {
-    [Symbol.iterator]: function* () {
-        for (const value of Object.values(this)) {
-            yield value;
-        }
-    },
-    map: function (func) {
-        return Array.from(this, func);
-    }
-};
+


### PR DESCRIPTION
Fixed hasDamage and hasHealing getters to work correctly with empty resources.

Before the fix, no damage.main and empty resources still led to `hasDamage = true`. This made the `damageField.execute` continue for an AttackAction that only had a save without any damage, having the action chain error out. 