### PR TITLE
[Feature] Resistance & Immunity Marking

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2458,6 +2458,7 @@
             "icon": "Icon",
             "identify": "Identity",
             "imagePath": "Image Path",
+            "immune": "Immune",
             "inactiveEffects": "Inactive Effects",
             "initial": "Initial",
             "inventory": "Inventory",
@@ -2501,6 +2502,7 @@
             "reroll": "Reroll",
             "rerolled": "Rerolled",
             "rerollThing": "Reroll {thing}",
+            "resistant": "Resistant",
             "result": {
                 "single": "Result",
                 "plural": "Results"

--- a/module/data/chat-message/actorRoll.mjs
+++ b/module/data/chat-message/actorRoll.mjs
@@ -136,21 +136,15 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
             const saveValue = this.targetSaves[data.id];
             const saveSuccessfull = saveValue === undefined ? false : 
                 saveValue >= (this.action.save.difficulty ?? this.action.actor?.baseSaveDifficulty);
-
-            let resistant = false;
-            let immune = false;
-            if (this.hasDamage && this.damage.active && actor) {
-                const data = actor.getResistanceStatus(this.damage.main.options.damageTypes);
-                resistant = data.resistant;
-                immune = data.immune;
-            }
+            const hasResistData = this.hasDamage && this.damage.active && actor;
+            const resistData = hasResistData ? actor.getResistanceStatus(this.damage.main.options.damageTypes) : null;
 
             return {
                 ...data,
                 hitResult: this.hasRoll ? { success: hitSuccessfull } : null,
                 saveResult: saveValue ? { success: saveSuccessfull } : null,
-                resistant,
-                immune
+                resistant: Boolean(resistData?.resistant),
+                immune: Boolean(resistData?.immune)
             }
         };
 

--- a/module/data/chat-message/actorRoll.mjs
+++ b/module/data/chat-message/actorRoll.mjs
@@ -112,17 +112,28 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
 
     get currentTargets() {
         const getCommonData = data => {
+            const actor = data.actorId ? foundry.utils.fromUuidSync(data.actorId) : null;
             const toHitNumber = data.difficulty || data.evasion;
             const hitSuccessfull = (toHitNumber === null || !this.roll) ? false : this.roll.total >= toHitNumber;
 
             const saveValue = this.targetSaves[data.id];
             const saveSuccessfull = saveValue === undefined ? false : 
                 saveValue >= (this.action.save.difficulty ?? this.action.actor?.baseSaveDifficulty);
-            
+
+            let resistant = false;
+            let immune = false;
+            if (this.hasDamage && this.damage.active && actor) {
+                const data = actor.getResistanceStatus(this.damage.main.options.damageTypes);
+                resistant = data.resistant;
+                immune = data.immune;
+            }
+
             return {
                 ...data,
                 hitResult: this.hasRoll ? { success: hitSuccessfull } : null,
-                saveResult: saveValue ? { success: saveSuccessfull } : null
+                saveResult: saveValue ? { success: saveSuccessfull } : null,
+                resistant,
+                immune
             }
         };
 

--- a/module/data/fields/action/damageField.mjs
+++ b/module/data/fields/action/damageField.mjs
@@ -105,15 +105,29 @@ export default class DamageField extends fields.SchemaField {
                 const configDamage = config.damage.clone();
                 configDamage.main &&= configDamage.main.toJSON();
                 if (configDamage.main) {
-                    const multiplier = config.actionActor?.system.rules?.attack?.damage?.hpDamageMultiplier ?? 1;
                     const takenMultiplier = actor.system.rules?.attack?.damage?.hpDamageTakenMultiplier;
-                    configDamage.main.total = Math.ceil(configDamage.main.total * multiplier * takenMultiplier);
+                    configDamage.main.total = Math.ceil(configDamage.main.total * takenMultiplier);
                 }
 
                 damagePromises.push(
                     actor
                         .takeDamage(configDamage, config.isDirect)
-                        .then(updates => targetDamage.push({ token, updates }))
+                        .then(updates => { 
+                            const resistanceData = 
+                                token.actor?.getResistanceStatus(configDamage.main?.options.damageTypes);
+                            const tokenData = {
+                                id: token.id, 
+                                name: token.prototype?.name ?? token.name, 
+                                img: token.texture.src,
+                                resistant: resistanceData?.resistant,
+                                immune: resistanceData?.immune
+                            };
+                            
+                            targetDamage.push({
+                                token: tokenData,
+                                updates 
+                            })
+                        })
                 );
             }
         }
@@ -124,6 +138,11 @@ export default class DamageField extends fields.SchemaField {
                 CONFIG.DH.SETTINGS.gameSettings.Automation
             ).summaryMessages;
             if (!summaryMessageSettings.damage) return;
+
+            const { hideObserverPermissionInChat } = game.settings.get(
+                CONFIG.DH.id,
+                CONFIG.DH.SETTINGS.gameSettings.Metagaming
+            );
 
             const cls = getDocumentClass('ChatMessage');
             const msg = {
@@ -136,7 +155,8 @@ export default class DamageField extends fields.SchemaField {
                 content: await foundry.applications.handlebars.renderTemplate(
                     'systems/daggerheart/templates/ui/chat/damageSummary.hbs',
                     {
-                        targets: targetDamage
+                        targets: targetDamage,
+                        hideObserverPermissionInChat
                     }
                 )
             };

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -165,6 +165,12 @@ export default class DhpActor extends Actor {
         }
     }
 
+    /**
+     * Get the bools for if the actor is resistant or immune to damage carrying certain damageTypes.
+     * An actor has to be resistant or immune to -all- related damageTypes for it to count.
+     * @param {string[]} damageTypes 
+     * @returns { resistant: bool, immune: bool }
+     */
     getResistanceStatus(damageTypes) {
         let resistant = null;
         let immune = null;

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -165,6 +165,22 @@ export default class DhpActor extends Actor {
         }
     }
 
+    getResistanceStatus(damageTypes) {
+        let resistant = null;
+        let immune = null;
+        
+        for (const type of damageTypes) {
+            if (resistant !== false && this.system.resistance?.[type]) {
+                resistant = this.system.resistance[type].resistance;
+            }
+            if (immune !== false && this.system.resistance?.[type]) {
+                immune = this.system.resistance[type].immunity;
+            }
+        }
+
+        return { resistant: Boolean(resistant), immune: Boolean(immune) }
+    }
+
     async updateLevel(newLevel) {
         if (!['character', 'companion'].includes(this.type) || newLevel === this.system.levelData.level.changed) return;
 
@@ -679,7 +695,7 @@ export default class DhpActor extends Actor {
                 damageTypes: new Set(args.main.damageTypes), 
                 key: CONFIG.DH.GENERAL.healingTypes.hitPoints.id
             };
-            if (this.type === 'character' && !isDirect && this.#canReduceDamage(hpDamage.value, hpDamage.damageTypes)) {
+            if (this.type === 'character' && !isDirect && hpDamage.value > 0 && this.#canReduceDamage(hpDamage.value, hpDamage.damageTypes)) {
                 const armorSlotResult = await this.owner.query(
                     'armorSlot',
                     {
@@ -778,18 +794,14 @@ export default class DhpActor extends Actor {
     }
 
     calculateDamage(baseDamage, type) {
-        if (this.canResist(type, 'immunity')) return 0;
-        if (this.canResist(type, 'resistance')) baseDamage = Math.ceil(baseDamage / 2);
+        const { resistant, immune } = this.getResistanceStatus(type);
+        if (immune) baseDamage = 0;
+        else if (resistant) baseDamage = Math.ceil(baseDamage / 2);
 
         const flatReduction = this.getDamageTypeReduction(type);
         const damage = Math.max(baseDamage - (flatReduction ?? 0), 0);
 
         return damage;
-    }
-
-    canResist(type, resistance) {
-        if (!type?.length) return false;
-        return type.every(t => this.system.resistance[t]?.[resistance] === true);
     }
 
     getDamageTypeReduction(type) {
@@ -881,6 +893,8 @@ export default class DhpActor extends Actor {
     }
 
     convertDamageToThreshold(damage) {
+        if (damage <= 0) return 0;
+
         const massiveDamageEnabled = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.variantRules)
             .massiveDamage.enabled;
         if (massiveDamageEnabled && damage >= this.system.damageThresholds.severe * 2) {

--- a/styles/less/ui/chat/chat.less
+++ b/styles/less/ui/chat/chat.less
@@ -166,10 +166,18 @@
             border-color: transparent;
         }
         [data-view-perm='false'] {
-            &[data-perm-hidden='true'],
+            &[data-perm-hidden='true'] {
+                display: none;
+
+                &::after {
+                    display: none;
+                }
+            }
+
             > * {
                 display: none;
             }
+
             &::after {
                 content: '??';
             }
@@ -463,6 +471,30 @@
                 .target-name {
                     text-align: left;
                 }
+
+                .target-roll-status {
+                    margin-top: 2px;
+                    display: flex;
+                    gap: 4px;
+
+                    .target-resistance-container {
+                        border: 1px solid currentColor;
+                        border-radius: 4px;
+                        padding: 3px 5px;
+                        text-transform: uppercase;
+                        font-weight: 600;
+
+                        &.resistant {
+                            color: @chat-orange;
+                            background-color: @chat-orange-10;
+                        }
+
+                        &.immune {
+                            color: @chat-purple;
+                            background-color: @chat-purple-10;
+                        }
+                    }
+                }
             }
 
             .target-save {
@@ -510,11 +542,6 @@
                 color: @medium-red;
                 background-color: @medium-red-10;
             }
-        }
-
-        .target-hit-status {
-            width: fit-content;
-            margin-top: 2px;
         }
 
         div[data-action='expandRoll'] {

--- a/styles/less/ui/chat/chat.less
+++ b/styles/less/ui/chat/chat.less
@@ -519,8 +519,8 @@
                         font-weight: 600;
 
                         &.resistant {
-                            color: @chat-orange;
-                            background-color: @chat-orange-10;
+                            color: @resistance-border;
+                            background-color: @resistance-bg;
                         }
 
                         &.immune {

--- a/styles/less/ui/chat/damage-summary.less
+++ b/styles/less/ui/chat/damage-summary.less
@@ -73,8 +73,8 @@
                     font-weight: 600;
 
                     &.resistant {
-                        color: @chat-orange;
-                        background-color: @chat-orange-10;
+                        color: @resistance-border;
+                        background-color: @resistance-bg;
                     }
 
                     &.immune {

--- a/styles/less/ui/chat/damage-summary.less
+++ b/styles/less/ui/chat/damage-summary.less
@@ -28,7 +28,7 @@
     .token-target-container {
         display: flex;
         flex-direction: column;
-        gap: 2px;
+        gap: 5px;
         transition: all 0.3s ease;
         border-radius: 6px;
 
@@ -43,10 +43,8 @@
         header {
             display: flex;
             align-items: center;
-            gap: 5px;
             pointer-events: none;
             position: relative;
-            margin-bottom: 10px;
 
             img {
                 width: 40px;
@@ -55,37 +53,59 @@
                 border-radius: 50%;
             }
 
-            .actor-name {
-                margin: 0;
-                color: @beige;
-                font-size: var(--font-size-20);
-                padding: 8px;
-            }
+            .token-header-data {
+                padding: 4px 8px 4px;
+                display: flex;
+                flex-direction: column;
 
-            &::after {
-                content: '';
-                position: absolute;
-                bottom: -10px;
-                background: @golden;
-                mask-image: linear-gradient(270deg, transparent 0%, black 50%, transparent 100%);
-                height: 2px;
-                width: 100%;
+                .actor-name {
+                    margin: 0;
+                    color: @beige;
+                    font-size: var(--font-size-20);
+                }
+
+                .token-resistance-container {
+                    width: fit-content;
+                    border: 1px solid currentColor;
+                    border-radius: 4px;
+                    padding: 3px 5px;
+                    text-transform: uppercase;
+                    font-weight: 600;
+
+                    &.resistant {
+                        color: @chat-orange;
+                        background-color: @chat-orange-10;
+                    }
+
+                    &.immune {
+                        color: @chat-purple;
+                        background-color: @chat-purple-10;
+                    }
+                }
             }
         }
 
         .damage-container {
+            margin: 0;
             display: flex;
             flex-direction: column;
             justify-content: center;
             gap: 5px;
             pointer-events: none;
-            margin-top: 5px;
             list-style: disc;
 
             .damage-row {
                 padding: 0 2px;
                 gap: 4px;
             }
+        }
+
+        &::after {
+            content: '';
+            background: @golden;
+            mask-image: linear-gradient(270deg, transparent 0%, black 50%, transparent 100%);
+            height: 2px;
+            width: 100%;
         }
     }
 }

--- a/styles/less/utils/colors.less
+++ b/styles/less/utils/colors.less
@@ -21,6 +21,9 @@
     --chat-purple-40: #a778b140;
     --chat-purple-bg: #2a152e99;
 
+    --chat-orange: #ffa500;
+    --chat-orange-10: #ffa50010;
+
     --medium-red: #d04747;
     --medium-red-10: #d0474710;
     --medium-red-40: #d0474740;
@@ -152,6 +155,9 @@
 @chat-purple-10: var(--chat-purple-10, #a778b110);
 @chat-purple-40: var(--chat-purple-40, #a778b140);
 @chat-purple-bg: var(--chat-purple-bg, #2a152e99);
+
+@chat-orange: var(--chat-orange, #ffa500);
+@chat-orange-10: var(--chat-orange-10, #ffa50010);
 
 @medium-red: var(--medium-red, #d04747);
 @medium-red-10: var(--medium-red-10, #d0474710);

--- a/styles/less/utils/colors.less
+++ b/styles/less/utils/colors.less
@@ -21,9 +21,6 @@
     --chat-purple-40: #a778b140;
     --chat-purple-bg: #2a152e99;
 
-    --chat-orange: #ffa500;
-    --chat-orange-10: #ffa50010;
-
     --medium-red: #d04747;
     --medium-red-10: #d0474710;
     --medium-red-40: #d0474740;
@@ -112,6 +109,8 @@
         --dh-trait-color-border: #8e8d96;
         --dh-window-button-color-bg: #e8e6e3;
         --dh-window-button-color-text: @dark-blue;
+        --dh-resistance-color-border: #ffa500;
+        --dh-resistance-color-bg: #ffa50010;  
     }
 }
 @scope (.theme-dark) to (.themed) {  
@@ -131,6 +130,8 @@
         --dh-trait-color-border: #927952;
         --dh-window-button-color-bg: @deep-black;
         --dh-window-button-color-text: @beige;
+        --dh-resistance-color-border: #ffa500;
+        --dh-resistance-color-bg: #ffa50010;
     }
 }
 
@@ -155,9 +156,6 @@
 @chat-purple-10: var(--chat-purple-10, #a778b110);
 @chat-purple-40: var(--chat-purple-40, #a778b140);
 @chat-purple-bg: var(--chat-purple-bg, #2a152e99);
-
-@chat-orange: var(--chat-orange, #ffa500);
-@chat-orange-10: var(--chat-orange-10, #ffa50010);
 
 @medium-red: var(--medium-red, #d04747);
 @medium-red-10: var(--medium-red-10, #d0474710);
@@ -255,3 +253,5 @@
 @input-color-text: var(--dh-input-color-text);
 @trait-color-bg: var(--dh-trait-color-bg);
 @trait-color-border: var(--dh-trait-color-border);
+@resistance-border: var(--dh-resistance-color-border);
+@resistance-bg: var(--dh-resistance-color-bg)

--- a/templates/ui/chat/damageSummary.hbs
+++ b/templates/ui/chat/damageSummary.hbs
@@ -2,8 +2,14 @@
     {{#each targets}}
         <li class="token-target-container {{#if this.token.id}}clickable{{/if}}" data-token="{{this.token.id}}">
             <header>
-                <img src="{{this.token.texture.src}}" />
-                <h2 class="actor-name">{{this.token.name}}</h2>
+                <img src="{{this.token.img}}" />
+                <div class="token-header-data">
+                    <h2 class="actor-name">{{this.token.name}}</h2>
+                    {{#unless (and (not ../isGM) ../hideObserverPermissionInChat)}}
+                        {{#if this.token.resistant}}<div class="token-resistance-container resistant">{{localize "Resistant"}}</div>{{/if}}
+                        {{#if this.token.immune}}<div class="token-resistance-container immune">{{localize "Immune"}}</div>{{/if}}
+                    {{/unless}}
+                </div>
             </header>
             <ul class="damage-container">
                 {{#each this.updates}}

--- a/templates/ui/chat/damageSummary.hbs
+++ b/templates/ui/chat/damageSummary.hbs
@@ -6,8 +6,8 @@
                 <div class="token-header-data">
                     <h2 class="actor-name">{{this.token.name}}</h2>
                     {{#unless (and (not ../isGM) ../hideObserverPermissionInChat)}}
-                        {{#if this.token.resistant}}<div class="token-resistance-container resistant">{{localize "Resistant"}}</div>{{/if}}
-                        {{#if this.token.immune}}<div class="token-resistance-container immune">{{localize "Immune"}}</div>{{/if}}
+                        {{#if this.token.resistant}}<div class="token-resistance-container resistant">{{localize "DAGGERHEART.GENERAL.resistant"}}</div>{{/if}}
+                        {{#if this.token.immune}}<div class="token-resistance-container immune">{{localize "DAGGERHEART.GENERAL.immune"}}</div>{{/if}}
                     {{/unless}}
                 </div>
             </header>

--- a/templates/ui/chat/parts/target-part.hbs
+++ b/templates/ui/chat/parts/target-part.hbs
@@ -24,25 +24,31 @@
                         </div>
                         <div class="roll-part-header"><div></div></div>
                     </div>
+                    {{#if (and hasSave parent.system.currentTargets.length)}}<div class="roll-part-extra roll-all-save-button">{{localize "DAGGERHEART.UI.Chat.saveRoll.reactionRollAllTargets"}}<i class="fa-solid fa-shield fa-lg"></i></div>{{/if}}
                 {{/if}}
-                {{#if (and hasSave parent.system.currentTargets.length)}}<div class="roll-part-extra roll-all-save-button">{{localize "DAGGERHEART.UI.Chat.saveRoll.reactionRollAllTargets"}}<i class="fa-solid fa-shield fa-lg"></i></div>{{/if}}
                 {{#each parent.system.currentTargets}}
                     <div class="roll-target" data-token="{{id}}">
                         <img class="target-img" src="{{img}}">
                         <div class="target-data">
                             <div class="target-name"><span>{{name}}</span></div>
-                            {{#if (and ../hasRoll hitResult)}}
-                                <div class="target-hit-status {{#if hitResult.success}}is-hit{{else}}is-miss{{/if}}" data-perm-id="{{actorId}}" data-perm-hidden="true">
-                                    {{#if hitResult.success}}
-                                        {{localize "DAGGERHEART.GENERAL.hit.single"}}
-                                    {{else}}
-                                        {{localize "DAGGERHEART.GENERAL.miss.single"}}
-                                    {{/if}}
-                                </div>
-                            {{/if}}
+                            <div class="target-roll-status" data-perm-id="{{actorId}}" data-perm-hidden="true">
+                                {{#if (and ../hasRoll hitResult)}}
+                                    <div class="target-hit-status {{#if hitResult.success}}is-hit{{else}}is-miss{{/if}}">
+                                        {{#if hitResult.success}}
+                                            {{localize "DAGGERHEART.GENERAL.hit.single"}}
+                                        {{else}}
+                                            {{localize "DAGGERHEART.GENERAL.miss.single"}}
+                                        {{/if}}
+                                    </div>
+                                {{/if}}
+                                {{#if (and ../hasDamage ../damage.active)}}
+                                    {{#if resistant}}<div class="target-resistance-container resistant">{{localize "Resistant"}}</div>{{/if}}
+                                    {{#if immune}}<div class="target-resistance-container immune">{{localize "Immune"}}</div>{{/if}}
+                                {{/if}}
+                            </div>
                         </div>
                         {{#if ../hasSave }}
-                            <div class="target-save{{#if saveResult}} is-rolled{{/if}}" data-perm-id="{{actorId}}">
+                            <div class="target-save{{#if saveResult}} is-rolled{{/if}}" data-perm-id="{{actorId}}" data-perm-hidden="true">
                                 <i class="fa-solid {{#if saveResult}}{{#if saveResult.success}}fa-check{{else}}fa-xmark{{/if}}{{else}}fa-shield{{/if}} fa-lg"></i>
                             </div>
                         {{/if}}

--- a/templates/ui/chat/parts/target-part.hbs
+++ b/templates/ui/chat/parts/target-part.hbs
@@ -42,8 +42,8 @@
                                     </div>
                                 {{/if}}
                                 {{#if (and ../hasDamage ../damage.active)}}
-                                    {{#if resistant}}<div class="target-resistance-container resistant">{{localize "Resistant"}}</div>{{/if}}
-                                    {{#if immune}}<div class="target-resistance-container immune">{{localize "Immune"}}</div>{{/if}}
+                                    {{#if resistant}}<div class="target-resistance-container resistant">{{localize "DAGGERHEART.GENERAL.resistant"}}</div>{{/if}}
+                                    {{#if immune}}<div class="target-resistance-container immune">{{localize "DAGGERHEART.GENERAL.immune"}}</div>{{/if}}
                                 {{/if}}
                             </div>
                         </div>


### PR DESCRIPTION
<img width="1298" height="1090" alt="image" src="https://github.com/user-attachments/assets/935f54cb-01cd-49de-a00e-838c6ec21fae" />

- Added Resistance/Immunity tags to ChatMessage and DamageSummary.
- Tags are hidden when Metagaming setting is on.
- Fixed a bug where Immunity didn't actually reduce the damage to 0.
- Fixed a bug where `[data-perm-hidden]` wasn't working, since the `::after` element didn't get effected by `display: none`.
- Changed so that saves in chat messages use `[data-perm-hidden]`. Seemed strange that we'd show `??` there but not for wether something hit or not. There's no actual `saves` header or anything, so it just seemed out of place to me.
