### PR TITLE
[Fix] Prevent domain cards with attribution double scroll bars when editing

### DIFF
--- a/styles/less/global/tab-description.less
+++ b/styles/less/global/tab-description.less
@@ -38,7 +38,7 @@
                     }
                 }
                 &.active {
-                    --min-height: 250px;
+                    --min-height: 240px;
                     padding: 8px 0 0 16px;
                     button[data-action=editGMNote] {
                         display: none;


### PR DESCRIPTION
Fixes this nonesense
<img width="474" height="720" alt="image" src="https://github.com/user-attachments/assets/2f6faffb-4ce5-446d-b528-7e25f45dd933" />
