### PR TITLE
[Fix] ChatMessage Hook Deregistration

### DIFF
--- a/module/data/chat-message/actorRoll.mjs
+++ b/module/data/chat-message/actorRoll.mjs
@@ -184,7 +184,7 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
 
 
     syncSelectedTokens = foundry.utils.debounce(async () => {
-        if (this.targeting.usingSelect) this.updateTargetHTML();
+        if (this.targeting.usingSelect && this.parent.id) this.updateTargetHTML();
     }, 50);
 
     /**

--- a/module/data/chat-message/actorRoll.mjs
+++ b/module/data/chat-message/actorRoll.mjs
@@ -184,7 +184,7 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
 
 
     syncSelectedTokens = foundry.utils.debounce(async () => {
-        if (this.targeting.usingSelect && this.parent.id) this.updateTargetHTML();
+        if (this.targeting.usingSelect) this.updateTargetHTML();
     }, 50);
 
     /**

--- a/module/documents/chatMessage.mjs
+++ b/module/documents/chatMessage.mjs
@@ -15,7 +15,7 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
 
     setupHooks() {
         if (this.system.hasTarget) {
-            Hooks.on('controlToken', this.onSelectToken.bind(this));
+            this.controlTokenHook = Hooks.on('controlToken', this.onSelectToken.bind(this));
         }
     }
 
@@ -62,7 +62,9 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
     _onDelete(options, userId) {
         super._onDelete(options, userId);
 
-        Hooks.off('controlToken', this.onSelectToken);
+        if (this.controlTokenHook) {
+            Hooks.off('controlToken', this.controlTokenHook);
+        }
     }
 
     enrichChatMessage(html) {


### PR DESCRIPTION
Fixed so that the controlToken hook on chatMessages ends up deregistered when the message is deleted