### PR TITLE
[Feature] Countdown Clearer Language

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3177,7 +3177,8 @@
                 "hide":"Hide Countdown",
                 "loop": "Looping",
                 "decreasingLoop": "Decreasing Looping",
-                "increasingLoop": "Increasing Looping"
+                "increasingLoop": "Increasing Looping",
+                "inherit": "Use Default"
             },
             "EffectsDisplay": {
                 "removeThing": "[Right Click] Remove {thing}",

--- a/lang/en.json
+++ b/lang/en.json
@@ -719,10 +719,9 @@
                 "explanation": "You are adding {class} as your multiclass",
                 "selectDomainPrompt": "Select your new domain"
             },
-            "OwnershipSelection": {
-                "title": "Ownership Selection - {name}",
+            "CountdownPermissions": {
+                "title": "Countdown Permissions - {name}",
                 "noPlayers": "No players to assign ownership to",
-                "default": "Default Ownership",
                 "defaultPermission": "Countdown Status"
             },
             "PendingReactionsDialog": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -721,7 +721,8 @@
             "OwnershipSelection": {
                 "title": "Ownership Selection - {name}",
                 "noPlayers": "No players to assign ownership to",
-                "default": "Default Ownership"
+                "default": "Default Ownership",
+                "defaultPermission": "Countdown Status"
             },
             "PendingReactionsDialog": {
                 "title": "Pending Reaction Rolls Found",
@@ -1224,6 +1225,10 @@
                     "name": "Blaze Of Glory",
                     "description": "Your character embraces death and goes out in a blaze of glory. Take one final action. It automatically critically succeeds (with GM approval), and then you cross through the veil of death. NOTE: A Blaze of Glory effect has been added to your character. Any Duality Roll will automatically be a critical."
                 }
+            },
+            "DefaultOwnershipLevels": {
+                "none": "Hidden",
+                "observer": "Revealed"
             },
             "DomainCardTypes": {
                 "ability": "Ability",
@@ -3178,7 +3183,7 @@
                 "loop": "Looping",
                 "decreasingLoop": "Decreasing Looping",
                 "increasingLoop": "Increasing Looping",
-                "inherit": "Use Default"
+                "inherit": "Follow Status"
             },
             "EffectsDisplay": {
                 "removeThing": "[Right Click] Remove {thing}",

--- a/lang/en.json
+++ b/lang/en.json
@@ -720,9 +720,14 @@
                 "selectDomainPrompt": "Select your new domain"
             },
             "CountdownPermissions": {
+                "HiddenOptions": {
+                    "true": "Hidden",
+                    "false": "Revealed"
+                },
                 "title": "Countdown Permissions - {name}",
                 "noPlayers": "No players to assign ownership to",
-                "defaultPermission": "Countdown Status"
+                "defaultPermission": "Base Visibility",
+                "inheritLabeled": "Base ({base})"
             },
             "PendingReactionsDialog": {
                 "title": "Pending Reaction Rolls Found",
@@ -1226,10 +1231,6 @@
                     "name": "Blaze Of Glory",
                     "description": "Your character embraces death and goes out in a blaze of glory. Take one final action. It automatically critically succeeds (with GM approval), and then you cross through the veil of death. NOTE: A Blaze of Glory effect has been added to your character. Any Duality Roll will automatically be a critical."
                 }
-            },
-            "DefaultOwnershipLevels": {
-                "none": "Hidden",
-                "observer": "Revealed"
             },
             "DomainCardTypes": {
                 "ability": "Ability",
@@ -3184,7 +3185,7 @@
                 "loop": "Looping",
                 "decreasingLoop": "Decreasing Looping",
                 "increasingLoop": "Increasing Looping",
-                "inherit": "Follow Status"
+                "inherit": "Base"
             },
             "EffectsDisplay": {
                 "removeThing": "[Right Click] Remove {thing}",

--- a/module/applications/dialogs/_module.mjs
+++ b/module/applications/dialogs/_module.mjs
@@ -9,7 +9,7 @@ export { default as Downtime } from './downtime.mjs';
 export { default as ImageSelectDialog } from './imageSelectDialog.mjs';
 export { default as ItemTransferDialog } from './itemTransfer.mjs';
 export { default as MulticlassChoiceDialog } from './multiclassChoiceDialog.mjs';
-export { default as OwnershipSelection } from './ownershipSelection.mjs';
+export { CountdownPermissionsDialog } from './countdownPermissions.mjs';
 export { default as ResourceDiceDialog } from './resourceDiceDialog.mjs';
 export { default as ActionSelectionDialog } from './actionSelectionDialog.mjs';
 export { default as TagTeamDialog } from './tagTeamDialog.mjs';

--- a/module/applications/dialogs/countdownPermissions.mjs
+++ b/module/applications/dialogs/countdownPermissions.mjs
@@ -44,18 +44,20 @@ export class CountdownPermissionsDialog extends HandlebarsApplicationMixin(Appli
 
     async _prepareContext(_options) {
         const context = await super._prepareContext(_options);
+        context.countdown = this.countdown;
         
         // Get ownership options. becuase of the use of numbers, the base collection is not correctly ordered.
         // So we have to redefine it ourselves in the correct order.
         const levels = CONST.DOCUMENT_OWNERSHIP_LEVELS;
-        context.ownershipOptions = [levels.INHERIT, levels.OBSERVER, levels.OWNER].map(value => ({
+        context.ownershipLevels = [levels.INHERIT, levels.OBSERVER, levels.OWNER].map(value => ({
             value, 
-            label: CONFIG.DH.GENERAL.simpleOwnershipLevels[value].label
+            label: CONFIG.DH.GENERAL.countdownOwnershipLevels[value].label
         }));
-        context.defaultOwnershipOptions = [levels.NONE, levels.OBSERVER].map(value => ({
-            value, 
-            label: CONFIG.DH.GENERAL.defaultOwnershipLevels[value].label
-        }));
+        context.ownershipLevels[0].label = this.#getBaseLabel();
+        context.defaultOwnershipLevels = [
+            { value: true, label: 'DAGGERHEART.APPLICATIONS.CountdownPermissions.HiddenOptions.true' },    
+            { value: false, label: 'DAGGERHEART.APPLICATIONS.CountdownPermissions.HiddenOptions.false' }
+        ];
         context.ownership = game.users.reduce((acc, user) => {
             if (!user.isGM) {
                 acc[user.id] = {
@@ -67,11 +69,19 @@ export class CountdownPermissionsDialog extends HandlebarsApplicationMixin(Appli
 
             return acc;
         }, {});
-        context.default = this.countdown.hidden ? levels.NONE : levels.OBSERVER;
-        context.showOwnership = Boolean(Object.keys(context.ownership).length);
-        context.defaultIcon = this.countdown.img;
 
         return context;
+    }
+
+    /** @inheritdoc */
+    _attachPartListeners(partId, htmlElement, options) {
+        super._attachPartListeners(partId, htmlElement, options);
+        const hiddenEl = htmlElement?.querySelector('[name=hidden]');
+        hiddenEl?.addEventListener('change', () => {
+            for (const option of htmlElement.querySelectorAll('option[value="-1"]')) {
+                option.textContent = this.#getBaseLabel(hiddenEl.value !== 'false');
+            }
+        })
     }
 
     static async updateData(event, _, formData) {
@@ -90,7 +100,7 @@ export class CountdownPermissionsDialog extends HandlebarsApplicationMixin(Appli
     /**
      * Creates a ownership selection dialog returns the result when resolved
      * @param {DhCountdown} countdown 
-     * @returns {Promise<{ ownership: number; default?: number }>}
+     * @returns {Promise<{ ownership: Record<string, number>; hidden: boolean }>}
      */
     static async configure(countdown) {
         return new Promise(resolve => {
@@ -98,5 +108,11 @@ export class CountdownPermissionsDialog extends HandlebarsApplicationMixin(Appli
             app.addEventListener('close', () => resolve(app.saveData), { once: true });
             app.render({ force: true });
         });
+    }
+
+    /** Returns the complete base label for an ownership option */
+    #getBaseLabel(hidden = this.countdown.hidden) {
+        const base = _loc(`DAGGERHEART.APPLICATIONS.CountdownPermissions.HiddenOptions.${String(Boolean(hidden))}`);
+        return _loc('DAGGERHEART.APPLICATIONS.CountdownPermissions.inheritLabeled', { base });
     }
 }

--- a/module/applications/dialogs/countdownPermissions.mjs
+++ b/module/applications/dialogs/countdownPermissions.mjs
@@ -17,7 +17,7 @@ export class CountdownPermissionsDialog extends HandlebarsApplicationMixin(Appli
 
     static DEFAULT_OPTIONS = {
         tag: 'form',
-        classes: ['daggerheart', 'views', 'dialog', 'dh-style', 'ownership-selection'],
+        classes: ['daggerheart', 'views', 'dialog', 'dh-style', 'countdown-permissions'],
         window: {
             icon: 'fa-solid fa-users'
         },

--- a/module/applications/dialogs/countdownPermissions.mjs
+++ b/module/applications/dialogs/countdownPermissions.mjs
@@ -1,30 +1,18 @@
 const { HandlebarsApplicationMixin, ApplicationV2 } = foundry.applications.api;
 
 /**
- * @typedef OwnershipOptions
- * @property {number[]} ownershipOptions the options that will be shown as possible choices for each user
- * @property {number} default The default ownership option the players will default to
- * @property {number[]} defaultOwnershipOptions 
+ * @import { DhCountdown } from "../../data/countdowns.mjs";
  */
 
 /** A dialog for ownership selection */
-export default class OwnershipSelection extends HandlebarsApplicationMixin(ApplicationV2) {
+export class CountdownPermissionsDialog extends HandlebarsApplicationMixin(ApplicationV2) {
     /**
-     * @param {string} name
-     * @param {Record<string, number>} options.ownership
-     * @param {OwnershipOptions} [options]
+     * Creates a new dialog for ownership selection
+     * @param {DhCountdown} countdown
      */
-    constructor(name, defaultIcon, ownership, options = {}) {
+    constructor(countdown) {
         super({});
-
-        this.name = name;
-        this.defaultIcon = defaultIcon;
-        this.ownership = ownership;
-        this.ownershipOptions = options.ownershipOptions ?? [-1, 0, 2, 3]; // 1 isn't in our dictionary
-        this.default = options.default;
-        this.defaultOwnershipOptions = typeof options.default === 'number' || options.defaultOwnershipOptions 
-            ? options.defaultOwnershipOptions ?? this.ownershipOptions
-            : null;
+        this.countdown = countdown;
     }
 
     static DEFAULT_OPTIONS = {
@@ -42,16 +30,16 @@ export default class OwnershipSelection extends HandlebarsApplicationMixin(Appli
 
     static PARTS = {
         selection: {
-            template: 'systems/daggerheart/templates/dialogs/ownershipSelection.hbs'
+            template: 'systems/daggerheart/templates/dialogs/countdownPermissions.hbs'
         }
     };
 
     get title() {
-        return game.i18n.format('DAGGERHEART.APPLICATIONS.OwnershipSelection.title', { name: this.name });
+        return game.i18n.format('DAGGERHEART.APPLICATIONS.CountdownPermissions.title', { name: this.countdown.name });
     }
 
     getOwnershipData(id) {
-        return this.ownership[id] ?? CONST.DOCUMENT_OWNERSHIP_LEVELS.INHERIT;
+        return this.countdown.ownership[id] ?? CONST.DOCUMENT_OWNERSHIP_LEVELS.INHERIT;
     }
 
     async _prepareContext(_options) {
@@ -59,11 +47,12 @@ export default class OwnershipSelection extends HandlebarsApplicationMixin(Appli
         
         // Get ownership options. becuase of the use of numbers, the base collection is not correctly ordered.
         // So we have to redefine it ourselves in the correct order.
-        context.ownershipOptions = this.ownershipOptions.map(value => ({
+        const levels = CONST.DOCUMENT_OWNERSHIP_LEVELS;
+        context.ownershipOptions = [levels.INHERIT, levels.OBSERVER, levels.OWNER].map(value => ({
             value, 
             label: CONFIG.DH.GENERAL.simpleOwnershipLevels[value].label
         }));
-        context.defaultOwnershipOptions = this.defaultOwnershipOptions?.map(value => ({
+        context.defaultOwnershipOptions = [levels.NONE, levels.OBSERVER].map(value => ({
             value, 
             label: CONFIG.DH.GENERAL.defaultOwnershipLevels[value].label
         }));
@@ -78,9 +67,9 @@ export default class OwnershipSelection extends HandlebarsApplicationMixin(Appli
 
             return acc;
         }, {});
-        context.default = this.default;
+        context.default = this.countdown.hidden ? levels.NONE : levels.OBSERVER;
         context.showOwnership = Boolean(Object.keys(context.ownership).length);
-        context.defaultIcon = this.defaultIcon;
+        context.defaultIcon = this.countdown.img;
 
         return context;
     }
@@ -100,14 +89,12 @@ export default class OwnershipSelection extends HandlebarsApplicationMixin(Appli
 
     /**
      * Creates a ownership selection dialog returns the result when resolved
-     * @param {string} name 
-     * @param {Record<string, number>} ownership
-     * @param {OwnershipOptions} options
+     * @param {DhCountdown} countdown 
      * @returns {Promise<{ ownership: number; default?: number }>}
      */
-    static async configure(name, defaultIcon, ownership, options) {
+    static async configure(countdown) {
         return new Promise(resolve => {
-            const app = new this(name, defaultIcon, ownership, options);
+            const app = new this(countdown);
             app.addEventListener('close', () => resolve(app.saveData), { once: true });
             app.render({ force: true });
         });

--- a/module/applications/dialogs/ownershipSelection.mjs
+++ b/module/applications/dialogs/ownershipSelection.mjs
@@ -14,10 +14,11 @@ export default class OwnershipSelection extends HandlebarsApplicationMixin(Appli
      * @param {Record<string, number>} options.ownership
      * @param {OwnershipOptions} [options]
      */
-    constructor(name, ownership, options = {}) {
+    constructor(name, defaultIcon, ownership, options = {}) {
         super({});
 
         this.name = name;
+        this.defaultIcon = defaultIcon;
         this.ownership = ownership;
         this.ownershipOptions = options.ownershipOptions ?? [-1, 0, 2, 3]; // 1 isn't in our dictionary
         this.default = options.default;
@@ -60,11 +61,11 @@ export default class OwnershipSelection extends HandlebarsApplicationMixin(Appli
         // So we have to redefine it ourselves in the correct order.
         context.ownershipOptions = this.ownershipOptions.map(value => ({
             value, 
-            label: CONFIG.DH.GENERAL.simpleOwnershiplevels[value].label
+            label: CONFIG.DH.GENERAL.simpleOwnershipLevels[value].label
         }));
         context.defaultOwnershipOptions = this.defaultOwnershipOptions?.map(value => ({
             value, 
-            label: CONFIG.DH.GENERAL.simpleOwnershiplevels[value].label
+            label: CONFIG.DH.GENERAL.defaultOwnershipLevels[value].label
         }));
         context.ownership = game.users.reduce((acc, user) => {
             if (!user.isGM) {
@@ -79,6 +80,7 @@ export default class OwnershipSelection extends HandlebarsApplicationMixin(Appli
         }, {});
         context.default = this.default;
         context.showOwnership = Boolean(Object.keys(context.ownership).length);
+        context.defaultIcon = this.defaultIcon;
 
         return context;
     }
@@ -103,9 +105,9 @@ export default class OwnershipSelection extends HandlebarsApplicationMixin(Appli
      * @param {OwnershipOptions} options
      * @returns {Promise<{ ownership: number; default?: number }>}
      */
-    static async configure(name, ownership, options) {
+    static async configure(name, defaultIcon, ownership, options) {
         return new Promise(resolve => {
-            const app = new this(name, ownership, options);
+            const app = new this(name, defaultIcon, ownership, options);
             app.addEventListener('close', () => resolve(app.saveData), { once: true });
             app.render({ force: true });
         });

--- a/module/applications/ui/countdownEdit.mjs
+++ b/module/applications/ui/countdownEdit.mjs
@@ -207,6 +207,7 @@ export default class CountdownEdit extends HandlebarsApplicationMixin(Applicatio
         const levels = CONST.DOCUMENT_OWNERSHIP_LEVELS;
         const data = await game.system.api.applications.dialogs.OwnershipSelection.configure(
             countdown.name,
+            countdown.img,
             countdown.ownership,
             { 
                 ownershipOptions: [levels.INHERIT, levels.OBSERVER, levels.OWNER],

--- a/module/applications/ui/countdownEdit.mjs
+++ b/module/applications/ui/countdownEdit.mjs
@@ -204,17 +204,7 @@ export default class CountdownEdit extends HandlebarsApplicationMixin(Applicatio
      */
     static async #onEditCountdownOwnership(_, button) {
         const countdown = this.data.countdowns[button.dataset.countdownId];
-        const levels = CONST.DOCUMENT_OWNERSHIP_LEVELS;
-        const data = await game.system.api.applications.dialogs.OwnershipSelection.configure(
-            countdown.name,
-            countdown.img,
-            countdown.ownership,
-            { 
-                ownershipOptions: [levels.INHERIT, levels.OBSERVER, levels.OWNER],
-                default: countdown.hidden ? levels.NONE : levels.OBSERVER,
-                defaultOwnershipOptions: [levels.NONE, levels.OBSERVER]
-            }
-        );
+        const data = await game.system.api.applications.dialogs.CountdownPermissionsDialog.configure(countdown);
         if (!data) return;
 
         const updateData = { ownership: data.ownership, hidden: data.default === 0 };

--- a/module/applications/ui/countdownEdit.mjs
+++ b/module/applications/ui/countdownEdit.mjs
@@ -204,11 +204,8 @@ export default class CountdownEdit extends HandlebarsApplicationMixin(Applicatio
      */
     static async #onEditCountdownOwnership(_, button) {
         const countdown = this.data.countdowns[button.dataset.countdownId];
-        const data = await game.system.api.applications.dialogs.CountdownPermissionsDialog.configure(countdown);
-        if (!data) return;
-
-        const updateData = { ownership: data.ownership, hidden: data.default === 0 };
-        this.updateSetting({ [`countdowns.${button.dataset.countdownId}`]: updateData });
+        const updateData = await game.system.api.applications.dialogs.CountdownPermissionsDialog.configure(countdown);
+        if (updateData) this.updateSetting({ [`countdowns.${button.dataset.countdownId}`]: updateData });
     }
 
     /** 

--- a/module/config/generalConfig.mjs
+++ b/module/config/generalConfig.mjs
@@ -937,12 +937,17 @@ export const fearPosition = {
     leftBottom: { value: 'leftBottom', label: 'DAGGERHEART.SETTINGS.Appearance.fearPosition.leftBottom' }
 };
 
-export const simpleOwnershiplevels = {
+export const simpleOwnershipLevels = {
     [-1]: { value: -1, label: 'DAGGERHEART.UI.Countdowns.inherit' },
     0: { value: 0, label: 'OWNERSHIP.NONE' },
     2: { value: 2, label: 'OWNERSHIP.OBSERVER' },
     3: { value: 3, label: 'OWNERSHIP.OWNER' }
 };
+
+export const defaultOwnershipLevels = {
+    0: { value: 0, label: 'DAGGERHEART.CONFIG.DefaultOwnershipLevels.none' },    
+    2: { value: 2, label: 'DAGGERHEART.CONFIG.DefaultOwnershipLevels.observer' }
+}
 
 export const countdownLoopingTypes = {
     noLooping: {

--- a/module/config/generalConfig.mjs
+++ b/module/config/generalConfig.mjs
@@ -937,17 +937,11 @@ export const fearPosition = {
     leftBottom: { value: 'leftBottom', label: 'DAGGERHEART.SETTINGS.Appearance.fearPosition.leftBottom' }
 };
 
-export const simpleOwnershipLevels = {
+export const countdownOwnershipLevels = {
     [-1]: { value: -1, label: 'DAGGERHEART.UI.Countdowns.inherit' },
-    0: { value: 0, label: 'OWNERSHIP.NONE' },
     2: { value: 2, label: 'OWNERSHIP.OBSERVER' },
     3: { value: 3, label: 'OWNERSHIP.OWNER' }
 };
-
-export const defaultOwnershipLevels = {
-    0: { value: 0, label: 'DAGGERHEART.CONFIG.DefaultOwnershipLevels.none' },    
-    2: { value: 2, label: 'DAGGERHEART.CONFIG.DefaultOwnershipLevels.observer' }
-}
 
 export const countdownLoopingTypes = {
     noLooping: {

--- a/module/config/generalConfig.mjs
+++ b/module/config/generalConfig.mjs
@@ -938,7 +938,7 @@ export const fearPosition = {
 };
 
 export const simpleOwnershiplevels = {
-    [-1]: { value: -1, label: 'OWNERSHIP.INHERIT' },
+    [-1]: { value: -1, label: 'DAGGERHEART.UI.Countdowns.inherit' },
     0: { value: 0, label: 'OWNERSHIP.NONE' },
     2: { value: 2, label: 'OWNERSHIP.OBSERVER' },
     3: { value: 3, label: 'OWNERSHIP.OWNER' }

--- a/module/data/countdowns.mjs
+++ b/module/data/countdowns.mjs
@@ -123,7 +123,7 @@ export class DhCountdown extends foundry.abstract.DataModel {
             ownership: new fields.TypedObjectField(
                 new fields.NumberField({
                     required: true,
-                    choices: omit(CONFIG.DH.GENERAL.simpleOwnershiplevels, [
+                    choices: omit(CONFIG.DH.GENERAL.simpleOwnershipLevels, [
                         CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE
                     ]),
                     initial: CONST.DOCUMENT_OWNERSHIP_LEVELS.INHERIT

--- a/module/data/countdowns.mjs
+++ b/module/data/countdowns.mjs
@@ -1,4 +1,4 @@
-import { mapValues, omit } from '../helpers/utils.mjs';
+import { mapValues } from '../helpers/utils.mjs';
 import { RefreshType, socketEvent } from '../systemRegistration/socket.mjs';
 import FormulaField from './fields/formulaField.mjs';
 
@@ -123,9 +123,7 @@ export class DhCountdown extends foundry.abstract.DataModel {
             ownership: new fields.TypedObjectField(
                 new fields.NumberField({
                     required: true,
-                    choices: omit(CONFIG.DH.GENERAL.simpleOwnershipLevels, [
-                        CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE
-                    ]),
+                    choices: CONFIG.DH.GENERAL.countdownOwnershipLevels,
                     initial: CONST.DOCUMENT_OWNERSHIP_LEVELS.INHERIT
                 })
             ),

--- a/styles/less/ui/countdown-permissions/index.less
+++ b/styles/less/ui/countdown-permissions/index.less
@@ -1,6 +1,6 @@
 @import '../../utils/colors.less';
 
-.daggerheart.views.ownership-selection {
+.daggerheart.views.countdown-permissions {
     .ownership-outer-container {
         display: flex;
         flex-direction: column;

--- a/styles/less/ui/countdown-permissions/index.less
+++ b/styles/less/ui/countdown-permissions/index.less
@@ -35,7 +35,8 @@
             }
 
             select {
-                flex: 1;
+                min-width: 150px;
+                width: auto;
                 margin: 4px 0;
             }
         }

--- a/styles/less/ui/index.less
+++ b/styles/less/ui/index.less
@@ -4,7 +4,7 @@
 @import './effects-display/index.less';
 @import './game-pause/index.less';
 @import './item-browser/index.less';
-@import './ownership-selection/index.less';
+@import './countdown-permissions/index.less';
 @import './resources/index.less';
 @import './scene-config/index.less';
 @import './scene-navigation/index.less';

--- a/styles/less/ui/ownership-selection/index.less
+++ b/styles/less/ui/ownership-selection/index.less
@@ -1,1 +1,0 @@
-@import './ownership-selection.less';

--- a/styles/less/ui/ownership-selection/ownership-selection.less
+++ b/styles/less/ui/ownership-selection/ownership-selection.less
@@ -20,7 +20,6 @@
             gap: 8px;
 
             &.default {
-                padding-left: 48px; // img + gap
                 padding-bottom: 4px;
                 border-bottom: 1px solid @color-border;
             }

--- a/styles/less/ui/ownership-selection/ownership-selection.less
+++ b/styles/less/ui/ownership-selection/ownership-selection.less
@@ -32,7 +32,7 @@
             }
 
             span {
-                flex: 3;
+                flex: 2;
             }
 
             select {

--- a/templates/dialogs/countdownPermissions.hbs
+++ b/templates/dialogs/countdownPermissions.hbs
@@ -4,7 +4,7 @@
             {{#if defaultOwnershipOptions}}
                 <li class="ownership-container default">
                     <img src="{{defaultIcon}}" />
-                    <span>{{localize "DAGGERHEART.APPLICATIONS.OwnershipSelection.defaultPermission"}}</span>
+                    <span>{{localize "DAGGERHEART.APPLICATIONS.CountdownPermissions.defaultPermission"}}</span>
                     <select name="default" value="{{default}}" data-dtype="Number">
                         {{selectOptions @root.defaultOwnershipOptions selected=default labelAttr="label" valueAttr="value" localize=true }}
                     </select>
@@ -21,7 +21,7 @@
             {{/each}}
         </ul>
     {{else}}
-        <span class="hint">{{localize "DAGGERHEART.APPLICATIONS.OwnershipSelection.noPlayers"}}</span>
+        <span class="hint">{{localize "DAGGERHEART.APPLICATIONS.CountdownPermissions.noPlayers"}}</span>
     {{/if}}
     <footer class="flexrow">
         <button type="submit">{{localize "Save"}}</button>

--- a/templates/dialogs/countdownPermissions.hbs
+++ b/templates/dialogs/countdownPermissions.hbs
@@ -1,28 +1,24 @@
 <div class="ownership-outer-container">
-    {{#if showOwnership}}
-        <ul class="ownership-list">
-            {{#if defaultOwnershipOptions}}
-                <li class="ownership-container default">
-                    <img src="{{defaultIcon}}" />
-                    <span>{{localize "DAGGERHEART.APPLICATIONS.CountdownPermissions.defaultPermission"}}</span>
-                    <select name="default" value="{{default}}" data-dtype="Number">
-                        {{selectOptions @root.defaultOwnershipOptions selected=default labelAttr="label" valueAttr="value" localize=true }}
-                    </select>
-                </li>
-            {{/if}}
-            {{#each ownership as |player id|}}
-                <li class="ownership-container">
-                    <img src="{{player.img}}" />
-                    <span>{{player.name}}</span>
-                    <select name="{{concat "ownership." id}}" data-dtype="Number">
-                        {{selectOptions @root.ownershipOptions selected=player.ownership  labelAttr="label" valueAttr="value" localize=true }}
-                    </select>
-                </li>
-            {{/each}}
-        </ul>
-    {{else}}
-        <span class="hint">{{localize "DAGGERHEART.APPLICATIONS.CountdownPermissions.noPlayers"}}</span>
-    {{/if}}
+    <ul class="ownership-list">
+        <li class="ownership-container default">
+            <img src="{{countdown.img}}" />
+            <span>{{localize "DAGGERHEART.APPLICATIONS.CountdownPermissions.defaultPermission"}}</span>
+            <select name="hidden" data-dtype="Boolean">
+                {{selectOptions @root.defaultOwnershipLevels selected=countdown.hidden labelAttr="label" valueAttr="value" localize=true }}
+            </select>
+        </li>
+        {{#each ownership as |player id|}}
+            <li class="ownership-container">
+                <img src="{{player.img}}" />
+                <span>{{player.name}}</span>
+                <select name="{{concat "ownership." id}}" data-dtype="Number">
+                    {{selectOptions @root.ownershipLevels selected=player.ownership  labelAttr="label" valueAttr="value" localize=true }}
+                </select>
+            </li>
+        {{else}}
+            <span class="hint">{{localize "DAGGERHEART.APPLICATIONS.CountdownPermissions.noPlayers"}}</span>
+        {{/each}}
+    </ul>
     <footer class="flexrow">
         <button type="submit">{{localize "Save"}}</button>
     </footer>

--- a/templates/dialogs/ownershipSelection.hbs
+++ b/templates/dialogs/ownershipSelection.hbs
@@ -3,7 +3,8 @@
         <ul class="ownership-list">
             {{#if defaultOwnershipOptions}}
                 <li class="ownership-container default">
-                    <span>Default Permission</span>
+                    <img src="{{defaultIcon}}" />
+                    <span>{{localize "DAGGERHEART.APPLICATIONS.OwnershipSelection.defaultPermission"}}</span>
                     <select name="default" value="{{default}}" data-dtype="Number">
                         {{selectOptions @root.defaultOwnershipOptions selected=default labelAttr="label" valueAttr="value" localize=true }}
                     </select>


### PR DESCRIPTION
I wanted to achieve 2 (3) things:
<img width="1117" height="516" alt="image" src="https://github.com/user-attachments/assets/4baff651-3dee-4af6-bc4c-c498ce4c305a" />
**1)** I think the `inherit` label should call back to whatever title we have for the `default permission` line to make the relationship clear. In this case I tried `Countdowns Status`, so the line became `Follow Status`.
**2)** The GM mainly interacts with `Hidden`/`Revealed`. I think that makes it a lot more clear to use those labels here aswell. `none='Hidden'`, `observer='Revealed'`.

**3)** Optional. I thought it looked a lot nicer to have the lines completly symmetrical instead of a void where the player lines have an image. Tossed in the selected icon for the countdown itself.