### PR TITLE
[Fix] Improve HP Damage Multiplier Active Effect

### DIFF
--- a/module/data/fields/action/damageField.mjs
+++ b/module/data/fields/action/damageField.mjs
@@ -105,9 +105,8 @@ export default class DamageField extends fields.SchemaField {
                 const configDamage = config.damage.clone();
                 configDamage.main &&= configDamage.main.toJSON();
                 if (configDamage.main) {
-                    const multiplier = config.actionActor?.system.rules?.attack?.damage?.hpDamageMultiplier ?? 1;
                     const takenMultiplier = actor.system.rules?.attack?.damage?.hpDamageTakenMultiplier;
-                    configDamage.main.total = Math.ceil(configDamage.main.total * multiplier * takenMultiplier);
+                    configDamage.main.total = Math.ceil(configDamage.main.total * takenMultiplier);
                 }
 
                 damagePromises.push(

--- a/module/dice/damageRoll.mjs
+++ b/module/dice/damageRoll.mjs
@@ -119,7 +119,9 @@ export default class DamageRoll extends DHRoll {
 
     getActionChangeKeys() {
         const type = this.options.messageType ?? (this.options.hasHealing ? 'healing' : 'damage');
-        const changeKeys = [];
+        const changeKeys = [
+            'system.rules.attack.damage.hpDamageMultiplier'
+        ];
 
         for (const damageType of this.options.damageFormula?.damageTypes?.values?.() ?? []) {
             changeKeys.push(`system.bonuses.${type}.${damageType}`);
@@ -197,6 +199,22 @@ export default class DamageRoll extends DHRoll {
                 if (total > 0) {
                     formulaData.roll.terms.push(...this.formatModifier(total));
                 }
+            }
+
+            const damageTakenMultiplier = this.getTotalBonus('system.rules.attack.damage.hpDamageMultiplier');
+            if (damageTakenMultiplier && damageTakenMultiplier !== 1) {
+                // The fully built up roll needs to be set inside of a paranthetical term, so we build the dice anew with all the pushed in terms.
+                // We clone it to avoid infinite recursion.
+                formulaData.roll = Roll.fromTerms(formulaData.roll.terms);
+
+                formulaData.roll.terms = [
+                    new foundry.dice.terms.ParentheticalTerm({ 
+                        roll: formulaData.roll.clone(), 
+                        term: formulaData.formula 
+                    }),
+                    new foundry.dice.terms.OperatorTerm({ operator: '*' }),
+                    new foundry.dice.terms.NumericTerm({ number: damageTakenMultiplier })
+                ];
             }
         }
 

--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -275,7 +275,7 @@ export default class DHRoll extends BaseRoll {
      * that match a given change.key partial path.
      * @param {string} path The full or partial effect.change key 
      * @param {string} label The label to give the modifiers
-     * @returns {[label: string, value: any]}
+     * @returns {[{ label: string, value: any} ]}
      */
     getBonus(path, label) {
         const modifiers = [];

--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -248,6 +248,13 @@ export default class DHRoll extends BaseRoll {
         });
     }
 
+    /**
+     * Sums the values of all instances of ActiveEffect.change values from the toggleable bonusEffects of the roll 
+     * that match a given change.key partial path. Only for use on ActiveEffects.change with strictly numerical values.
+     * @param {string} path The full or partial effect.change key 
+     * @param {string} label The label to give the modifiers
+     * @returns {[label: string, value: any]}
+     */
     getTotalBonus(path) {
         return Object.values(this.options.bonusEffects).reduce((acc, effect) => {
             if (!effect.selected) return acc;
@@ -264,6 +271,13 @@ export default class DHRoll extends BaseRoll {
         }, 0);
     }
 
+    /**
+     * Grabs all instances of ActiveEffect.change values from the toggleable bonusEffects of the roll 
+     * that match a given change.key partial path.
+     * @param {string} path The full or partial effect.change key 
+     * @param {string} label The label to give the modifiers
+     * @returns {[label: string, value: any]}
+     */
     getBonus(path, label) {
         const modifiers = [];
         for (const effect of Object.values(this.options.bonusEffects)) {

--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -252,8 +252,7 @@ export default class DHRoll extends BaseRoll {
      * Sums the values of all instances of ActiveEffect.change values from the toggleable bonusEffects of the roll 
      * that match a given change.key partial path. Only for use on ActiveEffects.change with strictly numerical values.
      * @param {string} path The full or partial effect.change key 
-     * @param {string} label The label to give the modifiers
-     * @returns {[label: string, value: any]}
+     * @returns {number}
      */
     getTotalBonus(path) {
         return Object.values(this.options.bonusEffects).reduce((acc, effect) => {

--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -248,6 +248,22 @@ export default class DHRoll extends BaseRoll {
         });
     }
 
+    getTotalBonus(path) {
+        return Object.values(this.options.bonusEffects).reduce((acc, effect) => {
+            if (!effect.selected) return acc;
+            return acc + effect.changes.reduce((acc, change) => {
+                if (!change.key.includes(path)) return acc;
+                const changeValue = game.system.api.documents.DhActiveEffect.getChangeValue(
+                    this.data,
+                    change,
+                    effect.origEffect
+                );
+                
+                return Number.isNumeric(changeValue) ? acc + changeValue : acc; 
+            }, 0);
+        }, 0);
+    }
+
     getBonus(path, label) {
         const modifiers = [];
         for (const effect of Object.values(this.options.bonusEffects)) {


### PR DESCRIPTION
- Fixed so that HpDamageMultiplier ActiveEffect actually modifiers the formula so doubled, halve etc damage is actually displayed instead of being invisible
- This active effect now shows up as a toggleable alternatie in the Damage Roll Dialog

<img width="862" height="547" alt="image" src="https://github.com/user-attachments/assets/05ea64fd-f801-4deb-9ed7-1bb44947ae89" />
