### PR TITLE
[Feature] Rework countdown inheritance

### DIFF
--- a/daggerheart.d.ts
+++ b/daggerheart.d.ts
@@ -14,7 +14,7 @@ import * as fields from './module/data/fields/_module.mjs';
 import { gameSettings } from './module/config/settingsConfig.mjs';
 import DhAutomation from './module/data/settings/Automation.mjs';
 import FearTracker from './module/applications/ui/fearTracker.mjs';
-import DhCountdowns from './module/applications/ui/countdowns.mjs';
+import DhCountdowns from './module/data/countdowns.mjs';
 import DhEffectsDisplay from './module/applications/ui/effectsDisplay.mjs';
 
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -3171,7 +3171,8 @@
             "Countdowns": {
                 "title": "Countdowns",
                 "toggleIconMode": "Toggle Icon Only",
-                "hidden": "This countdown is set to Hidden. {nr} players can see it.",
+                "hidden": "This countdown is hidden to all players.",
+                "hiddenPartial": "This countdown is hidden to players except {players}.",
                 "reveal":"Reveal Countdown",
                 "hide":"Hide Countdown",
                 "loop": "Looping",

--- a/lang/en.json
+++ b/lang/en.json
@@ -462,6 +462,7 @@
                     "countdowns": {
                         "element": {
                             "name": { "label": "Name" },
+                            "hidden": { "label": "Hidden" },
                             "progress": {
                                 "current": { "label": "Current" },
                                 "looping": { "label": "Looping" },
@@ -502,7 +503,6 @@
                 "progressionType": "Progression",
                 "decreasing": "Decreasing",
                 "looping": "Looping",
-                "defaultOwnershipTooltip": "The default player ownership of countdowns",
                 "hideNewCountdowns": "Hide New Countdowns"
             },
             "CreateItemDialog": {
@@ -3171,8 +3171,7 @@
             "Countdowns": {
                 "title": "Countdowns",
                 "toggleIconMode": "Toggle Icon Only",
-                "noPlayerAccess": "No player has access to this countdown",
-                "hidden": "This countdown is hidden",
+                "hidden": "This countdown is hidden to other users",
                 "reveal":"Reveal Countdown",
                 "hide":"Hide Countdown",
                 "loop": "Looping",

--- a/lang/en.json
+++ b/lang/en.json
@@ -3171,7 +3171,7 @@
             "Countdowns": {
                 "title": "Countdowns",
                 "toggleIconMode": "Toggle Icon Only",
-                "hidden": "This countdown is hidden to other users",
+                "hidden": "This countdown is set to Hidden. {nr} players can see it.",
                 "reveal":"Reveal Countdown",
                 "hide":"Hide Countdown",
                 "loop": "Looping",

--- a/module/applications/dialogs/ownershipSelection.mjs
+++ b/module/applications/dialogs/ownershipSelection.mjs
@@ -1,12 +1,29 @@
 const { HandlebarsApplicationMixin, ApplicationV2 } = foundry.applications.api;
 
+/**
+ * @typedef OwnershipOptions
+ * @property {number[]} ownershipOptions the options that will be shown as possible choices for each user
+ * @property {number} default The default ownership option the players will default to
+ * @property {number[]} defaultOwnershipOptions 
+ */
+
+/** A dialog for ownership selection */
 export default class OwnershipSelection extends HandlebarsApplicationMixin(ApplicationV2) {
-    constructor(name, ownership, defaultOwnership) {
+    /**
+     * @param {string} name
+     * @param {Record<string, number>} options.ownership
+     * @param {OwnershipOptions} [options]
+     */
+    constructor(name, ownership, options = {}) {
         super({});
 
         this.name = name;
-        this.ownership = foundry.utils.deepClone(ownership);
-        this.defaultOwnership = defaultOwnership;
+        this.ownership = ownership;
+        this.ownershipOptions = options.ownershipOptions ?? [-1, 0, 2, 3]; // 1 isn't in our dictionary
+        this.default = options.default;
+        this.defaultOwnershipOptions = typeof options.default === 'number' || options.defaultOwnershipOptions 
+            ? options.defaultOwnershipOptions ?? this.ownershipOptions
+            : null;
     }
 
     static DEFAULT_OPTIONS = {
@@ -16,7 +33,7 @@ export default class OwnershipSelection extends HandlebarsApplicationMixin(Appli
             icon: 'fa-solid fa-users'
         },
         position: {
-            width: 600,
+            width: 450,
             height: 'auto'
         },
         form: { handler: this.updateData }
@@ -38,8 +55,17 @@ export default class OwnershipSelection extends HandlebarsApplicationMixin(Appli
 
     async _prepareContext(_options) {
         const context = await super._prepareContext(_options);
-        context.ownershipOptions = CONFIG.DH.GENERAL.simpleOwnershiplevels;
-        context.defaultOwnership = this.defaultOwnership;
+        
+        // Get ownership options. becuase of the use of numbers, the base collection is not correctly ordered.
+        // So we have to redefine it ourselves in the correct order.
+        context.ownershipOptions = this.ownershipOptions.map(value => ({
+            value, 
+            label: CONFIG.DH.GENERAL.simpleOwnershiplevels[value].label
+        }));
+        context.defaultOwnershipOptions = this.defaultOwnershipOptions?.map(value => ({
+            value, 
+            label: CONFIG.DH.GENERAL.simpleOwnershiplevels[value].label
+        }));
         context.ownership = game.users.reduce((acc, user) => {
             if (!user.isGM) {
                 acc[user.id] = {
@@ -51,6 +77,7 @@ export default class OwnershipSelection extends HandlebarsApplicationMixin(Appli
 
             return acc;
         }, {});
+        context.default = this.default;
         context.showOwnership = Boolean(Object.keys(context.ownership).length);
 
         return context;
@@ -69,9 +96,16 @@ export default class OwnershipSelection extends HandlebarsApplicationMixin(Appli
         await super.close();
     }
 
-    static async configure(name, ownership, defaultOwnership) {
+    /**
+     * Creates a ownership selection dialog returns the result when resolved
+     * @param {string} name 
+     * @param {Record<string, number>} ownership
+     * @param {OwnershipOptions} options
+     * @returns {Promise<{ ownership: number; default?: number }>}
+     */
+    static async configure(name, ownership, options) {
         return new Promise(resolve => {
-            const app = new this(name, ownership, defaultOwnership);
+            const app = new this(name, ownership, options);
             app.addEventListener('close', () => resolve(app.saveData), { once: true });
             app.render({ force: true });
         });

--- a/module/applications/ui/countdownEdit.mjs
+++ b/module/applications/ui/countdownEdit.mjs
@@ -11,7 +11,6 @@ export default class CountdownEdit extends HandlebarsApplicationMixin(Applicatio
         this.data = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Countdowns);
         this.editingCountdowns = new Set();
         this.currentEditCountdown = null;
-        this.hideNewCountdowns = false;
     }
 
     static DEFAULT_OPTIONS = {
@@ -43,12 +42,11 @@ export default class CountdownEdit extends HandlebarsApplicationMixin(Applicatio
     async _prepareContext(_options) {
         const context = await super._prepareContext(_options);
         context.isGM = game.user.isGM;
-        context.ownershipDefaultOptions = CONFIG.DH.GENERAL.basicOwnershiplevels;
         context.defaultOwnership = this.data.defaultOwnership;
+        context.hideNewCountdowns = this.data.hideNewCountdowns;
         context.countdownTypes = CONFIG.DH.GENERAL.countdownTypes;
         context.countdownProgressionTypes = CONFIG.DH.GENERAL.countdownProgressionTypes;
         context.countdownLoopingTypes = CONFIG.DH.GENERAL.countdownLoopingTypes;
-        context.hideNewCountdowns = this.hideNewCountdowns;
         context.countdowns = Object.keys(this.data.countdowns).reduce((acc, key) => {
             const countdown = this.data.countdowns[key];
             const isLooping = countdown.progress.looping !== CONFIG.DH.GENERAL.countdownLoopingTypes.noLooping;
@@ -122,7 +120,7 @@ export default class CountdownEdit extends HandlebarsApplicationMixin(Applicatio
     }
 
     static async updateData(_event, _, formData) {
-        const { hideNewCountdowns, ...settingsData } = foundry.utils.expandObject(formData.object);
+        const settingsData = foundry.utils.expandObject(formData.object);
 
         // Sync current and max if max is changing and they were equal before
         for (const [id, countdown] of Object.entries(settingsData.countdowns ?? {})) {
@@ -134,7 +132,6 @@ export default class CountdownEdit extends HandlebarsApplicationMixin(Applicatio
             );
         }
 
-        this.hideNewCountdowns = hideNewCountdowns;
         this.updateSetting(settingsData);
     }
 
@@ -164,7 +161,7 @@ export default class CountdownEdit extends HandlebarsApplicationMixin(Applicatio
         this.editingCountdowns.add(id);
         this.currentEditCountdown = id;
         this.updateSetting({
-            [`countdowns.${id}`]: DhCountdown.defaultCountdown(null, this.hideNewCountdowns)
+            [`countdowns.${id}`]: DhCountdown.defaultCountdown(null, this.data.hideNewCountdowns)
         });
     }
 
@@ -207,14 +204,20 @@ export default class CountdownEdit extends HandlebarsApplicationMixin(Applicatio
      */
     static async #onEditCountdownOwnership(_, button) {
         const countdown = this.data.countdowns[button.dataset.countdownId];
+        const levels = CONST.DOCUMENT_OWNERSHIP_LEVELS;
         const data = await game.system.api.applications.dialogs.OwnershipSelection.configure(
             countdown.name,
             countdown.ownership,
-            this.data.defaultOwnership
+            { 
+                ownershipOptions: [levels.INHERIT, levels.OBSERVER, levels.OWNER],
+                default: countdown.hidden ? levels.NONE : levels.OBSERVER,
+                defaultOwnershipOptions: [levels.NONE, levels.OBSERVER]
+            }
         );
         if (!data) return;
 
-        this.updateSetting({ [`countdowns.${button.dataset.countdownId}`]: data });
+        const updateData = { ownership: data.ownership, hidden: data.default === 0 };
+        this.updateSetting({ [`countdowns.${button.dataset.countdownId}`]: updateData });
     }
 
     /** 

--- a/module/applications/ui/countdownEdit.mjs
+++ b/module/applications/ui/countdownEdit.mjs
@@ -23,12 +23,12 @@ export default class CountdownEdit extends HandlebarsApplicationMixin(Applicatio
             icon: 'fa-solid fa-clock-rotate-left'
         },
         actions: {
-            addCountdown: CountdownEdit.#addCountdown,
-            toggleCountdownEdit: CountdownEdit.#toggleCountdownEdit,
-            editCountdownImage: CountdownEdit.#editCountdownImage,
-            editCountdownOwnership: CountdownEdit.#editCountdownOwnership,
-            randomiseCountdownStart: CountdownEdit.#randomiseCountdownStart,
-            removeCountdown: CountdownEdit.#removeCountdown
+            addCountdown: CountdownEdit.#onAddCountdown,
+            toggleCountdownEdit: CountdownEdit.#onToggleCountdownEdit,
+            editCountdownImage: CountdownEdit.#onEditCountdownImage,
+            editCountdownOwnership: CountdownEdit.#onEditCountdownOwnership,
+            randomiseCountdownStart: CountdownEdit.#onRandomiseCountdownStart,
+            removeCountdown: CountdownEdit.#onRemoveCountdown
         },
         form: { handler: this.updateData, submitOnChange: true }
     };
@@ -155,7 +155,11 @@ export default class CountdownEdit extends HandlebarsApplicationMixin(Applicatio
         });
     }
 
-    static #addCountdown() {
+    /** 
+     * @this CountdownEdit
+     * @type {import('@client/applications/_types.mjs').ApplicationClickAction}
+     */
+    static #onAddCountdown() {
         const id = foundry.utils.randomID();
         this.editingCountdowns.add(id);
         this.currentEditCountdown = id;
@@ -164,7 +168,11 @@ export default class CountdownEdit extends HandlebarsApplicationMixin(Applicatio
         });
     }
 
-    static #editCountdownImage(_, target) {
+    /** 
+     * @this CountdownEdit
+     * @type {import('@client/applications/_types.mjs').ApplicationClickAction}
+     */
+    static #onEditCountdownImage(_, target) {
         const countdown = this.data.countdowns[target.id];
         const fp = new foundry.applications.apps.FilePicker.implementation({
             current: countdown.img,
@@ -176,7 +184,11 @@ export default class CountdownEdit extends HandlebarsApplicationMixin(Applicatio
         return fp.browse();
     }
 
-    static #toggleCountdownEdit(_, button) {
+    /** 
+     * @this CountdownEdit
+     * @type {import('@client/applications/_types.mjs').ApplicationClickAction}
+     */
+    static #onToggleCountdownEdit(_, button) {
         const { countdownId } = button.dataset;
 
         const isEditing = this.editingCountdowns.has(countdownId);
@@ -189,7 +201,11 @@ export default class CountdownEdit extends HandlebarsApplicationMixin(Applicatio
         this.render();
     }
 
-    static async #editCountdownOwnership(_, button) {
+    /** 
+     * @this CountdownEdit
+     * @type {import('@client/applications/_types.mjs').ApplicationClickAction}
+     */
+    static async #onEditCountdownOwnership(_, button) {
         const countdown = this.data.countdowns[button.dataset.countdownId];
         const data = await game.system.api.applications.dialogs.OwnershipSelection.configure(
             countdown.name,
@@ -201,7 +217,11 @@ export default class CountdownEdit extends HandlebarsApplicationMixin(Applicatio
         this.updateSetting({ [`countdowns.${button.dataset.countdownId}`]: data });
     }
 
-    static async #randomiseCountdownStart(_, button) {
+    /** 
+     * @this CountdownEdit
+     * @type {import('@client/applications/_types.mjs').ApplicationClickAction}
+     */
+    static async #onRandomiseCountdownStart(_, button) {
         const countdown = this.data.countdowns[button.dataset.countdownId];
         const roll = await new Roll(countdown.progress.startFormula).roll();
         const message = await roll.toMessage({ title: 'Countdown' });
@@ -216,7 +236,11 @@ export default class CountdownEdit extends HandlebarsApplicationMixin(Applicatio
         this.render();
     }
 
-    static async #removeCountdown(event, button) {
+    /** 
+     * @this CountdownEdit
+     * @type {import('@client/applications/_types.mjs').ApplicationClickAction}
+     */
+    static async #onRemoveCountdown(event, button) {
         const { countdownId } = button.dataset;
 
         if (!event.shiftKey) {

--- a/module/applications/ui/countdowns.mjs
+++ b/module/applications/ui/countdowns.mjs
@@ -9,7 +9,6 @@ const { HandlebarsApplicationMixin, ApplicationV2 } = foundry.applications.api;
  * @extends ApplicationV2
  * @mixes HandlebarsApplication
  */
-
 export default class DhCountdowns extends HandlebarsApplicationMixin(ApplicationV2) {
     previousCountdownData = null;
 
@@ -141,22 +140,14 @@ export default class DhCountdowns extends HandlebarsApplicationMixin(Application
             key,
             countdown,
             ownership: countdown.getUserLevel(game.user),
-            hidden: countdown.hidden && !game.user.isGM
+            hidden: countdown.hidden,
+            visible: countdown.visible
         }));
-        return values.filter(v => v.ownership !== CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE && v.hidden == false);
+        return values.filter(v => v.visible);
     }
 
-    _getCountdownData() {
+    #prepareCountdownData() {
         return this.#getCountdowns().reduce((acc, { key, countdown, ownership }) => {
-            const playersWithAccess = game.users.reduce((acc, user) => {
-                const ownership = countdown.getUserLevel(user);
-                if (!user.isGM && ownership && ownership !== CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE) {
-                    acc.push(user);
-                }
-                return acc;
-            }, []);
-            const nonGmPlayers = game.users.filter(x => !x.isGM);
-
             const countdownEditable = game.user.isGM || ownership === CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER;
             const isLooping = countdown.progress.looping !== CONFIG.DH.GENERAL.countdownLoopingTypes.noLooping;
             const loopTooltip = isLooping
@@ -173,7 +164,6 @@ export default class DhCountdowns extends HandlebarsApplicationMixin(Application
             acc[countdown.type][key] = {
                 ...countdown,
                 editable: countdownEditable,
-                noPlayerAccess: nonGmPlayers.length && playersWithAccess.length === 0,
                 hidden: countdown.hidden,
                 shouldLoop: isLooping && countdown.progress.current === 0 && countdown.progress.start > 0,
                 loopDisabled: isLooping ? loopDisabled : null,
@@ -204,7 +194,7 @@ export default class DhCountdowns extends HandlebarsApplicationMixin(Application
                 active: context.userCountdownTypes.includes(type.id)
             }));
 
-        context.countdowns = this._getCountdownData();
+        context.countdowns = this.#prepareCountdownData();
         context.countdownTypesWithVisibleEntries = this.#getCountdowns().reduce((acc, data) => {
             if (context.userCountdownTypes.includes(data.countdown.type) && !acc.includes(data.countdown.type)) 
                 acc.push(data.countdown.type);
@@ -379,7 +369,7 @@ export default class DhCountdowns extends HandlebarsApplicationMixin(Application
                 label: 'DAGGERHEART.UI.Countdowns.reveal',
                 icon: 'fa-solid fa-eye',
                 visible: element => {
-                    return getCountdownFromElement(element).hidden && game.user.isGM
+                    return game.user.isGM && getCountdownFromElement(element).hidden
                 },
                 onClick: (_, target) => {
                     getCountdownFromElement(target)?.toggleVisibility();
@@ -389,7 +379,7 @@ export default class DhCountdowns extends HandlebarsApplicationMixin(Application
                 label: 'DAGGERHEART.UI.Countdowns.hide',
                 icon: 'fa-solid fa-eye-slash',
                 visible: element => {
-                    return !getCountdownFromElement(element).hidden && game.user.isGM
+                    return game.user.isGM && !getCountdownFromElement(element).hidden
                 },
                 onClick: (_, target) => {
                     getCountdownFromElement(target)?.toggleVisibility();

--- a/module/applications/ui/countdowns.mjs
+++ b/module/applications/ui/countdowns.mjs
@@ -161,10 +161,13 @@ export default class DhCountdowns extends HandlebarsApplicationMixin(Application
                 !countdownEditable ||
                 (isLooping && (countdown.progress.current > 0 || countdown.progress.start === '0'));
 
+            const playersCountdownIsVisibleTo = game.users.filter(x => 
+                !x.isGM && (!countdown.hidden || countdown.ownership[x.id] > CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE));
+
             acc[countdown.type][key] = {
                 ...countdown,
                 editable: countdownEditable,
-                hidden: countdown.hidden,
+                playersCountdownIsVisibleTo,
                 shouldLoop: isLooping && countdown.progress.current === 0 && countdown.progress.start > 0,
                 loopDisabled: isLooping ? loopDisabled : null,
                 loopTooltip: isLooping && game.i18n.localize(loopTooltip)

--- a/module/applications/ui/countdowns.mjs
+++ b/module/applications/ui/countdowns.mjs
@@ -163,11 +163,14 @@ export default class DhCountdowns extends HandlebarsApplicationMixin(Application
 
             const playersCountdownIsVisibleTo = game.users.filter(x => 
                 !x.isGM && (!countdown.hidden || countdown.ownership[x.id] > CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE));
+            const visiblePlayersText = playersCountdownIsVisibleTo.length
+                ? game.i18n.getListFormatter({ style: 'narrow' }).format(playersCountdownIsVisibleTo.map(u => u.name))
+                : null;
 
             acc[countdown.type][key] = {
                 ...countdown,
                 editable: countdownEditable,
-                playersCountdownIsVisibleTo,
+                visiblePlayersText,
                 shouldLoop: isLooping && countdown.progress.current === 0 && countdown.progress.start > 0,
                 loopDisabled: isLooping ? loopDisabled : null,
                 loopTooltip: isLooping && game.i18n.localize(loopTooltip)

--- a/module/config/generalConfig.mjs
+++ b/module/config/generalConfig.mjs
@@ -937,15 +937,11 @@ export const fearPosition = {
     leftBottom: { value: 'leftBottom', label: 'DAGGERHEART.SETTINGS.Appearance.fearPosition.leftBottom' }
 };
 
-export const basicOwnershiplevels = {
+export const simpleOwnershiplevels = {
+    [-1]: { value: -1, label: 'OWNERSHIP.INHERIT' },
     0: { value: 0, label: 'OWNERSHIP.NONE' },
     2: { value: 2, label: 'OWNERSHIP.OBSERVER' },
     3: { value: 3, label: 'OWNERSHIP.OWNER' }
-};
-
-export const simpleOwnershiplevels = {
-    [-1]: { value: -1, label: 'OWNERSHIP.INHERIT' },
-    ...basicOwnershiplevels
 };
 
 export const countdownLoopingTypes = {

--- a/module/data/_types.d.ts
+++ b/module/data/_types.d.ts
@@ -3,6 +3,7 @@ export {}; // top level import/export required for merges to happen
 declare module './countdowns.mjs' {
     export default interface DhCountdowns {
         countdowns: Record<string, DhCountdown>;
+        hideNewCountdowns: boolean;
     }
 
     export interface DhCountdown {

--- a/module/data/_types.d.ts
+++ b/module/data/_types.d.ts
@@ -1,7 +1,23 @@
-import { DhCountdown } from './countdowns.mjs'
+export {}; // top level import/export required for merges to happen
 
 declare module './countdowns.mjs' {
     export default interface DhCountdowns {
         countdowns: Record<string, DhCountdown>;
+    }
+
+    export interface DhCountdown {
+        type: string;
+        name: string;
+        img?: string;
+        ownership: Record<string, number>
+        /** True if the countdown is hidden to players by default, unless the player has the observer or owner permission */
+        hidden: boolean;
+        progress: {
+            current: number;
+            start: number;
+            startFormula?: number;
+            looping: keyof typeof CONFIG.DH.GENERAL.countdownLoopingTypes;
+            type: keyof typeof CONFIG.DH.GENERAL.countdownProgressionTypes;
+        }
     }
 }

--- a/module/data/action/countdownAction.mjs
+++ b/module/data/action/countdownAction.mjs
@@ -42,6 +42,11 @@ export default class DhCountdownAction extends DHBaseAction {
                 countdown.progress.start = 1;
                 countdown.progress.max = null;
             }
+            if (countdown.defaultOwnership) {
+                // Inherit (-1) is use default, and None (0) is hidden. All others are visible
+                countdown.hidden = countdown.defaultOwnership === -1 ? null : countdown.defaultOwnership === 0;
+                delete countdown.defaultOwnership;
+            }
         }
 
         return super.migrateData(source);

--- a/module/data/countdowns.mjs
+++ b/module/data/countdowns.mjs
@@ -1,4 +1,4 @@
-import { omit } from '../helpers/utils.mjs';
+import { mapValues, omit } from '../helpers/utils.mjs';
 import { RefreshType, socketEvent } from '../systemRegistration/socket.mjs';
 import FormulaField from './fields/formulaField.mjs';
 
@@ -53,7 +53,8 @@ export default class DhCountdowns extends foundry.abstract.DataModel {
 
     static migrateData(source) {
         const migrateOldCountdowns = (data, type) => {
-            for (const key of Object.keys(data.countdowns)) {
+            if (!data) return;
+            for (const key of Object.keys(data.countdowns ?? {})) {
                 const countdown = data.countdowns[key];
                 source.countdowns[key] = {
                     ...countdown,
@@ -72,13 +73,22 @@ export default class DhCountdowns extends foundry.abstract.DataModel {
 
             source[type] = null;
         };
+        migrateOldCountdowns(source.narrative, 'narrative');
+        migrateOldCountdowns(source.encounter, 'encounter');
 
-        if (source.narrative) {
-            migrateOldCountdowns(source.narrative, 'narrative');
-        }
-
-        if (source.encounter) {
-            migrateOldCountdowns(source.encounter, 'encounter');
+        // Hidden was added to countdowns after 2.6.5, and Observer allows visibility despite that status
+        // Before, countdowns used to be hidden by setting specific player ownerships to NONE.
+        // The old behavior of INHERIT used to be based off the global setting and cannot be replicated
+        const levels = CONST.DOCUMENT_OWNERSHIP_LEVELS;
+        for (const countdown of Object.values(source.countdowns ?? {})) {
+            const wasHidden = Object.values(countdown.ownership ?? {}).some(v => v === levels.NONE);
+            if (wasHidden) {
+                countdown.hidden = true;
+                countdown.ownership = mapValues(
+                    countdown.ownership, 
+                    v => v === levels.NONE ? levels.INHERIT : Math.max(levels.OBSERVER, v)
+                );
+            }
         }
 
         return super.migrateData(source);

--- a/module/data/countdowns.mjs
+++ b/module/data/countdowns.mjs
@@ -1,16 +1,20 @@
+import { omit } from '../helpers/utils.mjs';
 import { RefreshType, socketEvent } from '../systemRegistration/socket.mjs';
 import FormulaField from './fields/formulaField.mjs';
 
+/** 
+ * The main setting data for the countdown editor
+ */
 export default class DhCountdowns extends foundry.abstract.DataModel {
     static defineSchema() {
         const fields = foundry.data.fields;
 
         return {
             countdowns: new fields.TypedObjectField(new fields.EmbeddedDataField(DhCountdown)),
-            defaultOwnership: new fields.NumberField({
+            hideNewCountdowns: new fields.BooleanField({
                 required: true,
-                choices: CONFIG.DH.GENERAL.basicOwnershiplevels,
-                initial: CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER
+                nullable: false,
+                initial: false
             })
         };
     }
@@ -100,14 +104,21 @@ export class DhCountdown extends foundry.abstract.DataModel {
                 base64: false,
                 initial: 'icons/magic/time/hourglass-yellow-green.webp'
             }),
+            hidden: new fields.BooleanField({ 
+                required: true,
+                nullable: false,
+                initial: false,
+                label: 'DAGGERHEART.APPLICATIONS.Countdown.FIELDS.countdowns.element.hidden.label'
+            }),
             ownership: new fields.TypedObjectField(
                 new fields.NumberField({
                     required: true,
-                    choices: CONFIG.DH.GENERAL.simpleOwnershiplevels,
+                    choices: omit(CONFIG.DH.GENERAL.simpleOwnershiplevels, [
+                        CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE
+                    ]),
                     initial: CONST.DOCUMENT_OWNERSHIP_LEVELS.INHERIT
                 })
             ),
-            hidden: new fields.BooleanField({ initial: false }),
             progress: new fields.SchemaField({
                 current: new fields.NumberField({
                     required: true,
@@ -146,7 +157,7 @@ export class DhCountdown extends foundry.abstract.DataModel {
         return {
             type: type ?? CONFIG.DH.GENERAL.countdownTypes.encounter.id,
             name: game.i18n.localize('DAGGERHEART.APPLICATIONS.Countdown.newCountdown'),
-            img: 'icons/magic/time/hourglass-yellow-green.webp',            
+            img: 'icons/magic/time/hourglass-yellow-green.webp',
             hidden: playerHidden,
             progress: {
                 current: 1,
@@ -168,6 +179,14 @@ export class DhCountdown extends foundry.abstract.DataModel {
 
             return acc;
         }, {});
+    }
+
+    /**
+     * A boolean indicator for whether the current game User can see this countdown
+     * @returns {boolean}
+     */
+    get visible() {
+        return this.getUserLevel(game.user) !== CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE;
     }
 
     /**
@@ -195,15 +214,14 @@ export class DhCountdown extends foundry.abstract.DataModel {
      * granular per-User ownership definitions and Embedded Documents defer to their parent ownership.
      *
      * @param {BaseUser} [user=game.user] The User being tested
-     * @returns {DocumentOwnershipNumber} A numeric permission level from {@link CONST.DOCUMENT_OWNERSHIP_LEVELS}
+     * @returns {import('@common/constants.mjs').DocumentOwnershipNumber} A numeric permission level from {@link CONST.DOCUMENT_OWNERSHIP_LEVELS}
      */
     getUserLevel(user) {
         if (user.isGM) return CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER;
 
-        const setting = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Countdowns);
         const playerOwnership = this.ownership[user.id];
         return playerOwnership === undefined || playerOwnership === CONST.DOCUMENT_OWNERSHIP_LEVELS.INHERIT
-            ? setting.defaultOwnership
+            ? (this.hidden ? CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE : CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER)
             : playerOwnership;
     }
 

--- a/module/data/fields/_module.mjs
+++ b/module/data/fields/_module.mjs
@@ -4,4 +4,5 @@ export { default as FormulaField } from './formulaField.mjs';
 export { default as ForeignDocumentUUIDField } from './foreignDocumentUUIDField.mjs';
 export { default as ForeignDocumentUUIDArrayField } from './foreignDocumentUUIDArrayField.mjs';
 export { default as TriggerField } from './triggerField.mjs';
+export { NullableBooleanField } from './nullableBooleanField.mjs';
 export * as ActionFields from './action/_module.mjs';

--- a/module/data/fields/action/countdownField.mjs
+++ b/module/data/fields/action/countdownField.mjs
@@ -17,11 +17,11 @@ export default class CountdownField extends fields.ArrayField {
                 initial: game.i18n.localize('DAGGERHEART.APPLICATIONS.Countdown.newCountdown'),
                 label: 'DAGGERHEART.APPLICATIONS.Countdown.FIELDS.countdowns.element.name.label'
             }),
-            defaultOwnership: new fields.NumberField({
+            hidden: new fields.BooleanField({
                 required: true,
-                choices: CONFIG.DH.GENERAL.simpleOwnershiplevels,
-                initial: CONST.DOCUMENT_OWNERSHIP_LEVELS.INHERIT,
-                label: 'DAGGERHEART.ACTIONS.Config.countdown.defaultOwnership'
+                nullable: false,
+                initial: false,
+                label: 'DAGGERHEART.APPLICATIONS.Countdown.FIELDS.countdowns.element.hidden.label'
             })
         });
         super(element, options, context);
@@ -57,10 +57,6 @@ export default class CountdownField extends fields.ArrayField {
 
             data.countdowns[foundry.utils.randomID()] = {
                 ...countdown,
-                ownership: game.users.reduce((acc, curr) => {
-                    if (!curr.isGM) acc[curr.id] = countdown.defaultOwnership;
-                    return acc;
-                }, {}),
                 progress: {
                     ...countdown.progress,
                     current: countdownStart,

--- a/module/data/fields/action/countdownField.mjs
+++ b/module/data/fields/action/countdownField.mjs
@@ -1,4 +1,5 @@
 import { emitGMUpdate, GMUpdateEvent, RefreshType, socketEvent } from '../../../systemRegistration/socket.mjs';
+import { NullableBooleanField } from '../nullableBooleanField.mjs';
 
 const fields = foundry.data.fields;
 
@@ -17,9 +18,10 @@ export default class CountdownField extends fields.ArrayField {
                 initial: game.i18n.localize('DAGGERHEART.APPLICATIONS.Countdown.newCountdown'),
                 label: 'DAGGERHEART.APPLICATIONS.Countdown.FIELDS.countdowns.element.name.label'
             }),
-            hidden: new fields.BooleanField({
+            // Hidden is nullable to allow defaulting to the global setting
+            hidden: new NullableBooleanField({
                 required: true,
-                nullable: false,
+                nullable: true,
                 initial: false,
                 label: 'DAGGERHEART.APPLICATIONS.Countdown.FIELDS.countdowns.element.hidden.label'
             })
@@ -55,8 +57,10 @@ export default class CountdownField extends fields.ArrayField {
                 }
             }
 
+            const setting = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Countdowns);
             data.countdowns[foundry.utils.randomID()] = {
                 ...countdown,
+                hidden: countdown.hidden ?? setting.hideNewCountdowns,
                 progress: {
                     ...countdown.progress,
                     current: countdownStart,

--- a/module/data/fields/nullableBooleanField.mjs
+++ b/module/data/fields/nullableBooleanField.mjs
@@ -1,0 +1,26 @@
+/** 
+ * A BooleanField that can handle null in form inputs and form parsing.
+ */
+export class NullableBooleanField extends foundry.data.fields.BooleanField {
+    /** @inheritdoc */
+    _cast(value) {
+        if (value === 'true') return true;
+        if (value === 'false') return false;
+        if (value === 'null' || value === '') return this.nullable ? null : false;
+        if (typeof value === 'object') return false;
+        return Boolean(value);
+    }
+
+    /** @inheritdoc. */
+    _toInput(config) {
+        if (!this.nullable) return super._toInput(config);
+        const value = String(config.value ?? null);
+        const options = [
+            { value: 'true', label: _loc('COMMON.Yes'), selected: value === 'true' },
+            { value: 'false', label: _loc('COMMON.No'), selected: value === 'false' },
+            { value: 'null', label: '', selected: value === 'null' }
+        ];
+        const data = foundry.utils.mergeObject(config, { value, options, dataset: { data: 'JSON' } });
+        return foundry.applications.fields.createSelectInput(data);
+    }
+}

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -24,6 +24,22 @@ export function omit(obj, keys) {
     }, {});
 }
 
+/** 
+ * Given an object, returns a new object with each value altered by a transform function
+ * @template {string} K
+ * @template V
+ * @template R
+ * @param {Record<K, V>} obj object to transform
+ * @param {(value: V, index: number) => R} transform mapping function
+ * @returns {Record<K, R>} new object with mapped values
+ */
+export function mapValues(obj, transform) {
+    return Object.entries(obj).reduce((r, [k, v], index) => {
+        r[k] = transform(v, index);
+        return r;
+    }, {});
+}
+
 export function rollCommandToJSON(text) {
     if (!text) return {};
 

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -5,9 +5,24 @@ import Tagify from '@yaireo/tagify';
  * @import DhpActor from '../documents/actor.mjs';
  */
 
-export const capitalize = string => {
-    return string.charAt(0).toUpperCase() + string.slice(1);
-};
+/** Given an object, returns a new object with the keys listed in keys */
+export function pick(obj, keys) {
+    return keys.reduce((r, k) => {
+        r[k] = obj[k];
+        return r;
+    }, {});
+}
+
+/** Given an object, returns a new object with the keys not listed in keys */
+export function omit(obj, keys) {
+    const keysAsString = keys.map(k => String(k));
+    return Object.keys(obj).reduce((r, k) => {
+        if (!keysAsString.includes(k)) {
+            r[k] = obj[k];
+        }
+        return r;
+    }, {});
+}
 
 export function rollCommandToJSON(text) {
     if (!text) return {};

--- a/src/packs/adversaries/adversary_Adult_Flickerfly_G7jiltRjgvVhZewm.json
+++ b/src/packs/adversaries/adversary_Adult_Flickerfly_G7jiltRjgvVhZewm.json
@@ -879,7 +879,6 @@
               {
                 "name": "Hallucinatory Breath",
                 "type": "encounter",
-                "defaultOwnership": -1,
                 "img": "icons/magic/air/fog-gas-smoke-purple.webp",
                 "progress": {
                   "looping": "looping",
@@ -889,7 +888,7 @@
                   "current": 1
                 },
                 "ownership": {},
-                "hidden": false
+                "hidden": null
               }
             ],
             "name": "Start Countdown",

--- a/src/packs/adversaries/adversary_Arch_Necromancer_WPEOIGfclNJxWb87.json
+++ b/src/packs/adversaries/adversary_Arch_Necromancer_WPEOIGfclNJxWb87.json
@@ -927,7 +927,6 @@
               {
                 "name": "Your Life Is Mine",
                 "type": "encounter",
-                "defaultOwnership": -1,
                 "img": "icons/magic/unholy/hand-claw-fire-green.webp",
                 "progress": {
                   "looping": "looping",
@@ -937,7 +936,7 @@
                   "current": 1
                 },
                 "ownership": {},
-                "hidden": false
+                "hidden": null
               }
             ],
             "name": "Start Countdown",

--- a/src/packs/adversaries/adversary_Demon_of_Wrath_5lphJAgzoqZI3VoG.json
+++ b/src/packs/adversaries/adversary_Demon_of_Wrath_5lphJAgzoqZI3VoG.json
@@ -592,7 +592,6 @@
               {
                 "name": "Blood and Souls",
                 "type": "encounter",
-                "defaultOwnership": -1,
                 "img": "icons/creatures/unholy/demon-fire-horned-clawed.webp",
                 "progress": {
                   "looping": "looping",
@@ -602,7 +601,7 @@
                   "current": 1
                 },
                 "ownership": {},
-                "hidden": false
+                "hidden": null
               }
             ],
             "name": "Countdown",

--- a/src/packs/adversaries/adversary_Fallen_Sorcerer_PELRry1vqjBzSAlr.json
+++ b/src/packs/adversaries/adversary_Fallen_Sorcerer_PELRry1vqjBzSAlr.json
@@ -672,7 +672,6 @@
               {
                 "name": "Shackles of Guilt",
                 "type": "encounter",
-                "defaultOwnership": -1,
                 "img": "icons/magic/unholy/strike-hand-glow-pink.webp",
                 "progress": {
                   "looping": "looping",
@@ -682,7 +681,7 @@
                   "current": 1
                 },
                 "ownership": {},
-                "hidden": false
+                "hidden": null
               }
             ],
             "name": "Start Countdown",

--- a/src/packs/adversaries/adversary_Fallen_Warlord__Realm_Breaker_hxZ0sgoFJubh5aj6.json
+++ b/src/packs/adversaries/adversary_Fallen_Warlord__Realm_Breaker_hxZ0sgoFJubh5aj6.json
@@ -707,7 +707,6 @@
               {
                 "name": "All-Consuming Rage",
                 "type": "encounter",
-                "defaultOwnership": -1,
                 "img": "icons/magic/control/fear-fright-monster-grin-red-orange.webp",
                 "progress": {
                   "looping": "decreasing",
@@ -717,7 +716,7 @@
                   "current": 1
                 },
                 "ownership": {},
-                "hidden": false
+                "hidden": null
               }
             ],
             "name": "Start Countdown",

--- a/src/packs/adversaries/adversary_Fallen_Warlord__Undefeated_Champion_RXkZTwBRi4dJ3JE5.json
+++ b/src/packs/adversaries/adversary_Fallen_Warlord__Undefeated_Champion_RXkZTwBRi4dJ3JE5.json
@@ -683,7 +683,6 @@
               {
                 "name": "Circle of Defilement",
                 "type": "encounter",
-                "defaultOwnership": -1,
                 "img": "icons/magic/unholy/barrier-fire-pink.webp",
                 "progress": {
                   "looping": "noLooping",
@@ -693,7 +692,7 @@
                   "current": 1
                 },
                 "ownership": {},
-                "hidden": false
+                "hidden": null
               }
             ],
             "name": "Start Countdown",

--- a/src/packs/adversaries/adversary_Gorgon_8mJYMpbLTb8qIOrr.json
+++ b/src/packs/adversaries/adversary_Gorgon_8mJYMpbLTb8qIOrr.json
@@ -709,7 +709,6 @@
               {
                 "name": "Petrifying Gaze",
                 "type": "encounter",
-                "defaultOwnership": -1,
                 "img": "icons/magic/earth/strike-body-stone-crumble.webp",
                 "progress": {
                   "looping": "noLooping",
@@ -719,7 +718,7 @@
                   "current": 1
                 },
                 "ownership": {},
-                "hidden": false
+                "hidden": null
               }
             ],
             "name": "Start Countdown",

--- a/src/packs/adversaries/adversary_Head_Guard_mK3A5FTx6k8iPU3F.json
+++ b/src/packs/adversaries/adversary_Head_Guard_mK3A5FTx6k8iPU3F.json
@@ -378,7 +378,6 @@
               {
                 "name": "On My Signal",
                 "type": "encounter",
-                "defaultOwnership": -1,
                 "img": "icons/skills/ranged/target-bullseye-arrow-blue.webp",
                 "progress": {
                   "looping": "noLooping",
@@ -388,7 +387,7 @@
                   "current": 1
                 },
                 "ownership": {},
-                "hidden": false
+                "hidden": null
               }
             ],
             "name": "Start Countdown",

--- a/src/packs/adversaries/adversary_Juvenile_Flickerfly_MYXmTx2FHcIjdfYZ.json
+++ b/src/packs/adversaries/adversary_Juvenile_Flickerfly_MYXmTx2FHcIjdfYZ.json
@@ -727,7 +727,6 @@
               {
                 "name": "Hallucinatory Breath",
                 "type": "encounter",
-                "defaultOwnership": -1,
                 "img": "icons/magic/air/fog-gas-smoke-purple.webp",
                 "progress": {
                   "looping": "looping",
@@ -737,7 +736,7 @@
                   "current": 1
                 },
                 "ownership": {},
-                "hidden": false
+                "hidden": null
               }
             ],
             "name": "Start Countdown",

--- a/src/packs/adversaries/adversary_Monarch_yx0vK2yfNVZKWUUi.json
+++ b/src/packs/adversaries/adversary_Monarch_yx0vK2yfNVZKWUUi.json
@@ -377,7 +377,6 @@
               {
                 "name": "Casus Belli",
                 "type": "narrative",
-                "defaultOwnership": -1,
                 "img": "icons/sundries/scrolls/scroll-bound-sealed-red-tan.webp",
                 "progress": {
                   "looping": "noLooping",
@@ -387,7 +386,7 @@
                   "current": 1
                 },
                 "ownership": {},
-                "hidden": false
+                "hidden": null
               }
             ],
             "name": "Start Countdown",

--- a/src/packs/adversaries/adversary_Mortal_Hunter_mVV7a7KQAORoPMgZ.json
+++ b/src/packs/adversaries/adversary_Mortal_Hunter_mVV7a7KQAORoPMgZ.json
@@ -844,7 +844,6 @@
               {
                 "name": "Rampage",
                 "type": "encounter",
-                "defaultOwnership": -1,
                 "img": "icons/magic/movement/trail-streak-zigzag-yellow.webp",
                 "progress": {
                   "looping": "looping",
@@ -854,7 +853,7 @@
                   "current": 1
                 },
                 "ownership": {},
-                "hidden": false
+                "hidden": null
               }
             ],
             "name": "Start Countdown",

--- a/src/packs/adversaries/adversary_Secret_Keeper_sLAccjvCWfeedbpI.json
+++ b/src/packs/adversaries/adversary_Secret_Keeper_sLAccjvCWfeedbpI.json
@@ -507,7 +507,6 @@
               {
                 "name": "Summoning Ritual",
                 "type": "encounter",
-                "defaultOwnership": -1,
                 "img": "icons/magic/unholy/silhouette-light-fire-blue.webp",
                 "progress": {
                   "looping": "noLooping",
@@ -517,7 +516,7 @@
                   "current": 1
                 },
                 "ownership": {},
-                "hidden": false
+                "hidden": null
               }
             ],
             "name": "Start Countdown",

--- a/src/packs/adversaries/adversary_Stonewraith_3aAS2Qm3R6cgaYfE.json
+++ b/src/packs/adversaries/adversary_Stonewraith_3aAS2Qm3R6cgaYfE.json
@@ -626,7 +626,6 @@
               {
                 "name": "Avalanche Roar",
                 "type": "encounter",
-                "defaultOwnership": -1,
                 "img": "icons/magic/sonic/projectile-sound-rings-wave.webp",
                 "progress": {
                   "looping": "noLooping",
@@ -636,7 +635,7 @@
                   "current": 1
                 },
                 "ownership": {},
-                "hidden": false
+                "hidden": null
               }
             ],
             "name": "Start Countdown",

--- a/src/packs/adversaries/adversary_Volcanic_Dragon__Ashen_Tyrant_pMuXGCSOQaxpi5tb.json
+++ b/src/packs/adversaries/adversary_Volcanic_Dragon__Ashen_Tyrant_pMuXGCSOQaxpi5tb.json
@@ -1016,7 +1016,6 @@
               {
                 "name": "Apocalyptic Thrasing",
                 "type": "encounter",
-                "defaultOwnership": -1,
                 "img": "icons/creatures/abilities/mouth-teeth-fire-orange.webp",
                 "progress": {
                   "looping": "noLooping",
@@ -1026,7 +1025,7 @@
                   "current": 1
                 },
                 "ownership": {},
-                "hidden": false
+                "hidden": null
               }
             ],
             "name": "Start Countdown",

--- a/src/packs/domains/domainCard_Mass_Disguise_dT95m0Jam8sWbeuC.json
+++ b/src/packs/domains/domainCard_Mass_Disguise_dT95m0Jam8sWbeuC.json
@@ -65,7 +65,6 @@
           {
             "name": "Mass Disguise",
             "type": "encounter",
-            "defaultOwnership": -1,
             "img": "icons/magic/time/hourglass-brown-orange.webp",
             "progress": {
               "looping": "noLooping",
@@ -75,7 +74,7 @@
               "current": 1
             },
             "ownership": {},
-            "hidden": false
+            "hidden": null
           }
         ],
         "name": "Start Countdown",

--- a/src/packs/environments/environment_Burning_Heart_of_the_Woods_oY69NN4rYxoRE4hl.json
+++ b/src/packs/environments/environment_Burning_Heart_of_the_Woods_oY69NN4rYxoRE4hl.json
@@ -610,7 +610,6 @@
               {
                 "name": "Choking Ash",
                 "type": "encounter",
-                "defaultOwnership": -1,
                 "img": "icons/magic/air/fog-gas-smoke-brown.webp",
                 "progress": {
                   "looping": "looping",
@@ -620,7 +619,7 @@
                   "current": 1
                 },
                 "ownership": {},
-                "hidden": false
+                "hidden": null
               }
             ],
             "name": "Start Countdown",

--- a/src/packs/environments/environment_Bustling_Marketplace_HZKA7hkej7JJY503.json
+++ b/src/packs/environments/environment_Bustling_Marketplace_HZKA7hkej7JJY503.json
@@ -274,7 +274,6 @@
               {
                 "name": "Chase Thief",
                 "type": "encounter",
-                "defaultOwnership": -1,
                 "img": "icons/skills/movement/feet-winged-boots-brown.webp",
                 "progress": {
                   "looping": "noLooping",
@@ -284,12 +283,11 @@
                   "current": 1
                 },
                 "ownership": {},
-                "hidden": false
+                "hidden": null
               },
               {
                 "name": "Escape To Hideout",
                 "type": "encounter",
-                "defaultOwnership": -1,
                 "img": "icons/magic/perception/silhouette-stealth-shadow.webp",
                 "progress": {
                   "looping": "noLooping",
@@ -299,7 +297,7 @@
                   "current": 1
                 },
                 "ownership": {},
-                "hidden": false
+                "hidden": null
               }
             ],
             "name": "Start Countdowns",

--- a/src/packs/environments/environment_Castle_Siege_1eZ32Esq7rfZOjlu.json
+++ b/src/packs/environments/environment_Castle_Siege_1eZ32Esq7rfZOjlu.json
@@ -297,7 +297,6 @@
               {
                 "name": "Siege Weapons (Environment Change)",
                 "type": "encounter",
-                "defaultOwnership": -1,
                 "img": "icons/weapons/artillery/catapult-simple.webp",
                 "progress": {
                   "looping": "noLooping",
@@ -307,7 +306,7 @@
                   "current": 1
                 },
                 "ownership": {},
-                "hidden": false
+                "hidden": null
               }
             ],
             "name": "Start Countdown",

--- a/src/packs/environments/environment_Chaos_Realm_2Z1mKc65LxNk2PqR.json
+++ b/src/packs/environments/environment_Chaos_Realm_2Z1mKc65LxNk2PqR.json
@@ -243,7 +243,6 @@
               {
                 "name": "Impossible Architecture",
                 "type": "encounter",
-                "defaultOwnership": -1,
                 "img": "icons/magic/symbols/squares-3d-green.webp",
                 "progress": {
                   "looping": "noLooping",
@@ -253,7 +252,7 @@
                   "current": 1
                 },
                 "ownership": {},
-                "hidden": false
+                "hidden": null
               }
             ],
             "name": "Start Countdown",
@@ -369,7 +368,6 @@
               {
                 "name": "Everything You Are This Place Will Take from You",
                 "type": "encounter",
-                "defaultOwnership": -1,
                 "img": "icons/magic/control/sihouette-hold-beam-green.webp",
                 "progress": {
                   "looping": "looping",
@@ -378,7 +376,7 @@
                   "start": 1
                 },
                 "ownership": {},
-                "hidden": false
+                "hidden": null
               }
             ],
             "name": "Start Countdown",

--- a/src/packs/environments/environment_Cliffside_Ascent_LPpfdlNKqiZIl04w.json
+++ b/src/packs/environments/environment_Cliffside_Ascent_LPpfdlNKqiZIl04w.json
@@ -156,7 +156,6 @@
               {
                 "name": "The Climb",
                 "type": "encounter",
-                "defaultOwnership": -1,
                 "img": "icons/environment/wilderness/terrain-rocks-brown.webp",
                 "progress": {
                   "looping": "noLooping",
@@ -166,7 +165,7 @@
                   "current": 1
                 },
                 "ownership": {},
-                "hidden": false
+                "hidden": null
               }
             ],
             "name": "Start Countdown",

--- a/src/packs/environments/environment_Cult_Ritual_QAXXiOKBDmCTauHD.json
+++ b/src/packs/environments/environment_Cult_Ritual_QAXXiOKBDmCTauHD.json
@@ -420,7 +420,6 @@
               {
                 "name": "The Summoning",
                 "type": "encounter",
-                "defaultOwnership": -1,
                 "img": "icons/magic/unholy/barrier-fire-pink.webp",
                 "progress": {
                   "looping": "noLooping",
@@ -430,7 +429,7 @@
                   "current": 1
                 },
                 "ownership": {},
-                "hidden": false
+                "hidden": null
               }
             ],
             "name": "Start Countdown",

--- a/src/packs/environments/environment_Divine_Usurpation_4DLYez7VbMCFDAuZ.json
+++ b/src/packs/environments/environment_Divine_Usurpation_4DLYez7VbMCFDAuZ.json
@@ -186,7 +186,6 @@
               {
                 "name": "Final Preparations",
                 "type": "encounter",
-                "defaultOwnership": -1,
                 "img": "icons/magic/unholy/hands-circle-light-green.webp",
                 "progress": {
                   "looping": "noLooping",
@@ -196,7 +195,7 @@
                   "current": 1
                 },
                 "ownership": {},
-                "hidden": false
+                "hidden": null
               }
             ],
             "name": "Start Countdown",
@@ -623,7 +622,6 @@
               {
                 "name": "Beginning of the End",
                 "type": "encounter",
-                "defaultOwnership": -1,
                 "img": "icons/magic/unholy/silhouette-robe-evil-glow.webp",
                 "progress": {
                   "looping": "noLooping",
@@ -632,7 +630,7 @@
                   "start": 1
                 },
                 "ownership": {},
-                "hidden": false
+                "hidden": null
               }
             ],
             "name": "Countdown",

--- a/src/packs/environments/environment_Haunted_City_OzYbizKraK92FDiI.json
+++ b/src/packs/environments/environment_Haunted_City_OzYbizKraK92FDiI.json
@@ -331,7 +331,6 @@
               {
                 "name": "Apocalypse Then",
                 "type": "encounter",
-                "defaultOwnership": -1,
                 "img": "icons/magic/death/skull-weapon-staff-glow-pink.webp",
                 "progress": {
                   "looping": "noLooping",
@@ -341,7 +340,7 @@
                   "current": 1
                 },
                 "ownership": {},
-                "hidden": false
+                "hidden": null
               }
             ],
             "name": "Start Countdown",

--- a/src/packs/environments/environment_Mountain_Pass_acMu9wJrMZZzLSTJ.json
+++ b/src/packs/environments/environment_Mountain_Pass_acMu9wJrMZZzLSTJ.json
@@ -477,7 +477,6 @@
               {
                 "name": "Icy Winds",
                 "type": "encounter",
-                "defaultOwnership": -1,
                 "img": "icons/magic/water/snowflake-ice-blue-white.webp",
                 "progress": {
                   "looping": "looping",
@@ -487,7 +486,7 @@
                   "current": 1
                 },
                 "ownership": {},
-                "hidden": false
+                "hidden": null
               }
             ],
             "name": "Start Countdown",

--- a/src/packs/environments/environment_Raging_River_t4cdqTfzcqP3H1vJ.json
+++ b/src/packs/environments/environment_Raging_River_t4cdqTfzcqP3H1vJ.json
@@ -165,7 +165,6 @@
               {
                 "name": "Dangerous Crossing",
                 "type": "encounter",
-                "defaultOwnership": -1,
                 "img": "icons/magic/water/wave-water-blue.webp",
                 "progress": {
                   "looping": "noLooping",
@@ -175,7 +174,7 @@
                   "current": 1
                 },
                 "ownership": {},
-                "hidden": false
+                "hidden": null
               }
             ],
             "name": "Start Countdown",

--- a/styles/less/ui/countdown/countdown-edit.less
+++ b/styles/less/ui/countdown/countdown-edit.less
@@ -20,36 +20,21 @@
         }
 
         .header-tools {
-            display: grid;
-            grid-template-columns: 2fr 1fr 144px;
-            gap: 8px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
 
             .hide-tools {
                 white-space: nowrap;
                 flex-wrap: nowrap;
                 display: flex;
                 align-items: center;
-
-                input {
-                    position: relative;
-                    top: 2px;
-                }
+                gap: 4px;
             }
 
             .header-main-button {
                 height: 32px;
-                flex: 1;
-            }
-
-            .default-ownership-tools {
-                display: flex;
-                align-items: center;
-                gap: 8px;
-
-                select {
-                    flex: 1;
-                    background: light-dark(@beige, @dark-blue);
-                }
+                width: 250px;
             }
         }
 

--- a/styles/less/ui/ownership-selection/ownership-selection.less
+++ b/styles/less/ui/ownership-selection/ownership-selection.less
@@ -15,10 +15,15 @@
 
         .ownership-container {
             display: flex;
-            border-radius: 6px;
             padding: 0 4px 0 0;
             align-items: center;
             gap: 8px;
+
+            &.default {
+                padding-left: 48px; // img + gap
+                padding-bottom: 4px;
+                border-bottom: 1px solid @color-border;
+            }
 
             img {
                 height: 40px;

--- a/templates/actionTypes/countdown.hbs
+++ b/templates/actionTypes/countdown.hbs
@@ -10,7 +10,7 @@
         </div>
         <div class="nest-inputs">
             {{formField ../fields.type value=countdown.type name=(concat "countdown." index ".type") localize=true}}
-            {{formField ../fields.defaultOwnership value=countdown.defaultOwnership name=(concat "countdown." index ".defaultOwnership") localize=true}}
+            {{formField ../fields.hidden value=countdown.hidden name=(concat "countdown." index ".hidden") classes="checkbox" id=(concat @root.appId ".countdown.hidden") localize=true}}
         </div>
         {{formField ../fields.img value=countdown.img name=(concat "countdown." index ".img") label="DAGGERHEART.GENERAL.imagePath" localize=true}}
         <div class="nest-inputs">

--- a/templates/actionTypes/countdown.hbs
+++ b/templates/actionTypes/countdown.hbs
@@ -10,7 +10,7 @@
         </div>
         <div class="nest-inputs">
             {{formField ../fields.type value=countdown.type name=(concat "countdown." index ".type") localize=true}}
-            {{formField ../fields.hidden value=countdown.hidden name=(concat "countdown." index ".hidden") classes="checkbox" id=(concat @root.appId ".countdown.hidden") localize=true}}
+            {{formField ../fields.hidden value=countdown.hidden name=(concat "countdown." index ".hidden") id=(concat @root.appId ".countdown.hidden") localize=true}}
         </div>
         {{formField ../fields.img value=countdown.img name=(concat "countdown." index ".img") label="DAGGERHEART.GENERAL.imagePath" localize=true}}
         <div class="nest-inputs">

--- a/templates/dialogs/ownershipSelection.hbs
+++ b/templates/dialogs/ownershipSelection.hbs
@@ -1,6 +1,14 @@
 <div class="ownership-outer-container">
     {{#if showOwnership}}
         <ul class="ownership-list">
+            {{#if defaultOwnershipOptions}}
+                <li class="ownership-container default">
+                    <span>Default Permission</span>
+                    <select name="default" value="{{default}}" data-dtype="Number">
+                        {{selectOptions @root.defaultOwnershipOptions selected=default labelAttr="label" valueAttr="value" localize=true }}
+                    </select>
+                </li>
+            {{/if}}
             {{#each ownership as |player id|}}
                 <li class="ownership-container">
                     <img src="{{player.img}}" />

--- a/templates/ui/countdowns/countdown-edit.hbs
+++ b/templates/ui/countdowns/countdown-edit.hbs
@@ -6,17 +6,11 @@
 
         <div class="header-tools">
             <button class="header-main-button" data-action="addCountdown"><i class="fa-solid fa-plus"></i> {{localize "DAGGERHEART.APPLICATIONS.CountdownEdit.newCountdown"}}</button>
-            <div class="hide-tools">
-                <label>{{localize "DAGGERHEART.APPLICATIONS.CountdownEdit.hideNewCountdowns"}}</label>
-                <input type="checkbox" name="hideNewCountdowns" {{checked hideNewCountdowns}} />
-            </div>
             {{#if isGM}}
-                <div class="default-ownership-tools">
-                    <i class="fa-solid fa-eye" data-tooltip="{{localize "DAGGERHEART.APPLICATIONS.CountdownEdit.defaultOwnershipTooltip"}}"></i>
-                    <select name="defaultOwnership">
-                        {{selectOptions ownershipDefaultOptions selected=defaultOwnership labelAttr="label" valueAttr="value" localize=true}}
-                    </select>
-                </div>
+                <label class="hide-tools">
+                    <span>{{localize "DAGGERHEART.APPLICATIONS.CountdownEdit.hideNewCountdowns"}}</span>
+                    <input id="hide-new-countdowns" type="checkbox" name="hideNewCountdowns" {{checked hideNewCountdowns}} />
+                </label>
             {{/if}}
         </div>
 

--- a/templates/ui/countdowns/parts/countdowns.hbs
+++ b/templates/ui/countdowns/parts/countdowns.hbs
@@ -19,7 +19,11 @@
                             <div class="countdown-tool-icons">
                                 {{#if (not @root.iconOnly)}}
                                     {{#if countdown.hidden}}
-                                        <i class="fa-solid fa-eye-slash" data-tooltip="{{localize 'DAGGERHEART.UI.Countdowns.hidden' nr=playersCountdownIsVisibleTo.length}}"></i>
+                                        {{#if visiblePlayersText}}
+                                            <i class="fa-solid fa-eye-low-vision" data-tooltip="{{localize "DAGGERHEART.UI.Countdowns.hiddenPartial" players=visiblePlayersText}}"></i>
+                                        {{else}}
+                                            <i class="fa-solid fa-eye-slash" data-tooltip="{{localize "DAGGERHEART.UI.Countdowns.hidden"}}"></i>
+                                        {{/if}}
                                     {{/if}}
                                     {{#unless (eq countdown.progress.looping "noLooping")}}
                                         <span data-tooltip="{{countdown.loopTooltip}}">

--- a/templates/ui/countdowns/parts/countdowns.hbs
+++ b/templates/ui/countdowns/parts/countdowns.hbs
@@ -18,11 +18,8 @@
                             </div>
                             <div class="countdown-tool-icons">
                                 {{#if (not @root.iconOnly)}}
-                                    {{#if (and (or countdown.hidden countdown.noPlayerAccess) @root.isGM)}}
-                                    <i class="fa-solid fa-eye-slash" data-tooltip="
-                                        {{#if countdown.noPlayerAccess }}{{localize 'DAGGERHEART.UI.Countdowns.noPlayerAccess'}}{{/if}}
-                                        {{#if countdown.hidden }}{{#if countdown.noPlayerAccess }}</br>{{/if}}{{localize 'DAGGERHEART.UI.Countdowns.hidden'}}{{/if}}
-                                    "></i>
+                                    {{#if countdown.hidden}}
+                                        <i class="fa-solid fa-eye-slash" data-tooltip="{{localize 'DAGGERHEART.UI.Countdowns.hidden'}}"></i>
                                     {{/if}}
                                     {{#unless (eq countdown.progress.looping "noLooping")}}
                                         <span data-tooltip="{{countdown.loopTooltip}}">

--- a/templates/ui/countdowns/parts/countdowns.hbs
+++ b/templates/ui/countdowns/parts/countdowns.hbs
@@ -19,7 +19,7 @@
                             <div class="countdown-tool-icons">
                                 {{#if (not @root.iconOnly)}}
                                     {{#if countdown.hidden}}
-                                        <i class="fa-solid fa-eye-slash" data-tooltip="{{localize 'DAGGERHEART.UI.Countdowns.hidden'}}"></i>
+                                        <i class="fa-solid fa-eye-slash" data-tooltip="{{localize 'DAGGERHEART.UI.Countdowns.hidden' nr=playersCountdownIsVisibleTo.length}}"></i>
                                     {{/if}}
                                     {{#unless (eq countdown.progress.looping "noLooping")}}
                                         <span data-tooltip="{{countdown.loopTooltip}}">


### PR DESCRIPTION
This allows setting the value of "hidden" in the ownership selection and changes the default permission in the field to be hidden instead. Furthermore, players now only have INHERIT/OWNER/OBSERVER permissions. Players set to observer or owner can see hidden countdowns. The "Hide new countdowns" option is now persisted, and replaces default permission for all intents and purposes.

<img width="610" height="575" alt="image" src="https://github.com/user-attachments/assets/0aa6534f-2bf0-454e-aa2b-fda860c98fab" />

There are no migrations, and I didn't localize a label. I'll do so after this is approved.