### PR TITLE
[Feature] CountdownUI Empty Render

### DIFF
--- a/templates/ui/countdowns/countdowns-view.hbs
+++ b/templates/ui/countdowns/countdowns-view.hbs
@@ -21,7 +21,9 @@
             <i class="fa-solid fa-down-left-and-up-right-to-center" inert></i>
         </a>
     </header>
-    <div class="countdowns-container">
-        {{> "systems/daggerheart/templates/ui/countdowns/parts/countdowns.hbs" }}
-    </div>
+    {{#if countdownTypesWithVisibleEntries.length}}
+        <div class="countdowns-container">
+            {{> "systems/daggerheart/templates/ui/countdowns/parts/countdowns.hbs" }}
+        </div>
+    {{/if}}
 </div>


### PR DESCRIPTION
Changed so that the countdowns-container with a lot of padding is not rendered if there are no countdowns or they're not visible.

**Old**
<img width="462" height="155" alt="image" src="https://github.com/user-attachments/assets/4c7c1c24-62f2-498d-8e61-cfe2a2f0124b" />

**Now**
<img width="457" height="162" alt="image" src="https://github.com/user-attachments/assets/c6ce09fb-3539-4244-a9cc-09f4232fdbe8" />
