### PR TITLE
[Feature] CountdownAction Hidden Label

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -486,7 +486,8 @@
                 "types": {
                     "narrative": "Narrative",
                     "encounter": "Encounter"
-                }
+                },
+                "hiddenNullLabel": "Set To Countdown UI Default"
             },
             "CountdownEdit": {
                 "title": "Countdown Edit",

--- a/module/data/fields/action/countdownField.mjs
+++ b/module/data/fields/action/countdownField.mjs
@@ -24,7 +24,7 @@ export default class CountdownField extends fields.ArrayField {
                 nullable: true,
                 initial: false,
                 label: 'DAGGERHEART.APPLICATIONS.Countdown.FIELDS.countdowns.element.hidden.label'
-            })
+            }, { nullLabel: 'DAGGERHEART.APPLICATIONS.Countdown.hiddenNullLabel' })
         });
         super(element, options, context);
     }

--- a/module/data/fields/action/countdownField.mjs
+++ b/module/data/fields/action/countdownField.mjs
@@ -22,7 +22,7 @@ export default class CountdownField extends fields.ArrayField {
             hidden: new NullableBooleanField({
                 required: true,
                 nullable: true,
-                initial: null,
+                initial: false,
                 label: 'DAGGERHEART.APPLICATIONS.Countdown.FIELDS.countdowns.element.hidden.label'
             }, { nullLabel: 'DAGGERHEART.APPLICATIONS.Countdown.hiddenNullLabel' })
         });

--- a/module/data/fields/action/countdownField.mjs
+++ b/module/data/fields/action/countdownField.mjs
@@ -22,7 +22,7 @@ export default class CountdownField extends fields.ArrayField {
             hidden: new NullableBooleanField({
                 required: true,
                 nullable: true,
-                initial: false,
+                initial: null,
                 label: 'DAGGERHEART.APPLICATIONS.Countdown.FIELDS.countdowns.element.hidden.label'
             }, { nullLabel: 'DAGGERHEART.APPLICATIONS.Countdown.hiddenNullLabel' })
         });

--- a/module/data/fields/nullableBooleanField.mjs
+++ b/module/data/fields/nullableBooleanField.mjs
@@ -3,6 +3,12 @@
  */
 export class NullableBooleanField extends foundry.data.fields.BooleanField {
     /** @inheritdoc */
+    constructor(options = {}, {nullLabel, ...context} = {}) {
+        super(options, context);
+
+        this.nullLabel = nullLabel;
+    }
+    /** @inheritdoc */
     _cast(value) {
         if (value === 'true') return true;
         if (value === 'false') return false;
@@ -18,7 +24,7 @@ export class NullableBooleanField extends foundry.data.fields.BooleanField {
         const options = [
             { value: 'true', label: _loc('COMMON.Yes'), selected: value === 'true' },
             { value: 'false', label: _loc('COMMON.No'), selected: value === 'false' },
-            { value: 'null', label: '', selected: value === 'null' }
+            { value: 'null', label: this.nullLabel ?? '', selected: value === 'null' }
         ];
         const data = foundry.utils.mergeObject(config, { value, options, dataset: { data: 'JSON' } });
         return foundry.applications.fields.createSelectInput(data);


### PR DESCRIPTION
Added a nullLabel context prop to NullableBooleanField. 
If you feel another label better communicates that the hidden property gets -hardset- to the current global default, then feel free to change it. I feel it's important to be clear that it does get a static value based on the current default, and doesn't dynamically change it if you flip the global default later.