### PR TITLE
Reduce top center fear tracker shifting on lower resolutions

### DIFF
--- a/module/applications/ui/fearTracker.mjs
+++ b/module/applications/ui/fearTracker.mjs
@@ -149,11 +149,12 @@ export default class FearTracker extends HandlebarsApplicationMixin(ApplicationV
             const top = document.getElementById('ui-top');
 
             // Logic derived from the internal code's ChatLog#offsetHotbar(). Since the sidebar might be mid animation, we can't really check directly.
+            // Treat effects as always open to minimize UI shifting
             const { uiScale } = game.settings.get('core', 'uiConfig');
             const sidebarWidth = (348 * ui.sidebar.expanded) / uiScale;
             const countdownsWidth = countdowns.getBoundingClientRect().width;
-            const effectsWidth = effectsDisplay.getBoundingClientRect().width;
-            const rightWidth = sidebarWidth + countdownsWidth + 16 + (effectsWidth ? 62 : 0);
+            const effectsWidth = Math.max(46, effectsDisplay.getBoundingClientRect().width);
+            const rightWidth = sidebarWidth + countdownsWidth + 16 + effectsWidth + 16;
             const countdownLeftEdge = window.innerWidth - rightWidth - 16; // w/ extra padding
 
             const topBounds = top.getBoundingClientRect();


### PR DESCRIPTION
Same as before, but now no longer shifts position based on selecting tokens with effects or not, it only shifts based on countdown size and sidebar status.