### PR TITLE
Prefer item roll data as a base for actions

### DIFF
--- a/daggerheart.d.ts
+++ b/daggerheart.d.ts
@@ -22,6 +22,11 @@ import DhEffectsDisplay from './module/applications/ui/effectsDisplay.mjs';
 // This declare global hopefully fixes that
 // Note: eslint is not aware of these, whatever is added here should go in the eslint's globals list
 declare global {
+    // These are convenience types for common imported things. This allows them to be used in JSDoc directly
+    // For actual use such as instanceof, an import is still required
+    type DHItem<T extends BaseDataItem = BaseDataItem> = InstanceType<typeof documents.DHItem<T>>;
+    type DhpActor<T extends BaseDataItem = BaseDataItem> = InstanceType<typeof documents.DhpActor<T>>;
+
     /**
      * A simple event framework used throughout Foundry Virtual Tabletop.
      * When key actions or events occur, a "hook" is defined where user-defined callback functions can execute.

--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -124,6 +124,7 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
 
     /**
      * Return Item the action is attached too.
+     * @returns {DHItem}
      */
     get item() {
         if (!this.parent.parent && this.systemPath)
@@ -204,7 +205,7 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
      * @returns {object}
      */
     getRollData(data = {}) {
-        const actorData = this.actor ? this.actor.getRollData(false) : {};
+        const actorData = this.item?.getRollData() ?? {};
         actorData.result = data.roll?.total ?? 1;
         actorData.scale = data.costs?.length // Right now only return the first scalable cost.
             ? (data.costs.find(c => c.scalable)?.total ?? 1)

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -639,6 +639,7 @@ export default class DhpActor extends Actor {
         rollData.system = this.system.getRollData();
         rollData.prof = this.system.proficiency ?? 1;
         rollData.cast = this.system.spellcastModifier ?? 1;
+        rollData.fear = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Resources.Fear);
 
         return rollData;
     }


### PR DESCRIPTION
In an action, get actor() requires retrieving the item's actor, so if there is no item, there is no actor regardless.