### PR TITLE
[Fix] Healing Damage Summary Token Data

### DIFF
--- a/module/data/fields/action/damageField.mjs
+++ b/module/data/fields/action/damageField.mjs
@@ -101,7 +101,14 @@ export default class DamageField extends fields.SchemaField {
                 : actor.prototypeToken;
             if (config.hasHealing)
                 damagePromises.push(
-                    actor.takeHealing(config.damage).then(updates => targetDamage.push({ token, updates }))
+                    actor.takeHealing(config.damage).then(updates => targetDamage.push({ 
+                        token: { 
+                            id: token.id,
+                            name: token.prototypeToken?.name ?? token.name,
+                            img: token.texture.src  
+                        }, 
+                        updates 
+                    }))
                 );
             else {
                 const configDamage = config.damage.clone();

--- a/styles/less/ui/chat/damage-summary.less
+++ b/styles/less/ui/chat/damage-summary.less
@@ -47,8 +47,8 @@
             position: relative;
 
             img {
-                width: 40px;
-                height: 40px;
+                width: 32px;
+                height: 32px;
                 padding: 0;
                 border-radius: 50%;
             }
@@ -61,7 +61,7 @@
                 .actor-name {
                     margin: 0;
                     color: @beige;
-                    font-size: var(--font-size-20);
+                    font-size: var(--font-size-18);
                 }
 
                 .token-resistance-container {

--- a/styles/less/ui/chat/damage-summary.less
+++ b/styles/less/ui/chat/damage-summary.less
@@ -99,13 +99,5 @@
                 gap: 4px;
             }
         }
-
-        &::after {
-            content: '';
-            background: @golden;
-            mask-image: linear-gradient(270deg, transparent 0%, black 50%, transparent 100%);
-            height: 2px;
-            width: 100%;
-        }
     }
 }

--- a/templates/ui/chat/damageSummary.hbs
+++ b/templates/ui/chat/damageSummary.hbs
@@ -4,7 +4,7 @@
             <header>
                 <img src="{{this.token.img}}" />
                 <div class="token-header-data">
-                    <h2 class="actor-name">{{this.token.name}}</h2>
+                    <span class="actor-name">{{this.token.name}}</span>
                     {{#unless (and (not ../isGM) ../hideObserverPermissionInChat)}}
                         {{#if this.token.resistant}}<div class="token-resistance-container resistant">{{localize "DAGGERHEART.GENERAL.resistant"}}</div>{{/if}}
                         {{#if this.token.immune}}<div class="token-resistance-container immune">{{localize "DAGGERHEART.GENERAL.immune"}}</div>{{/if}}


### PR DESCRIPTION
- Fixed an issue where DamageSummary wasn't shown correctly for healing
- Removed separator line between multiple actors in DamageSummary