### PR TITLE
[Feature] Support tooltips for loadout card view

### DIFF
--- a/module/applications/sheets/api/base-actor.mjs
+++ b/module/applications/sheets/api/base-actor.mjs
@@ -38,7 +38,9 @@ export default class DHBaseActorSheet extends DHApplicationMixin(ActorSheetV2) {
         ],
         dragDrop: [
             { dragSelector: '.inventory-item[data-type="attack"]', dropSelector: null },
-            { dragSelector: '.currency[data-currency] .drag-handle', dropSelector: null }
+            { dragSelector: '.currency[data-currency] .drag-handle', dropSelector: null },
+            // This exists in order to cancel a drag drop from happening. Implementation in _onDragStart()
+            { dragSelector: '[draggable="true"] input[type=text], [draggable="true"] input[type=number]', dropSelector: null }
         ]
     };
 
@@ -424,6 +426,14 @@ export default class DHBaseActorSheet extends DHApplicationMixin(ActorSheetV2) {
      * @param {DragEvent} event - The drag event
      */
     async _onDragStart(event) {
+        // If the target is an input element, stop the dragdrop. This may be a resource inside a draggable
+        // This relies on a dragdrop selector being registered for inputs specifically
+        if (event.target.tagName === 'INPUT' && ['number', 'text'].includes(event.target.type)) {
+            event.preventDefault();
+            event.stopPropagation();
+            return;
+        }
+
         // Handle drag/dropping currencies
         const currencyEl = event.currentTarget.closest('.currency[data-currency]');
         if (currencyEl) {

--- a/styles/less/global/inventory-item.less
+++ b/styles/less/global/inventory-item.less
@@ -293,9 +293,9 @@
             height: 100%;
             width: 100%;
             object-fit: cover;
-            object-fit: top center;
+            object-position: top center;
             border-radius: 6px;
-            padding-bottom: 16px; // should be obscured, but helps aspect ratio
+            padding-bottom: 26px; // should be obscured, but helps aspect ratio
         }
 
         .recall-cost {
@@ -348,7 +348,7 @@
                 text-align: center;
                 padding-top: 6px;
                 padding-bottom: 4px;
-                min-height: 25px;
+                min-height: 30px;
                 display: flex;
                 align-items: center;
 

--- a/styles/less/global/inventory-item.less
+++ b/styles/less/global/inventory-item.less
@@ -312,7 +312,7 @@
             color: @golden;
             display: flex;
             justify-content: center;
-            padding-top: 1px; // compensate for font
+            padding-top: 0.1em; // compensate for font
             gap: 1px;
 
             i {
@@ -348,7 +348,7 @@
                 display: flex;
                 align-items: center;
 
-                color: @beige;
+                color: @color-text-primary;
             }
 
             .menu {

--- a/styles/less/global/inventory-item.less
+++ b/styles/less/global/inventory-item.less
@@ -257,9 +257,17 @@
         position: relative;
         height: 120px;
         width: 98px;
-        border: 1px solid @color-border;
         border-radius: 6px;
         cursor: pointer;
+
+        &::after {
+            content: ' ';
+            position: absolute;
+            inset: 0;
+            border: 1px solid @color-border;
+            border-radius: 6px;
+            pointer-events: none;
+        }
 
         &:hover {
             .card-label {
@@ -324,9 +332,9 @@
         .card-label {
             /** Placed at bottom, overlap with border */
             position: absolute;
-            left: -1px;
-            bottom: -1px;
-            right: -1px;
+            left: 0;
+            bottom: 0;
+            right: 0;
 
             display: flex;
             flex-direction: column;
@@ -341,9 +349,6 @@
             padding-top: 2px;
 
             .card-name {
-                font-style: normal;
-                font-weight: 400;
-                font-size: var(--font-size-12);
                 line-height: 1;
                 text-align: center;
                 padding-top: 6px;
@@ -351,8 +356,12 @@
                 min-height: 30px;
                 display: flex;
                 align-items: center;
+                z-index: 1; // render over buttons to avoid tooltip jank
 
-                color: @color-text-primary;
+                color: @beige;
+                font-style: normal;
+                font-weight: 400;
+                font-size: var(--font-size-12);
             }
 
             .menu {

--- a/styles/less/global/inventory-item.less
+++ b/styles/less/global/inventory-item.less
@@ -295,7 +295,7 @@
             object-fit: cover;
             object-fit: top center;
             border-radius: 6px;
-            padding-bottom: 26px;
+            padding-bottom: 16px; // should be obscured, but helps aspect ratio
         }
 
         .recall-cost {
@@ -312,11 +312,11 @@
             color: @golden;
             display: flex;
             justify-content: center;
-            padding-top: 0.1em; // compensate for font
             gap: 1px;
 
             i {
                 font-size: 0.68em;
+                padding-top: 0.01em; // compensate for font
                 width: auto;
             }
         }
@@ -332,7 +332,10 @@
             flex-direction: column;
             height: fit-content;
             align-items: center;
+            width: 100%;
+            position: absolute;
             background-color: @dark-blue;
+            bottom: 0;
             mask-image: linear-gradient(180deg, transparent 0%, black 4px);
             border-radius: 0 0 6px 6px;
             padding-top: 2px;
@@ -343,8 +346,9 @@
                 font-size: var(--font-size-12);
                 line-height: 1;
                 text-align: center;
-                padding: 4px 2px 4px 2px;
-                min-height: 30px;
+                padding-top: 6px;
+                padding-bottom: 4px;
+                min-height: 25px;
                 display: flex;
                 align-items: center;
 

--- a/templates/sheets/actors/character/loadout.hbs
+++ b/templates/sheets/actors/character/loadout.hbs
@@ -21,23 +21,55 @@
     </div>
 
     <div class="items-section">
-        {{> 'daggerheart.inventory-items'
-        title='DAGGERHEART.GENERAL.Tabs.loadout'
-        type='domainCard'
-        isGlassy=true
-        cardView=cardView
-        collection=document.system.domainCards.loadout
-        canCreate=@root.editable
-        inVault=false
-        }}
-        {{> 'daggerheart.inventory-items'
-        title='DAGGERHEART.GENERAL.Tabs.vault'
-        type='domainCard'
-        isGlassy=true
-        cardView=cardView
-        collection=document.system.domainCards.vault
-        canCreate=@root.editable
-        inVault=true
-        }}
+        {{#if cardView}}
+            {{> cardList
+                title="DAGGERHEART.GENERAL.Tabs.loadout"
+                collection=document.system.domainCards.loadout
+                inVault=false
+            }}
+            {{> cardList
+                title="DAGGERHEART.GENERAL.Tabs.vault"
+                collection=document.system.domainCards.vault
+                inVault=true
+            }}
+        {{else}}
+            {{> 'daggerheart.inventory-items'
+                title='DAGGERHEART.GENERAL.Tabs.loadout'
+                type='domainCard'
+                isGlassy=true
+                collection=document.system.domainCards.loadout
+                canCreate=@root.editable
+                inVault=false
+            }}
+            {{> 'daggerheart.inventory-items'
+                title='DAGGERHEART.GENERAL.Tabs.vault'
+                type='domainCard'
+                isGlassy=true
+                collection=document.system.domainCards.vault
+                canCreate=@root.editable
+                inVault=true
+            }}
+        {{/if}}
     </div>
 </section>
+
+{{#*inline "cardList"}}
+    <fieldset class="glassy drop-section" data-in-vault="{{inVault}}">
+        <legend>
+            {{localize title}}
+            {{#if @root.editable}}
+                <a data-action="addNewItem" data-document-class="Item" data-type="domainCard" data-tooltip="{{localize "DOCUMENT.Create"}}">
+                    <i class="fa-solid fa-plus icon-button"></i>
+                </a>
+            {{/if}}
+        </legend>
+        <ul class="card-list">
+            {{#each collection as |item|}}
+                {{> 'systems/daggerheart/templates/sheets/global/partials/domain-card-item.hbs'
+                    item=item
+                    type='domainCard'
+                }}
+            {{/each}}
+        </ul>
+    </fieldset>
+{{/inline}}

--- a/templates/sheets/global/partials/domain-card-item.hbs
+++ b/templates/sheets/global/partials/domain-card-item.hbs
@@ -8,7 +8,7 @@
         <div
             class="menu {{#if item.system.resource}}resource-menu{{/if}} {{#if (eq item.system.resource.type 'diceValue')}}dice-menu{{/if}}">
             {{#if item.system.resource}}
-            {{> "systems/daggerheart/templates/sheets/global/partials/item-resource.hbs"}}
+                {{> "systems/daggerheart/templates/sheets/global/partials/item-resource.hbs"}}
             {{/if}}
             <div class="controls">
                 <a data-action="toggleVault"
@@ -23,6 +23,6 @@
                 </a>
             </div>
         </div>
-        <a class="card-name" data-action="viewItem">{{item.name}}</a>
+        <a class="card-name" data-action="viewItem" data-tooltip="#item#{{item.uuid}}">{{item.name}}</a>
     </div>
 </li>

--- a/templates/sheets/global/partials/inventory-fieldset-items-V2.hbs
+++ b/templates/sheets/global/partials/inventory-fieldset-items-V2.hbs
@@ -8,7 +8,6 @@ Parameters:
 - collection {array} : Array of items to render.
 - type {string} : The type of items in the list:
 - isGlassy {boolean} : If true, applies the 'glassy' class to the fieldset.
-- cardView {boolean} : If true and type is 'domainCard', renders using domain card layout.
 - isActor {boolean} : Passed through to inventory-item partials.
 - isItem {boolean} : Passed through to inventory-item partials
 - actorType {boolean} : The actor type of the parent actor
@@ -40,18 +39,6 @@ Parameters:
     </a>
     {{/if }}
   </legend>
-  {{#if (and cardView (eq type 'domainCard'))}}
-  <ul class="card-list">
-    {{#each collection as |item|}}
-
-    {{> 'systems/daggerheart/templates/sheets/global/partials/domain-card-item.hbs'
-    item=item
-    type='domainCard'
-    }}
-
-    {{/each}}
-  </ul>
-  {{else}}
   <ul class="items-list">
     {{#each collection as |item|}}
     {{> 'daggerheart.inventory-item'
@@ -74,5 +61,4 @@ Parameters:
 
     {{/each}}
   </ul>
-  {{/if}}
 </fieldset>


### PR DESCRIPTION
Cleans up loadout card view and adds tooltips. Also fixes some css regression in v14 due to font awesome changes. Tooltips only show up when mousing over the name.

This was mostly a request @cptn-cosmo so I'm going to tag them as a reviewer.