### PR TITLE
[Fix] visibility of equipped weapons with transparency in party sheet

### DIFF
--- a/styles/less/sheets/actors/party/party-members.less
+++ b/styles/less/sheets/actors/party/party-members.less
@@ -66,6 +66,7 @@
                     flex-direction: column;
                     gap: 1px;
                     img {
+                        background-color: #111;
                         border-radius: 50%;
                         width: 24px;
                         height: 24px;


### PR DESCRIPTION
The top left is an svg with transparency

<img width="142" height="131" alt="image" src="https://github.com/user-attachments/assets/b12b958b-545e-4a14-9bc5-99397410bffd" />
