### PR TITLE
[Fix] Scene Refresh

### DIFF
--- a/module/config/generalConfig.mjs
+++ b/module/config/generalConfig.mjs
@@ -810,7 +810,7 @@ export const getDiceSoNicePresets = async (
 
 export const refreshTypes = {
     scene: {
-        id: 'session',
+        id: 'scene',
         label: 'DAGGERHEART.GENERAL.RefreshType.scene'
     },
     session: {


### PR DESCRIPTION
Refreshing scene resources didn't work because it was set up with the wrong ID in the config