### PR TITLE
[Fix] ContextMenu Damage Option

### DIFF
--- a/module/applications/sheets/api/application-mixin.mjs
+++ b/module/applications/sheets/api/application-mixin.mjs
@@ -509,9 +509,10 @@ export default function DHApplicationMixin(Base) {
                     icon: 'fa-solid fa-explosion',
                     visible: target => {
                         const doc = getDocFromElementSync(target);
-                        const hasDamage =
-                            !foundry.utils.isEmpty(doc?.system?.attack?.damage.parts) ||
-                            !foundry.utils.isEmpty(doc?.damage?.parts);
+                        const hasDamage = doc?.system?.attack?.damage && (
+                            doc.system.attack.damage.main || 
+                            Object.keys(doc.system.attack.damage.resources ?? {}).length
+                        );
                         return doc?.isOwner && hasDamage;
                     },
                     onClick: async (event, target) => {


### PR DESCRIPTION
The Damage option in a weapon's context menu wasn't changed with the damage rework. Fixed so that it's available again.
<img width="855" height="342" alt="image" src="https://github.com/user-attachments/assets/3f513b43-bb13-43d3-a031-fdf3287af4ec" />