### PR TITLE
[Fix] error in char creator if items exist with invalid domains

### DIFF
--- a/module/config/itemBrowserConfig.mjs
+++ b/module/config/itemBrowserConfig.mjs
@@ -378,7 +378,7 @@ export const typeConfig = {
                 format: domains => {
                     const config = CONFIG.DH.DOMAIN.allDomains();
                     return domains
-                        .map(x => (x ? game.i18n.localize(config[x].label) : null))
+                        .map(x => _loc(config[x]?.label) ?? null)
                         .filter(x => x)
                         .join(', ');
                 }


### PR DESCRIPTION
Minor fix that is probably beneath patch note mention, but it occurs if there are compendium items for domains that are unregistered.