### PR TITLE
Improve visibility in light mode, fix theme mix errors, and loadout card tweaks

### DIFF
--- a/styles/less/global/elements.less
+++ b/styles/less/global/elements.less
@@ -99,9 +99,10 @@
     }
 
     button:where(:not(.plain, color-picker *, file-picker *)) {
-        background: light-dark(transparent, @golden);
-        border: 1px solid light-dark(@dark-blue, @dark-blue);
-        color: light-dark(@dark-blue, @dark-blue);
+        background: @button-color-bg;
+        border: 1px solid @button-color-border;
+        border-radius: 4px;
+        color: @button-color-text;
         outline: none;
         box-shadow: none;
 
@@ -116,13 +117,13 @@
 
         &:disabled {
             background: light-dark(transparent, @golden);
-            color: light-dark(@dark-blue, @dark-blue);
+            color: @button-color-text;
             opacity: 0.6;
             cursor: not-allowed;
 
             &:hover {
                 background: light-dark(transparent, @golden);
-                color: light-dark(@dark-blue, @dark-blue);
+                color: @button-color-text;
             }
         }
 
@@ -132,7 +133,7 @@
             border: 1px solid light-dark(@dark, transparent);
             &:hover {
                 background: light-dark(transparent, @golden);
-                color: light-dark(@dark-blue, @dark-blue);
+                color: @button-color-text;
             }
             img {
                 border-radius: 3px;
@@ -556,8 +557,10 @@
     /* A multi-button element used to attach resources to other buttons */
     .item-button {
         display: flex;
+        border: 1px solid @button-color-border;
+        border-radius: 4px;
         button {
-            color: light-dark(@dark-blue, @dark-blue);
+            color: @button-color-text;
             white-space: nowrap;
             border: none;
 

--- a/styles/less/global/inventory-item.less
+++ b/styles/less/global/inventory-item.less
@@ -2,7 +2,11 @@
 @import '../utils/fonts.less';
 @import '../utils/mixin.less';
 
-.theme-light .application.daggerheart.dh-style {
+.appTheme({}, {
+    .inventory-item .img-portait .roll-img {
+        filter: invert(1);
+    }
+
     .inventory-item,
     .card-item {
         .item-resource .item-dice-resource {
@@ -10,12 +14,6 @@
                 filter: brightness(0) saturate(100%);
             }
         }
-    }
-}
-
-.appTheme({}, {
-    .inventory-item .img-portait .roll-img {
-        filter: invert(1);
     }
 });
 
@@ -265,7 +263,7 @@
 
         &:hover {
             .card-label {
-                padding-top: 15px;
+                padding-top: 8px;
                 .menu {
                     opacity: 1;
                     visibility: visible;
@@ -295,15 +293,17 @@
             height: 100%;
             width: 100%;
             object-fit: cover;
+            object-fit: top center;
             border-radius: 6px;
+            padding-bottom: 26px;
         }
 
         .recall-cost {
             position: absolute;
             right: 4px;
             top: 4px;
-            width: 1.75em;
-            height: 1.75em;
+            width: 1.5rem;
+            height: 1.5rem;
 
             align-items: center;
             background: @dark-blue;
@@ -312,34 +312,41 @@
             color: @golden;
             display: flex;
             justify-content: center;
-            padding-top: 0.1em; // compensate for font
+            padding-top: 1px; // compensate for font
+            gap: 1px;
 
             i {
                 font-size: 0.68em;
+                width: auto;
             }
         }
 
         .card-label {
+            /** Placed at bottom, overlap with border */
+            position: absolute;
+            left: -1px;
+            bottom: -1px;
+            right: -1px;
+
             display: flex;
             flex-direction: column;
             height: fit-content;
             align-items: center;
-            gap: 5px;
-            padding-top: 5px;
-            padding-bottom: 5px;
-            width: 100%;
-            position: absolute;
             background-color: @dark-blue;
-            bottom: 0;
-            mask-image: linear-gradient(180deg, transparent 0%, black 20%);
+            mask-image: linear-gradient(180deg, transparent 0%, black 4px);
             border-radius: 0 0 6px 6px;
+            padding-top: 2px;
 
             .card-name {
                 font-style: normal;
                 font-weight: 400;
                 font-size: var(--font-size-12);
-                line-height: 15px;
+                line-height: 1;
                 text-align: center;
+                padding: 4px 2px 4px 2px;
+                min-height: 30px;
+                display: flex;
+                align-items: center;
 
                 color: @beige;
             }
@@ -356,7 +363,6 @@
 
                 .controls {
                     display: flex;
-                    gap: 2px;
                     gap: 15px;
                     justify-content: center;
                 }

--- a/styles/less/global/resource-bar.less
+++ b/styles/less/global/resource-bar.less
@@ -149,6 +149,7 @@
         border-radius: 6px;
         z-index: 0;
         background: @dark-blue;
+        color: var(--beige, #efe6d8);
 
         &::-webkit-progress-bar {
             border: none;

--- a/styles/less/sheets/actors/character/sidebar.less
+++ b/styles/less/sheets/actors/character/sidebar.less
@@ -244,18 +244,11 @@
                     font-size: 1.2rem;
                     width: 80px;
                     height: 30px;
-                    justify-content: center;
-                    color: light-dark(@dark-blue, @beige);
 
                     input[type='number'] {
                         font-size: 1.2rem;
                         width: 30px;
                         height: 20px;
-                        color: light-dark(@dark-blue, @beige);
-
-                        &.bar-input {
-                            color: light-dark(@dark-blue, @beige);
-                        }
                     }
 
                     .bar-label {
@@ -263,9 +256,12 @@
                     }
                 }
                 .progress-bar {
-                    background: light-dark(transparent, @dark-blue);
                     border-bottom: none;
                     border-radius: 6px 6px 0 0;
+                    &::-webkit-progress-bar,
+                    &::-webkit-progress-value {
+                        border-radius: 6px 6px 0 0;
+                    }
                 }
             }
 

--- a/styles/less/utils/colors.less
+++ b/styles/less/utils/colors.less
@@ -105,6 +105,9 @@
         --dh-color-text-shadow-contrast: light-dark(#ffffffa0, @dark-80);
         --dh-input-color-border: light-dark(@dark, @beige);
         --dh-input-color-text: light-dark(@dark, @beige);
+        --dh-button-color-bg: light-dark(transparent, @golden);
+        --dh-button-color-border: @dark-blue;
+        --dh-button-color-text: @dark-blue;
         --dh-trait-color-bg: light-dark(#b1afb6, #50433F);
         --dh-trait-color-border: light-dark(#8e8d96, #927952);
         --dh-window-button-color-bg: light-dark(#e8e6e3, @deep-black);
@@ -232,6 +235,9 @@
 @color-text-shadow-contrast: var(--dh-color-text-shadow-contrast);
 @input-color-border: var(--dh-input-color-border);
 @input-color-text: var(--dh-input-color-text);
+@button-color-bg: var(--dh-button-color-bg);
+@button-color-border: var(--dh-button-color-border);
+@button-color-text: var(--dh-button-color-text);
 @trait-color-bg: var(--dh-trait-color-bg);
 @trait-color-border: var(--dh-trait-color-border);
 @resistance-color-border: var(--dh-resistance-color-border);

--- a/styles/less/utils/mixin.less
+++ b/styles/less/utils/mixin.less
@@ -5,19 +5,21 @@
  */
 .appTheme(@darkRules, @lightRules) {
     // Dark theme selectors
-    .themed.theme-dark .application.daggerheart.dh-style,
-    .themed.theme-dark.application.daggerheart.dh-style,
-    body.theme-dark .application.daggerheart,
-    body.theme-dark.application.daggerheart {
-        @darkRules();
+    @scope (.theme-dark) to (.themed) {
+        .application.daggerheart :scope,
+        :scope.application.daggerheart,
+        .application.daggerheart {
+            @darkRules();
+        }
     }
 
     // Light theme selectors
-    .themed.theme-light .application.daggerheart.dh-style,
-    .themed.theme-light.application.daggerheart.dh-style,
-    body.theme-light .application.daggerheart,
-    body.theme-light.application.daggerheart {
-        @lightRules();
+    @scope (.theme-light) to (.themed) {
+        .application.daggerheart :scope,
+        :scope.application.daggerheart,
+        .application.daggerheart {    
+            @lightRules();
+        }
     }
 }
 

--- a/templates/sheets/global/partials/domain-card-item.hbs
+++ b/templates/sheets/global/partials/domain-card-item.hbs
@@ -23,6 +23,6 @@
                 </a>
             </div>
         </div>
-        <span class="card-name" data-action="viewItem">{{item.name}}</span>
+        <a class="card-name" data-action="viewItem">{{item.name}}</a>
     </div>
 </li>


### PR DESCRIPTION
First, a few new descriptive css variables. Yay! While button color css already exists in foundry, its another one of those absurdly scoped ones, forcing us to redefine it.

Certain elements in light mode are more visible, such as resources. While this styling may not be ideal, tweaking it otherwise has bad visibility. It may be worth giving it another look once resources have been further tweaked:

<img width="311" height="146" alt="image" src="https://github.com/user-attachments/assets/9560c522-2fa3-4728-8a8b-c6bf3c24c3aa" />

This also fixes issues that would occur if foundry was set to light mode but a specific sheet was set to dark mode. Certain elements with specific overrides using the appTheme mixin would continue to use light mode styling even on a dark mode sheet. This caused issues with things like the unstoppable die.

Finally, it carries over some of the non-controversial elements of https://github.com/Foundryborne/daggerheart/pull/2107. Specifically changes in the appearance of the recall cost, handling of multilines, and the image aspect ratio. No tooltip though.