### PR TITLE
Countdown Rework - Markers

### DIFF
--- a/module/applications/ui/countdowns.mjs
+++ b/module/applications/ui/countdowns.mjs
@@ -161,13 +161,23 @@ export default class DhCountdowns extends HandlebarsApplicationMixin(Application
                 !countdownEditable ||
                 (isLooping && (countdown.progress.current > 0 || countdown.progress.start === '0'));
 
-            const playersCountdownIsVisibleTo = game.users.filter(x => 
+            const usersCountdownIsVisibleTo = game.users.filter(x => 
                 !x.isGM && (!countdown.hidden || countdown.ownership[x.id] > CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE));
+            const visibleToUsers = {
+                total: usersCountdownIsVisibleTo.length,
+                groupings: usersCountdownIsVisibleTo.reduce((acc, curr, index) => {
+                    const groupingIndex = Math.floor(index / 4); 
+                    if (!acc[groupingIndex]) acc[groupingIndex] = [];
+                    acc[groupingIndex].push(curr);
+
+                    return acc;
+                }, {})
+            };
 
             acc[countdown.type][key] = {
                 ...countdown,
                 editable: countdownEditable,
-                playersCountdownIsVisibleTo,
+                visibleToUsers,
                 shouldLoop: isLooping && countdown.progress.current === 0 && countdown.progress.start > 0,
                 loopDisabled: isLooping ? loopDisabled : null,
                 loopTooltip: isLooping && game.i18n.localize(loopTooltip)

--- a/styles/less/ui/countdown/countdown.less
+++ b/styles/less/ui/countdown/countdown.less
@@ -157,6 +157,7 @@
                         display: flex;
                         align-items: center;
                         justify-content: space-between;
+                        gap: 4px;
 
                         .countdown-tool-controls {
                             display: flex;
@@ -172,9 +173,31 @@
                         }
 
                         .countdown-tool-icons {
+                            height: 100%;
                             display: flex;
                             align-items: center;
+                            justify-content: flex-end;
                             gap: 8px;
+                            flex: 1;
+
+                            .markers-container {
+                                height: 20px;
+                                display: flex;
+                                flex-direction: column;
+                                gap: 2px;
+
+                                .markers-inner-container {
+                                    display: flex;
+                                    justify-content: flex-end;
+                                    gap: 2px;
+                                    
+                                    .marker-container {
+                                        border-radius: 50%;
+                                        height: 9px;
+                                        width: 9px;
+                                    }
+                                }
+                            }
 
                             .looping-container {
                                 position: relative;

--- a/templates/ui/countdowns/parts/countdowns.hbs
+++ b/templates/ui/countdowns/parts/countdowns.hbs
@@ -18,8 +18,19 @@
                             </div>
                             <div class="countdown-tool-icons">
                                 {{#if (not @root.iconOnly)}}
+                                    {{#if (and countdown.hidden countdown.visibleToUsers.total)}}
+                                        <div class="markers-container">
+                                            {{#each countdown.visibleToUsers.groupings as | grouping |}}
+                                                <div class="markers-inner-container">
+                                                    {{#each grouping as |user|}}
+                                                        <div class="marker-container" style="background: {{user.color.css}}" data-tooltip="{{user.name}}"></div>
+                                                    {{/each}}
+                                                </div>
+                                            {{/each}}
+                                        </div>
+                                    {{/if}}
                                     {{#if countdown.hidden}}
-                                        <i class="fa-solid fa-eye-slash" data-tooltip="{{localize 'DAGGERHEART.UI.Countdowns.hidden' nr=playersCountdownIsVisibleTo.length}}"></i>
+                                        <i class="fa-solid fa-eye-slash" data-tooltip="{{localize 'DAGGERHEART.UI.Countdowns.hidden' nr=visibleToUsers.total}}"></i>
                                     {{/if}}
                                     {{#unless (eq countdown.progress.looping "noLooping")}}
                                         <span data-tooltip="{{countdown.loopTooltip}}">


### PR DESCRIPTION
There is one situation I think ends up akward for the GM with the current hidden handling.

If a player has hidden a countdown, that countdown will show the `eye-slash` icon to denote that it is hidden. But since players can be set to `Observer` and `Owner`, the countdown is in fact not hidden to everyone.
In the main PR I added a small quality of life where the tooltip tells you how many it is still visible to, but I still think GMs will be confused about which countdowns are -actually- hidden to everyone.

The solution I tried here is to add coloured dots with the user color for the users that can still see a hidden countdown.
<img width="382" height="328" alt="image" src="https://github.com/user-attachments/assets/e82a25c9-1821-4f0b-af51-d56eb42b052b" />

**Hidden - No Player Access**
<img width="568" height="382" alt="image" src="https://github.com/user-attachments/assets/bd1b61f6-27c8-4cc0-83d5-bb13f020c148" />

**Hidden - One Player Access**
<img width="566" height="348" alt="image" src="https://github.com/user-attachments/assets/2ac74130-8cdd-4525-b5cc-210233e1fa3a" />

**Hidden - 7 Players Access**
Completly unrealistic case. I designed the dots to fit 4x2. More than that and it currently doesn't layout well, but I really don't think that's an issue. You'd have to hide a countdown and explicitly give 9 players access anyway.
<img width="508" height="337" alt="image" src="https://github.com/user-attachments/assets/c8106aae-34f6-4963-9261-c0781ead3c9e" />

**Hover Shows Player Name**
<img width="395" height="342" alt="image" src="https://github.com/user-attachments/assets/d8353926-dfe8-41d8-8691-215ef5417d7f" />
