### PR TITLE
[Feature] Targeting Rework

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2458,6 +2458,7 @@
             "icon": "Icon",
             "identify": "Identity",
             "imagePath": "Image Path",
+            "immune": "Immune",
             "inactiveEffects": "Inactive Effects",
             "initial": "Initial",
             "inventory": "Inventory",
@@ -2501,6 +2502,7 @@
             "reroll": "Reroll",
             "rerolled": "Rerolled",
             "rerollThing": "Reroll {thing}",
+            "resistant": "Resistant",
             "result": {
                 "single": "Result",
                 "plural": "Results"

--- a/lang/en.json
+++ b/lang/en.json
@@ -3089,8 +3089,11 @@
                     "dealDamage": "Deal Damage",
                     "rollDamage": "Roll Damage",
                     "hitTarget": "Hit",
-                    "targettingInitial": "Targets",
-                    "targettingSelected": "Selected"
+                    "targetingInitial": "Targets",
+                    "targetingSelected": "Selected",
+                    "totalTargetedTokens": "{total} selected",
+                    "noTokensSelected": "No Tokens Selected",
+                    "setSelectedAsTargets": "Set Selected As Targets"
                 },
                 "deathMove": {
                     "title": "Death Move",
@@ -3213,6 +3216,7 @@
                 "beastformInapplicable": "A beastform can only be applied to a Character.",
                 "beastformAlreadyApplied": "The character already has a beastform applied!",
                 "noTargetsSelected": "No targets are selected.",
+                "noTargetsHit": "No targets are hit",
                 "attackTargetDoesNotExist": "The target token no longer exists",
                 "insufficentAdvancements": "You don't have enough advancements left.",
                 "noAssignedPlayerCharacter": "You have no assigned character.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -3213,7 +3213,6 @@
                 "beastformInapplicable": "A beastform can only be applied to a Character.",
                 "beastformAlreadyApplied": "The character already has a beastform applied!",
                 "noTargetsSelected": "No targets are selected.",
-                "noTargetsSelectedOrPerm": "No targets are selected or with the update permission.",
                 "attackTargetDoesNotExist": "The target token no longer exists",
                 "insufficentAdvancements": "You don't have enough advancements left.",
                 "noAssignedPlayerCharacter": "You have no assigned character.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -3089,8 +3089,8 @@
                     "dealDamage": "Deal Damage",
                     "rollDamage": "Roll Damage",
                     "hitTarget": "Hit",
-                    "selectedTarget": "Selected",
-                    "currentTarget": "Current"
+                    "targettingInitial": "Target",
+                    "targettingSelected": "Selected"
                 },
                 "deathMove": {
                     "title": "Death Move",

--- a/lang/en.json
+++ b/lang/en.json
@@ -3089,7 +3089,7 @@
                     "dealDamage": "Deal Damage",
                     "rollDamage": "Roll Damage",
                     "hitTarget": "Hit",
-                    "targettingInitial": "Target",
+                    "targettingInitial": "Targets",
                     "targettingSelected": "Selected"
                 },
                 "deathMove": {

--- a/module/data/chat-message/actorRoll.mjs
+++ b/module/data/chat-message/actorRoll.mjs
@@ -129,17 +129,22 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
      */
     _getCurrentTargets() {
         const getCommonData = data => {
+            const actor = data.actorId ? foundry.utils.fromUuidSync(data.actorId) : null;
             const toHitNumber = data.difficulty || data.evasion;
             const hitSuccessfull = (toHitNumber === null || !this.roll) ? false : this.roll.total >= toHitNumber;
 
             const saveValue = this.targetSaves[data.id];
             const saveSuccessfull = saveValue === undefined ? false : 
                 saveValue >= (this.action.save.difficulty ?? this.action.actor?.baseSaveDifficulty);
-            
+            const hasResistData = this.hasDamage && this.damage.active && actor;
+            const resistData = hasResistData ? actor.getResistanceStatus(this.damage.main.options.damageTypes) : null;
+
             return {
                 ...data,
                 hitResult: this.hasRoll ? { success: hitSuccessfull } : null,
-                saveResult: saveValue ? { success: saveSuccessfull } : null
+                saveResult: saveValue ? { success: saveSuccessfull } : null,
+                resistant: Boolean(resistData?.resistant),
+                immune: Boolean(resistData?.immune)
             }
         };
 
@@ -198,6 +203,8 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
                 selectedTargetsData: this._getSelectedTargetsData(),
                 hasSave: this.hasSave,
                 hasRoll: this.hasRoll,
+                hasDamage: this.hasDamage,
+                damage: this.damage,
                 isGM: game.user.isGM
             }
         );

--- a/module/data/chat-message/actorRoll.mjs
+++ b/module/data/chat-message/actorRoll.mjs
@@ -3,23 +3,6 @@ import { ChatDamageData } from './chatDamageData.mjs';
 
 const fields = foundry.data.fields;
 
-const targetsField = () =>
-    new fields.ArrayField(
-        new fields.SchemaField({
-            id: new fields.StringField({}),
-            actorId: new fields.StringField({}),
-            name: new fields.StringField({}),
-            img: new fields.StringField({}),
-            difficulty: new fields.NumberField({ integer: true, nullable: true }),
-            evasion: new fields.NumberField({ integer: true }),
-            hit: new fields.BooleanField({ initial: false }),
-            saved: new fields.SchemaField({
-                result: new fields.NumberField(),
-                success: new fields.BooleanField({ nullable: true, initial: null })
-            })
-        })
-    );
-
 export const originItemField = () =>
     new fields.SchemaField({
         type: new fields.StringField({
@@ -31,11 +14,16 @@ export const originItemField = () =>
     });
 
 export default class DHActorRoll extends foundry.abstract.TypeDataModel {
+    constructor(data, options) {
+        super(data, options);
+
+        this.targeting = { usingSelect: !this.targets.length };
+    }
+
     static defineSchema() {
         return {
             title: new fields.StringField(),
             actionDescription: new fields.HTMLField(),
-            targets: targetsField(),
             hasRoll: new fields.BooleanField({ initial: false }),
             hasDamage: new fields.BooleanField({ initial: false }),
             hasHealing: new fields.BooleanField({ initial: false }),
@@ -45,6 +33,17 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
             reloadCheckValue: new fields.NumberField({ integer: true, nullable: true, initial: null }),
             isDirect: new fields.BooleanField({ initial: false }),
             onSave: new fields.StringField(),
+            targets: new fields.ArrayField(
+                new fields.SchemaField({
+                    id: new fields.StringField({}),
+                    actorId: new fields.StringField({}),
+                    name: new fields.StringField({}),
+                    img: new fields.StringField({}),
+                    difficulty: new fields.NumberField({ integer: true, nullable: true }),
+                    evasion: new fields.NumberField({ integer: true })
+                })
+            ),
+            targetSaves: new fields.TypedObjectField(new fields.NumberField({ integer: true })),
             source: new fields.SchemaField({
                 actor: new fields.StringField(),
                 item: new fields.StringField(),
@@ -111,38 +110,36 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
         return null;
     }
 
-    get targetMode() {
-        return this.parent.targetSelection;
-    }
+    get currentTargets() {
+        const getCommonData = data => {
+            const toHitNumber = data.difficulty || data.evasion;
+            const hitSuccessfull = (toHitNumber === null || !this.roll) ? false : this.roll.total >= toHitNumber;
 
-    set targetMode(mode) {
-        if (!this.parent.isAuthor) return;
-        this.parent.targetSelection = mode;
-        this.registerTargetHook();
-        this.updateTargets();
-    }
-
-    get hitTargets() {
-        return this.currentTargets.filter(t => t.hit || !this.hasRoll || !this.targetMode);
-    }
-
-    async updateTargets() {
-        if (!ui.chat.collection.get(this.parent.id)) return;
-        let targets;
-        if (this.targetMode) targets = this.targets;
-        else
-            targets = Array.from(game.user.targets).map(t =>
-                game.system.api.fields.ActionFields.TargetField.formatTarget(t)
-            );
-
-        await this.parent.update({
-            flags: {
-                [game.system.id]: {
-                    targets: targets,
-                    targetMode: this.targetMode
-                }
+            const saveValue = this.targetSaves[data.id];
+            const saveSuccessfull = saveValue === undefined ? false : 
+                saveValue >= (this.action.save.difficulty ?? this.action.actor?.baseSaveDifficulty);
+            
+            return {
+                ...data,
+                hitResult: this.hasRoll ? { success: hitSuccessfull } : null,
+                saveResult: saveValue ? { success: saveSuccessfull } : null
             }
-        });
+        };
+
+        if (!this.targeting.usingSelect) return this.targets.map(getCommonData);
+
+        return (canvas.tokens?.controlled ?? []).map(token => ({
+            id: token.id,
+            actorId: token.document.actor?.uuid,
+            name: token.document.prototype?.name ?? token.document.name,
+            img: token.document.texture.src,
+            difficulty: token.document.actor?.system.difficulty,
+            evasion: token.document.actor?.system.evasion
+        })).map(getCommonData);
+    }
+
+    get hasUnfinishedSaves() {
+        return this.hasSaves && this.currentTargets.some(x => !x.saveResult);
     }
 
     async getRerolledDamage() {
@@ -167,38 +164,7 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
         return update;
     }
 
-    registerTargetHook() {
-        if (!this.parent.isAuthor || !this.hasTarget) return;
-        if (this.targetMode && this.parent.targetHook !== null) {
-            Hooks.off('targetToken', this.parent.targetHook);
-            return (this.parent.targetHook = null);
-        } else if (!this.targetMode && this.parent.targetHook === null) {
-            return (this.parent.targetHook = Hooks.on(
-                'targetToken',
-                foundry.utils.debounce(this.updateTargets.bind(this), 50)
-            ));
-        }
-    }
-
     prepareDerivedData() {
-        if (this.hasTarget) {
-            this.hasHitTarget = this.targets.filter(t => t.hit === true).length > 0;
-            this.currentTargets = this.getTargetList();
-            // this.registerTargetHook();
-
-            if (this.hasRoll) {
-                this.targetShort = this.targets.reduce(
-                    (a, c) => {
-                        if (c.hit) a.hit += 1;
-                        else a.miss += 1;
-                        return a;
-                    },
-                    { hit: 0, miss: 0 }
-                );
-            }
-            if (this.hasSave) this.setPendingSaves();
-        }
-
         this.canViewSecret = this.parent.speakerActor?.testUserPermission(game.user, 'OBSERVER');
         this.canButtonApply = game.user.isGM; //temp
         this.isGM = game.user.isGM; //temp
@@ -238,29 +204,5 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
         }
         
         return source;
-    }
-
-
-    getTargetList() {
-        const targets =
-                this.targetMode && this.parent.isAuthor
-                    ? this.targets
-                    : (this.parent.getFlag(game.system.id, 'targets') ?? this.targets),
-            reactionRolls = this.parent.getFlag(game.system.id, 'reactionRolls');
-
-        if (reactionRolls) {
-            Object.entries(reactionRolls).forEach(([k, r]) => {
-                const target = targets.find(t => t.id === k);
-                if (target) target.saved = r;
-            });
-        }
-
-        return targets;
-    }
-
-    setPendingSaves() {
-        this.pendingSaves = this.targetMode
-            ? this.targets.filter(target => target.hit && target.saved.success === null).length > 0
-            : this.currentTargets.filter(target => target.saved.success === null).length > 0;
     }
 }

--- a/module/data/chat-message/actorRoll.mjs
+++ b/module/data/chat-message/actorRoll.mjs
@@ -111,7 +111,23 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
         return null;
     }
 
-    get currentTargets() {
+    get currentHitTargets() {
+        const currentTargets = this._getCurrentTargets();
+        if (!this.hasRoll || this.targeting.usingSelect) return currentTargets;
+
+        return currentTargets.filter(x => x.hitResult.success)
+    }
+
+    get hasUnfinishedSaves() {
+        return this.hasSave && this.currentHitTargets.some(x => !x.saveResult);
+    }
+
+    /**
+     * Get the target data for the current targets of the roll. 
+     * This will either be the initial targets, or the currently selected tokens depending on which tab the GM has open.
+     * @returns {TargetData[]}
+     */
+    _getCurrentTargets() {
         const getCommonData = data => {
             const toHitNumber = data.difficulty || data.evasion;
             const hitSuccessfull = (toHitNumber === null || !this.roll) ? false : this.roll.total >= toHitNumber;
@@ -140,21 +156,20 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
         })).map(getCommonData);
     }
 
-    get currentHitTargets() {
-        if (!this.hasRoll || this.targeting.usingSelect) return this.currentTargets;
-
-        return this.currentTargets.filter(x => x.hitResult.success)
-    }
-
-    get selectedTargetsData() {
+    /**
+     * Returns the needed render data for the Selected tab of the targeting section.
+     * @returns {{ totalTokens: number, uniqueTokens: number, tokens: TokenData[] }}
+     */
+    _getSelectedTargetsData() {
         if (!this.targeting.usingSelect) return [];
 
-        const currentTargets = this.currentTargets;
+        const currentTargets = this._getCurrentTargets();
         const uniqueTokens = currentTargets.reduce((acc, target) => {
             if (acc.find(x => x._actorId === target._actorId)) return acc;
             acc.push(target);
             return acc;
         }, []);
+
         return {
             totalTokens: currentTargets.length,
             uniqueTokens: uniqueTokens.length,
@@ -162,9 +177,6 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
         }
     }
 
-    get hasUnfinishedSaves() {
-        return this.hasSave && this.currentHitTargets.some(x => !x.saveResult);
-    }
 
     syncSelectedTokens = foundry.utils.debounce(async () => {
         if (this.targeting.usingSelect) this.updateTargetHTML();
@@ -182,8 +194,8 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
             'systems/daggerheart/templates/ui/chat/parts/target-tokens-part.hbs',
             {
                 targeting: this.targeting,
-                currentTargets: this.currentTargets,
-                selectedTargetsData: this.selectedTargetsData,
+                currentTargets: this._getCurrentTargets(),
+                selectedTargetsData: this._getSelectedTargetsData(),
                 hasSave: this.hasSave,
                 hasRoll: this.hasRoll,
                 isGM: game.user.isGM

--- a/module/data/chat-message/actorRoll.mjs
+++ b/module/data/chat-message/actorRoll.mjs
@@ -190,10 +190,6 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
         element.outerHTML = targetTokensHTML;
         this.parent.addTargetSectionListeners(chatMessageHTML);
     }
-    
-    setSelectedAsTargets() {
-        this.parent.update({ 'system.targets': this.currentTargets });
-    }
 
     async getRerolledDamage() {
         if (!this.damage.active) return;

--- a/module/data/chat-message/actorRoll.mjs
+++ b/module/data/chat-message/actorRoll.mjs
@@ -131,6 +131,7 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
         return (canvas.tokens?.controlled ?? []).map(token => ({
             id: token.id,
             actorId: token.document.actor?.uuid,
+            _actorId: token.document.actor?.id,
             name: token.document.prototype?.name ?? token.document.name,
             img: token.document.texture.src,
             difficulty: token.document.actor?.system.difficulty,
@@ -138,8 +139,30 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
         })).map(getCommonData);
     }
 
+    get currentHitTargets() {
+        if (!this.hasRoll || this.targeting.usingSelect) return this.currentTargets;
+
+        return this.currentTargets.filter(x => x.hitResult.success)
+    }
+
+    get selectedTargetsData() {
+        if (!this.targeting.usingSelect) return [];
+
+        const currentTargets = this.currentTargets;
+        const uniqueTokens = currentTargets.reduce((acc, target) => {
+            if (acc.find(x => x._actorId === target._actorId)) return acc;
+            acc.push(target);
+            return acc;
+        }, []);
+        return {
+            totalTokens: currentTargets.length,
+            uniqueTokens: uniqueTokens.length,
+            tokens: uniqueTokens.slice(0, 3)
+        }
+    }
+
     get hasUnfinishedSaves() {
-        return this.hasSaves && this.currentTargets.some(x => !x.saveResult);
+        return this.hasSaves && this.currentHitTargets.some(x => !x.saveResult);
     }
 
     syncSelectedTokens = foundry.utils.debounce(async () => {
@@ -156,6 +179,7 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
             {
                 targeting: this.targeting,
                 currentTargets: this.currentTargets,
+                selectedTargetsData: this.selectedTargetsData,
                 hasSave: this.hasSave,
                 hasRoll: this.hasRoll,
                 isGM: game.user.isGM
@@ -165,6 +189,10 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
         const element = chatMessageHTML.querySelector('.chat-roll .target-section .roll-part-content .wrapper');
         element.outerHTML = targetTokensHTML;
         this.parent.addTargetSectionListeners(chatMessageHTML);
+    }
+    
+    setSelectedAsTargets() {
+        this.parent.update({ 'system.targets': this.currentTargets });
     }
 
     async getRerolledDamage() {

--- a/module/data/chat-message/actorRoll.mjs
+++ b/module/data/chat-message/actorRoll.mjs
@@ -150,7 +150,7 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
 
     /**
      * Updates the target section of the chat message through direct HTML manipulation.
-     * Listeners are reattched.
+     * Listeners are reattached.
      */
     async updateTargetHTML() {
         const targetTokensHTML = await foundry.applications.handlebars.renderTemplate(

--- a/module/data/chat-message/actorRoll.mjs
+++ b/module/data/chat-message/actorRoll.mjs
@@ -142,6 +142,33 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
         return this.hasSaves && this.currentTargets.some(x => !x.saveResult);
     }
 
+    syncSelectedTokens = foundry.utils.debounce(async () => {
+        if (!this.targeting.usingSelect) return;
+        
+        this.updateTargetHTML();
+    }, 50);
+
+    /**
+     * Updates the target section of the chat message through direct HTML manipulation.
+     * Listeners are reattched.
+     */
+    async updateTargetHTML() {
+        const targetTokensHTML = await foundry.applications.handlebars.renderTemplate(
+            'systems/daggerheart/templates/ui/chat/parts/target-tokens-part.hbs',
+            {
+                targeting: this.targeting,
+                currentTargets: this.currentTargets,
+                hasSave: this.hasSave,
+                hasRoll: this.hasRoll,
+                isGM: game.user.isGM
+            }
+        );
+        const chatMessageHTML = ui.chat.element.querySelector(`.chat-message[data-message-id="${this.parent.id}"]`);
+        const element = chatMessageHTML.querySelector('.chat-roll .target-section .roll-part-content .wrapper');
+        element.outerHTML = targetTokensHTML;
+        this.parent.addTargetSectionListeners(chatMessageHTML);
+    }
+
     async getRerolledDamage() {
         if (!this.damage.active) return;
 

--- a/module/data/chat-message/actorRoll.mjs
+++ b/module/data/chat-message/actorRoll.mjs
@@ -134,7 +134,7 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
             actorId: token.document.actor?.uuid,
             _actorId: token.document.actor?.id,
             name: token.document.prototype?.name ?? token.document.name,
-            img: token.document.texture.src,
+            img: token.document.actor?.img ?? token.document.texture.src,
             difficulty: token.document.actor?.system.difficulty,
             evasion: token.document.actor?.system.evasion
         })).map(getCommonData);

--- a/module/data/chat-message/actorRoll.mjs
+++ b/module/data/chat-message/actorRoll.mjs
@@ -143,9 +143,7 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
     }
 
     syncSelectedTokens = foundry.utils.debounce(async () => {
-        if (!this.targeting.usingSelect) return;
-        
-        this.updateTargetHTML();
+        if (this.targeting.usingSelect) this.updateTargetHTML();
     }, 50);
 
     /**

--- a/module/data/chat-message/actorRoll.mjs
+++ b/module/data/chat-message/actorRoll.mjs
@@ -162,7 +162,7 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
     }
 
     get hasUnfinishedSaves() {
-        return this.hasSaves && this.currentHitTargets.some(x => !x.saveResult);
+        return this.hasSave && this.currentHitTargets.some(x => !x.saveResult);
     }
 
     syncSelectedTokens = foundry.utils.debounce(async () => {

--- a/module/data/chat-message/actorRoll.mjs
+++ b/module/data/chat-message/actorRoll.mjs
@@ -53,6 +53,7 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
             damage: new fields.EmbeddedDataField(ChatDamageData),
             damageOptions: new fields.ObjectField(),
             costs: new fields.ArrayField(new fields.ObjectField()),
+            uses: new fields.ObjectField(),
             successConsumed: new fields.BooleanField({ initial: false })
         };
     }

--- a/module/data/chat-message/actorRoll.mjs
+++ b/module/data/chat-message/actorRoll.mjs
@@ -173,8 +173,11 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
     /**
      * Updates the target section of the chat message through direct HTML manipulation.
      * Listeners are reattached.
+     * @param {object} options
+     * @param {"targets" | "select" | null} [options.tab] If set, switches to this tab before updates
      */
-    async updateTargetHTML() {
+    async updateTargetHTML({ tab = null } = {}) {
+        if (tab) this.targeting.usingSelect = tab === 'select';
         const targetTokensHTML = await foundry.applications.handlebars.renderTemplate(
             'systems/daggerheart/templates/ui/chat/parts/target-tokens-part.hbs',
             {

--- a/module/data/fields/action/damageField.mjs
+++ b/module/data/fields/action/damageField.mjs
@@ -112,7 +112,22 @@ export default class DamageField extends fields.SchemaField {
                 damagePromises.push(
                     actor
                         .takeDamage(configDamage, config.isDirect)
-                        .then(updates => targetDamage.push({ token, updates }))
+                        .then(updates => { 
+                            const resistanceData = 
+                                token.actor?.getResistanceStatus(configDamage.main?.options.damageTypes);
+                            const tokenData = {
+                                id: token.id, 
+                                name: token.prototype?.name ?? token.name, 
+                                img: token.texture.src,
+                                resistant: resistanceData?.resistant,
+                                immune: resistanceData?.immune
+                            };
+                            
+                            targetDamage.push({
+                                token: tokenData,
+                                updates 
+                            })
+                        })
                 );
             }
         }
@@ -123,6 +138,11 @@ export default class DamageField extends fields.SchemaField {
                 CONFIG.DH.SETTINGS.gameSettings.Automation
             ).summaryMessages;
             if (!summaryMessageSettings.damage) return;
+
+            const { hideObserverPermissionInChat } = game.settings.get(
+                CONFIG.DH.id,
+                CONFIG.DH.SETTINGS.gameSettings.Metagaming
+            );
 
             const cls = getDocumentClass('ChatMessage');
             const msg = {
@@ -135,7 +155,8 @@ export default class DamageField extends fields.SchemaField {
                 content: await foundry.applications.handlebars.renderTemplate(
                     'systems/daggerheart/templates/ui/chat/damageSummary.hbs',
                     {
-                        targets: targetDamage
+                        targets: targetDamage,
+                        hideObserverPermissionInChat
                     }
                 )
             };

--- a/module/data/fields/action/effectsField.mjs
+++ b/module/data/fields/action/effectsField.mjs
@@ -48,10 +48,10 @@ export default class EffectsField extends fields.ArrayField {
         let effects = this.effects;
         const messageTargets = [];
         for (const baseToken of targets) {
-            if (this.hasSave && baseToken.saveResult.success === true) 
+            if (this.hasSave && baseToken.saveResult?.success === true) 
                 effects = this.effects.filter(e => e.onSave === true);
             
-            if (!effects.length) return;
+            if (!effects.length) continue;
 
             const token =
                 canvas.tokens.get(baseToken.id) ?? foundry.utils.fromUuidSync(baseToken.actorId).prototypeToken;
@@ -73,8 +73,9 @@ export default class EffectsField extends fields.ArrayField {
 
             for (const e of effects) {
                 const effect = (this.item.applyEffects ?? this.item.effects).get(e._id);
-                if (!token.actor || !effect) return;
-                await EffectsField.applyEffect(effect, token.actor);
+                if (token.actor && effect) {
+                    await EffectsField.applyEffect(effect, token.actor);
+                }
             }
         }
 

--- a/module/data/fields/action/effectsField.mjs
+++ b/module/data/fields/action/effectsField.mjs
@@ -47,7 +47,7 @@ export default class EffectsField extends fields.ArrayField {
         const conditions = CONFIG.DH.GENERAL.conditions();
         let effects = this.effects;
         const messageTargets = [];
-        targets.forEach(async baseToken => {
+        for (const baseToken of targets) {
             if (this.hasSave && baseToken.saveResult.success === true) 
                 effects = this.effects.filter(e => e.onSave === true);
             
@@ -71,12 +71,12 @@ export default class EffectsField extends fields.ArrayField {
                     : null
             });
 
-            effects.forEach(async e => {
+            for (const e of effects) {
                 const effect = (this.item.applyEffects ?? this.item.effects).get(e._id);
                 if (!token.actor || !effect) return;
                 await EffectsField.applyEffect(effect, token.actor);
-            });
-        });
+            }
+        }
 
         if (messageTargets.length === 0) return;
 

--- a/module/data/fields/action/effectsField.mjs
+++ b/module/data/fields/action/effectsField.mjs
@@ -48,7 +48,9 @@ export default class EffectsField extends fields.ArrayField {
         let effects = this.effects;
         const messageTargets = [];
         targets.forEach(async baseToken => {
-            if (this.hasSave && baseToken.saved.success === true) effects = this.effects.filter(e => e.onSave === true);
+            if (this.hasSave && baseToken.saveResult.success === true) 
+                effects = this.effects.filter(e => e.onSave === true);
+            
             if (!effects.length) return;
 
             const token =

--- a/module/data/fields/action/saveField.mjs
+++ b/module/data/fields/action/saveField.mjs
@@ -44,7 +44,7 @@ export default class SaveField extends fields.SchemaField {
             message = config.message = await CONFIG.Dice.daggerheart.DHRoll.toMessage(roll, config);
         }
         if (SaveField.getAutomation() !== CONFIG.DH.SETTINGS.actionAutomationChoices.never.id || force) {
-            targets ??= config.targets.filter(t => !config.hasRoll || t.hit);
+            targets ??= config.targets.filter(t => !config.hasRoll || t.hitResult?.success);
             await SaveField.rollAllSave.call(this, targets, config.event, message);
         } else return;
     }
@@ -125,20 +125,10 @@ export default class SaveField extends fields.SchemaField {
     static async updateSaveMessage(result, message, targetId) {
         if (!result) return;
 
-        const chatMessage = ui.chat.collection.get(message._id),
-            changes = {
-                flags: {
-                    [game.system.id]: {
-                        reactionRolls: {
-                            [targetId]: {
-                                result: result.roll.total,
-                                success: result.roll.success
-                            }
-                        }
-                    }
-                }
-            };
-        await chatMessage.update(changes);
+        const chatMessage = ui.chat.collection.get(message._id);
+        await chatMessage.update({
+            [`system.targetSaves.${targetId}`]: result.roll.total
+        });
     }
 
     /**

--- a/module/data/settings/Appearance.mjs
+++ b/module/data/settings/Appearance.mjs
@@ -63,8 +63,7 @@ export default class DhAppearance extends foundry.abstract.DataModel {
             expandRollMessage: new SchemaField({
                 desc: new BooleanField({ initial: true }),
                 roll: new BooleanField(),
-                damage: new BooleanField(),
-                target: new BooleanField()
+                damage: new BooleanField()
             }),
             showTokenDistance: new StringField({
                 required: true,

--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -169,6 +169,7 @@ export default class DHRoll extends BaseRoll {
         } else return msgData;
     }
 
+    // TODO - Possibly remove this completly if actorRoll.renderHTML implementation can take over getting the chatData prepared.
     /** @inheritDoc */
     async render({ flavor, template = this.constructor.CHAT_TEMPLATE, isPrivate = false, ...options } = {}) {
         if (!this._evaluated) return;
@@ -179,6 +180,10 @@ export default class DHRoll extends BaseRoll {
         return foundry.applications.handlebars.renderTemplate(template, {
             roll: this,
             ...chatData,
+            targetData: chatData.hasTarget ? {
+                currentTargets: chatData._getCurrentTargets(),
+                selectedTargetsData: chatData._getSelectedTargetsData()
+            } : null,
             action: chatData.action,
             parent: chatData.parent,
             targetMode: chatData.targetMode,

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -165,6 +165,28 @@ export default class DhpActor extends Actor {
         }
     }
 
+    /**
+     * Get the bools for if the actor is resistant or immune to damage carrying certain damageTypes.
+     * An actor has to be resistant or immune to -all- related damageTypes for it to count.
+     * @param {string[]} damageTypes 
+     * @returns { resistant: bool, immune: bool }
+     */
+    getResistanceStatus(damageTypes) {
+        let resistant = null;
+        let immune = null;
+        
+        for (const type of damageTypes) {
+            if (resistant !== false && this.system.resistance?.[type]) {
+                resistant = this.system.resistance[type].resistance;
+            }
+            if (immune !== false && this.system.resistance?.[type]) {
+                immune = this.system.resistance[type].immunity;
+            }
+        }
+
+        return { resistant: Boolean(resistant), immune: Boolean(immune) }
+    }
+
     async updateLevel(newLevel) {
         if (!['character', 'companion'].includes(this.type) || newLevel === this.system.levelData.level.changed) return;
 
@@ -679,7 +701,7 @@ export default class DhpActor extends Actor {
                 damageTypes: new Set(args.main.damageTypes), 
                 key: CONFIG.DH.GENERAL.healingTypes.hitPoints.id
             };
-            if (this.type === 'character' && !isDirect && this.#canReduceDamage(hpDamage.value, hpDamage.damageTypes)) {
+            if (this.type === 'character' && !isDirect && hpDamage.value > 0 && this.#canReduceDamage(hpDamage.value, hpDamage.damageTypes)) {
                 const armorSlotResult = await this.owner.query(
                     'armorSlot',
                     {
@@ -778,18 +800,14 @@ export default class DhpActor extends Actor {
     }
 
     calculateDamage(baseDamage, type) {
-        if (this.canResist(type, 'immunity')) return 0;
-        if (this.canResist(type, 'resistance')) baseDamage = Math.ceil(baseDamage / 2);
+        const { resistant, immune } = this.getResistanceStatus(type);
+        if (immune) baseDamage = 0;
+        else if (resistant) baseDamage = Math.ceil(baseDamage / 2);
 
         const flatReduction = this.getDamageTypeReduction(type);
         const damage = Math.max(baseDamage - (flatReduction ?? 0), 0);
 
         return damage;
-    }
-
-    canResist(type, resistance) {
-        if (!type?.length) return false;
-        return type.every(t => this.system.resistance[t]?.[resistance] === true);
     }
 
     getDamageTypeReduction(type) {
@@ -881,6 +899,8 @@ export default class DhpActor extends Actor {
     }
 
     convertDamageToThreshold(damage) {
+        if (damage <= 0) return 0;
+
         const massiveDamageEnabled = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.variantRules)
             .massiveDamage.enabled;
         if (massiveDamageEnabled && damage >= this.system.damageThresholds.severe * 2) {

--- a/module/documents/chatMessage.mjs
+++ b/module/documents/chatMessage.mjs
@@ -20,7 +20,7 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
     }
 
     async onSelectToken() {
-        await this.update({}, { diff: false });
+        this.system.syncSelectedTokens();
     }
 
     async renderHTML() {
@@ -132,14 +132,6 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
             element.addEventListener('click', this.onApplyDamage.bind(this))
         );
 
-        html.querySelectorAll('.target-save').forEach(element =>
-            element.addEventListener('click', this.onRollSave.bind(this))
-        );
-
-        html.querySelectorAll('.roll-all-save-button').forEach(element =>
-            element.addEventListener('click', this.onRollAllSave.bind(this))
-        );
-
         html.querySelectorAll('.duality-action-effect').forEach(element =>
             element.addEventListener('click', this.onApplyEffect.bind(this))
         );
@@ -147,6 +139,18 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
         for (const element of html.querySelectorAll('.action-areas')) {
             element.addEventListener('click', this.onCreateAreas.bind(this));
         }
+
+        this.addTargetSectionListeners(html);
+    }
+
+    addTargetSectionListeners(html) {
+        html.querySelectorAll('.roll-all-save-button').forEach(element =>
+            element.addEventListener('click', this.onRollAllSave.bind(this))
+        );
+
+        html.querySelectorAll('.target-save').forEach(element =>
+            element.addEventListener('click', this.onRollSave.bind(this))
+        );
 
         html.querySelectorAll('.roll-target').forEach(element => {
             element.addEventListener('mouseenter', this.hoverTarget);
@@ -380,7 +384,7 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
         event.stopPropagation();
         if (!event.target.classList.contains('target-selected')) {
             this.system.targeting.usingSelect = Boolean(event.target.dataset.selected);
-            this.update({}, { diff: false });
+            this.system.updateTargetHTML();
         }
     }
 }

--- a/module/documents/chatMessage.mjs
+++ b/module/documents/chatMessage.mjs
@@ -211,7 +211,6 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
             if (!confirm) return;
         }
 
-        this.consumeOnSuccess();
         if (this.system.action) this.system.action.workflow.get('applyDamage')?.execute(config, targets, true);
         else {
             for (const target of targets) {
@@ -287,8 +286,6 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
             if (!confirm) return;
         }
         
-
-        this.consumeOnSuccess();
         this.system.action?.workflow.get('effects')?.execute(config, targets, true);
     }
 
@@ -367,10 +364,6 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
         }
     }
 
-    consumeOnSuccess() {
-        if (!this.system.successConsumed) this.system.action?.consume(this.system, true);
-    }
-
     hoverTarget(event) {
         event.stopPropagation();
         const token = canvas.tokens.get(event.currentTarget.dataset.token);
@@ -394,7 +387,7 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
 
     onSelectedToTargets(event) {
         event.stopPropagation();
-        this.system.setSelectedAsTargets();
+        this.update({ 'system.targets': this.system.currentTargets });
     }
 
     onTargetSelection(event) {

--- a/module/documents/chatMessage.mjs
+++ b/module/documents/chatMessage.mjs
@@ -189,7 +189,7 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
 
     async onApplyDamage(event) {
         event.stopPropagation();
-        if (this.system.currentTargets.length === 0)
+        if (this.system._getCurrentTargets().length === 0)
             return ui.notifications.info(game.i18n.localize('DAGGERHEART.UI.Notifications.noTargetsSelected'));
 
         const targets = this.system.currentHitTargets;
@@ -265,7 +265,7 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
 
     async onApplyEffect(event) {
         event.stopPropagation();
-        if (this.system.currentTargets.length === 0)
+        if (this.system._getCurrentTargets().length === 0)
             return ui.notifications.info(game.i18n.localize('DAGGERHEART.UI.Notifications.noTargetsSelected'));
         
         const targets = this.system.currentHitTargets;
@@ -398,7 +398,7 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
     async #onSelectedToTargets(event) {
         event.stopPropagation();
         // Update the targets and ensure that we swap to the targets tab
-        if (!(await this.update({ 'system.targets': this.system.currentTargets }))) {
+        if (!(await this.update({ 'system.targets': this.system._getCurrentTargets() }))) {
             this.system.updateTargetHTML({ tab: 'targets' });
         }
     }

--- a/module/documents/chatMessage.mjs
+++ b/module/documents/chatMessage.mjs
@@ -211,6 +211,7 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
             if (!confirm) return;
         }
 
+        this.consumeOnSuccess();
         if (this.system.action) this.system.action.workflow.get('applyDamage')?.execute(config, targets, true);
         else {
             for (const target of targets) {
@@ -286,6 +287,7 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
             if (!confirm) return;
         }
         
+        this.consumeOnSuccess();
         this.system.action?.workflow.get('effects')?.execute(config, targets, true);
     }
 
@@ -362,6 +364,13 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
 
             CONFIG.ux.ContextMenu.triggerContextMenu(event, '.action-areas');
         }
+    }
+
+    /**
+     * If an action with consumeOnSuccess hasn't consumed resources initially, this function will do so if there were no initial targets.
+     */
+    consumeOnSuccess() {
+        if (!this.system.successConsumed && !this.system.targets.length) this.system.action?.consume(this.system, true);
     }
 
     hoverTarget(event) {

--- a/module/documents/chatMessage.mjs
+++ b/module/documents/chatMessage.mjs
@@ -198,7 +198,7 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
         }
 
         if (targets.length === 0)
-            return ui.notifications.info(game.i18n.localize('DAGGERHEART.UI.Notifications.noTargetsSelectedOrPerm'));
+            return ui.notifications.info(game.i18n.localize('DAGGERHEART.UI.Notifications.noTargetsSelected'));
 
         this.consumeOnSuccess();
         if (this.system.action) this.system.action.workflow.get('applyDamage')?.execute(config, targets, true);
@@ -257,7 +257,7 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
         config.event = event;
 
         if (targets.length === 0)
-            return ui.notifications.info(game.i18n.localize('DAGGERHEART.UI.Notifications.noTargetsSelectedOrPerm'));
+            return ui.notifications.info(game.i18n.localize('DAGGERHEART.UI.Notifications.noTargetsSelected'));
 
         if (this.system.hasUnfinishedSaves) {
             const confirm = await foundry.applications.api.DialogV2.confirm({

--- a/module/documents/chatMessage.mjs
+++ b/module/documents/chatMessage.mjs
@@ -1,14 +1,28 @@
 import { emitGMUpdate, emitGMCreate, GMUpdateEvent } from '../systemRegistration/socket.mjs';
 
 export default class DhpChatMessage extends foundry.documents.ChatMessage {
-    targetHook = null;
-
     static #EXPAND_SECTIONS = [
         { selector: '.roll-section [data-action="expandRoll"]', key: 'roll' },
         { selector: '.damage-section', key: 'damage' },
         { selector: '.target-section', key: 'target' },
         { selector: '.description-section', key: 'desc' }
     ];
+
+    constructor(data, options) {
+        super(data, options);
+
+        this.setupHooks();
+    }
+
+    setupHooks() {
+        if (this.system.hasTarget) {
+            Hooks.on('controlToken', this.onSelectToken.bind(this));
+        }
+    }
+
+    async onSelectToken() {
+        await this.update({}, { diff: false });
+    }
 
     async renderHTML() {
         const actor = game.actors.get(this.speaker.actor);
@@ -35,28 +49,6 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
     /* -------------------------------------------- */
 
     /** @inheritDoc */
-    prepareData() {
-        if (this.isAuthor && this.targetSelection === undefined) this.targetSelection = this.system.targets?.length > 0;
-        super.prepareData();
-    }
-
-    /* -------------------------------------------- */
-
-    /** @inheritDoc */
-    _onCreate(data, options, userId) {
-        super._onCreate(data, options, userId);
-        if (this.system.registerTargetHook) this.system.registerTargetHook();
-    }
-
-    /* -------------------------------------------- */
-
-    /** @inheritDoc */
-    async _preDelete(options, user) {
-        if (this.targetHook !== null) Hooks.off('targetToken', this.targetHook);
-        return super._preDelete(options, user);
-    }
-
-    /** @inheritDoc */
     _onUpdate(changes, options, userId) {
         super._onUpdate(changes, options, userId);
 
@@ -66,6 +58,12 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
                 ui.chat.scrollBottom();
             }, 5);
         }
+    }
+
+    _onDelete(options, userId) {
+        super._onDelete(options, userId);
+
+        Hooks.off('targetToken', this.onSelectToken);
     }
 
     enrichChatMessage(html) {
@@ -184,23 +182,20 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
 
     async onApplyDamage(event) {
         event.stopPropagation();
-        const targets = this.filterPermTargets(this.system.hitTargets),
-            config = foundry.utils.deepClone(this.system);
+        const targets = this.system.currentTargets;
+        const config = foundry.utils.deepClone(this.system);
         config.event = event;
 
-        if (config.hasSave) {
-            const pendingingSaves = targets.filter(t => t.saved.success === null);
-            if (pendingingSaves.length) {
-                const confirm = await foundry.applications.api.DialogV2.confirm({
-                    window: { title: game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.title') },
-                    content: `
-                        <p>${game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.unfinishedRolls')}</p>
-                        <p><i>${game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.warning')}</i></p>
-                        <p>${game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.confirmation')}</p>
-                    `
-                });
-                if (!confirm) return;
-            }
+        if (this.system.hasUnfinishedSaves) {
+            const confirm = await foundry.applications.api.DialogV2.confirm({
+                window: { title: game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.title') },
+                content: `
+                    <p>${game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.unfinishedRolls')}</p>
+                    <p><i>${game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.warning')}</i></p>
+                    <p>${game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.confirmation')}</p>
+                `
+            });
+            if (!confirm) return;
         }
 
         if (targets.length === 0)
@@ -210,7 +205,7 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
         if (this.system.action) this.system.action.workflow.get('applyDamage')?.execute(config, targets, true);
         else {
             for (const target of targets) {
-                const actor = await foundry.utils.fromUuid(target.actorId);
+                const actor = target.document.actor;
                 if (!actor) continue;
 
                 if (this.system.hasHealing) actor.takeHealing(this.system.damage);
@@ -250,34 +245,33 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
     async onRollAllSave(event) {
         event.stopPropagation();
         if (!game.user.isGM) return;
-        const targets = this.system.hitTargets,
-            config = foundry.utils.deepClone(this.system);
+        const targets = this.system.currentTargets;
+        const config = foundry.utils.deepClone(this.system);
         config.event = event;
         this.system.action?.workflow.get('save')?.execute(config, targets, true);
     }
 
     async onApplyEffect(event) {
         event.stopPropagation();
-        const targets = this.filterPermTargets(this.system.hitTargets),
-            config = foundry.utils.deepClone(this.system);
+        const targets = this.system.currentTargets;
+        const config = foundry.utils.deepClone(this.system);
         config.event = event;
 
         if (targets.length === 0)
             return ui.notifications.info(game.i18n.localize('DAGGERHEART.UI.Notifications.noTargetsSelectedOrPerm'));
-        else if (config.hasSave) {
-            const pendingingSaves = targets.filter(t => t.saved.success === null);
-            if (pendingingSaves.length) {
-                const confirm = await foundry.applications.api.DialogV2.confirm({
-                    window: { title: game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.title') },
-                    content: `
-                        <p>${game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.unfinishedRolls')}</p>
-                        <p><i>${game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.warning')}</i></p>
-                        <p>${game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.confirmation')}</p>
-                    `
-                });
-                if (!confirm) return;
-            }
+
+        if (this.system.hasUnfinishedSaves) {
+            const confirm = await foundry.applications.api.DialogV2.confirm({
+                window: { title: game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.title') },
+                content: `
+                    <p>${game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.unfinishedRolls')}</p>
+                    <p><i>${game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.warning')}</i></p>
+                    <p>${game.i18n.localize('DAGGERHEART.APPLICATIONS.PendingReactionsDialog.confirmation')}</p>
+                `
+            });
+            if (!confirm) return;
         }
+        
 
         this.consumeOnSuccess();
         this.system.action?.workflow.get('effects')?.execute(config, targets, true);
@@ -358,12 +352,8 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
         }
     }
 
-    filterPermTargets(targets) {
-        return targets.filter(t => fromUuidSync(t.actorId)?.canUserModify(game.user, 'update'));
-    }
-
     consumeOnSuccess() {
-        if (!this.system.successConsumed && !this.targetSelection) this.system.action?.consume(this.system, true);
+        if (!this.system.successConsumed && !this.system.targets) this.system.action?.consume(this.system, true);
     }
 
     hoverTarget(event) {
@@ -389,7 +379,9 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
 
     onTargetSelection(event) {
         event.stopPropagation();
-        if (!event.target.classList.contains('target-selected'))
-            this.system.targetMode = Boolean(event.target.dataset.targetHit);
+        if (!event.target.classList.contains('target-selected')) {
+            this.system.targeting.usingSelect = Boolean(event.target.dataset.selected);
+            this.update({}, { diff: false });
+        }
     }
 }

--- a/module/documents/chatMessage.mjs
+++ b/module/documents/chatMessage.mjs
@@ -397,7 +397,7 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
     /** Handle the user clicking the button to convert selected to targets and update the chat message */
     async #onSelectedToTargets(event) {
         event.stopPropagation();
-        // Update the targets. Regardless of what happens, swap to the targets tab
+        // Update the targets and ensure that we swap to the targets tab
         if (!(await this.update({ 'system.targets': this.system.currentTargets }))) {
             this.system.updateTargetHTML({ tab: 'targets' });
         }

--- a/module/documents/chatMessage.mjs
+++ b/module/documents/chatMessage.mjs
@@ -4,7 +4,6 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
     static #EXPAND_SECTIONS = [
         { selector: '.roll-section [data-action="expandRoll"]', key: 'roll' },
         { selector: '.damage-section', key: 'damage' },
-        { selector: '.target-section', key: 'target' },
         { selector: '.description-section', key: 'desc' }
     ];
 

--- a/module/documents/chatMessage.mjs
+++ b/module/documents/chatMessage.mjs
@@ -62,7 +62,7 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
     _onDelete(options, userId) {
         super._onDelete(options, userId);
 
-        Hooks.off('targetToken', this.onSelectToken);
+        Hooks.off('controlToken', this.onSelectToken);
     }
 
     enrichChatMessage(html) {
@@ -368,7 +368,7 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
     }
 
     consumeOnSuccess() {
-        if (!this.system.successConsumed && !this.system.targets) this.system.action?.consume(this.system, true);
+        if (!this.system.successConsumed) this.system.action?.consume(this.system, true);
     }
 
     hoverTarget(event) {

--- a/module/documents/chatMessage.mjs
+++ b/module/documents/chatMessage.mjs
@@ -158,6 +158,10 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
             element.addEventListener('click', this.clickTarget);
         });
 
+        html.querySelectorAll('.selected-to-targets-button').forEach(element => {
+            element.addEventListener('click', this.onSelectedToTargets.bind(this));
+        });
+
         html.querySelectorAll('.button-target-selection').forEach(element => {
             element.addEventListener('click', this.onTargetSelection.bind(this));
         });
@@ -185,7 +189,13 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
 
     async onApplyDamage(event) {
         event.stopPropagation();
-        const targets = this.system.currentTargets;
+        if (this.system.currentTargets.length === 0)
+            return ui.notifications.info(game.i18n.localize('DAGGERHEART.UI.Notifications.noTargetsSelected'));
+
+        const targets = this.system.currentHitTargets;
+        if (targets.length === 0)
+            return ui.notifications.info(game.i18n.localize('DAGGERHEART.UI.Notifications.noTargetsHit'));
+
         const config = foundry.utils.deepClone(this.system);
         config.event = event;
 
@@ -200,9 +210,6 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
             });
             if (!confirm) return;
         }
-
-        if (targets.length === 0)
-            return ui.notifications.info(game.i18n.localize('DAGGERHEART.UI.Notifications.noTargetsSelected'));
 
         this.consumeOnSuccess();
         if (this.system.action) this.system.action.workflow.get('applyDamage')?.execute(config, targets, true);
@@ -219,8 +226,9 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
 
     async onRollSave(event) {
         event.stopPropagation();
-        const tokenId = event.target.closest('[data-token]')?.dataset.token,
-            token = game.canvas.tokens.get(tokenId);
+        const tokenId = event.target.closest('[data-token]')?.dataset.token;
+        const token = game.canvas.tokens.get(tokenId);
+        
         if (!token?.actor || !token.isOwner) return true;
         if (this.system.source.item && this.system.source.action) {
             const action = this.system.action;
@@ -248,7 +256,8 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
     async onRollAllSave(event) {
         event.stopPropagation();
         if (!game.user.isGM) return;
-        const targets = this.system.currentTargets;
+        
+        const targets = this.system.currentHitTargets;
         const config = foundry.utils.deepClone(this.system);
         config.event = event;
         this.system.action?.workflow.get('save')?.execute(config, targets, true);
@@ -256,12 +265,15 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
 
     async onApplyEffect(event) {
         event.stopPropagation();
-        const targets = this.system.currentTargets;
+        if (this.system.currentTargets.length === 0)
+            return ui.notifications.info(game.i18n.localize('DAGGERHEART.UI.Notifications.noTargetsSelected'));
+        
+        const targets = this.system.currentHitTargets;
+        if (targets.length === 0)
+            return ui.notifications.info(game.i18n.localize('DAGGERHEART.UI.Notifications.noTargetsHit'));
+
         const config = foundry.utils.deepClone(this.system);
         config.event = event;
-
-        if (targets.length === 0)
-            return ui.notifications.info(game.i18n.localize('DAGGERHEART.UI.Notifications.noTargetsSelected'));
 
         if (this.system.hasUnfinishedSaves) {
             const confirm = await foundry.applications.api.DialogV2.confirm({
@@ -378,6 +390,11 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
             return;
         }
         game.canvas.pan(token);
+    }
+
+    onSelectedToTargets(event) {
+        event.stopPropagation();
+        this.system.setSelectedAsTargets();
     }
 
     onTargetSelection(event) {

--- a/module/documents/chatMessage.mjs
+++ b/module/documents/chatMessage.mjs
@@ -159,11 +159,11 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
         });
 
         html.querySelectorAll('.selected-to-targets-button').forEach(element => {
-            element.addEventListener('click', this.onSelectedToTargets.bind(this));
+            element.addEventListener('click', this.#onSelectedToTargets.bind(this));
         });
 
         html.querySelectorAll('.button-target-selection').forEach(element => {
-            element.addEventListener('click', this.onTargetSelection.bind(this));
+            element.addEventListener('click', this.#onTargetSelection.bind(this));
         });
 
         html.querySelectorAll('.token-target-container').forEach(element => {
@@ -394,16 +394,20 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
         game.canvas.pan(token);
     }
 
-    onSelectedToTargets(event) {
+    /** Handle the user clicking the button to convert selected to targets and update the chat message */
+    async #onSelectedToTargets(event) {
         event.stopPropagation();
-        this.update({ 'system.targets': this.system.currentTargets });
+        // Update the targets. Regardless of what happens, swap to the targets tab
+        if (!(await this.update({ 'system.targets': this.system.currentTargets }))) {
+            this.system.updateTargetHTML({ tab: 'targets' });
+        }
     }
 
-    onTargetSelection(event) {
+    /** Handle changing tabs on the target section */
+    #onTargetSelection(event) {
         event.stopPropagation();
         if (!event.target.classList.contains('target-selected')) {
-            this.system.targeting.usingSelect = Boolean(event.target.dataset.selected);
-            this.system.updateTargetHTML();
+            this.system.updateTargetHTML({ tab: event.target.dataset.selected ? 'select' : 'targets'});
         }
     }
 }

--- a/module/systemRegistration/handlebars.mjs
+++ b/module/systemRegistration/handlebars.mjs
@@ -53,6 +53,7 @@ export const preloadHandlebarsTemplates = async function () {
         'systems/daggerheart/templates/ui/countdowns/parts/countdowns.hbs',
         'systems/daggerheart/templates/scene/dh-config.hbs',
         'systems/daggerheart/templates/settings/appearance-settings/diceSoNiceTab.hbs',
-        'systems/daggerheart/templates/sheets/activeEffect/typeChanges/armorChange.hbs'
+        'systems/daggerheart/templates/sheets/activeEffect/typeChanges/armorChange.hbs',
+        'systems/daggerheart/templates/ui/chat/parts/target-tokens-part.hbs'
     ]);
 };

--- a/src/packs/items/consumables/consumable_Armor_Stitcher_VlbsCjvvLNfTzNXb.json
+++ b/src/packs/items/consumables/consumable_Armor_Stitcher_VlbsCjvvLNfTzNXb.json
@@ -7,13 +7,19 @@
     "description": "<p>You can use this stitcher to spend any number of Hope and clear that many Armor Slots.</p>",
     "quantity": 1,
     "actions": {
-      "htoGx8qrv8trds81": {
-        "type": "effect",
-        "_id": "htoGx8qrv8trds81",
+      "abD6jRVvOJnKUQaE": {
+        "type": "healing",
+        "_id": "abD6jRVvOJnKUQaE",
         "systemPath": "actions",
-        "description": "<p>You can use this stitcher to spend any number of Hope and clear that many Armor Slots.</p>",
+        "baseAction": false,
+        "description": "",
         "chatDisplay": true,
+        "originItem": {
+          "type": "itemCollection"
+        },
         "actionType": "action",
+        "triggers": [],
+        "areas": [],
         "cost": [
           {
             "scalable": true,
@@ -35,16 +41,61 @@
         "uses": {
           "value": null,
           "max": "",
-          "recovery": null
+          "recovery": null,
+          "consumeOnSuccess": false
         },
-        "effects": [],
+        "damage": {
+          "main": null,
+          "resources": {
+            "armor": {
+              "base": false,
+              "applyTo": "armor",
+              "resultBased": false,
+              "value": {
+                "multiplier": "flat",
+                "flatMultiplier": 1,
+                "dice": "d6",
+                "bonus": null,
+                "custom": {
+                  "enabled": true,
+                  "formula": "@scale"
+                }
+              },
+              "valueAlt": {
+                "multiplier": "flat",
+                "flatMultiplier": 1,
+                "dice": "d6",
+                "bonus": null,
+                "custom": {
+                  "enabled": false,
+                  "formula": ""
+                }
+              }
+            }
+          }
+        },
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
-        "name": "Stitch",
-        "img": "icons/skills/trades/textiles-stitching-leather-brown.webp",
-        "range": "self"
+        "effects": [],
+        "roll": {
+          "type": null,
+          "trait": null,
+          "difficulty": null,
+          "bonus": null,
+          "advState": "neutral",
+          "diceRolling": {
+            "multiplier": "prof",
+            "flatMultiplier": 1,
+            "dice": "d6",
+            "compare": null,
+            "treshold": null
+          },
+          "useDefault": false
+        },
+        "name": "Spend Hope",
+        "range": ""
       }
     },
     "consumeOnUse": true,

--- a/src/packs/items/consumables/consumable_Attune_Potion_JGD3M9hBHtVAA8XP.json
+++ b/src/packs/items/consumables/consumable_Attune_Potion_JGD3M9hBHtVAA8XP.json
@@ -36,12 +36,12 @@
           }
         ],
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "name": "Drink",
         "img": "icons/consumables/potions/bottle-conical-corked-purple.webp",
-        "range": "self"
+        "range": ""
       }
     },
     "consumeOnUse": true,
@@ -59,24 +59,22 @@
       "transfer": false,
       "_id": "I5vgALTNDVApxy9d",
       "type": "base",
-      "system": {},
-      "changes": [
-        {
-          "key": "system.traits.instinct.value",
-          "type": "add",
-          "value": "1",
-          "priority": null
-        }
-      ],
+      "system": {
+        "changes": [
+          {
+            "key": "system.traits.instinct.value",
+            "type": "add",
+            "value": 1,
+            "priority": null
+          }
+        ]
+      },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null,
-        "seconds": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "tint": "#ffffff",
@@ -86,6 +84,9 @@
       "_stats": {
         "compendiumSource": null
       },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
       "_key": "!items.effects!JGD3M9hBHtVAA8XP.I5vgALTNDVApxy9d"
     }
   ],

--- a/src/packs/items/consumables/consumable_Bolster_Potion_FOPQNqXbiVO0ilYL.json
+++ b/src/packs/items/consumables/consumable_Bolster_Potion_FOPQNqXbiVO0ilYL.json
@@ -36,12 +36,12 @@
           }
         ],
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "name": "Drink",
         "img": "icons/consumables/potions/potion-vial-tube-yellow.webp",
-        "range": "self"
+        "range": ""
       }
     },
     "consumeOnUse": true,
@@ -59,24 +59,22 @@
       "transfer": false,
       "_id": "HVCJp9Tkhr1i4Oc1",
       "type": "base",
-      "system": {},
-      "changes": [
-        {
-          "key": "system.traits.strength.value",
-          "type": "add",
-          "value": "1",
-          "priority": null
-        }
-      ],
+      "system": {
+        "changes": [
+          {
+            "key": "system.traits.strength.value",
+            "type": "add",
+            "value": 1,
+            "priority": null
+          }
+        ]
+      },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null,
-        "seconds": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "tint": "#ffffff",
@@ -86,6 +84,9 @@
       "_stats": {
         "compendiumSource": null
       },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
       "_key": "!items.effects!FOPQNqXbiVO0ilYL.HVCJp9Tkhr1i4Oc1"
     }
   ],

--- a/src/packs/items/consumables/consumable_Charm_Potion_CVBbFfOY75YwyQsp.json
+++ b/src/packs/items/consumables/consumable_Charm_Potion_CVBbFfOY75YwyQsp.json
@@ -36,7 +36,7 @@
           }
         ],
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "name": "Drink",
@@ -59,24 +59,22 @@
       "transfer": false,
       "_id": "COrKb7gBin4Ro6r6",
       "type": "base",
-      "system": {},
-      "changes": [
-        {
-          "key": "system.traits.presence.value",
-          "type": "add",
-          "value": "1",
-          "priority": null
-        }
-      ],
+      "system": {
+        "changes": [
+          {
+            "key": "system.traits.presence.value",
+            "type": "add",
+            "value": 1,
+            "priority": null
+          }
+        ]
+      },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null,
-        "seconds": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "tint": "#ffffff",
@@ -86,6 +84,9 @@
       "_stats": {
         "compendiumSource": null
       },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
       "_key": "!items.effects!CVBbFfOY75YwyQsp.COrKb7gBin4Ro6r6"
     }
   ],

--- a/src/packs/items/consumables/consumable_Control_Potion_eeBhZSGLjuNZuJuI.json
+++ b/src/packs/items/consumables/consumable_Control_Potion_eeBhZSGLjuNZuJuI.json
@@ -36,7 +36,7 @@
           }
         ],
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "name": "Drink",
@@ -59,24 +59,22 @@
       "transfer": false,
       "_id": "1VAQYZ1YYc9ew9UR",
       "type": "base",
-      "system": {},
-      "changes": [
-        {
-          "key": "system.traits.finesse.value",
-          "type": "add",
-          "value": "1",
-          "priority": null
-        }
-      ],
+      "system": {
+        "changes": [
+          {
+            "key": "system.traits.finesse.value",
+            "type": "add",
+            "value": 1,
+            "priority": null
+          }
+        ]
+      },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null,
-        "seconds": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "tint": "#ffffff",
@@ -86,6 +84,9 @@
       "_stats": {
         "compendiumSource": null
       },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
       "_key": "!items.effects!eeBhZSGLjuNZuJuI.1VAQYZ1YYc9ew9UR"
     }
   ],

--- a/src/packs/items/consumables/consumable_Death_Tea_xDnJeF1grkmKck8Q.json
+++ b/src/packs/items/consumables/consumable_Death_Tea_xDnJeF1grkmKck8Q.json
@@ -36,12 +36,12 @@
           }
         ],
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "name": "Drink",
         "img": "icons/consumables/drinks/wine-amphora-clay-gray.webp",
-        "range": "self"
+        "range": ""
       }
     },
     "consumeOnUse": true,
@@ -64,13 +64,10 @@
       },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null,
-        "seconds": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "<p><span style=\"color:rgb(239, 230, 216);font-family:Montserrat, sans-serif;font-size:14px;font-style:normal;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-align:start;text-indent:0px;text-transform:none;widows:2;word-spacing:0px;-webkit-text-stroke-width:0px;white-space:normal;background-color:rgba(24, 22, 46, 0.376);text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial;display:inline !important;float:none\">After you drink this tea, you instantly kill your target when you critically succeed on an attack. If you don’t critically succeed on an attack before your next long rest, you die.</p>",
       "tint": "#ffffff",
@@ -80,6 +77,9 @@
       "_stats": {
         "compendiumSource": null
       },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
       "_key": "!items.effects!xDnJeF1grkmKck8Q.IqlpqsgurXsUEQhs"
     }
   ],

--- a/src/packs/items/consumables/consumable_Dripfang_Poison_eU8VpbWB2NHIL47n.json
+++ b/src/packs/items/consumables/consumable_Dripfang_Poison_eU8VpbWB2NHIL47n.json
@@ -61,7 +61,7 @@
           "includeBase": false
         },
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "effects": [],

--- a/src/packs/items/consumables/consumable_Enlighten_Potion_aWHSO2AqDufi7nL4.json
+++ b/src/packs/items/consumables/consumable_Enlighten_Potion_aWHSO2AqDufi7nL4.json
@@ -36,7 +36,7 @@
           }
         ],
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "name": "Drink",
@@ -59,24 +59,22 @@
       "transfer": false,
       "_id": "QNzVrDW73jF1d5wE",
       "type": "base",
-      "system": {},
-      "changes": [
-        {
-          "key": "system.traits.knowledge.value",
-          "type": "add",
-          "value": "1",
-          "priority": null
-        }
-      ],
+      "system": {
+        "changes": [
+          {
+            "key": "system.traits.knowledge.value",
+            "type": "add",
+            "value": 1,
+            "priority": null
+          }
+        ]
+      },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null,
-        "seconds": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "tint": "#ffffff",
@@ -86,6 +84,9 @@
       "_stats": {
         "compendiumSource": null
       },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
       "_key": "!items.effects!aWHSO2AqDufi7nL4.QNzVrDW73jF1d5wE"
     }
   ],

--- a/src/packs/items/consumables/consumable_Feast_of_Xuria_aX6NyxkNzu0LcJpt.json
+++ b/src/packs/items/consumables/consumable_Feast_of_Xuria_aX6NyxkNzu0LcJpt.json
@@ -109,7 +109,7 @@
           "includeBase": false
         },
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "effects": [],

--- a/src/packs/items/consumables/consumable_Featherbone_DpxEMpwfasEBpORU.json
+++ b/src/packs/items/consumables/consumable_Featherbone_DpxEMpwfasEBpORU.json
@@ -36,12 +36,12 @@
           }
         ],
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "name": "Use",
         "img": "icons/commodities/bones/bones-stack-worn-brown.webp",
-        "range": "self"
+        "range": ""
       }
     },
     "consumeOnUse": true,
@@ -64,13 +64,10 @@
       },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null,
-        "seconds": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "<p>You can use this bone to control your falling speed for a number of minutes equal to your level.</p>",
       "tint": "#ffffff",
@@ -80,6 +77,9 @@
       "_stats": {
         "compendiumSource": null
       },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
       "_key": "!items.effects!DpxEMpwfasEBpORU.VfJIJBW96e45xQHY"
     }
   ],

--- a/src/packs/items/consumables/consumable_Gill_Salve_Nvbb9mze6o5D0AEg.json
+++ b/src/packs/items/consumables/consumable_Gill_Salve_Nvbb9mze6o5D0AEg.json
@@ -36,12 +36,12 @@
           }
         ],
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "name": "Apply",
         "img": "icons/commodities/materials/bowl-powder-blue.webp",
-        "range": "self"
+        "range": ""
       }
     },
     "consumeOnUse": true,
@@ -64,13 +64,10 @@
       },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null,
-        "seconds": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "<p>You can apply this salve to your neck to breathe underwater for a number of minutes equal to your level.</p>",
       "tint": "#ffffff",
@@ -80,6 +77,9 @@
       "_stats": {
         "compendiumSource": null
       },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
       "_key": "!items.effects!Nvbb9mze6o5D0AEg.5rL9CY5GO9SJcEZq"
     }
   ],

--- a/src/packs/items/consumables/consumable_Grindletooth_Venom_8WkhvSzeOmLdnoLJ.json
+++ b/src/packs/items/consumables/consumable_Grindletooth_Venom_8WkhvSzeOmLdnoLJ.json
@@ -36,7 +36,7 @@
           }
         ],
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "name": "Apply",
@@ -71,13 +71,10 @@
       },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null,
-        "seconds": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "<p><span style=\"color:rgb(239, 230, 216);font-family:Montserrat, sans-serif;font-size:14px;font-style:normal;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-align:start;text-indent:0px;text-transform:none;widows:2;word-spacing:0px;-webkit-text-stroke-width:0px;white-space:normal;background-color:rgba(24, 22, 46, 0.376);text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial;display:inline !important;float:none\">You deal 1d6 additional physical damage on your next damage roll with the weapon the venom was applied to.</p>",
       "tint": "#ffffff",
@@ -87,6 +84,9 @@
       "_stats": {
         "compendiumSource": null
       },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
       "_key": "!items.effects!8WkhvSzeOmLdnoLJ.yx4ZkXeuXgw2KvV4"
     }
   ],

--- a/src/packs/items/consumables/consumable_Growing_Potion_fl2f3ees8RFMze9t.json
+++ b/src/packs/items/consumables/consumable_Growing_Potion_fl2f3ees8RFMze9t.json
@@ -36,7 +36,7 @@
           }
         ],
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "name": "Drink",

--- a/src/packs/items/consumables/consumable_Health_Potion_Aruc2NLutWuVIjP1.json
+++ b/src/packs/items/consumables/consumable_Health_Potion_Aruc2NLutWuVIjP1.json
@@ -59,7 +59,7 @@
           "includeBase": false
         },
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "effects": [],

--- a/src/packs/items/consumables/consumable_Homet_s_Secret_Potion_VSwa1LpQ9PjZKsWF.json
+++ b/src/packs/items/consumables/consumable_Homet_s_Secret_Potion_VSwa1LpQ9PjZKsWF.json
@@ -36,7 +36,7 @@
           }
         ],
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "name": "Drink",
@@ -64,13 +64,10 @@
       },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null,
-        "seconds": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "<p><span style=\"color:rgb(239, 230, 216);font-family:Montserrat, sans-serif;font-size:14px;font-style:normal;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-align:start;text-indent:0px;text-transform:none;widows:2;word-spacing:0px;-webkit-text-stroke-width:0px;white-space:normal;background-color:rgba(24, 22, 46, 0.376);text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial;display:inline !important;float:none\">The next successful attack you make critically succeeds.</p>",
       "tint": "#ffffff",
@@ -80,6 +77,9 @@
       "_stats": {
         "compendiumSource": null
       },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
       "_key": "!items.effects!VSwa1LpQ9PjZKsWF.QyzXAnvho7lVQQtP"
     }
   ],

--- a/src/packs/items/consumables/consumable_Improved_Grindletooth_Venom_BqBWXXe9T07AMV4u.json
+++ b/src/packs/items/consumables/consumable_Improved_Grindletooth_Venom_BqBWXXe9T07AMV4u.json
@@ -36,7 +36,7 @@
           }
         ],
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "name": "Apply",
@@ -71,13 +71,10 @@
       },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null,
-        "seconds": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "<p><span style=\"color:rgb(239, 230, 216);font-family:Montserrat, sans-serif;font-size:14px;font-style:normal;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-align:start;text-indent:0px;text-transform:none;widows:2;word-spacing:0px;-webkit-text-stroke-width:0px;white-space:normal;background-color:rgba(24, 22, 46, 0.376);text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial;display:inline !important;float:none\">You deal 1d8 additional physical damage on your next damage roll with the weapon the venom was applied to.</p>",
       "tint": "#ffffff",
@@ -87,6 +84,9 @@
       "_stats": {
         "compendiumSource": null
       },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
       "_key": "!items.effects!BqBWXXe9T07AMV4u.P7tbNjq58bQ9R1Cc"
     }
   ],

--- a/src/packs/items/consumables/consumable_Jumping_Root_c2putn9apuurJhWX.json
+++ b/src/packs/items/consumables/consumable_Jumping_Root_c2putn9apuurJhWX.json
@@ -31,7 +31,7 @@
         },
         "effects": [],
         "target": {
-          "type": "any",
+          "type": "",
           "amount": null
         },
         "name": "Eat",

--- a/src/packs/items/consumables/consumable_Major_Attune_Potion_CCPFm5iXXwvyYYwR.json
+++ b/src/packs/items/consumables/consumable_Major_Attune_Potion_CCPFm5iXXwvyYYwR.json
@@ -36,7 +36,7 @@
           }
         ],
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "name": "Drink",
@@ -59,24 +59,22 @@
       "transfer": false,
       "_id": "v2EXGXbJaewaMxFC",
       "type": "base",
-      "system": {},
-      "changes": [
-        {
-          "key": "system.traits.instinct.value",
-          "type": "add",
-          "value": "1",
-          "priority": null
-        }
-      ],
+      "system": {
+        "changes": [
+          {
+            "key": "system.traits.instinct.value",
+            "type": "add",
+            "value": 1,
+            "priority": null
+          }
+        ]
+      },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null,
-        "seconds": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "tint": "#ffffff",
@@ -86,6 +84,9 @@
       "_stats": {
         "compendiumSource": null
       },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
       "_key": "!items.effects!CCPFm5iXXwvyYYwR.v2EXGXbJaewaMxFC"
     }
   ],

--- a/src/packs/items/consumables/consumable_Major_Bolster_Potion_mnyQDRtngWWQeRXF.json
+++ b/src/packs/items/consumables/consumable_Major_Bolster_Potion_mnyQDRtngWWQeRXF.json
@@ -36,7 +36,7 @@
           }
         ],
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "name": "Drink",
@@ -59,24 +59,22 @@
       "transfer": false,
       "_id": "3PfXBJy0ZjLBDAIn",
       "type": "base",
-      "system": {},
-      "changes": [
-        {
-          "key": "system.traits.strength.value",
-          "type": "add",
-          "value": "1",
-          "priority": null
-        }
-      ],
+      "system": {
+        "changes": [
+          {
+            "key": "system.traits.strength.value",
+            "type": "add",
+            "value": 1,
+            "priority": null
+          }
+        ]
+      },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null,
-        "seconds": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "tint": "#ffffff",
@@ -86,6 +84,9 @@
       "_stats": {
         "compendiumSource": null
       },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
       "_key": "!items.effects!mnyQDRtngWWQeRXF.3PfXBJy0ZjLBDAIn"
     }
   ],

--- a/src/packs/items/consumables/consumable_Major_Charm_Potion_IJLAUlQymbSjzsri.json
+++ b/src/packs/items/consumables/consumable_Major_Charm_Potion_IJLAUlQymbSjzsri.json
@@ -36,7 +36,7 @@
           }
         ],
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "name": "Drink",
@@ -59,24 +59,22 @@
       "transfer": false,
       "_id": "3iXv9QiuLGOfDCi2",
       "type": "base",
-      "system": {},
-      "changes": [
-        {
-          "key": "system.traits.presence.value",
-          "type": "add",
-          "value": "1",
-          "priority": null
-        }
-      ],
+      "system": {
+        "changes": [
+          {
+            "key": "system.traits.presence.value",
+            "type": "add",
+            "value": 1,
+            "priority": null
+          }
+        ]
+      },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null,
-        "seconds": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "tint": "#ffffff",
@@ -86,6 +84,9 @@
       "_stats": {
         "compendiumSource": null
       },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
       "_key": "!items.effects!IJLAUlQymbSjzsri.3iXv9QiuLGOfDCi2"
     }
   ],

--- a/src/packs/items/consumables/consumable_Major_Control_Potion_80s1FLmTLtohZ5GH.json
+++ b/src/packs/items/consumables/consumable_Major_Control_Potion_80s1FLmTLtohZ5GH.json
@@ -36,7 +36,7 @@
           }
         ],
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "name": "Drink",
@@ -59,24 +59,22 @@
       "transfer": false,
       "_id": "YOgojNdjARXUUrky",
       "type": "base",
-      "system": {},
-      "changes": [
-        {
-          "key": "system.traits.finesse.value",
-          "type": "add",
-          "value": "1",
-          "priority": null
-        }
-      ],
+      "system": {
+        "changes": [
+          {
+            "key": "system.traits.finesse.value",
+            "type": "add",
+            "value": 1,
+            "priority": null
+          }
+        ]
+      },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null,
-        "seconds": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "tint": "#ffffff",
@@ -86,6 +84,9 @@
       "_stats": {
         "compendiumSource": null
       },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
       "_key": "!items.effects!80s1FLmTLtohZ5GH.YOgojNdjARXUUrky"
     }
   ],

--- a/src/packs/items/consumables/consumable_Major_Enlighten_Potion_SDdv1G2veMLKrxcJ.json
+++ b/src/packs/items/consumables/consumable_Major_Enlighten_Potion_SDdv1G2veMLKrxcJ.json
@@ -36,7 +36,7 @@
           }
         ],
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "name": "Drink",
@@ -59,24 +59,22 @@
       "transfer": false,
       "_id": "Ul5brgnx88npVGNj",
       "type": "base",
-      "system": {},
-      "changes": [
-        {
-          "key": "system.traits.knowledge.value",
-          "type": "add",
-          "value": "1",
-          "priority": null
-        }
-      ],
+      "system": {
+        "changes": [
+          {
+            "key": "system.traits.knowledge.value",
+            "type": "add",
+            "value": 1,
+            "priority": null
+          }
+        ]
+      },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null,
-        "seconds": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "tint": "#ffffff",
@@ -86,6 +84,9 @@
       "_stats": {
         "compendiumSource": null
       },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
       "_key": "!items.effects!SDdv1G2veMLKrxcJ.Ul5brgnx88npVGNj"
     }
   ],

--- a/src/packs/items/consumables/consumable_Major_Health_Potion_cM7pHe8bBAxSZ2xR.json
+++ b/src/packs/items/consumables/consumable_Major_Health_Potion_cM7pHe8bBAxSZ2xR.json
@@ -59,7 +59,7 @@
           "includeBase": false
         },
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "effects": [],

--- a/src/packs/items/consumables/consumable_Major_Stamina_Potion_I4cQ03xbxnc81EGa.json
+++ b/src/packs/items/consumables/consumable_Major_Stamina_Potion_I4cQ03xbxnc81EGa.json
@@ -59,7 +59,7 @@
           "includeBase": false
         },
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "effects": [],

--- a/src/packs/items/consumables/consumable_Major_Stride_Potion_yK6eEDUrsPbZA8G0.json
+++ b/src/packs/items/consumables/consumable_Major_Stride_Potion_yK6eEDUrsPbZA8G0.json
@@ -36,7 +36,7 @@
           }
         ],
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "name": "Drink",

--- a/src/packs/items/consumables/consumable_Minor_Health_Potion_tPfKtKRRjv8qdSqy.json
+++ b/src/packs/items/consumables/consumable_Minor_Health_Potion_tPfKtKRRjv8qdSqy.json
@@ -59,7 +59,7 @@
           "includeBase": false
         },
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "effects": [],

--- a/src/packs/items/consumables/consumable_Minor_Stamina_Potion_b6vGSPFWOlzZZDLO.json
+++ b/src/packs/items/consumables/consumable_Minor_Stamina_Potion_b6vGSPFWOlzZZDLO.json
@@ -59,7 +59,7 @@
           "includeBase": false
         },
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "effects": [],

--- a/src/packs/items/consumables/consumable_Mirror_of_Marigold_UFQVwgYOUZ88UxcH.json
+++ b/src/packs/items/consumables/consumable_Mirror_of_Marigold_UFQVwgYOUZ88UxcH.json
@@ -31,7 +31,7 @@
         },
         "effects": [],
         "target": {
-          "type": "any",
+          "type": "",
           "amount": null
         },
         "name": "Use",

--- a/src/packs/items/consumables/consumable_Morphing_Clay_f1NHVSIHJJCIOaBl.json
+++ b/src/packs/items/consumables/consumable_Morphing_Clay_f1NHVSIHJJCIOaBl.json
@@ -36,7 +36,7 @@
           }
         ],
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "name": "Use",

--- a/src/packs/items/consumables/consumable_Mythic_Dust_Zsh2AvZr8EkGtLyw.json
+++ b/src/packs/items/consumables/consumable_Mythic_Dust_Zsh2AvZr8EkGtLyw.json
@@ -36,7 +36,7 @@
           }
         ],
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "name": "Use",
@@ -71,13 +71,10 @@
       },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null,
-        "seconds": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "<p><span style=\"color:rgb(239, 230, 216);font-family:Montserrat, sans-serif;font-size:14px;font-style:normal;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-align:start;text-indent:0px;text-transform:none;widows:2;word-spacing:0px;-webkit-text-stroke-width:0px;white-space:normal;background-color:rgba(24, 22, 46, 0.376);text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial;display:inline !important;float:none\">You deal 1d12 additional magical damage on your next damage roll with the weapon the venom was applied to.</p>",
       "tint": "#ffffff",
@@ -87,6 +84,9 @@
       "_stats": {
         "compendiumSource": null
       },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
       "_key": "!items.effects!Zsh2AvZr8EkGtLyw.L68lFhuWdS3ppDxR"
     }
   ],

--- a/src/packs/items/consumables/consumable_Ogre_Musk_qr1bosjFcUfuwq4B.json
+++ b/src/packs/items/consumables/consumable_Ogre_Musk_qr1bosjFcUfuwq4B.json
@@ -36,7 +36,7 @@
           }
         ],
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "name": "Use",

--- a/src/packs/items/consumables/consumable_Potion_of_Stability_dvL8oaxpEF6jKvYN.json
+++ b/src/packs/items/consumables/consumable_Potion_of_Stability_dvL8oaxpEF6jKvYN.json
@@ -36,7 +36,7 @@
           }
         ],
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "name": "Drink",
@@ -59,30 +59,28 @@
       "transfer": false,
       "_id": "PjjGC4TpzjSz9z8s",
       "type": "base",
-      "system": {},
-      "changes": [
-        {
-          "key": "system.bonuses.rest.shortRest.shortMoves",
-          "type": "add",
-          "value": "1",
-          "priority": null
-        },
-        {
-          "key": "system.bonuses.rest.longRest.longMoves",
-          "type": "add",
-          "value": "1",
-          "priority": null
-        }
-      ],
+      "system": {
+        "changes": [
+          {
+            "key": "system.bonuses.rest.shortRest.shortMoves",
+            "type": "add",
+            "value": 1,
+            "priority": null
+          },
+          {
+            "key": "system.bonuses.rest.longRest.longMoves",
+            "type": "add",
+            "value": 1,
+            "priority": null
+          }
+        ]
+      },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null,
-        "seconds": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "tint": "#ffffff",
@@ -92,6 +90,9 @@
       "_stats": {
         "compendiumSource": null
       },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
       "_key": "!items.effects!dvL8oaxpEF6jKvYN.PjjGC4TpzjSz9z8s"
     }
   ],

--- a/src/packs/items/consumables/consumable_Redthorn_Saliva_s2Exl2XFuoOhtIov.json
+++ b/src/packs/items/consumables/consumable_Redthorn_Saliva_s2Exl2XFuoOhtIov.json
@@ -36,7 +36,7 @@
           }
         ],
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "name": "Apply",
@@ -71,13 +71,10 @@
       },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null,
-        "seconds": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "<p><span style=\"color:rgb(239, 230, 216);font-family:Montserrat, sans-serif;font-size:14px;font-style:normal;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-align:start;text-indent:0px;text-transform:none;widows:2;word-spacing:0px;-webkit-text-stroke-width:0px;white-space:normal;background-color:rgba(24, 22, 46, 0.376);text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial;display:inline !important;float:none\">You deal 1d12 additional physical damage on your next damage roll with the weapon the saliva was applied to.</p>",
       "tint": "#ffffff",
@@ -87,6 +84,9 @@
       "_stats": {
         "compendiumSource": null
       },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
       "_key": "!items.effects!s2Exl2XFuoOhtIov.tWf00ezdpxQQLuZ1"
     }
   ],

--- a/src/packs/items/consumables/consumable_Replication_Parchment_yJkwz4AP6yhGo8Vj.json
+++ b/src/packs/items/consumables/consumable_Replication_Parchment_yJkwz4AP6yhGo8Vj.json
@@ -31,7 +31,7 @@
         },
         "effects": [],
         "target": {
-          "type": "any",
+          "type": "",
           "amount": null
         },
         "name": "Use",

--- a/src/packs/items/consumables/consumable_Shrinking_Potion_HGixKenQwhyRAYNk.json
+++ b/src/packs/items/consumables/consumable_Shrinking_Potion_HGixKenQwhyRAYNk.json
@@ -36,7 +36,7 @@
           }
         ],
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "name": "Drink",

--- a/src/packs/items/consumables/consumable_Sleeping_Sap_XZavUVlHEvE2srEt.json
+++ b/src/packs/items/consumables/consumable_Sleeping_Sap_XZavUVlHEvE2srEt.json
@@ -60,7 +60,7 @@
           "includeBase": false
         },
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "effects": [],

--- a/src/packs/items/consumables/consumable_Snap_Powder_cg6VtQ0eVZjDdcK0.json
+++ b/src/packs/items/consumables/consumable_Snap_Powder_cg6VtQ0eVZjDdcK0.json
@@ -17,6 +17,14 @@
         "cost": [
           {
             "scalable": false,
+            "key": "stress",
+            "value": 1,
+            "itemId": null,
+            "step": null,
+            "consumeOnSuccess": false
+          },
+          {
+            "scalable": false,
             "key": "quantity",
             "value": 1,
             "itemId": "cg6VtQ0eVZjDdcK0",
@@ -60,7 +68,7 @@
           "includeBase": false
         },
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "effects": [],

--- a/src/packs/items/consumables/consumable_Stamina_Potion_hf3k1POoVSooJyN2.json
+++ b/src/packs/items/consumables/consumable_Stamina_Potion_hf3k1POoVSooJyN2.json
@@ -59,7 +59,7 @@
           "includeBase": false
         },
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "effects": [],

--- a/src/packs/items/consumables/consumable_Stride_Potion_lNtcrkgFGOJNaroE.json
+++ b/src/packs/items/consumables/consumable_Stride_Potion_lNtcrkgFGOJNaroE.json
@@ -36,7 +36,7 @@
           }
         ],
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "name": "Drink",
@@ -59,24 +59,22 @@
       "transfer": false,
       "_id": "xQ0xPDxskzZH4jeK",
       "type": "base",
-      "system": {},
-      "changes": [
-        {
-          "key": "system.traits.agility.value",
-          "type": "add",
-          "value": "1",
-          "priority": null
-        }
-      ],
+      "system": {
+        "changes": [
+          {
+            "key": "system.traits.agility.value",
+            "type": "add",
+            "value": 1,
+            "priority": null
+          }
+        ]
+      },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null,
-        "seconds": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "tint": "#ffffff",
@@ -86,6 +84,9 @@
       "_stats": {
         "compendiumSource": null
       },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
       "_key": "!items.effects!lNtcrkgFGOJNaroE.xQ0xPDxskzZH4jeK"
     }
   ],

--- a/src/packs/items/consumables/consumable_Sun_Tree_Sap_kwexUzdM9wm1Qums.json
+++ b/src/packs/items/consumables/consumable_Sun_Tree_Sap_kwexUzdM9wm1Qums.json
@@ -34,7 +34,7 @@
           "includeBase": false
         },
         "target": {
-          "type": "any",
+          "type": "",
           "amount": null
         },
         "effects": [],

--- a/src/packs/items/consumables/consumable_Sweet_Moss_GrDrRqWgv7gvl9vn.json
+++ b/src/packs/items/consumables/consumable_Sweet_Moss_GrDrRqWgv7gvl9vn.json
@@ -59,7 +59,7 @@
           "includeBase": false
         },
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "effects": [],
@@ -134,7 +134,7 @@
           "includeBase": false
         },
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "effects": [],

--- a/src/packs/items/consumables/consumable_Varik_Leaves_hvy5BkG3F6iOIXTx.json
+++ b/src/packs/items/consumables/consumable_Varik_Leaves_hvy5BkG3F6iOIXTx.json
@@ -60,7 +60,7 @@
           "includeBase": false
         },
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "effects": [],

--- a/src/packs/items/consumables/consumable_Vial_of_Darksmoke_Nwv5ydGf0MWnzq1n.json
+++ b/src/packs/items/consumables/consumable_Vial_of_Darksmoke_Nwv5ydGf0MWnzq1n.json
@@ -31,7 +31,7 @@
         },
         "effects": [],
         "target": {
-          "type": "any",
+          "type": "",
           "amount": null
         },
         "name": "Use",

--- a/src/packs/items/consumables/consumable_Vial_of_Moondrip_VqEX5YwK5oL3r1t6.json
+++ b/src/packs/items/consumables/consumable_Vial_of_Moondrip_VqEX5YwK5oL3r1t6.json
@@ -36,7 +36,7 @@
           }
         ],
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "name": "Drink",

--- a/src/packs/items/consumables/consumable_Wingsprout_n10vozlmosVR6lo4.json
+++ b/src/packs/items/consumables/consumable_Wingsprout_n10vozlmosVR6lo4.json
@@ -36,7 +36,7 @@
           }
         ],
         "target": {
-          "type": "self",
+          "type": "",
           "amount": null
         },
         "name": "Use",
@@ -64,13 +64,10 @@
       },
       "disabled": false,
       "duration": {
-        "startTime": null,
-        "combat": null,
-        "seconds": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
       },
       "description": "<p><span style=\"color:rgb(239, 230, 216);font-family:Montserrat, sans-serif;font-size:14px;font-style:normal;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-align:start;text-indent:0px;text-transform:none;widows:2;word-spacing:0px;-webkit-text-stroke-width:0px;white-space:normal;background-color:rgba(24, 22, 46, 0.376);text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial;display:inline !important;float:none\">You gain magic wings that allow you to fly for a number of minutes equal to your level.</p>",
       "tint": "#ffffff",
@@ -80,6 +77,9 @@
       "_stats": {
         "compendiumSource": null
       },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
       "_key": "!items.effects!n10vozlmosVR6lo4.80F8gAn7ejhhNL7R"
     }
   ],

--- a/styles/less/ui/chat/chat.less
+++ b/styles/less/ui/chat/chat.less
@@ -488,6 +488,7 @@
                 width: 40px;
                 height: 40px;
                 object-fit: cover;
+                object-position: top center;
             }
 
             .target-data {

--- a/styles/less/ui/chat/chat.less
+++ b/styles/less/ui/chat/chat.less
@@ -166,10 +166,18 @@
             border-color: transparent;
         }
         [data-view-perm='false'] {
-            &[data-perm-hidden='true'],
+            &[data-perm-hidden='true'] {
+                display: none;
+
+                &::after {
+                    display: none;
+                }
+            }
+
             > * {
                 display: none;
             }
+
             &::after {
                 content: '??';
             }
@@ -497,6 +505,30 @@
                 .target-name {
                     text-align: left;
                 }
+
+                .target-roll-status {
+                    margin-top: 2px;
+                    display: flex;
+                    gap: 4px;
+
+                    .target-resistance-container {
+                        border: 1px solid currentColor;
+                        border-radius: 4px;
+                        padding: 3px 5px;
+                        text-transform: uppercase;
+                        font-weight: 600;
+
+                        &.resistant {
+                            color: @resistance-border;
+                            background-color: @resistance-bg;
+                        }
+
+                        &.immune {
+                            color: @chat-purple;
+                            background-color: @chat-purple-10;
+                        }
+                    }
+                }
             }
 
             .target-save {
@@ -544,11 +576,6 @@
                 color: @medium-red;
                 background-color: @medium-red-10;
             }
-        }
-
-        .target-hit-status {
-            width: fit-content;
-            margin-top: 2px;
         }
 
         div[data-action='expandRoll'] {

--- a/styles/less/ui/chat/chat.less
+++ b/styles/less/ui/chat/chat.less
@@ -439,6 +439,39 @@
             text-align: center;
         }
 
+        .selected-targets-container {
+            height: 40px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 18px;
+
+            .roll-target {
+                width: fit-content;
+
+                &:not(:first-child) {
+                    margin-left: -22px;
+                }
+            }
+
+            .ellipsis-marker {
+                margin-left: -20px;
+            }
+
+            .targets-tools-container {
+                flex: 1;
+                display: flex;
+                align-items: center;
+                justify-content: flex-end;
+                gap: 4px;
+            }
+
+            .empty-text {
+                flex: 1;
+                text-align: center;
+            }
+        }
+
         .roll-target {
             display: flex;
             width: 100%;

--- a/styles/less/ui/chat/damage-summary.less
+++ b/styles/less/ui/chat/damage-summary.less
@@ -28,7 +28,7 @@
     .token-target-container {
         display: flex;
         flex-direction: column;
-        gap: 2px;
+        gap: 5px;
         transition: all 0.3s ease;
         border-radius: 6px;
 
@@ -43,10 +43,8 @@
         header {
             display: flex;
             align-items: center;
-            gap: 5px;
             pointer-events: none;
             position: relative;
-            margin-bottom: 10px;
 
             img {
                 width: 40px;
@@ -55,37 +53,59 @@
                 border-radius: 50%;
             }
 
-            .actor-name {
-                margin: 0;
-                color: @beige;
-                font-size: var(--font-size-20);
-                padding: 8px;
-            }
+            .token-header-data {
+                padding: 4px 8px 4px;
+                display: flex;
+                flex-direction: column;
 
-            &::after {
-                content: '';
-                position: absolute;
-                bottom: -10px;
-                background: @golden;
-                mask-image: linear-gradient(270deg, transparent 0%, black 50%, transparent 100%);
-                height: 2px;
-                width: 100%;
+                .actor-name {
+                    margin: 0;
+                    color: @beige;
+                    font-size: var(--font-size-20);
+                }
+
+                .token-resistance-container {
+                    width: fit-content;
+                    border: 1px solid currentColor;
+                    border-radius: 4px;
+                    padding: 3px 5px;
+                    text-transform: uppercase;
+                    font-weight: 600;
+
+                    &.resistant {
+                        color: @resistance-border;
+                        background-color: @resistance-bg;
+                    }
+
+                    &.immune {
+                        color: @chat-purple;
+                        background-color: @chat-purple-10;
+                    }
+                }
             }
         }
 
         .damage-container {
+            margin: 0;
             display: flex;
             flex-direction: column;
             justify-content: center;
             gap: 5px;
             pointer-events: none;
-            margin-top: 5px;
             list-style: disc;
 
             .damage-row {
                 padding: 0 2px;
                 gap: 4px;
             }
+        }
+
+        &::after {
+            content: '';
+            background: @golden;
+            mask-image: linear-gradient(270deg, transparent 0%, black 50%, transparent 100%);
+            height: 2px;
+            width: 100%;
         }
     }
 }

--- a/styles/less/utils/colors.less
+++ b/styles/less/utils/colors.less
@@ -109,6 +109,8 @@
         --dh-trait-color-border: #8e8d96;
         --dh-window-button-color-bg: #e8e6e3;
         --dh-window-button-color-text: @dark-blue;
+        --dh-resistance-color-border: #ffa500;
+        --dh-resistance-color-bg: #ffa50010;  
     }
 }
 @scope (.theme-dark) to (.themed) {  
@@ -128,6 +130,8 @@
         --dh-trait-color-border: #927952;
         --dh-window-button-color-bg: @deep-black;
         --dh-window-button-color-text: @beige;
+        --dh-resistance-color-border: #ffa500;
+        --dh-resistance-color-bg: #ffa50010;
     }
 }
 
@@ -249,3 +253,5 @@
 @input-color-text: var(--dh-input-color-text);
 @trait-color-bg: var(--dh-trait-color-bg);
 @trait-color-border: var(--dh-trait-color-border);
+@resistance-border: var(--dh-resistance-color-border);
+@resistance-bg: var(--dh-resistance-color-bg)

--- a/templates/settings/appearance-settings/main.hbs
+++ b/templates/settings/appearance-settings/main.hbs
@@ -50,13 +50,8 @@
 
     <fieldset>
         <legend>{{localize 'DAGGERHEART.SETTINGS.Appearance.FIELDS.expandRollMessage.title'}}</legend>
-        {{formGroup fields.expandRollMessage.fields.desc value=setting.expandRollMessage.desc
-        localize=true}}
-        {{formGroup fields.expandRollMessage.fields.roll value=setting.expandRollMessage.roll
-        localize=true}}
-        {{formGroup fields.expandRollMessage.fields.damage
-        value=setting.expandRollMessage.damage localize=true}}
-        {{formGroup fields.expandRollMessage.fields.target
-        value=setting.expandRollMessage.target localize=true}}
+        {{formGroup fields.expandRollMessage.fields.desc value=setting.expandRollMessage.desc localize=true}}
+        {{formGroup fields.expandRollMessage.fields.roll value=setting.expandRollMessage.roll localize=true}}
+        {{formGroup fields.expandRollMessage.fields.damage value=setting.expandRollMessage.damage localize=true}}
     </fieldset>
 </section>

--- a/templates/ui/chat/damageSummary.hbs
+++ b/templates/ui/chat/damageSummary.hbs
@@ -2,8 +2,14 @@
     {{#each targets}}
         <li class="token-target-container {{#if this.token.id}}clickable{{/if}}" data-token="{{this.token.id}}">
             <header>
-                <img src="{{this.token.texture.src}}" />
-                <h2 class="actor-name">{{this.token.name}}</h2>
+                <img src="{{this.token.img}}" />
+                <div class="token-header-data">
+                    <h2 class="actor-name">{{this.token.name}}</h2>
+                    {{#unless (and (not ../isGM) ../hideObserverPermissionInChat)}}
+                        {{#if this.token.resistant}}<div class="token-resistance-container resistant">{{localize "DAGGERHEART.GENERAL.resistant"}}</div>{{/if}}
+                        {{#if this.token.immune}}<div class="token-resistance-container immune">{{localize "DAGGERHEART.GENERAL.immune"}}</div>{{/if}}
+                    {{/unless}}
+                </div>
             </header>
             <ul class="damage-container">
                 {{#each this.updates}}

--- a/templates/ui/chat/parts/target-part.hbs
+++ b/templates/ui/chat/parts/target-part.hbs
@@ -1,4 +1,4 @@
-<div class="roll-part target-section dice-roll" data-action="expandRoll">
+<div class="roll-part target-section dice-roll expanded" data-action="expandRoll">
     <div class="roll-part-header"><div><span>{{pluralize currentTargets.length "DAGGERHEART.GENERAL.Target"}}</span></div></div>
 
     {{#if (or isGM (not metagamingSettings.hideObserverPermissionInChat))}}
@@ -15,7 +15,7 @@
     <div class="roll-part-content dice-result">
         <div class="dice-tooltip">
             <div class="wrapper">
-                {{#if (and isGM parent.isAuthor)}}
+                {{#if isGM}}
                     <div class="target-selector">
                         <div class="roll-part-header"><div></div></div>
                         <div class="target-choice">

--- a/templates/ui/chat/parts/target-part.hbs
+++ b/templates/ui/chat/parts/target-part.hbs
@@ -12,7 +12,7 @@
     {{/if}}
     <div class="roll-part-content dice-result">
         <div class="dice-tooltip">
-            {{> "systems/daggerheart/templates/ui/chat/parts/target-tokens-part.hbs" targeting=parent.system.targeting currentTargets=parent.system.currentTargets selectedTargetsData=parent.system.selectedTargetsData }}
+            {{> "systems/daggerheart/templates/ui/chat/parts/target-tokens-part.hbs" targeting=parent.system.targeting currentTargets=targetData.currentTargets selectedTargetsData=targetData.selectedTargetsData }}
         </div>
     </div>
 </div>

--- a/templates/ui/chat/parts/target-part.hbs
+++ b/templates/ui/chat/parts/target-part.hbs
@@ -1,5 +1,6 @@
 <div class="roll-part target-section dice-roll" data-action="expandRoll">
     <div class="roll-part-header"><div><span>{{pluralize currentTargets.length "DAGGERHEART.GENERAL.Target"}}</span></div></div>
+
     {{#if (or isGM (not metagamingSettings.hideObserverPermissionInChat))}}
         <div class="roll-part-extra on-reduced">
             <div class="wrapper">
@@ -14,25 +15,25 @@
     <div class="roll-part-content dice-result">
         <div class="dice-tooltip">
             <div class="wrapper">
-                {{#if (and parent.isAuthor targets.length)}}
+                {{#if (and isGM parent.isAuthor)}}
                     <div class="target-selector">
                         <div class="roll-part-header"><div></div></div>
                         <div class="target-choice">
-                            <div class="button-target-selection{{#if targetMode}} target-selected{{/if}}" data-target-hit="true">{{localize "DAGGERHEART.UI.Chat.damageRoll.hitTarget"}}</div>
-                            <div class="button-target-selection{{#unless targetMode}} target-selected{{/unless}}">{{localize "DAGGERHEART.UI.Chat.damageRoll.currentTarget"}}</div>
+                            <div class="button-target-selection{{#unless parent.system.targeting.usingSelect}} target-selected{{/unless}}">{{localize "DAGGERHEART.UI.Chat.damageRoll.targettingInitial"}}</div>
+                            <div class="button-target-selection{{#if parent.system.targeting.usingSelect}} target-selected{{/if}}" data-selected="true">{{localize "DAGGERHEART.UI.Chat.damageRoll.targettingSelected"}}</div>
                         </div>
                         <div class="roll-part-header"><div></div></div>
                     </div>
                 {{/if}}
-                {{#if (and hasSave currentTargets.length)}}<div class="roll-part-extra roll-all-save-button">{{localize "DAGGERHEART.UI.Chat.saveRoll.reactionRollAllTargets"}}<i class="fa-solid fa-shield fa-lg"></i></div>{{/if}}
-                {{#each currentTargets}}
+                {{#if (and hasSave parent.system.currentTargets.length)}}<div class="roll-part-extra roll-all-save-button">{{localize "DAGGERHEART.UI.Chat.saveRoll.reactionRollAllTargets"}}<i class="fa-solid fa-shield fa-lg"></i></div>{{/if}}
+                {{#each parent.system.currentTargets}}
                     <div class="roll-target" data-token="{{id}}">
                         <img class="target-img" src="{{img}}">
                         <div class="target-data">
                             <div class="target-name"><span>{{name}}</span></div>
-                            {{#if (and ../hasRoll (hasProperty this "hit"))}}
-                                <div class="target-hit-status {{#if hit}}is-hit{{else}}is-miss{{/if}}" data-perm-id="{{actorId}}" data-perm-hidden="true">
-                                    {{#if hit}}
+                            {{#if (and ../hasRoll hitResult)}}
+                                <div class="target-hit-status {{#if hitResult.success}}is-hit{{else}}is-miss{{/if}}" data-perm-id="{{actorId}}" data-perm-hidden="true">
+                                    {{#if hitResult.success}}
                                         {{localize "DAGGERHEART.GENERAL.hit.single"}}
                                     {{else}}
                                         {{localize "DAGGERHEART.GENERAL.miss.single"}}
@@ -40,9 +41,9 @@
                                 </div>
                             {{/if}}
                         </div>
-                        {{#if (and ../hasSave (or hit (not @root.hasRoll) (not @root.targetMode)))}}
-                            <div class="target-save{{#if saved.result includeZero=true}} is-rolled{{/if}}" data-perm-id="{{actorId}}">
-                                <i class="fa-solid {{#if saved.result includeZero=true}}{{#if saved.success}}fa-check{{else}}fa-xmark{{/if}}{{else}}fa-shield{{/if}} fa-lg"></i>
+                        {{#if ../hasSave }}
+                            <div class="target-save{{#if saveResult}} is-rolled{{/if}}" data-perm-id="{{actorId}}">
+                                <i class="fa-solid {{#if saveResult}}{{#if saveResult.success}}fa-check{{else}}fa-xmark{{/if}}{{else}}fa-shield{{/if}} fa-lg"></i>
                             </div>
                         {{/if}}
                     </div>

--- a/templates/ui/chat/parts/target-part.hbs
+++ b/templates/ui/chat/parts/target-part.hbs
@@ -14,43 +14,7 @@
     {{/if}}
     <div class="roll-part-content dice-result">
         <div class="dice-tooltip">
-            <div class="wrapper">
-                {{#if isGM}}
-                    <div class="target-selector">
-                        <div class="roll-part-header"><div></div></div>
-                        <div class="target-choice">
-                            <div class="button-target-selection{{#unless parent.system.targeting.usingSelect}} target-selected{{/unless}}">{{localize "DAGGERHEART.UI.Chat.damageRoll.targettingInitial"}}</div>
-                            <div class="button-target-selection{{#if parent.system.targeting.usingSelect}} target-selected{{/if}}" data-selected="true">{{localize "DAGGERHEART.UI.Chat.damageRoll.targettingSelected"}}</div>
-                        </div>
-                        <div class="roll-part-header"><div></div></div>
-                    </div>
-                {{/if}}
-                {{#if (and hasSave parent.system.currentTargets.length)}}<div class="roll-part-extra roll-all-save-button">{{localize "DAGGERHEART.UI.Chat.saveRoll.reactionRollAllTargets"}}<i class="fa-solid fa-shield fa-lg"></i></div>{{/if}}
-                {{#each parent.system.currentTargets}}
-                    <div class="roll-target" data-token="{{id}}">
-                        <img class="target-img" src="{{img}}">
-                        <div class="target-data">
-                            <div class="target-name"><span>{{name}}</span></div>
-                            {{#if (and ../hasRoll hitResult)}}
-                                <div class="target-hit-status {{#if hitResult.success}}is-hit{{else}}is-miss{{/if}}" data-perm-id="{{actorId}}" data-perm-hidden="true">
-                                    {{#if hitResult.success}}
-                                        {{localize "DAGGERHEART.GENERAL.hit.single"}}
-                                    {{else}}
-                                        {{localize "DAGGERHEART.GENERAL.miss.single"}}
-                                    {{/if}}
-                                </div>
-                            {{/if}}
-                        </div>
-                        {{#if ../hasSave }}
-                            <div class="target-save{{#if saveResult}} is-rolled{{/if}}" data-perm-id="{{actorId}}">
-                                <i class="fa-solid {{#if saveResult}}{{#if saveResult.success}}fa-check{{else}}fa-xmark{{/if}}{{else}}fa-shield{{/if}} fa-lg"></i>
-                            </div>
-                        {{/if}}
-                    </div>
-                {{else}}
-                    <i>{{localize "DAGGERHEART.GENERAL.noTarget"}}</i>
-                {{/each}}
-            </div>
+            {{> "systems/daggerheart/templates/ui/chat/parts/target-tokens-part.hbs" targeting=parent.system.targeting currentTargets=parent.system.currentTargets }}
         </div>
     </div>
 </div>

--- a/templates/ui/chat/parts/target-part.hbs
+++ b/templates/ui/chat/parts/target-part.hbs
@@ -14,7 +14,7 @@
     {{/if}}
     <div class="roll-part-content dice-result">
         <div class="dice-tooltip">
-            {{> "systems/daggerheart/templates/ui/chat/parts/target-tokens-part.hbs" targeting=parent.system.targeting currentTargets=parent.system.currentTargets }}
+            {{> "systems/daggerheart/templates/ui/chat/parts/target-tokens-part.hbs" targeting=parent.system.targeting currentTargets=parent.system.currentTargets selectedTargetsData=parent.system.selectedTargetsData }}
         </div>
     </div>
 </div>

--- a/templates/ui/chat/parts/target-part.hbs
+++ b/templates/ui/chat/parts/target-part.hbs
@@ -1,6 +1,4 @@
-<div class="roll-part target-section dice-roll expanded" data-action="expandRoll">
-    <div class="roll-part-header"><div><span>{{pluralize currentTargets.length "DAGGERHEART.GENERAL.Target"}}</span></div></div>
-
+<div class="roll-part target-section">
     {{#if (or isGM (not metagamingSettings.hideObserverPermissionInChat))}}
         <div class="roll-part-extra on-reduced">
             <div class="wrapper">

--- a/templates/ui/chat/parts/target-tokens-part.hbs
+++ b/templates/ui/chat/parts/target-tokens-part.hbs
@@ -49,7 +49,7 @@
                 {{#if (gt totalTokens 0)}}
                 <div class="targets-tools-container">
                     <div>{{localize "DAGGERHEART.UI.Chat.damageRoll.totalTargetedTokens" total=totalTokens}}</div>
-                    <a class="selected-to-targets-button" title="{{localize "DAGGERHEART.UI.Chat.damageRoll.setSelectedAsTargets"}}"><i class="fa-solid fa-bullseye"></i></a>
+                    <a class="selected-to-targets-button" data-tooltip="{{localize "DAGGERHEART.UI.Chat.damageRoll.setSelectedAsTargets"}}"><i class="fa-solid fa-bullseye"></i></a>
                 </div>
                 {{else}}
                     <span class="empty-text">{{localize "DAGGERHEART.UI.Chat.damageRoll.noTokensSelected"}}</span>

--- a/templates/ui/chat/parts/target-tokens-part.hbs
+++ b/templates/ui/chat/parts/target-tokens-part.hbs
@@ -39,7 +39,7 @@
         <div class="selected-targets-container">
             {{#with selectedTargetsData}}
                 {{#each tokens as |target|}}
-                    <div class="roll-target">
+                    <div class="roll-target" data-token="{{target.id}}">
                         <img class="target-img" src="{{target.img}}" />
                     </div>
                 {{/each}}

--- a/templates/ui/chat/parts/target-tokens-part.hbs
+++ b/templates/ui/chat/parts/target-tokens-part.hbs
@@ -1,0 +1,37 @@
+<div class="wrapper">
+    {{#if isGM}}
+        <div class="target-selector">
+            <div class="roll-part-header"><div></div></div>
+            <div class="target-choice">
+                <div class="button-target-selection{{#unless targeting.usingSelect}} target-selected{{/unless}}">{{localize "DAGGERHEART.UI.Chat.damageRoll.targettingInitial"}}</div>
+                <div class="button-target-selection{{#if targeting.usingSelect}} target-selected{{/if}}" data-selected="true">{{localize "DAGGERHEART.UI.Chat.damageRoll.targettingSelected"}}</div>
+            </div>
+            <div class="roll-part-header"><div></div></div>
+        </div>
+    {{/if}}
+    {{#if (and hasSave currentTargets.length)}}<div class="roll-part-extra roll-all-save-button">{{localize "DAGGERHEART.UI.Chat.saveRoll.reactionRollAllTargets"}}<i class="fa-solid fa-shield fa-lg"></i></div>{{/if}}
+    {{#each currentTargets}}
+        <div class="roll-target" data-token="{{id}}">
+            <img class="target-img" src="{{img}}">
+            <div class="target-data">
+                <div class="target-name"><span>{{name}}</span></div>
+                {{#if (and ../hasRoll hitResult)}}
+                    <div class="target-hit-status {{#if hitResult.success}}is-hit{{else}}is-miss{{/if}}" data-perm-id="{{actorId}}" data-perm-hidden="true">
+                        {{#if hitResult.success}}
+                            {{localize "DAGGERHEART.GENERAL.hit.single"}}
+                        {{else}}
+                            {{localize "DAGGERHEART.GENERAL.miss.single"}}
+                        {{/if}}
+                    </div>
+                {{/if}}
+            </div>
+            {{#if ../hasSave }}
+                <div class="target-save{{#if saveResult}} is-rolled{{/if}}" data-perm-id="{{actorId}}">
+                    <i class="fa-solid {{#if saveResult}}{{#if saveResult.success}}fa-check{{else}}fa-xmark{{/if}}{{else}}fa-shield{{/if}} fa-lg"></i>
+                </div>
+            {{/if}}
+        </div>
+    {{else}}
+        <i>{{localize "DAGGERHEART.GENERAL.noTarget"}}</i>
+    {{/each}}
+</div>

--- a/templates/ui/chat/parts/target-tokens-part.hbs
+++ b/templates/ui/chat/parts/target-tokens-part.hbs
@@ -39,7 +39,7 @@
         <div class="selected-targets-container">
             {{#with selectedTargetsData}}
                 {{#each tokens as |target|}}
-                    <div class="roll-target" data-token="{{target.token.id}}">
+                    <div class="roll-target">
                         <img class="target-img" src="{{target.img}}" />
                     </div>
                 {{/each}}

--- a/templates/ui/chat/parts/target-tokens-part.hbs
+++ b/templates/ui/chat/parts/target-tokens-part.hbs
@@ -16,15 +16,21 @@
                 <img class="target-img" src="{{img}}">
                 <div class="target-data">
                     <div class="target-name"><span>{{name}}</span></div>
-                    {{#if (and ../hasRoll hitResult)}}
-                        <div class="target-hit-status {{#if hitResult.success}}is-hit{{else}}is-miss{{/if}}" data-perm-id="{{actorId}}" data-perm-hidden="true">
-                            {{#if hitResult.success}}
-                                {{localize "DAGGERHEART.GENERAL.hit.single"}}
-                            {{else}}
-                                {{localize "DAGGERHEART.GENERAL.miss.single"}}
-                            {{/if}}
-                        </div>
-                    {{/if}}
+                    <div class="target-roll-status" data-perm-id="{{actorId}}" data-perm-hidden="true">
+                        {{#if (and ../hasRoll hitResult)}}
+                            <div class="target-hit-status {{#if hitResult.success}}is-hit{{else}}is-miss{{/if}}">
+                                {{#if hitResult.success}}
+                                    {{localize "DAGGERHEART.GENERAL.hit.single"}}
+                                {{else}}
+                                    {{localize "DAGGERHEART.GENERAL.miss.single"}}
+                                {{/if}}
+                            </div>
+                        {{/if}}
+                        {{#if (and ../hasDamage ../damage.active)}}
+                            {{#if resistant}}<div class="target-resistance-container resistant">{{localize "DAGGERHEART.GENERAL.resistant"}}</div>{{/if}}
+                            {{#if immune}}<div class="target-resistance-container immune">{{localize "DAGGERHEART.GENERAL.immune"}}</div>{{/if}}
+                        {{/if}}
+                    </div>
                 </div>
                 {{#if ../hasSave }}
                     <div class="target-save{{#if saveResult}} is-rolled{{/if}}" data-perm-id="{{actorId}}">

--- a/templates/ui/chat/parts/target-tokens-part.hbs
+++ b/templates/ui/chat/parts/target-tokens-part.hbs
@@ -3,35 +3,58 @@
         <div class="target-selector">
             <div class="roll-part-header"><div></div></div>
             <div class="target-choice">
-                <div class="button-target-selection{{#unless targeting.usingSelect}} target-selected{{/unless}}">{{localize "DAGGERHEART.UI.Chat.damageRoll.targettingInitial"}}</div>
-                <div class="button-target-selection{{#if targeting.usingSelect}} target-selected{{/if}}" data-selected="true">{{localize "DAGGERHEART.UI.Chat.damageRoll.targettingSelected"}}</div>
+                <div class="button-target-selection{{#unless targeting.usingSelect}} target-selected{{/unless}}">{{localize "DAGGERHEART.UI.Chat.damageRoll.targetingInitial"}}</div>
+                <div class="button-target-selection{{#if targeting.usingSelect}} target-selected{{/if}}" data-selected="true">{{localize "DAGGERHEART.UI.Chat.damageRoll.targetingSelected"}}</div>
             </div>
             <div class="roll-part-header"><div></div></div>
         </div>
     {{/if}}
     {{#if (and hasSave currentTargets.length)}}<div class="roll-part-extra roll-all-save-button">{{localize "DAGGERHEART.UI.Chat.saveRoll.reactionRollAllTargets"}}<i class="fa-solid fa-shield fa-lg"></i></div>{{/if}}
-    {{#each currentTargets}}
-        <div class="roll-target" data-token="{{id}}">
-            <img class="target-img" src="{{img}}">
-            <div class="target-data">
-                <div class="target-name"><span>{{name}}</span></div>
-                {{#if (and ../hasRoll hitResult)}}
-                    <div class="target-hit-status {{#if hitResult.success}}is-hit{{else}}is-miss{{/if}}" data-perm-id="{{actorId}}" data-perm-hidden="true">
-                        {{#if hitResult.success}}
-                            {{localize "DAGGERHEART.GENERAL.hit.single"}}
-                        {{else}}
-                            {{localize "DAGGERHEART.GENERAL.miss.single"}}
-                        {{/if}}
+    {{#unless targeting.usingSelect}}
+        {{#each currentTargets}}
+            <div class="roll-target" data-token="{{id}}">
+                <img class="target-img" src="{{img}}">
+                <div class="target-data">
+                    <div class="target-name"><span>{{name}}</span></div>
+                    {{#if (and ../hasRoll hitResult)}}
+                        <div class="target-hit-status {{#if hitResult.success}}is-hit{{else}}is-miss{{/if}}" data-perm-id="{{actorId}}" data-perm-hidden="true">
+                            {{#if hitResult.success}}
+                                {{localize "DAGGERHEART.GENERAL.hit.single"}}
+                            {{else}}
+                                {{localize "DAGGERHEART.GENERAL.miss.single"}}
+                            {{/if}}
+                        </div>
+                    {{/if}}
+                </div>
+                {{#if ../hasSave }}
+                    <div class="target-save{{#if saveResult}} is-rolled{{/if}}" data-perm-id="{{actorId}}">
+                        <i class="fa-solid {{#if saveResult}}{{#if saveResult.success}}fa-check{{else}}fa-xmark{{/if}}{{else}}fa-shield{{/if}} fa-lg"></i>
                     </div>
                 {{/if}}
             </div>
-            {{#if ../hasSave }}
-                <div class="target-save{{#if saveResult}} is-rolled{{/if}}" data-perm-id="{{actorId}}">
-                    <i class="fa-solid {{#if saveResult}}{{#if saveResult.success}}fa-check{{else}}fa-xmark{{/if}}{{else}}fa-shield{{/if}} fa-lg"></i>
-                </div>
-            {{/if}}
-        </div>
+        {{else}}
+            <i>{{localize "DAGGERHEART.GENERAL.noTarget"}}</i>
+        {{/each}}
     {{else}}
-        <i>{{localize "DAGGERHEART.GENERAL.noTarget"}}</i>
-    {{/each}}
+        <div class="selected-targets-container">
+            {{#with selectedTargetsData}}
+                {{#each tokens as |target|}}
+                    <div class="roll-target" data-token="{{target.token.id}}">
+                        <img class="target-img" src="{{target.img}}" />
+                    </div>
+                {{/each}}
+                {{#if (gt uniqueTokens 3)}}
+                    <i class="fa-solid fa-ellipsis ellipsis-marker"></i>
+                {{/if}}
+                {{#if (gt totalTokens 0)}}
+                <div class="targets-tools-container">
+                    <div>{{localize "DAGGERHEART.UI.Chat.damageRoll.totalTargetedTokens" total=totalTokens}}</div>
+                    <a class="selected-to-targets-button" title="{{localize "DAGGERHEART.UI.Chat.damageRoll.setSelectedAsTargets"}}"><i class="fa-solid fa-bullseye"></i></a>
+                </div>
+                {{else}}
+                    <span class="empty-text">{{localize "DAGGERHEART.UI.Chat.damageRoll.noTokensSelected"}}</span>
+                {{/if}}
+            {{/with}}
+        </div>
+    {{/unless}}
 </div>


### PR DESCRIPTION
Added in a D&D style `Targets | Selected` split in targeting. Players do not see any tabs.

**Targets Tab**: Tokens the user of the ability had `targeted` before using the ability.
**Selected Tab**: Tokens that are currently selected on the canvas.

The GM has access to the two tabs. If they want to target something different than the initial targeting for any reason, they can just swap to the `Selected` tab and select the tokens they want.

**Neat Things**
If nothing is targeted initially, the `Selected` tab will be selected right away.
In a players case, they are also put into select mode. This means that Player A can use a healing potion to heal Player B -> Player B has their own token selected and uses the heal button.

I removed `self` targeting on all typical potions consumables in the SRD to work according to the flow above.