### PR TITLE
[Fix] Improve responsiveness of drag/drop to item sheets

### DIFF
--- a/module/applications/sheets-configs/environment-settings.mjs
+++ b/module/applications/sheets-configs/environment-settings.mjs
@@ -130,6 +130,11 @@ export default class DHEnvironmentSettings extends DHBaseActorSettings {
         event.stopPropagation();
         const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
         const doc = await fromUuid(data.uuid);
+       
+        if (data.type === 'Item') {
+            return super._onDropItem(event, doc);
+        }
+
         if (doc?.type === 'adversary' && event.target.closest('.category-container')) {
             const target = event.target.closest('.category-container');
             const path = `system.potentialAdversaries.${target.dataset.potentialAdversary}.adversaries`;
@@ -138,8 +143,6 @@ export default class DHEnvironmentSettings extends DHBaseActorSettings {
                 await this.actor.update({ [path]: [...current, doc.uuid] });
             }
             return;
-        }
-        
-        return super._onDrop(event);
+        } 
     }
 }

--- a/module/applications/sheets/api/actor-setting.mjs
+++ b/module/applications/sheets/api/actor-setting.mjs
@@ -86,13 +86,10 @@ export default class DHBaseActorSettings extends DHApplicationMixin(ActorSheetV2
         }
     }
 
-    async _onDrop(event) {
-        event.stopPropagation();
-        const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
-        const item = await fromUuid(data.uuid);
+    async _onDropItem(event, item) {
         if (item?.type === 'feature') {
-            if (data.fromInternal && item.parent?.uuid === this.actor.uuid) {
-                return super._onDrop(event);
+            if (item.parent?.uuid === this.actor.uuid) {
+                return super._onDropItem(event);
             }
 
             const itemData = item.toObject();

--- a/module/applications/sheets/api/base-item.mjs
+++ b/module/applications/sheets/api/base-item.mjs
@@ -3,7 +3,10 @@ import DHApplicationMixin from './application-mixin.mjs';
 
 const { ItemSheetV2 } = foundry.applications.sheets;
 
-/**@typedef {import('@client/applications/_types.mjs').ApplicationClickAction} ApplicationClickAction */
+/**
+ * @typedef {import('@client/applications/_types.mjs').ApplicationClickAction} ApplicationClickAction *
+ * @import DHItem from '../../../documents/item.mjs';
+ /
 
 /**
  * A base item sheet extending {@link ItemSheetV2} via {@link DHApplicationMixin}
@@ -289,13 +292,25 @@ export default class DHBaseItemSheet extends DHApplicationMixin(ItemSheetV2) {
      * @param {DragEvent} event - The drag event
      */
     async _onDrop(event) {
+        event.stopPropagation();
         super._onDrop(event);
 
         const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
         if (data.fromInternal === this.document.id) return;
+        
+        const documentClass = foundry.utils.getDocumentClass(data.type);
+        if (documentClass) {
+            const document = await documentClass.fromDropData(data);
+            await this._onDropDocument(event, document);
+        }
+    }
 
+    /**
+     * @param {DragEvent} event 
+     * @param {DHItem} item 
+     */
+    async _onDropItem(event, item) {
         const target = event.target.closest('fieldset.drop-section');
-        let item = await fromUuid(data.uuid);
         if (item?.type === 'feature') {
             const cls = foundry.documents.Item.implementation;
 
@@ -316,7 +331,7 @@ export default class DHBaseItemSheet extends DHApplicationMixin(ItemSheetV2) {
                 );
             }
 
-            if (target.dataset.type) {
+            if (target?.dataset.type) {
                 await this.document.update(
                     {
                         'system.features': [...this.document.system.features, { type: target.dataset.type, item }].map(
@@ -336,6 +351,30 @@ export default class DHBaseItemSheet extends DHApplicationMixin(ItemSheetV2) {
                     { parent: this.document.parent?.type === 'character' ? this.document.parent : undefined }
                 );
             }
+        }
+    }
+
+    /**
+     * Handle a dropped document on this item sheet. This is a re-implementation of what's in the ActorSheet
+     * @template {Document} TDocument
+     * @param {DragEvent} event         The initiating drop event
+     * @param {TDocument} document       The resolved Document class
+     * @returns {Promise<TDocument|null>} A Document of the same type as the dropped one in case of a successful result,
+     *                                    or null in case of failure or no action being taken
+     * @protected
+     */
+    async _onDropDocument(event, document) {
+        switch (document.documentName) {
+            case 'ActiveEffect':
+                return (await this._onDropActiveEffect?.(event, document)) ?? null;
+            case 'Actor':
+                return (await this._onDropActor?.(event, document)) ?? null;
+            case 'Item':
+                return (await this._onDropItem?.(event, document)) ?? null;
+            case 'Folder':
+                return (await this._onDropFolder?.(event, document)) ?? null;
+            default:
+                return null;
         }
     }
 

--- a/module/applications/sheets/items/class.mjs
+++ b/module/applications/sheets/items/class.mjs
@@ -1,7 +1,5 @@
 import DHBaseItemSheet from '../api/base-item.mjs';
 
-const { TextEditor } = foundry.applications.ux;
-
 export default class ClassSheet extends DHBaseItemSheet {
     /**@inheritdoc */
     static DEFAULT_OPTIONS = {
@@ -123,58 +121,53 @@ export default class ClassSheet extends DHBaseItemSheet {
 
     /* -------------------------------------------- */
 
-    async _onDrop(event) {
-        event.stopPropagation();
-        const data = TextEditor.getDragEventData(event);
-        const item = await fromUuid(data.uuid);
-        const itemType = data.type === 'ActiveEffect' ? data.type : item.type;
+    async _onDropItem(event, item) {
         const target = event.target.closest('fieldset.drop-section');
-
-        if (['feature', 'ActiveEffect'].includes(itemType)) {
-            super._onDrop(event);
-        } else if (this.document.parent?.type !== 'character') {
-            if (itemType === 'weapon') {
+        if (target && this.document.parent?.type !== 'character') {
+            if (item.type === 'weapon') {
                 if (target.classList.contains('primary-weapon-section')) {
                     if (!item.system.secondary)
-                        await this.document.update({
+                        return await this.document.update({
                             'system.characterGuide.suggestedPrimaryWeapon': item.uuid
                         });
                 } else if (target.classList.contains('secondary-weapon-section')) {
                     if (item.system.secondary)
-                        await this.document.update({
+                        return await this.document.update({
                             'system.characterGuide.suggestedSecondaryWeapon': item.uuid
                         });
                 }
-            } else if (itemType === 'armor') {
+            } else if (item.type === 'armor') {
                 if (target.classList.contains('armor-section')) {
-                    await this.document.update({
+                    return await this.document.update({
                         'system.characterGuide.suggestedArmor': item.uuid
                     });
                 }
             } else if (target.classList.contains('choice-a-section')) {
-                if (itemType === 'loot' || itemType === 'consumable') {
+                if (item.type === 'loot' || item.type === 'consumable') {
                     const filteredChoiceA = this.document.system.inventory.choiceA;
                     if (filteredChoiceA.length < 2)
-                        await this.document.update({
+                        return await this.document.update({
                             'system.inventory.choiceA': [...filteredChoiceA.map(x => x.uuid), item.uuid]
                         });
                 }
-            } else if (itemType === 'loot') {
+            } else if (item.type === 'loot') {
                 if (target.classList.contains('take-section')) {
                     const filteredTake = this.document.system.inventory.take.filter(x => x);
                     if (filteredTake.length < 3)
-                        await this.document.update({
+                        return await this.document.update({
                             'system.inventory.take': [...filteredTake.map(x => x.uuid), item.uuid]
                         });
                 } else if (target.classList.contains('choice-b-section')) {
                     const filteredChoiceB = this.document.system.inventory.choiceB.filter(x => x);
                     if (filteredChoiceB.length < 2)
-                        await this.document.update({
+                        return await this.document.update({
                             'system.inventory.choiceB': [...filteredChoiceB.map(x => x.uuid), item.uuid]
                         });
                 }
             }
         }
+
+        return super._onDropItem(event, item);
     }
 
     /* -------------------------------------------- */

--- a/module/applications/sheets/items/subclass.mjs
+++ b/module/applications/sheets/items/subclass.mjs
@@ -53,12 +53,8 @@ export default class SubclassSheet extends DHBaseItemSheet {
         return context;
     }
 
-    async _onDrop(event) {
-        event.stopPropagation();
-        const data = TextEditor.getDragEventData(event);
-        const item = await fromUuid(data.uuid);
-        const itemType = data.type === 'ActiveEffect' ? data.type : item.type;
-        if (itemType === 'class') {
+    async _onDropItem(event, item) {
+        if (item.type === 'class') {
             const uuid = item.sourceUuid;
             if (this.document.system.linkedClass !== uuid) {
                 await this.document.update({ 'system.linkedClass': uuid });
@@ -70,6 +66,6 @@ export default class SubclassSheet extends DHBaseItemSheet {
             return;
         }
 
-        return super._onDrop(event);
+        return super._onDropItem(event, item);
     }
 }


### PR DESCRIPTION
This fixes a weird quirk I ran into. If you try to drag a feature from the compendium into a subclass's or class's features, the feature will not be successfully dragged. You actually need to drag it a second time for it to stick. I don't know why this happens, but its like the event loses all drag data during the super call.

This PR adds something similar to _onDropItem() from the actor sheet, which allows the drag event data to be parsed only once. This seems to circumvent the whole issue.

I could use some help testing, particularly with ancestry, where I don't understand what it is trying to do.