### PR TITLE
[Fix] ChatMessage Migration

### DIFF
--- a/module/data/chat-message/actorRoll.mjs
+++ b/module/data/chat-message/actorRoll.mjs
@@ -254,6 +254,7 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
                 return oldRoll ? JSON.stringify({
                     ...oldRoll,
                     class: 'DamageRoll',
+                    evaluated: true,
                     options: {
                         ...oldRoll.options,
                         damageTypes: damageData.parts[0].damageTypes ?? []


### PR DESCRIPTION
Tested migration of an old world. The old way of storing damage rolls was so brokenly bad that it's a real bother to try and stitch it together into a proper roll.

We -could- do it, but I'm not sure it's really worthwhile. Any existing damge messages in chat should sensibly not be relevant next session that's started up. With that in mind I simply set old damage messages to have their rolls evaluated as they were always `evaluated = false` in the old messages, and that causes an error that makes the chat message invalid.