### PR TITLE
[Feature] support lookup enricher types and index adjustments

### DIFF
--- a/module/config/_module.mjs
+++ b/module/config/_module.mjs
@@ -12,3 +12,4 @@ export * as systemConfig from './system.mjs';
 export * as itemBrowserConfig from './itemBrowserConfig.mjs';
 export * as triggerConfig from './triggerConfig.mjs';
 export * as resourceConfig from './resourceConfig.mjs';
+export * as lookupConfig from './lookupConfig.mjs';

--- a/module/config/lookupConfig.mjs
+++ b/module/config/lookupConfig.mjs
@@ -1,0 +1,7 @@
+import { omit } from '../helpers/utils.mjs';
+import { range as rangeConfig } from './generalConfig.mjs';
+
+/** Configuration for @Lookup[] of type range */
+export const range = {
+    entries: foundry.utils.deepClone(omit(rangeConfig, ['self']))
+};

--- a/module/config/system.mjs
+++ b/module/config/system.mjs
@@ -11,6 +11,7 @@ import * as FLAGS from './flagsConfig.mjs';
 import * as HOOKS from './hooksConfig.mjs';
 import * as TRIGGER from './triggerConfig.mjs';
 import * as ITEMBROWSER from './itemBrowserConfig.mjs';
+import * as LOOKUP from './lookupConfig.mjs';
 
 /** @type {"daggerheart"} */
 export const SYSTEM_ID = 'daggerheart';
@@ -30,6 +31,7 @@ export const SYSTEM = {
     HOOKS,
     TRIGGER,
     ITEMBROWSER,
+    LOOKUP,
 
     /**
      * Lore entries are used by items to link to the journal entry for the full description

--- a/module/enrichers/LookupEnricher.mjs
+++ b/module/enrichers/LookupEnricher.mjs
@@ -1,13 +1,45 @@
 import { parseInlineParams } from './parser.mjs';
 
+/**
+ * Enricher to take a path or string and returns a string.
+ * Supports the following parameters:
+ * - type - A key of the CONFIG.DH.LOOKUP export. By default, its "text", which means no table
+ * - adjustment - a numerical adjustment to go up and down choices
+ * - key - a property of the lookup table. If there is no lookup table, it is ignored. Defaults to "label".
+ * The label, such as @Lookup[formula]{label}, is shown on a failed lookup if given even if blank
+ */
 export function DhLookupEnricher(match, { rollData }) {
-    const results = parseInlineParams(match[1], { first: 'formula' });
+    const params = parseInlineParams(match[1], { first: 'formula' });
     const element = document.createElement('span');
 
-    const lookupCommand = match[0];
-    const lookupParam = match[1];
-    const lookupText = Roll.replaceFormulaData(String(results.formula), rollData);
-    element.textContent = lookupText === lookupParam ? lookupCommand : lookupText;
+    // Get parameters and check validity
+    const unparsedOriginal = match[0];
+    const label = match[2];
+    const type = params.type || 'text';
+    const table = type !== 'text' ? CONFIG.DH.LOOKUP[type] : null;
+    const key = params.key || 'label';
+    if (type !== 'text' && !table?.entries) {
+        element.textContent = `&lt;Lookup table "${type}" does not exist&gt;`;
+        return element;
+    }
+    
+    // Perform lookup/replacement, and handle lookup tables
+    const lookupText = Roll.replaceFormulaData(String(params.formula), rollData);
+    if (table && lookupText in table.entries) {
+        let entry = table.entries[lookupText];
+        const adjustment = params.adjustment ? Number(params.adjustment) : null;
+        if (Number.isInteger(adjustment)) {
+            const keys = Object.keys(table.entries);
+            const idx = keys.indexOf(lookupText);
+            const newIdx = Math.clamp(idx + adjustment, 0, keys.length - 1);
+            entry = table.entries[keys[newIdx]];
+        }
+        element.textContent = _loc(entry[key] ?? entry.label);
+    } else if (lookupText !== params.formula) {
+        element.textContent = lookupText;
+    } else {
+        element.textContent = label ?? unparsedOriginal;
+    }
 
     return element;
 }

--- a/module/enrichers/ResolveEnricher.mjs
+++ b/module/enrichers/ResolveEnricher.mjs
@@ -4,7 +4,7 @@ import { parseInlineParams } from './parser.mjs';
 export function DhResolveEnricher(match, { rollData }) {
     const results = parseInlineParams(match[1], { first: 'formula' });
     const element = document.createElement('span');
-    const label = match[2]?.slice(1, -1);
+    const label = match[2];
     try {
         const evaluated = Roll.safeEval(Roll.replaceFormulaData(String(results.formula), rollData));
         element.textContent = results.sign && evaluated >= 0 ? `+${evaluated}` : String(evaluated);

--- a/module/enrichers/_module.mjs
+++ b/module/enrichers/_module.mjs
@@ -9,33 +9,34 @@ import { DhEmbedTableEnricher } from './EmbedTableEnricher.mjs';
 
 export { DhDamageEnricher, DhDualityRollEnricher, DhEffectEnricher, DhTemplateEnricher, DhFateRollEnricher };
 
+// @todo standardize enricher regex and use match labels
 export const enricherConfig = [
     {
-        pattern: /@Damage\[([^[\]]*)\]({[^}]*})?/g,
+        pattern: /@Damage\[([^[\]]*)\](?:{([^}]*)})?/g,
         enricher: DhDamageEnricher
     },
     {
-        pattern: /\[\[\/dr\s?(.*?)\]\]({[^}]*})?/g,
+        pattern: /\[\[\/dr\s?(.*?)\]\](?:{([^}]*)})?/g,
         enricher: DhDualityRollEnricher
     },
     {
-        pattern: /\[\[\/fr\s?(.*?)\]\]({[^}]*})?/g,
+        pattern: /\[\[\/fr\s?(.*?)\]\](?:{([^}]*)})?/g,
         enricher: DhFateRollEnricher
     },
     {
-        pattern: /@Effect\[([^[\]]*)\]({[^}]*})?/g,
+        pattern: /@Effect\[([^[\]]*)\](?:{([^}]*)})?/g,
         enricher: DhEffectEnricher
     },
     {
-        pattern: /@Template\[([^[\]]*)\]({[^}]*})?/g,
+        pattern: /@Template\[([^[\]]*)\](?:{([^}]*)})?/g,
         enricher: DhTemplateEnricher
     },
     {
-        pattern: /@Lookup\[([^[\]]*)\]({[^}]*})?/g,
+        pattern: /@Lookup\[([^[\]]*)\](?:{([^}]*)})?/g,
         enricher: DhLookupEnricher
     },
     {
-        pattern: /@Resolve\[([^[\]]*)\]({[^}]*})?/g,
+        pattern: /@Resolve\[([^[\]]*)\](?:{([^}]*)})?/g,
         enricher: DhResolveEnricher
     },
     {


### PR DESCRIPTION
Adds support for `@Lookup[@item.attack.range|type:range|adjustment:2]{some fallback label}` which will be handy for certain H&F features.