### PR TITLE
[Fix] fear tracker offset on appearance change

### DIFF
--- a/module/data/settings/Appearance.mjs
+++ b/module/data/settings/Appearance.mjs
@@ -127,8 +127,7 @@ export default class DhAppearance extends foundry.abstract.DataModel {
             if (this.displayFear === 'hide') {
                 ui.resources.close({ allowed: true });
             } else {
-                ui.resources.render({ force: true });
-                ui.resources.handleOffset();
+                ui.resources.render({ force: true }).then(() => ui.resources.handleOffset());
             }
         }
 

--- a/styles/less/ui/countdown/countdown.less
+++ b/styles/less/ui/countdown/countdown.less
@@ -21,9 +21,10 @@
     width: 18.75rem;
     pointer-events: all;
     align-self: flex-end;
-    transition: 0.3s right ease-in-out;
+    transition: right 0.1s ease;
     display: flex;
     flex-direction: column;
+    right: 0;
 
     &::before {
         content: ' ';

--- a/styles/less/ui/resources/resources.less
+++ b/styles/less/ui/resources/resources.less
@@ -155,7 +155,6 @@ body.theme-light {
             opacity: 0;
             transition: all 0.3s ease;
         }
-        
 
         .resource-bar {
             display: flex;


### PR DESCRIPTION
Fixes a particular case when switching from top right position (2 rows) to top center (1 row) on a 1080p monitor while the sidebar is open and a creature with effects is selected. While it would rectify itself on any change, giving the user the impression its broken is not ideal.