### PR TITLE
[Fix] Critical Damage Lost When Applying

### DIFF
--- a/module/data/fields/action/damageField.mjs
+++ b/module/data/fields/action/damageField.mjs
@@ -108,7 +108,7 @@ export default class DamageField extends fields.SchemaField {
                 configDamage.main &&= configDamage.main.toJSON();
                 if (configDamage.main) {
                     const takenMultiplier = actor.system.rules?.attack?.damage?.hpDamageTakenMultiplier;
-                    configDamage.main.total = Math.ceil(configDamage.main.total * takenMultiplier);
+                    configDamage.main.total = Math.ceil(config.damage.main.total * takenMultiplier);
                 }
 
                 damagePromises.push(


### PR DESCRIPTION
Fixed so that we don't lost critical damage when applying it. 

Since we run `main.toJSON()` we end up with a simple object. Normally a `DamageRoll` uses an overriding `get Total` to get the correct critical/non-critical damage. 
It was easily solved here though by just modifying from the original object's value instead.