### PR TITLE
Add support for embedded item tables

### DIFF
--- a/daggerheart.d.ts
+++ b/daggerheart.d.ts
@@ -17,7 +17,6 @@ import FearTracker from './module/applications/ui/fearTracker.mjs';
 import DhCountdowns from './module/data/countdowns.mjs';
 import DhEffectsDisplay from './module/applications/ui/effectsDisplay.mjs';
 
-
 // Foundry's use of `Object.assign(globalThis) means many globally available objects are not read as such
 // This declare global hopefully fixes that
 // Note: eslint is not aware of these, whatever is added here should go in the eslint's globals list
@@ -58,7 +57,9 @@ declare global {
 
     const Collection: foundry.utils.Collection;
     const FormDataExtended: foundry.applications.ux.FormDataExtended;
+    /** @deprecated */
     const TextEditor: foundry.applications.ux.TextEditor;
+    const Roll: dice.BaseRoll;
 
     /**
      * Data used to build rolls such as duality rolls. The definition is incomplete and likely incorrect.

--- a/lang/en.json
+++ b/lang/en.json
@@ -1495,7 +1495,7 @@
             "WeaponFeature": {
                 "barrier": {
                     "name": "Barrier",
-                    "description": "Gain Weapon Tier + 1 to Armor Score; -1 to Evasion",
+                    "description": "@Resolve[@item.tier + 1|sign]{Gain Weapon Tier + 1} to Armor Score; -1 to Evasion",
                     "effects": {
                         "barrier": {
                             "name": "Barrier",
@@ -1813,7 +1813,7 @@
                 },
                 "paired": {
                     "name": "Paired",
-                    "description": "Add this Secondary Weapon's tier + 1 to your primary weapon damage against targets within Melee range",
+                    "description": "@Resolve[@item.tier + 1|sign]{Add this Secondary Weapon's tier + 1} to primary weapon damage to targets within Melee range",
                     "actions": {
                         "paired": {
                             "name": "Paired",
@@ -1875,7 +1875,7 @@
                 },
                 "protective": {
                     "name": "Protective",
-                    "description": "Add the item's Tier to your Armor Score",
+                    "description": "@Resolve[@item.tier|sign]{Add the item's Tier} to Armor Score",
                     "effects": {
                         "protective": {
                             "name": "Protective",

--- a/module/applications/sheets/api/heritage-sheet.mjs
+++ b/module/applications/sheets/api/heritage-sheet.mjs
@@ -10,7 +10,10 @@ export default class DHHeritageSheet extends DHBaseItemSheet {
     /**@override */
     static PARTS = {
         tabs: { template: 'systems/daggerheart/templates/sheets/global/tabs/tab-navigation.hbs' },
-        description: { template: 'systems/daggerheart/templates/sheets/global/tabs/tab-description.hbs' },
+        description: { 
+            template: 'systems/daggerheart/templates/sheets/global/tabs/tab-description.hbs',
+            scrollable: ['.description-section']
+        },
         effects: {
             template: 'systems/daggerheart/templates/sheets/global/tabs/tab-effects.hbs',
             scrollable: ['.effects']

--- a/module/dice/baseRoll.mjs
+++ b/module/dice/baseRoll.mjs
@@ -1,4 +1,4 @@
-export default class BaseRoll extends Roll {
+export default class BaseRoll extends foundry.dice.Roll {
     /** @inheritdoc */
     static CHAT_TEMPLATE = 'systems/daggerheart/templates/ui/chat/foundryRoll.hbs';
 

--- a/module/enrichers/DamageEnricher.mjs
+++ b/module/enrichers/DamageEnricher.mjs
@@ -1,6 +1,6 @@
 import { parseInlineParams } from './parser.mjs';
 
-export default function DhDamageEnricher(match, _options) {
+export function DhDamageEnricher(match, _options) {
     const { value, type, inline } = parseInlineParams(match[1], { first: 'value' });
     if (!value || !type) return match[0];
     return getDamageMessage(value, type, inline, match[0]);

--- a/module/enrichers/DualityRollEnricher.mjs
+++ b/module/enrichers/DualityRollEnricher.mjs
@@ -1,7 +1,7 @@
 import { abilities } from '../config/actorConfig.mjs';
 import { getCommandTarget, rollCommandToJSON } from '../helpers/utils.mjs';
 
-export default function DhDualityRollEnricher(match, _options) {
+export function DhDualityRollEnricher(match, _options) {
     const roll = rollCommandToJSON(match[0]);
     if (!roll) return match[0];
 

--- a/module/enrichers/EffectEnricher.mjs
+++ b/module/enrichers/EffectEnricher.mjs
@@ -1,4 +1,4 @@
-export default async function DhEffectEnricher(match, _options) {
+export async function DhEffectEnricher(match, _options) {
     const effect = await foundry.utils.fromUuid(match[1]);
     if (!effect) return match[0];
 

--- a/module/enrichers/EmbedTableEnricher.mjs
+++ b/module/enrichers/EmbedTableEnricher.mjs
@@ -1,0 +1,132 @@
+import { fromUuids } from '../helpers/utils.mjs';
+import { parseInlineParams } from './parser.mjs';
+
+export async function DhEmbedTableEnricher(match) {
+    const results = parseInlineParams(match[1], { first: 'uuids' });
+    const fromPath = results.path ? foundry.utils.getProperty(globalThis, results.path) : null;
+    const uuids = [...(fromPath ?? []), ...(results.uuids?.split(' ') ?? [])];
+    const items = (await fromUuids(uuids)).filter(i => !!i);
+
+    const itemType = results.type ?? items[0]?.type;
+    const definition = rowsByItemType[itemType];
+    if (!itemType) return createErrorMessage('No items available and no item type to define');
+    if (items.some(d => d.type !== itemType)) return createErrorMessage('Not all items match the item type');
+    if (!definition) return createErrorMessage('Invalid item type for embed table');
+
+    
+    const element = document.createElement('table');
+    element.classList.add('embed-item-table', `${itemType}-table`);
+    const head = document.createElement('thead');
+    const body = document.createElement('tbody');
+    element.append(head, body);
+
+    const headerRow = document.createElement('tr');
+    head.appendChild(headerRow);
+    for (const cell of definition.cells) {
+        headerRow.append(createHtmlElement('th', { text: _loc(cell.label) }));
+    }
+
+    const runData = definition.init?.();
+    for (const item of items) {
+        const row = body.appendChild(document.createElement('tr'));
+        for (const cell of definition.cells) {
+            const key = cell.html ? 'html' : 'text';
+            row.append(createHtmlElement('td', { [key]: await cell.value(item, runData) }));
+        }
+    }
+
+    return element;
+}
+
+/** @type {Record<string, { init?: () => unknown; cells: { label: string; value: (item: DHItem, init) => string | Promise<string>; html?: boolean }[] }>} */
+const rowsByItemType = {
+    weapon: {
+        init: () => ({ features: CONFIG.DH.ITEM.allWeaponFeatures() }),
+        cells: [
+            {
+                label: 'DAGGERHEART.GENERAL.name',
+                value: i => i.name
+            },
+            {
+                label: 'DAGGERHEART.GENERAL.Trait.single',
+                value: i => _loc(CONFIG.DH.ACTOR.abilities[i.system.attack.roll.trait]?.label)
+            },
+            {
+                label: 'DAGGERHEART.GENERAL.range',
+                value: i => _loc(CONFIG.DH.GENERAL.templateRanges[i.system.attack.range]?.label) 
+            },
+            {
+                label: 'DAGGERHEART.GENERAL.burden',
+                value: i => _loc(CONFIG.DH.GENERAL.burden[i.system.burden]?.label)
+            },
+            {
+                label: 'TYPES.Item.feature',
+                value: async (item, { features }) => {
+                    const itemFeatures = item.system.weaponFeatures.map(x => features[x.value]).filter(x => x);
+                    if (!itemFeatures.length) return '—';
+                    const TextEditor = foundry.applications.ux.TextEditor;
+                    const rollData = item.getRollData();
+                    return Promise.all(
+                        itemFeatures.map(async f => {
+                            const description = await TextEditor.enrichHTML(_loc(f.description), { rollData });
+                            return `<div class="feature"><strong>${_loc(f.label)}:</strong> ${description}</div>`;
+                        })
+                    );
+                },
+                html: true
+            }
+        ]
+    },
+    armor: {
+        init: () => ({ features: CONFIG.DH.ITEM.allArmorFeatures() }),
+        cells: [
+            {
+                label: 'DAGGERHEART.GENERAL.name',
+                value: i => i.name
+            },
+            {
+                label: 'DAGGERHEART.ITEMS.Armor.baseThresholds.base',
+                value: i => `${i.system.baseThresholds.major} / ${i.system.baseThresholds.severe}`
+            },
+            {
+                label: 'DAGGERHEART.ITEMS.Armor.baseScore',
+                value: i => i.system.armor.max
+            },
+            {
+                label: 'TYPES.Item.feature',
+                value: async (i, { features }) => {
+                    const itemFeatures = i.system.armorFeatures.map(x => features[x.value]).filter(x => x);
+                    if (!itemFeatures.length) return '—';
+                    const TextEditor = foundry.applications.ux.TextEditor;
+                    const rollData = i.getRollData();
+                    return Promise.all(
+                        itemFeatures.map(async f => {
+                            const description = await TextEditor.enrichHTML(_loc(f.description), { rollData });
+                            return `<div class="feature"><strong>${_loc(f.label)}:</strong> ${description}</div>`;
+                        })
+                    );
+                },
+                html: true
+            }
+        ]
+    }
+}
+
+/**
+ * 
+ * @param {keyof HTMLElementTagNameMap} tagName 
+ * @param {*} param1 
+ * @returns 
+ */
+function createHtmlElement(tagName, { text = null, html = null }) {
+    const tag = document.createElement(tagName);
+    if (text) tag.textContent = text;
+    if (html) tag.innerHTML = html;
+    return tag;
+}
+
+function createErrorMessage(message) {
+    const div = createHtmlElement('div', { text: message })
+    div.classList.add('error');
+    return div;
+}

--- a/module/enrichers/EmbedTableEnricher.mjs
+++ b/module/enrichers/EmbedTableEnricher.mjs
@@ -23,7 +23,9 @@ export async function DhEmbedTableEnricher(match) {
     const headerRow = document.createElement('tr');
     head.appendChild(headerRow);
     for (const cell of definition.cells) {
-        headerRow.append(createHtmlElement('th', { text: _loc(cell.label) }));
+        const element = createHtmlElement('th', { text: _loc(cell.label) });
+        if (cell.cssClass) element.classList.add(cell.cssClass);
+        headerRow.append(element);
     }
 
     const runData = definition.init?.();
@@ -31,36 +33,43 @@ export async function DhEmbedTableEnricher(match) {
         const row = body.appendChild(document.createElement('tr'));
         for (const cell of definition.cells) {
             const key = cell.html ? 'html' : 'text';
-            row.append(createHtmlElement('td', { [key]: await cell.value(item, runData) }));
+            const element = createHtmlElement('td', { [key]: await cell.value(item, runData) });
+            if (cell.cssClass) element.classList.add(cell.cssClass);
+            row.append(element);
         }
     }
 
     return element;
 }
 
-/** @type {Record<string, { init?: () => unknown; cells: { label: string; value: (item: DHItem, init) => string | Promise<string>; html?: boolean }[] }>} */
+/** @type {Record<string, { init?: () => unknown; cells: { label: string; cssClass?: string; value: (item: DHItem, init) => string | Promise<string>; html?: boolean }[] }>} */
 const rowsByItemType = {
     weapon: {
         init: () => ({ features: CONFIG.DH.ITEM.allWeaponFeatures() }),
         cells: [
             {
                 label: 'DAGGERHEART.GENERAL.name',
+                cssClass: 'name',
                 value: i => i.name
             },
             {
                 label: 'DAGGERHEART.GENERAL.Trait.single',
+                cssClass: 'trait',
                 value: i => _loc(CONFIG.DH.ACTOR.abilities[i.system.attack.roll.trait]?.label)
             },
             {
                 label: 'DAGGERHEART.GENERAL.range',
+                cssClass: 'range',
                 value: i => _loc(CONFIG.DH.GENERAL.templateRanges[i.system.attack.range]?.label) 
             },
             {
                 label: 'DAGGERHEART.GENERAL.burden',
+                cssClass: 'burden',
                 value: i => _loc(CONFIG.DH.GENERAL.burden[i.system.burden]?.label)
             },
             {
                 label: 'TYPES.Item.feature',
+                cssClass: 'features',
                 value: async (item, { features }) => {
                     const itemFeatures = item.system.weaponFeatures.map(x => features[x.value]).filter(x => x);
                     if (!itemFeatures.length) return '—';
@@ -82,18 +91,22 @@ const rowsByItemType = {
         cells: [
             {
                 label: 'DAGGERHEART.GENERAL.name',
+                cssClass: 'name',
                 value: i => i.name
             },
             {
                 label: 'DAGGERHEART.ITEMS.Armor.baseThresholds.base',
+                cssClass: 'thresholds',
                 value: i => `${i.system.baseThresholds.major} / ${i.system.baseThresholds.severe}`
             },
             {
                 label: 'DAGGERHEART.ITEMS.Armor.baseScore',
+                cssClass: 'armor-score',
                 value: i => i.system.armor.max
             },
             {
                 label: 'TYPES.Item.feature',
+                cssClass: 'features',
                 value: async (i, { features }) => {
                     const itemFeatures = i.system.armorFeatures.map(x => features[x.value]).filter(x => x);
                     if (!itemFeatures.length) return '—';

--- a/module/enrichers/FateRollEnricher.mjs
+++ b/module/enrichers/FateRollEnricher.mjs
@@ -1,6 +1,6 @@
 import { getCommandTarget, rollCommandToJSON } from '../helpers/utils.mjs';
 
-export default function DhFateRollEnricher(match, _options) {
+export function DhFateRollEnricher(match, _options) {
     const roll = rollCommandToJSON(match[0]);
     if (!roll) return match[0];
 

--- a/module/enrichers/LookupEnricher.mjs
+++ b/module/enrichers/LookupEnricher.mjs
@@ -1,6 +1,6 @@
 import { parseInlineParams } from './parser.mjs';
 
-export default function DhLookupEnricher(match, { rollData }) {
+export function DhLookupEnricher(match, { rollData }) {
     const results = parseInlineParams(match[1], { first: 'formula' });
     const element = document.createElement('span');
 

--- a/module/enrichers/ResolveEnricher.mjs
+++ b/module/enrichers/ResolveEnricher.mjs
@@ -1,0 +1,17 @@
+import { parseInlineParams } from './parser.mjs';
+
+/** Similar to lookup, but resolves the data to a value, returning what's in {} on failure as a fallback */
+export function DhResolveEnricher(match, { rollData }) {
+    const results = parseInlineParams(match[1], { first: 'formula' });
+    const element = document.createElement('span');
+    const label = match[2]?.slice(1, -1);
+    try {
+        const evaluated = Roll.safeEval(Roll.replaceFormulaData(String(results.formula), rollData));
+        element.textContent = results.sign && evaluated >= 0 ? `+${evaluated}` : String(evaluated);
+        if (label) element.dataset.tooltip = label;
+    } catch {
+        element.textContent = label ?? match[1];
+    }
+
+    return element;
+}

--- a/module/enrichers/TemplateEnricher.mjs
+++ b/module/enrichers/TemplateEnricher.mjs
@@ -1,6 +1,6 @@
 import { parseInlineParams } from './parser.mjs';
 
-export default function DhTemplateEnricher(match, _options) {
+export function DhTemplateEnricher(match, _options) {
     const params = parseInlineParams(match[1]);
     const { type, angle = CONFIG.MeasuredTemplate.defaults.angle, inline = false } = params;
     const direction = Number(params.direction) || 0;

--- a/module/enrichers/_module.mjs
+++ b/module/enrichers/_module.mjs
@@ -1,9 +1,11 @@
-import { default as DhDamageEnricher, renderDamageButton } from './DamageEnricher.mjs';
-import { default as DhDualityRollEnricher, renderDualityButton } from './DualityRollEnricher.mjs';
-import { default as DhFateRollEnricher, renderFateButton } from './FateRollEnricher.mjs';
-import { default as DhEffectEnricher } from './EffectEnricher.mjs';
-import { default as DhTemplateEnricher, renderMeasuredTemplate } from './TemplateEnricher.mjs';
-import { default as DhLookupEnricher } from './LookupEnricher.mjs';
+import { DhDamageEnricher, renderDamageButton } from './DamageEnricher.mjs';
+import { DhDualityRollEnricher, renderDualityButton } from './DualityRollEnricher.mjs';
+import { DhFateRollEnricher, renderFateButton } from './FateRollEnricher.mjs';
+import { DhEffectEnricher } from './EffectEnricher.mjs';
+import { DhTemplateEnricher, renderMeasuredTemplate } from './TemplateEnricher.mjs';
+import { DhLookupEnricher } from './LookupEnricher.mjs';
+import { DhResolveEnricher } from './ResolveEnricher.mjs';
+import { DhEmbedTableEnricher } from './EmbedTableEnricher.mjs';
 
 export { DhDamageEnricher, DhDualityRollEnricher, DhEffectEnricher, DhTemplateEnricher, DhFateRollEnricher };
 
@@ -31,6 +33,14 @@ export const enricherConfig = [
     {
         pattern: /@Lookup\[([^[\]]*)\]({[^}]*})?/g,
         enricher: DhLookupEnricher
+    },
+    {
+        pattern: /@Resolve\[([^[\]]*)\]({[^}]*})?/g,
+        enricher: DhResolveEnricher
+    },
+    {
+        pattern: /@EmbedTable\[([^[\]]*)\]/g,
+        enricher: DhEmbedTableEnricher
     }
 ];
 

--- a/styles/less/global/enrichment.less
+++ b/styles/less/global/enrichment.less
@@ -15,6 +15,9 @@
 }
 
 .embed-item-table {
+    .burden {
+        white-space: nowrap;
+    }
     .feature {
         > p:first-of-type {
             display: inline;

--- a/styles/less/global/enrichment.less
+++ b/styles/less/global/enrichment.less
@@ -13,3 +13,11 @@
         font-size: 12px;
     }
 }
+
+.embed-item-table {
+    .feature {
+        > p:first-of-type {
+            display: inline;
+        }
+    }
+}


### PR DESCRIPTION
<img width="973" height="807" alt="image" src="https://github.com/user-attachments/assets/a1ad4f65-38c3-4830-b350-26431661f43f" />

Supports either `@EmbedTable[UUID1 UUID2 UUID3]` or `@EmbedTable[path=some.path.to.uuids]`. This also adds support to a new `@Resolve` enricher that simplifies to a number (and also creates a tooltip for any fallback labels).

Currently only weapon and armor is supported. Consumables and Loot have a numerical "rarity value" that I don't know yet how to reproduce, and we need to discuss it. I'm also not sure about the enricher name, and am wondering if something like `@Compute` or `@Evaluate` might be better.