### PR TITLE
[Feature] Otherwordly

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1931,6 +1931,16 @@
                         }
                     }
                 },
+                "otherwordly": {
+                    "name": "Otherwordly",
+                    "description": "On a successful attack, you can deal physical or magic damage.",
+                    "effects": {
+                        "otherwordly": {
+                            "name": "Otherwordly",
+                            "description": "On a successful attack, you can deal physical or magic damage."
+                        }
+                    }
+                },
                 "painful": {
                     "name": "Painful",
                     "description": "Each time you make a successful attack, you must mark a Stress.",

--- a/module/applications/dialogs/damageDialog.mjs
+++ b/module/applications/dialogs/damageDialog.mjs
@@ -27,6 +27,7 @@ export default class DamageDialog extends HandlebarsApplicationMixin(Application
         },
         actions: {
             toggleSelectedEffect: this.toggleSelectedEffect,
+            updateDamageType: DamageDialog.#onUpdateDamageType,
             updateGroupAttack: this.updateGroupAttack,
             toggleCritical: this.toggleCritical,
             submitRoll: this.submitRoll
@@ -76,6 +77,25 @@ export default class DamageDialog extends HandlebarsApplicationMixin(Application
 
         context.damageOptions = this.config.damageOptions;
         context.rangeOptions = CONFIG.DH.GENERAL.groupAttackRange;
+        
+        if (this.config.canChooseDamageType) {
+            const previousDamageType = 
+                game.user.getFlag(CONFIG.DH.id, CONFIG.DH.FLAGS.userFlags.previousDamageTypeChoice);
+            context.selectedDamageTypes = 
+                previousDamageType ? new Set([previousDamageType]) : damageFormula.damageTypes;  
+
+            context.canChooseDamageType = true;
+            context.damageTypesChoices = Object.entries(CONFIG.DH.GENERAL.damageTypes).reduce((acc, [key, data]) => {
+                acc[key] = {
+                    ...data,
+                    selected: context.selectedDamageTypes.has(key)
+                };
+
+                return acc;
+            }, {});
+        } else {
+            context.selectedDamageTypes = damageFormula.damageTypes;
+        }
 
         return context;
     }
@@ -125,6 +145,17 @@ export default class DamageDialog extends HandlebarsApplicationMixin(Application
         this.render();
     }
 
+    static #onUpdateDamageType(_, button) {
+        this.config.damageFormula.damageTypes = new Set([button.dataset.type]);
+        game.user.setFlag(
+            CONFIG.DH.id, 
+            CONFIG.DH.FLAGS.userFlags.previousDamageTypeChoice, 
+            button.dataset.type
+        );
+
+        this.render();
+    }
+
     static async submitRoll() {
         /* Sideeffect occuring in constructFormulas that sets this.config.isCritical to the false value. Can remove the below if it can be prevented */
         const sideEffectSafeIsCritical = this.config.isCritical;
@@ -142,6 +173,7 @@ export default class DamageDialog extends HandlebarsApplicationMixin(Application
 
         this.config.damageFormula = damageFormula;
         this.config.resourceFormulas = resourceFormulas;
+
         await this.close({ submitted: true });
     }
 

--- a/module/config/flagsConfig.mjs
+++ b/module/config/flagsConfig.mjs
@@ -23,7 +23,8 @@ export const compendiumBrowserLite = {
 export const userFlags = {
     welcomeMessage: 'welcome-message',
     countdownMode: 'countdown-mode',
-    countdownTypeModes: 'countdown-type-modes'
+    countdownTypeModes: 'countdown-type-modes',
+    previousDamageTypeChoice: 'previous-damage-type-choice'
 };
 
 export const combatToggle = 'combat-toggle-origin';

--- a/module/config/itemConfig.mjs
+++ b/module/config/itemConfig.mjs
@@ -1120,6 +1120,26 @@ export const weaponFeatures = {
             }
         ]
     },
+    otherwordly: {
+        label: 'DAGGERHEART.CONFIG.WeaponFeature.otherwordly.name',
+        description: 'DAGGERHEART.CONFIG.WeaponFeature.otherwordly.description',
+        effects: [
+            {
+                name: 'DAGGERHEART.CONFIG.WeaponFeature.otherwordly.effects.otherwordly.name',
+                description: 'DAGGERHEART.CONFIG.WeaponFeature.otherwordly.effects.otherwordly.description',
+                img: 'icons/weapons/swords/sword-flanged-lightning.webp',
+                system: {
+                    changes: [
+                        {
+                            key: 'system.rules.attack.damage.canChooseDamageType',
+                            type: 'override',
+                            value: 1
+                        }
+                    ]
+                }
+            }
+        ]
+    },
     painful: {
         label: 'DAGGERHEART.CONFIG.WeaponFeature.painful.name',
         description: 'DAGGERHEART.CONFIG.WeaponFeature.painful.description',

--- a/module/data/action/attackAction.mjs
+++ b/module/data/action/attackAction.mjs
@@ -10,7 +10,7 @@ export default class DHAttackAction extends DHDamageAction {
     prepareData() {
         super.prepareData();
         if (this.item?.system?.attack) {
-            if (this.damage.main.includeBase) {
+            if (this.damage.main?.includeBase) {
                 const baseDamage = this.getParentHitPointDamage();
                 if (baseDamage) {
                     if (!this.damage.main) {

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -258,6 +258,11 @@ export default class DhCharacter extends DhCreature {
                                 initial: 0,
                                 min: 0,
                                 label: 'DAGGERHEART.GENERAL.Rules.attack.damage.bonus.label'
+                            }),
+                            canChooseDamageType: new fields.BooleanField({
+                                required: true,
+                                nullable: false,
+                                initial: false
                             })
                         },
                         roll: new fields.SchemaField({

--- a/module/data/fields/action/damageField.mjs
+++ b/module/data/fields/action/damageField.mjs
@@ -49,7 +49,10 @@ export default class DamageField extends fields.SchemaField {
             damageFormula,
             resourceFormulas, 
             data: this.getRollData(),
-            isCritical: Boolean(message?.system.roll?.isCritical)
+            isCritical: Boolean(message?.system.roll?.isCritical),
+            canChooseDamageType: this.actor.appliedEffects.some(
+                x => x.parent.id === this.item.id && x.system.changes.some(x => x.key === 'system.rules.attack.damage.canChooseDamageType')
+            )
         };
         delete damageConfig.evaluate;
 

--- a/src/packs/items/weapons/weapon_Ghostblade_6gFvOFTE97QZ74Zr.json
+++ b/src/packs/items/weapons/weapon_Ghostblade_6gFvOFTE97QZ74Zr.json
@@ -11,7 +11,15 @@
     "equipped": false,
     "secondary": false,
     "burden": "oneHanded",
-    "weaponFeatures": [],
+    "weaponFeatures": [
+      {
+        "value": "otherwordly",
+        "effectIds": [
+          "WT5wBYRkENaUPvBw"
+        ],
+        "actionIds": []
+      }
+    ],
     "attack": {
       "name": "Attack",
       "img": "icons/skills/melee/blood-slash-foam-red.webp",
@@ -52,7 +60,6 @@
             }
           },
           "type": [
-            "physical",
             "magical"
           ],
           "applyTo": "hitPoints",
@@ -112,7 +119,51 @@
     "resource": null,
     "quantity": 1
   },
-  "effects": [],
+  "effects": [
+    {
+      "name": "DAGGERHEART.CONFIG.WeaponFeature.otherwordly.effects.otherwordly.name",
+      "description": "DAGGERHEART.CONFIG.WeaponFeature.otherwordly.effects.otherwordly.description",
+      "img": "icons/weapons/swords/sword-flanged-lightning.webp",
+      "system": {
+        "changes": [
+          {
+            "key": "system.rules.attack.damage.canChooseDamageType",
+            "type": "override",
+            "value": 1,
+            "phase": "initial"
+          }
+        ],
+        "duration": {
+          "description": ""
+        },
+        "rangeDependence": null,
+        "stacking": null,
+        "targetDispositions": []
+      },
+      "_id": "WT5wBYRkENaUPvBw",
+      "type": "base",
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!items.effects!6gFvOFTE97QZ74Zr.WT5wBYRkENaUPvBw"
+    }
+  ],
   "sort": 0,
   "flags": {},
   "_key": "!items!6gFvOFTE97QZ74Zr"

--- a/styles/less/global/dialog.less
+++ b/styles/less/global/dialog.less
@@ -58,12 +58,19 @@
 
     .damage-formula {
         display: flex;
+        align-items: center;
         justify-content: space-between;
+        
         .damage-details {
-            font-style: italic;
             display: flex;
             align-items: center;
             gap: 5px;
+
+            .damage-choice {
+                display: flex;
+                align-items: center;
+                gap: 2px;
+            }
         }
     }
 

--- a/templates/dialogs/dice-roll/damageSelection.hbs
+++ b/templates/dialogs/dice-roll/damageSelection.hbs
@@ -38,13 +38,21 @@
             <div class="damage-formula">
                 <span class="damage-resource"><b>{{localize "DAGGERHEART.GENERAL.formula"}}:</b> {{roll.formula}}</span>
                 <span class="damage-details">
-                    {{localize "DAGGERHEART.GENERAL.damage"}}
                     {{#if damageTypes}}
-                        {{#each damageTypes as | type | }}
-                            {{#with (lookup @root.config.GENERAL.damageTypes type)}}
-                                <i class="fa-solid {{icon}}"></i>
-                            {{/with}}
-                        {{/each}}
+                        {{#if @root.canChooseDamageType}}
+                            {{#each @root.damageTypesChoices as | choice |}}
+                                <div class="damage-choice">
+                                    <input type="radio" data-action="updateDamageType" data-type="{{choice.id}}" {{#if choice.selected}}checked{{/if}}>
+                                    <i class="fa-solid {{choice.icon}}" data-tooltip="{{localize choice.label}}"></i>
+                                </div>
+                            {{/each}}
+                        {{else}}
+                            {{#each damageTypes as | type | }}
+                                {{#with (lookup @root.config.GENERAL.damageTypes type)}}
+                                    <i class="fa-solid {{icon}}"></i>
+                                {{/with}}
+                            {{/each}}
+                        {{/if}}
                     {{/if}}
                 </span>
             </div>


### PR DESCRIPTION
Added support for `Otherwordly` via a rules effect that allows you to select your damage type in the DamageDialog.
<img width="422" height="58" alt="image" src="https://github.com/user-attachments/assets/fac8231f-913a-4add-9d93-82fd748c43c9" />

<img width="513" height="309" alt="image" src="https://github.com/user-attachments/assets/dfe9a01f-7127-4f17-ac5c-aa89c6238f7b" />

----
Implementation details to note:
- I added a user flag that stores which damage type the user chose last. This is used for which initial damage type should be selected when selection is available in the DamageDialog. Since I put it on the user, it does mean that if you have more than one items/things that let you select damage type, they don't individually track your last preference. 
I think this is fine though, or perhaps even preferable.
- The way I set it up only really works for a weapon. I added a check so that the choice is only available if the DamageDialog is popped by the item that has the ActiveEffect rule on itself. This is so that someone with a `Ghostblade` doesn't get to choose to make their fireballs physical.