### PR TITLE
[Fix] DiceSoNice Without Canvas

### DIFF
--- a/module/applications/settings/appearanceSettings.mjs
+++ b/module/applications/settings/appearanceSettings.mjs
@@ -82,7 +82,7 @@ export default class DHAppearanceSettings extends HandlebarsApplicationMixin(App
     /** @inheritdoc */
     _configureRenderParts(options) {
         const parts = super._configureRenderParts(options);
-        if (!game.modules.get('dice-so-nice')?.active) {
+        if (!game.dice3d) {
             delete parts.diceSoNice;
             delete parts.tabs;
         }
@@ -115,7 +115,9 @@ export default class DHAppearanceSettings extends HandlebarsApplicationMixin(App
         if (partId in context.tabs) partContext.tab = partContext.tabs[partId];
         switch (partId) {
             case 'diceSoNice':
-                await this.prepareDiceSoNiceContext(partContext);
+                if (game.dice3d)
+                    await this.prepareDiceSoNiceContext(partContext);
+
                 break;
             case 'footer':
                 partContext.buttons = [

--- a/module/data/action/attackAction.mjs
+++ b/module/data/action/attackAction.mjs
@@ -68,7 +68,7 @@ export default class DHAttackAction extends DHDamageAction {
 
     async handleReload(options = { awaitRoll: false }) {
         const roll = await new Roll('1d6').evaluate();
-        if (game.modules.get('dice-so-nice')?.active) {
+        if (game.dice3d) {
             if (options.awaitRoll)
                 await game.dice3d.showForRoll(roll, game.user, true);
             else

--- a/module/data/fields/action/countdownField.mjs
+++ b/module/data/fields/action/countdownField.mjs
@@ -70,7 +70,7 @@ export default class CountdownField extends fields.ArrayField {
             };
         }
 
-        if (game.modules.get('dice-so-nice')?.active) {
+        if (game.dice3d) {
             await Promise.all(
                 countdownMessages.map(message => {
                     return game.dice3d.waitFor3DAnimationByMessageID(message.id);

--- a/module/dice/damageRoll.mjs
+++ b/module/dice/damageRoll.mjs
@@ -71,7 +71,7 @@ export default class DamageRoll extends DHRoll {
             : getDocumentClass('ChatMessage').applyMode({}, config.rollMode ?? 'public');
 
         const diceRolls = [];
-        if (game.modules.get('dice-so-nice')?.active) {
+        if (game.dice3d) {
             config.mute = true;
             const pool = foundry.dice.terms.PoolTerm.fromRolls([
                 ...(config.damage.main ? [config.damage.main] : []),

--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -161,7 +161,7 @@ export default class DHRoll extends BaseRoll {
         if (roll._evaluated) {
             const message = await cls.create(msgData, { messageMode: config.selectedMessageMode });
 
-            if (roll.formula !== '' && game.modules.get('dice-so-nice')?.active) {
+            if (roll.formula !== '' && game.dice3d) {
                 await game.dice3d.waitFor3DAnimationByMessageID(message.id);
             }
 

--- a/module/dice/die/baseDie.mjs
+++ b/module/dice/die/baseDie.mjs
@@ -57,7 +57,7 @@ export default class BaseDie extends foundry.dice.terms.Die {
            We solve this by marking the results as hidden so they're not picked up by the auto roll of DiceSoNice.
            The actual rolls are done here in place so every dice gets the correct denomination.
         */
-        if (game.modules.get('dice-so-nice')?.active) {
+        if (game.dice3d) {
             const resultsToRoll = this.results.filter((x, index) => 
                 x.active && (!rerollStartIndex || index === rerollStartIndex || index > initialResultsLength - 1));
             const rolls = [];

--- a/module/dice/die/dualityDie.mjs
+++ b/module/dice/die/dualityDie.mjs
@@ -23,7 +23,7 @@ export default class DualityDie extends BaseDie {
 
         if (options?.liveRoll) {
             /* Can't currently test since DiceSoNice is not v14. Might need to set the appearance earlier if a roll is triggered by super.reroll */
-            if (game.modules.get('dice-so-nice')?.active) {
+            if (game.dice3d) {
                 const diceSoNiceRoll = {
                     _evaluated: true,
                     dice: [this],

--- a/module/dice/dualityRoll.mjs
+++ b/module/dice/dualityRoll.mjs
@@ -384,7 +384,7 @@ export default class DualityRoll extends D20Roll {
         const rerolled = DualityRoll.fromData((await super.reroll(options)).toJSON());
 
         if (options?.liveRoll) {
-            if (game.modules.get('dice-so-nice')?.active) {
+            if (game.dice3d) {
                 const diceAppearance = await getDiceSoNicePresets(
                     rerolled,
                     rerolled.dHope.denomination,

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -94,7 +94,7 @@ export const getCommandTarget = (options = {}) => {
 };
 
 export const setDiceSoNiceForDualityRoll = async (rollResult, advantageState, hopeFaces, fearFaces, advantageFaces) => {
-    if (!game.modules.get('dice-so-nice')?.active) return;
+    if (!game.dice3d) return;
     const diceSoNicePresets = await getDiceSoNicePresets(
         rollResult,
         hopeFaces,
@@ -111,14 +111,14 @@ export const setDiceSoNiceForDualityRoll = async (rollResult, advantageState, ho
 };
 
 export const setDiceSoNiceForHopeFateRoll = async (rollResult, hopeFaces) => {
-    if (!game.modules.get('dice-so-nice')?.active) return;
+    if (!game.dice3d) return;
     const { diceSoNice } = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.appearance);
     const diceSoNicePresets = await getDiceSoNicePreset(diceSoNice.hope, hopeFaces);
     rollResult.dice[0].options = diceSoNicePresets;
 };
 
 export const setDiceSoNiceForFearFateRoll = async (rollResult, fearFaces) => {
-    if (!game.modules.get('dice-so-nice')?.active) return;
+    if (!game.dice3d) return;
     const { diceSoNice } = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.appearance);
     const diceSoNicePresets = await getDiceSoNicePreset(diceSoNice.fear, fearFaces);
     rollResult.dice[0].options = diceSoNicePresets;
@@ -474,7 +474,7 @@ export function itemIsIdentical(a, b) {
 }
 
 export async function waitForDiceSoNice(message) {
-    if (message && game.modules.get('dice-so-nice')?.active) {
+    if (message && game.dice3d) {
         await game.dice3d.waitFor3DAnimationByMessageID(message.id);
     }
 }
@@ -899,7 +899,7 @@ export async function fromUuids(uuids) {
  */
 export async function triggerChatRollFx(rolls, options = { whisper: false, blind: false }) {
     const { whisper, blind } = options;
-    if (game.modules.get('dice-so-nice')?.active) {
+    if (game.dice3d) {
         const rerollPromises = rolls.map(roll => game.dice3d.showForRoll(roll, game.user, true, whisper, blind));
         await Promise.allSettled(rerollPromises);
     } else {


### PR DESCRIPTION
Appearantly if the Foundry canvas is deactivated, DiceSoNice omits to register game.dice3d

We have a bunch of checks that check for game.modules.get('dice-so-nice')?.active to know if we can use game.dice3d, but that check doesn't work with canvas off for this reason.

----
Fixed it by exchanging all checks for `game.modules-get('dice-so-nice')?.active` to instead be `if(game.dice3d)`