### PR TITLE
[Fix] using world item copies of classes in character creator

### DIFF
--- a/module/applications/characterCreation/characterCreation.mjs
+++ b/module/applications/characterCreation/characterCreation.mjs
@@ -526,6 +526,7 @@ export default class DhCharacterCreation extends HandlebarsApplicationMixin(Appl
         async function createEmbeddedItemData(baseData) {
             const uuid = baseData.uuid ?? baseData._uuid
             const data = baseData instanceof Item ? baseData : await foundry.utils.fromUuid(baseData.uuid) ?? baseData;
+            const compendiumSource = uuid.startsWith('Compendium.') ? uuid : baseData._stats?.compendiumSource ?? null;
             return {
                 ...baseData,
                 id: data.id,
@@ -535,8 +536,9 @@ export default class DhCharacterCreation extends HandlebarsApplicationMixin(Appl
                 flags: baseData.flags ?? data.flags,
                 _stats: {
                     ...data._stats,
-                    compendiumSource: uuid.startsWith('Compendium.') ? uuid : null,
-                    duplicateSource: uuid && !uuid.startsWith('Compendium.') ? uuid : null
+                    compendiumSource,
+                    // mutually exclusive with compendiumSource
+                    duplicateSource: !compendiumSource && uuid && !uuid.startsWith('Compendium.') ? uuid : null
                 }
             };
         }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -12,7 +12,7 @@ export default class DHItem extends foundry.documents.Item {
      */
     get sourceUuid() {
         const isCompendium = this._id && this.pack && !this.isEmbedded;
-        return isCompendium ? this.uuid : this._stats.duplicateSource ?? this._stats.compendiumSource ?? this.uuid;
+        return isCompendium ? this.uuid : this._stats.compendiumSource ?? this._stats.duplicateSource ?? this.uuid;
     }
 
     /** @inheritDoc */


### PR DESCRIPTION
Text by dragging bard to your world items, then going through character creation, and then drag the bard in your world items instead of the compendium. Afterwards complete the character creation. Before this PR, the subclass would fail to be added to the character at the end, as the class newly added would not have preserved compendium source info.