### PR TITLE
[Fix] 2146 - Chat Message Migrate Data

### DIFF
--- a/module/data/chat-message/actorRoll.mjs
+++ b/module/data/chat-message/actorRoll.mjs
@@ -277,7 +277,7 @@ export default class DHActorRoll extends foundry.abstract.TypeDataModel {
             }
         }
 
-        for (const key of Object.keys(source.targetSaves)) {
+        for (const key of Object.keys(source.targetSaves ?? {})) {
             const saveData = source.targetSaves[key];
             if (typeof saveData === 'number') {
                 source.targetSaves[key] = { value: saveData, isCritical: false };

--- a/module/documents/chatMessage.mjs
+++ b/module/documents/chatMessage.mjs
@@ -415,7 +415,7 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
 
     // Some old v13 messages don't have system data and will cause errors here during roll construction otherwise. TODO. See if message.roll.options.effects can be saved/instantiated as actual ActiveEffects, then this can be removed.
     static migrateData(source) {
-        for (let i = 0; i < source.rolls.length; i++) {
+        for (let i = 0; i < (source.rolls ?? []).length; i++) {
             const rollData = source.rolls[i];
             const roll = typeof rollData === 'string' ? Roll.fromJSON(rollData) : rollData;
             for (const effect of (roll.options.effects ?? [])) {


### PR DESCRIPTION
Fixes #2146 
Fixed migrateData issues caused by partial data being sent from preCreate. Appearantly `chatMessage._preCreate` runs an update only on it's content, leading to properties possibly missing from the full data set.