### PR TITLE
[Feature] Manual DualityRoll Labels

### DIFF
--- a/module/dice/_module.mjs
+++ b/module/dice/_module.mjs
@@ -6,3 +6,4 @@ export { default as DualityRoll } from './dualityRoll.mjs';
 export { default as FateRoll } from './fateRoll.mjs';
 export { BaseDie } from './die/_module.mjs';
 export { diceTypes } from './die/_module.mjs';
+export { default as RollResolver } from './rollResolver.mjs';

--- a/module/dice/dualityRoll.mjs
+++ b/module/dice/dualityRoll.mjs
@@ -117,6 +117,23 @@ export default class DualityRoll extends D20Roll {
         return game.i18n.localize(label);
     }
 
+    /** @inheritdoc */
+    static get resolverImplementation() {
+        const config = game.settings.get('core', Roll.DICE_CONFIGURATION_SETTING);
+        const methods = new Set(Object.values(config).filter(method => {
+            if (!method || (method === 'manual')) return false;
+            return CONFIG.Dice.fulfillment.methods[method]?.interactive;
+        }));
+
+        // If there is more than one interactive method configured, use the default resolver which has a combined, method-
+        // agnostic interface.
+        if (methods.size !== 1) return game.system.api.dice.RollResolver;
+
+        // Otherwise use the specific resolver configured for that method, if any.
+        const method = CONFIG.Dice.fulfillment.methods[methods.first()];
+        return method.resolver ?? game.system.api.dice.RollResolver;
+    }
+
     static getHooks(hooks) {
         return [...(hooks ?? []), 'Duality'];
     }

--- a/module/dice/rollResolver.mjs
+++ b/module/dice/rollResolver.mjs
@@ -1,0 +1,42 @@
+export default class DhRollResolver extends foundry.applications.dice.RollResolver {
+    /** @inheritDoc */
+    async _prepareContext(_options) {
+        const context = {
+            formula: this.roll.formula,
+            groups: {}
+        };
+        for (const fulfillable of this.fulfillable.values()) {
+            const { id, term, method, isNew } = fulfillable;
+            fulfillable.isNew = false;
+            const config = CONFIG.Dice.fulfillment.methods[method];
+
+            const dualityLabel = 
+                term instanceof game.system.api.dice.diceTypes.HopeDie ? _loc(`DAGGERHEART.GENERAL.rollWith`, { roll: _loc(`DAGGERHEART.GENERAL.hope`) }) : 
+                    term instanceof game.system.api.dice.diceTypes.FearDie ? _loc(`DAGGERHEART.GENERAL.rollWith`, { roll: _loc(`DAGGERHEART.GENERAL.fear`) }) : 
+                        null;
+            const label = dualityLabel ? `${dualityLabel} (${term.expression})` : term.expression;
+
+            const group = context.groups[id] = {
+                results: [],
+                label,
+                icon: config.icon ?? '<i class="fa-solid fa-bluetooth"></i>',
+                tooltip: _loc(config.label)
+            };
+            const { denomination, faces } = term;
+            const icon = CONFIG.Dice.fulfillment.dice[denomination]?.icon;
+            for (let i = 0; i < Math.max(term.number ?? 1, term.results.length); i++) {
+                const result = term.results[i];
+                const { result: value, exploded, rerolled } = result ?? {};
+                group.results.push({
+                    denomination, id, method, icon, exploded, rerolled, isNew,
+                    value: value ?? '',
+                    minValue: denomination === 'c' ? 0 : 1,
+                    maxValue: denomination === 'c' ? 1 : faces,
+                    readonly: method !== 'manual',
+                    disabled: !!result
+                });
+            }
+        }
+        return context;
+    }
+}


### PR DESCRIPTION
Fixed so that the manual roll inputs are labeled with hope and fear if applicable.
<img width="646" height="470" alt="image" src="https://github.com/user-attachments/assets/e6f34ba5-0065-4e32-a114-7f6ab3c84dde" />

Sadly, Foundry have not been very flexible here. The rollResolver fetch that happens in a `Roll` instance is hardcoded to be Foundry's base rollResolver, so I had to copy their existing `resolverImplementation` getter and hardcode in our own that makes the small label change.
```js
static get resolverImplementation() {
    const config = game.settings.get("core", Roll.DICE_CONFIGURATION_SETTING);
    const methods = new Set(Object.values(config).filter(method => {
      if ( !method || (method === "manual") ) return false;
      return CONFIG.Dice.fulfillment.methods[method]?.interactive;
    }));

    // If there is more than one interactive method configured, use the default resolver which has a combined, method-
    // agnostic interface.
    if ( methods.size !== 1 ) return foundry.applications.dice.RollResolver;  // <------- Replacing here in our version

    // Otherwise use the specific resolver configured for that method, if any.
    const method = CONFIG.Dice.fulfillment.methods[methods.first()];
    return method.resolver ?? foundry.applications.dice.RollResolver; <------- Replacing here in our version
  }
```