### PR TITLE
Avoid line wrap with custom weapon features

### DIFF
--- a/module/data/item/armor.mjs
+++ b/module/data/item/armor.mjs
@@ -64,8 +64,8 @@ export default class DHArmor extends BaseDataItem {
         const features = this.armorFeatures.map(x => allFeatures[x.value]).filter(x => x);
 
         const prefix = await foundry.applications.handlebars.renderTemplate(
-            'systems/daggerheart/templates/sheets/items/armor/description.hbs',
-            { item: this.parent, features }
+            'systems/daggerheart/templates/sheets/items/description.hbs',
+            { features }
         );
 
         return { prefix, value: baseDescription, suffix: null };

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -132,11 +132,8 @@ export default class DHWeapon extends BaseDataItem {
         const features = this.weaponFeatures.map(x => allFeatures[x.value]).filter(x => x);
 
         const prefix = await foundry.applications.handlebars.renderTemplate(
-            'systems/daggerheart/templates/sheets/items/weapon/description.hbs',
-            {
-                item: this,
-                features
-            }
+            'systems/daggerheart/templates/sheets/items/description.hbs',
+            { features }
         );
 
         return { prefix, value: baseDescription, suffix: null };

--- a/templates/sheets/items/armor/description.hbs
+++ b/templates/sheets/items/armor/description.hbs
@@ -1,9 +1,0 @@
-{{#if features.length}}
-    <div class="item-description-outer-container">
-        <div class="item-description-container">
-            {{#each features as | feature |}}
-                <div><strong>{{localize feature.label}}</strong>: {{{localize feature.description}}}</div>
-            {{/each}}
-        </div>
-    </div>
-{{/if}}

--- a/templates/sheets/items/description.hbs
+++ b/templates/sheets/items/description.hbs
@@ -1,8 +1,10 @@
-<div class="item-description-outer-container">
-    <div class="item-description-container">
-        <h4>{{localize label}}</h4>
-        {{#each features as | feature |}}
-            <div class="item-description-inner-container"><strong>{{localize feature.label}}</strong>: {{{localize feature.description}}}</div>
-        {{/each}}
+{{#if (or label features.length)}}
+    <div class="item-description-outer-container">
+        <div class="item-description-container">
+            {{#if label}}<h4>{{localize label}}</h4>{{/if}}
+            {{#each features as | feature |}}
+                <div class="item-description-inner-container"><strong>{{localize feature.label}}</strong>: {{{localize feature.description}}}</div>
+            {{/each}}
+        </div>
     </div>
-</div>
+{{/if}}

--- a/templates/sheets/items/weapon/description.hbs
+++ b/templates/sheets/items/weapon/description.hbs
@@ -1,9 +1,0 @@
-{{#if features.length}}
-    <div class="item-description-outer-container">
-        <div class="item-description-container">
-            {{#each features as | feature |}}
-                <div><strong>{{localize feature.label}}</strong>: {{{localize feature.description}}}</div>
-            {{/each}}
-        </div>
-    </div>
-{{/if}}


### PR DESCRIPTION
Internally, it works by making weapons and armor use the same features template as the other items

Before
<img width="609" height="403" alt="image" src="https://github.com/user-attachments/assets/72c4b635-e124-486e-90ab-218fcc7eace2" />

After
<img width="626" height="391" alt="image" src="https://github.com/user-attachments/assets/a08f311a-a565-4625-9c0e-8f36abb4b429" />