### PR TITLE
[Feature] Martial Stances

### DIFF
--- a/src/packs/subclasses/feature_Aggressive_RoG3RZWVnTK6TYFI.json
+++ b/src/packs/subclasses/feature_Aggressive_RoG3RZWVnTK6TYFI.json
@@ -1,0 +1,106 @@
+{
+  "folder": "K1Zh9uNgiR5UlOOE",
+  "name": "Aggressive",
+  "type": "feature",
+  "_id": "RoG3RZWVnTK6TYFI",
+  "img": "icons/skills/melee/maneuver-greatsword-yellow.webp",
+  "system": {
+    "attribution": {},
+    "description": "<p>Gain a -1 penalty to your Evasion. On a successful attack, roll an additional damage die and discard the lowest result.</p>",
+    "gmNotes": "",
+    "resource": null,
+    "actions": {
+      "9AsdA0xwYlajciA0": {
+        "type": "effect",
+        "_id": "9AsdA0xwYlajciA0",
+        "systemPath": "actions",
+        "baseAction": false,
+        "description": "",
+        "chatDisplay": true,
+        "originItem": {
+          "type": "itemCollection"
+        },
+        "actionType": "action",
+        "triggers": [],
+        "areas": [],
+        "cost": [],
+        "uses": {
+          "value": null,
+          "max": "",
+          "recovery": null,
+          "consumeOnSuccess": false
+        },
+        "effects": [
+          {
+            "_id": "SbL1r4YtyDX6eYLe",
+            "onSave": false
+          }
+        ],
+        "target": {
+          "type": "self",
+          "amount": null
+        },
+        "name": "Enter Stance",
+        "range": "self"
+      }
+    },
+    "granter": null,
+    "featureForm": "passive"
+  },
+  "effects": [
+    {
+      "name": "Stance: Aggressive",
+      "disabled": false,
+      "img": "icons/skills/melee/maneuver-greatsword-yellow.webp",
+      "description": "<p>Gain a -1 penalty to your Evasion. On a successful attack, roll an additional damage die and discard the lowest result.</p>",
+      "transfer": false,
+      "statuses": [],
+      "system": {
+        "changes": [
+          {
+            "key": "system.evasion",
+            "type": "subtract",
+            "value": 1,
+            "priority": null,
+            "phase": "initial"
+          }
+        ],
+        "duration": {
+          "description": "",
+          "type": "scene"
+        },
+        "rangeDependence": null,
+        "stacking": null,
+        "targetDispositions": []
+      },
+      "_id": "SbL1r4YtyDX6eYLe",
+      "type": "base",
+      "start": {
+        "time": 0,
+        "combat": null,
+        "combatant": null,
+        "initiative": null,
+        "round": null,
+        "turn": null
+      },
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "tint": "#ffffff",
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!items.effects!RoG3RZWVnTK6TYFI.SbL1r4YtyDX6eYLe"
+    }
+  ],
+  "sort": 0,
+  "flags": {},
+  "_key": "!items!RoG3RZWVnTK6TYFI"
+}

--- a/src/packs/subclasses/feature_Anchored_uLRkOyvk0n9QpZSi.json
+++ b/src/packs/subclasses/feature_Anchored_uLRkOyvk0n9QpZSi.json
@@ -1,0 +1,113 @@
+{
+  "folder": "K1Zh9uNgiR5UlOOE",
+  "name": "Anchored",
+  "type": "feature",
+  "_id": "uLRkOyvk0n9QpZSi",
+  "img": "icons/commodities/metal/mail-plate-steel.webp",
+  "system": {
+    "attribution": {},
+    "description": "<p>Gain a +2 bonus to your damage thresholds. While in this stance, you can't be moved against your will.</p>",
+    "gmNotes": "",
+    "resource": null,
+    "actions": {
+      "ZwzPSA5XCwLCzUJw": {
+        "type": "effect",
+        "_id": "ZwzPSA5XCwLCzUJw",
+        "systemPath": "actions",
+        "baseAction": false,
+        "description": "",
+        "chatDisplay": true,
+        "originItem": {
+          "type": "itemCollection"
+        },
+        "actionType": "action",
+        "triggers": [],
+        "areas": [],
+        "cost": [],
+        "uses": {
+          "value": null,
+          "max": "",
+          "recovery": null,
+          "consumeOnSuccess": false
+        },
+        "effects": [
+          {
+            "_id": "lIOscgRKYhFlGa9y",
+            "onSave": false
+          }
+        ],
+        "target": {
+          "type": "self",
+          "amount": null
+        },
+        "name": "Enter Stance",
+        "range": "self"
+      }
+    },
+    "granter": null,
+    "featureForm": "passive"
+  },
+  "effects": [
+    {
+      "name": "Stance: Anchored",
+      "disabled": false,
+      "img": "icons/commodities/metal/mail-plate-steel.webp",
+      "description": "<p>Gain a +2 bonus to your damage thresholds. While in this stance, you can't be moved against your will.</p>",
+      "transfer": false,
+      "statuses": [],
+      "system": {
+        "changes": [
+          {
+            "key": "system.damageThresholds.major",
+            "type": "add",
+            "value": 2,
+            "priority": null,
+            "phase": "initial"
+          },
+          {
+            "key": "system.damageThresholds.severe",
+            "type": "add",
+            "value": 2,
+            "priority": null,
+            "phase": "initial"
+          }
+        ],
+        "duration": {
+          "description": "",
+          "type": "scene"
+        },
+        "rangeDependence": null,
+        "stacking": null,
+        "targetDispositions": []
+      },
+      "_id": "lIOscgRKYhFlGa9y",
+      "type": "base",
+      "start": {
+        "time": 0,
+        "combat": null,
+        "combatant": null,
+        "initiative": null,
+        "round": null,
+        "turn": null
+      },
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "tint": "#ffffff",
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!items.effects!uLRkOyvk0n9QpZSi.lIOscgRKYhFlGa9y"
+    }
+  ],
+  "sort": 0,
+  "flags": {},
+  "_key": "!items!uLRkOyvk0n9QpZSi"
+}

--- a/src/packs/subclasses/feature_Crushing_3IT4w3WExpGFD3Mm.json
+++ b/src/packs/subclasses/feature_Crushing_3IT4w3WExpGFD3Mm.json
@@ -1,0 +1,167 @@
+{
+  "folder": "lWpkV14I1qmLrVHt",
+  "name": "Crushing",
+  "type": "feature",
+  "_id": "3IT4w3WExpGFD3Mm",
+  "img": "icons/skills/melee/strike-hammer-destructive-blue.webp",
+  "system": {
+    "attribution": {},
+    "description": "<p>When you deal Severe damage, you can <strong>spend a Hope</strong> to force the target to mark an additional Hit Point.</p>",
+    "gmNotes": "",
+    "resource": null,
+    "actions": {
+      "TAnFMnKyuU8AvRvm": {
+        "type": "effect",
+        "_id": "TAnFMnKyuU8AvRvm",
+        "systemPath": "actions",
+        "baseAction": false,
+        "description": "",
+        "chatDisplay": true,
+        "originItem": {
+          "type": "itemCollection"
+        },
+        "actionType": "action",
+        "triggers": [],
+        "areas": [],
+        "cost": [],
+        "uses": {
+          "value": null,
+          "max": "",
+          "recovery": null,
+          "consumeOnSuccess": false
+        },
+        "effects": [
+          {
+            "_id": "wTLu5PCb5tVANoXR",
+            "onSave": false
+          }
+        ],
+        "target": {
+          "type": "self",
+          "amount": null
+        },
+        "name": "Enter Stance",
+        "range": "self"
+      },
+      "SNQbyaTZxSfPUjyx": {
+        "type": "damage",
+        "damage": {
+          "main": null,
+          "resources": {
+            "hitPoints": {
+              "base": false,
+              "applyTo": "hitPoints",
+              "resultBased": false,
+              "fullRestore": false,
+              "value": {
+                "multiplier": "flat",
+                "flatMultiplier": 0,
+                "dice": "d6",
+                "bonus": 1,
+                "custom": {
+                  "enabled": false,
+                  "formula": ""
+                }
+              },
+              "valueAlt": {
+                "multiplier": "flat",
+                "flatMultiplier": 1,
+                "dice": "d6",
+                "bonus": null,
+                "custom": {
+                  "enabled": false,
+                  "formula": ""
+                }
+              }
+            }
+          }
+        },
+        "_id": "SNQbyaTZxSfPUjyx",
+        "systemPath": "actions",
+        "baseAction": false,
+        "description": "",
+        "chatDisplay": true,
+        "originItem": {
+          "type": "itemCollection"
+        },
+        "actionType": "action",
+        "triggers": [],
+        "areas": [],
+        "cost": [
+          {
+            "itemId": null,
+            "key": "hope",
+            "value": 1,
+            "scalable": false,
+            "step": null,
+            "consumeOnSuccess": false
+          }
+        ],
+        "uses": {
+          "value": null,
+          "max": "",
+          "recovery": null,
+          "consumeOnSuccess": false
+        },
+        "target": {
+          "type": "any",
+          "amount": null
+        },
+        "effects": [],
+        "name": "Spend Hope",
+        "range": "",
+        "img": "icons/skills/melee/strike-slashes-orange.webp"
+      }
+    },
+    "granter": null,
+    "featureForm": "passive"
+  },
+  "effects": [
+    {
+      "name": "Stance: Crushing",
+      "disabled": false,
+      "img": "icons/skills/melee/strike-hammer-destructive-blue.webp",
+      "description": "<p>When you deal Severe damage, you can <strong>spend a Hope</strong> to force the target to mark an additional Hit Point.</p>",
+      "transfer": false,
+      "statuses": [],
+      "system": {
+        "changes": [],
+        "duration": {
+          "description": "",
+          "type": "scene"
+        },
+        "rangeDependence": null,
+        "stacking": null,
+        "targetDispositions": []
+      },
+      "_id": "wTLu5PCb5tVANoXR",
+      "type": "base",
+      "start": {
+        "time": 0,
+        "combat": null,
+        "combatant": null,
+        "initiative": null,
+        "round": null,
+        "turn": null
+      },
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "tint": "#ffffff",
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!items.effects!3IT4w3WExpGFD3Mm.wTLu5PCb5tVANoXR"
+    }
+  ],
+  "sort": 0,
+  "flags": {},
+  "_key": "!items!3IT4w3WExpGFD3Mm"
+}

--- a/src/packs/subclasses/feature_Defensive_YGQ7hhRGrYm8BFDP.json
+++ b/src/packs/subclasses/feature_Defensive_YGQ7hhRGrYm8BFDP.json
@@ -1,0 +1,98 @@
+{
+  "folder": "K1Zh9uNgiR5UlOOE",
+  "name": "Defensive",
+  "type": "feature",
+  "_id": "YGQ7hhRGrYm8BFDP",
+  "img": "icons/magic/defensive/shield-barrier-deflect-teal.webp",
+  "system": {
+    "attribution": {},
+    "description": "<p>Attack rolls targeting you from within Melee range have disadvantage unless the attacker marks a Stress to negate the disadvantage.</p>",
+    "gmNotes": "",
+    "resource": null,
+    "actions": {
+      "syX0fPaPNwVqpwBP": {
+        "type": "effect",
+        "_id": "syX0fPaPNwVqpwBP",
+        "systemPath": "actions",
+        "baseAction": false,
+        "description": "",
+        "chatDisplay": true,
+        "originItem": {
+          "type": "itemCollection"
+        },
+        "actionType": "action",
+        "triggers": [],
+        "areas": [],
+        "cost": [],
+        "uses": {
+          "value": null,
+          "max": "",
+          "recovery": null,
+          "consumeOnSuccess": false
+        },
+        "effects": [
+          {
+            "_id": "cEi6RO2te92zNqm2",
+            "onSave": false
+          }
+        ],
+        "target": {
+          "type": "self",
+          "amount": null
+        },
+        "name": "Enter Stance",
+        "range": "self"
+      }
+    },
+    "granter": null,
+    "featureForm": "passive"
+  },
+  "effects": [
+    {
+      "name": "Stance: Defensive",
+      "disabled": false,
+      "img": "icons/magic/defensive/shield-barrier-deflect-teal.webp",
+      "description": "<p>Attack rolls targeting you from within Melee range have disadvantage unless the attacker marks a Stress to negate the disadvantage.</p>",
+      "transfer": false,
+      "statuses": [],
+      "system": {
+        "changes": [],
+        "duration": {
+          "description": "",
+          "type": "scene"
+        },
+        "rangeDependence": null,
+        "stacking": null,
+        "targetDispositions": []
+      },
+      "_id": "cEi6RO2te92zNqm2",
+      "type": "base",
+      "start": {
+        "time": 0,
+        "combat": null,
+        "combatant": null,
+        "initiative": null,
+        "round": null,
+        "turn": null
+      },
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "tint": "#ffffff",
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!items.effects!YGQ7hhRGrYm8BFDP.cEi6RO2te92zNqm2"
+    }
+  ],
+  "sort": 0,
+  "flags": {},
+  "_key": "!items!YGQ7hhRGrYm8BFDP"
+}

--- a/src/packs/subclasses/feature_Exacting_hzDDTkBp1cqMOq7z.json
+++ b/src/packs/subclasses/feature_Exacting_hzDDTkBp1cqMOq7z.json
@@ -1,0 +1,98 @@
+{
+  "folder": "lWpkV14I1qmLrVHt",
+  "name": "Exacting",
+  "type": "feature",
+  "_id": "hzDDTkBp1cqMOq7z",
+  "img": "icons/skills/melee/strike-axe-red.webp",
+  "system": {
+    "attribution": {},
+    "description": "<p>When you roll a 1 on a damage die, you can treat it as the highest value on the die instead.</p>",
+    "gmNotes": "",
+    "resource": null,
+    "actions": {
+      "HJqhV6t6uDlh7aWd": {
+        "type": "effect",
+        "_id": "HJqhV6t6uDlh7aWd",
+        "systemPath": "actions",
+        "baseAction": false,
+        "description": "",
+        "chatDisplay": true,
+        "originItem": {
+          "type": "itemCollection"
+        },
+        "actionType": "action",
+        "triggers": [],
+        "areas": [],
+        "cost": [],
+        "uses": {
+          "value": null,
+          "max": "",
+          "recovery": null,
+          "consumeOnSuccess": false
+        },
+        "effects": [
+          {
+            "_id": "lDRAICtZPyjMWKgB",
+            "onSave": false
+          }
+        ],
+        "target": {
+          "type": "self",
+          "amount": null
+        },
+        "name": "Enter Stance",
+        "range": "self"
+      }
+    },
+    "granter": null,
+    "featureForm": "passive"
+  },
+  "effects": [
+    {
+      "name": "Stance: Exacting",
+      "disabled": false,
+      "img": "icons/skills/melee/strike-axe-red.webp",
+      "description": "<p>When you roll a 1 on a damage die, you can treat it as the highest value on the die instead.</p>",
+      "transfer": false,
+      "statuses": [],
+      "system": {
+        "changes": [],
+        "duration": {
+          "description": "",
+          "type": "scene"
+        },
+        "rangeDependence": null,
+        "stacking": null,
+        "targetDispositions": []
+      },
+      "_id": "lDRAICtZPyjMWKgB",
+      "type": "base",
+      "start": {
+        "time": 0,
+        "combat": null,
+        "combatant": null,
+        "initiative": null,
+        "round": null,
+        "turn": null
+      },
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "tint": "#ffffff",
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!items.effects!hzDDTkBp1cqMOq7z.lDRAICtZPyjMWKgB"
+    }
+  ],
+  "sort": 0,
+  "flags": {},
+  "_key": "!items!hzDDTkBp1cqMOq7z"
+}

--- a/src/packs/subclasses/feature_Favored_W95PSU4iXjg2v5B5.json
+++ b/src/packs/subclasses/feature_Favored_W95PSU4iXjg2v5B5.json
@@ -1,0 +1,114 @@
+{
+  "folder": "M1QUCqLVHPOiWSPz",
+  "name": "Favored",
+  "type": "feature",
+  "_id": "W95PSU4iXjg2v5B5",
+  "img": "icons/magic/defensive/shield-hex-purple.webp",
+  "system": {
+    "attribution": {},
+    "description": "<p>Gain a bonus to damage rolls equal to a trait of your choice.</p>",
+    "gmNotes": "",
+    "resource": null,
+    "actions": {
+      "ohod7ZWfrILMq3dc": {
+        "type": "effect",
+        "_id": "ohod7ZWfrILMq3dc",
+        "systemPath": "actions",
+        "baseAction": false,
+        "description": "",
+        "chatDisplay": true,
+        "originItem": {
+          "type": "itemCollection"
+        },
+        "actionType": "action",
+        "triggers": [],
+        "areas": [],
+        "cost": [],
+        "uses": {
+          "value": null,
+          "max": "",
+          "recovery": null,
+          "consumeOnSuccess": false
+        },
+        "effects": [
+          {
+            "_id": "M3HdEjgCvl15S9HO",
+            "onSave": false
+          }
+        ],
+        "target": {
+          "type": "self",
+          "amount": null
+        },
+        "name": "Enter Stance",
+        "range": "self",
+        "img": "icons/magic/defensive/shield-hex-purple.webp"
+      }
+    },
+    "granter": null,
+    "featureForm": "passive"
+  },
+  "effects": [
+    {
+      "name": "Stance: Favored",
+      "disabled": false,
+      "img": "icons/magic/defensive/shield-hex-purple.webp",
+      "description": "<p>Gain a bonus to damage rolls equal to a trait of your choice.</p>",
+      "transfer": false,
+      "statuses": [],
+      "system": {
+        "changes": [
+          {
+            "key": "system.bonuses.damage.physical.bonus",
+            "type": "add",
+            "value": "@system.traits.instinct.value",
+            "priority": null,
+            "phase": "initial"
+          },
+          {
+            "key": "system.bonuses.damage.magical.bonus",
+            "type": "add",
+            "value": "@system.traits.instinct.value",
+            "priority": null,
+            "phase": "initial"
+          }
+        ],
+        "duration": {
+          "description": "",
+          "type": "scene"
+        },
+        "rangeDependence": null,
+        "stacking": null,
+        "targetDispositions": []
+      },
+      "_id": "M3HdEjgCvl15S9HO",
+      "type": "base",
+      "start": {
+        "time": 0,
+        "combat": null,
+        "combatant": null,
+        "initiative": null,
+        "round": null,
+        "turn": null
+      },
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "tint": "#ffffff",
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!items.effects!W95PSU4iXjg2v5B5.M3HdEjgCvl15S9HO"
+    }
+  ],
+  "sort": 0,
+  "flags": {},
+  "_key": "!items!W95PSU4iXjg2v5B5"
+}

--- a/src/packs/subclasses/feature_Grappling_aN9OhwIJXTCDc11u.json
+++ b/src/packs/subclasses/feature_Grappling_aN9OhwIJXTCDc11u.json
@@ -1,0 +1,186 @@
+{
+  "folder": "pwYRu6UvwBmqS8L1",
+  "name": "Grappling",
+  "type": "feature",
+  "_id": "aN9OhwIJXTCDc11u",
+  "img": "icons/magic/control/debuff-chains-blue.webp",
+  "system": {
+    "attribution": {},
+    "description": "<p>On a successful attack within Melee range, you can <strong>spend a Focu</strong>s or <strong>mark a Stress</strong> to temporarily <em>Restrain</em> the target or throw the target up to Close range.</p>",
+    "gmNotes": "",
+    "resource": null,
+    "actions": {
+      "K7VYEEaUWQN0hifO": {
+        "type": "effect",
+        "_id": "K7VYEEaUWQN0hifO",
+        "systemPath": "actions",
+        "baseAction": false,
+        "description": "",
+        "chatDisplay": true,
+        "originItem": {
+          "type": "itemCollection"
+        },
+        "actionType": "action",
+        "triggers": [],
+        "areas": [],
+        "cost": [],
+        "uses": {
+          "value": null,
+          "max": "",
+          "recovery": null,
+          "consumeOnSuccess": false
+        },
+        "effects": [
+          {
+            "_id": "zmML95HUwWUM8RqY",
+            "onSave": false
+          }
+        ],
+        "target": {
+          "type": "self",
+          "amount": null
+        },
+        "name": "Enter Stance",
+        "range": "self"
+      },
+      "ruHvEPZuzierWilg": {
+        "type": "effect",
+        "_id": "ruHvEPZuzierWilg",
+        "systemPath": "actions",
+        "baseAction": false,
+        "description": "",
+        "chatDisplay": true,
+        "originItem": {
+          "type": "itemCollection"
+        },
+        "actionType": "action",
+        "triggers": [],
+        "areas": [],
+        "cost": [
+          {
+            "scalable": false,
+            "key": "stress",
+            "value": 1,
+            "itemId": null,
+            "step": null,
+            "consumeOnSuccess": false
+          }
+        ],
+        "uses": {
+          "value": null,
+          "max": "",
+          "recovery": null,
+          "consumeOnSuccess": false
+        },
+        "effects": [
+          {
+            "_id": "0aPQdN2Anbw7WLph",
+            "onSave": false
+          }
+        ],
+        "target": {
+          "type": "any",
+          "amount": null
+        },
+        "name": "Grapple",
+        "range": "",
+        "img": "icons/magic/movement/trail-streak-impact-blue.webp"
+      }
+    },
+    "granter": null,
+    "featureForm": "passive"
+  },
+  "effects": [
+    {
+      "name": "Stance: Grappling",
+      "disabled": false,
+      "img": "icons/magic/control/debuff-chains-blue.webp",
+      "description": "<p>On a successful attack within Melee range, you can <strong>spend a Focu</strong>s or <strong>mark a Stress</strong> to temporarily <em>Restrain</em> the target or throw the target up to Close range.</p>",
+      "transfer": false,
+      "statuses": [],
+      "system": {
+        "changes": [],
+        "duration": {
+          "description": "",
+          "type": "scene"
+        },
+        "rangeDependence": null,
+        "stacking": null,
+        "targetDispositions": []
+      },
+      "_id": "zmML95HUwWUM8RqY",
+      "type": "base",
+      "start": {
+        "time": 0,
+        "combat": null,
+        "combatant": null,
+        "initiative": null,
+        "round": null,
+        "turn": null
+      },
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "tint": "#ffffff",
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!items.effects!aN9OhwIJXTCDc11u.zmML95HUwWUM8RqY"
+    },
+    {
+      "name": "Grabbed",
+      "disabled": false,
+      "img": "icons/magic/control/debuff-chains-shackle-movement-red.webp",
+      "description": "",
+      "transfer": true,
+      "statuses": [
+        "restrained"
+      ],
+      "system": {
+        "changes": [],
+        "duration": {
+          "description": "",
+          "type": ""
+        },
+        "rangeDependence": null,
+        "stacking": null,
+        "targetDispositions": []
+      },
+      "_id": "0aPQdN2Anbw7WLph",
+      "type": "base",
+      "start": {
+        "time": 0,
+        "combat": null,
+        "combatant": null,
+        "initiative": null,
+        "round": null,
+        "turn": null
+      },
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "tint": "#ffffff",
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!items.effects!aN9OhwIJXTCDc11u.0aPQdN2Anbw7WLph"
+    }
+  ],
+  "sort": 0,
+  "flags": {},
+  "_key": "!items!aN9OhwIJXTCDc11u"
+}

--- a/src/packs/subclasses/feature_Honed_aJKTuq1Ja5o9lB16.json
+++ b/src/packs/subclasses/feature_Honed_aJKTuq1Ja5o9lB16.json
@@ -1,0 +1,183 @@
+{
+  "folder": "lWpkV14I1qmLrVHt",
+  "name": "Honed",
+  "type": "feature",
+  "_id": "aJKTuq1Ja5o9lB16",
+  "img": "icons/magic/control/buff-strength-muscle-damage-orange.webp",
+  "system": {
+    "attribution": {},
+    "description": "<p><strong>Spend a Focus</strong> before you make an attack roll to gain a +1 bonus to your Proficiency for that attack.</p>",
+    "gmNotes": "",
+    "resource": null,
+    "actions": {
+      "Xs4xgmFwibfOp6Ky": {
+        "type": "effect",
+        "_id": "Xs4xgmFwibfOp6Ky",
+        "systemPath": "actions",
+        "baseAction": false,
+        "description": "",
+        "chatDisplay": true,
+        "originItem": {
+          "type": "itemCollection"
+        },
+        "actionType": "action",
+        "triggers": [],
+        "areas": [],
+        "cost": [],
+        "uses": {
+          "value": null,
+          "max": "",
+          "recovery": null,
+          "consumeOnSuccess": false
+        },
+        "effects": [
+          {
+            "_id": "HkFjCOTppPwFhoDD",
+            "onSave": false
+          }
+        ],
+        "target": {
+          "type": "self",
+          "amount": null
+        },
+        "name": "Enter Stance",
+        "range": "self"
+      },
+      "InclNwt5wzExUNUc": {
+        "type": "effect",
+        "_id": "InclNwt5wzExUNUc",
+        "systemPath": "actions",
+        "baseAction": false,
+        "description": "",
+        "chatDisplay": true,
+        "originItem": {
+          "type": "itemCollection"
+        },
+        "actionType": "action",
+        "triggers": [],
+        "areas": [],
+        "cost": [],
+        "uses": {
+          "value": null,
+          "max": "",
+          "recovery": null,
+          "consumeOnSuccess": false
+        },
+        "effects": [
+          {
+            "_id": "dyHrEgxlTrZPrV0p",
+            "onSave": false
+          }
+        ],
+        "target": {
+          "type": "self",
+          "amount": null
+        },
+        "name": "Spend Focus",
+        "range": "self",
+        "img": "icons/magic/control/buff-flight-wings-runes-red-yellow.webp"
+      }
+    },
+    "granter": null,
+    "featureForm": "passive"
+  },
+  "effects": [
+    {
+      "name": "Stance: Honed",
+      "disabled": false,
+      "img": "icons/magic/control/buff-strength-muscle-damage-orange.webp",
+      "description": "<p><strong>Spend a Focus</strong> before you make an attack roll to gain a +1 bonus to your Proficiency for that attack.</p>",
+      "transfer": false,
+      "statuses": [],
+      "system": {
+        "changes": [],
+        "duration": {
+          "description": "",
+          "type": "scene"
+        },
+        "rangeDependence": null,
+        "stacking": null,
+        "targetDispositions": []
+      },
+      "_id": "HkFjCOTppPwFhoDD",
+      "type": "base",
+      "start": {
+        "time": 0,
+        "combat": null,
+        "combatant": null,
+        "initiative": null,
+        "round": null,
+        "turn": null
+      },
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "tint": "#ffffff",
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!items.effects!aJKTuq1Ja5o9lB16.HkFjCOTppPwFhoDD"
+    },
+    {
+      "name": "Honed",
+      "disabled": false,
+      "img": "icons/magic/control/buff-flight-wings-runes-red-yellow.webp",
+      "description": "<p>Gain a +1 bonus to your Proficiency for that attack.</p>",
+      "transfer": false,
+      "statuses": [],
+      "system": {
+        "changes": [
+          {
+            "key": "system.proficiency",
+            "type": "add",
+            "value": 1,
+            "priority": null,
+            "phase": "initial"
+          }
+        ],
+        "duration": {
+          "description": "",
+          "type": ""
+        },
+        "rangeDependence": null,
+        "stacking": null,
+        "targetDispositions": []
+      },
+      "_id": "dyHrEgxlTrZPrV0p",
+      "type": "base",
+      "start": {
+        "time": 0,
+        "combat": null,
+        "combatant": null,
+        "initiative": null,
+        "round": null,
+        "turn": null
+      },
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "tint": "#ffffff",
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!items.effects!aJKTuq1Ja5o9lB16.dyHrEgxlTrZPrV0p"
+    }
+  ],
+  "sort": 0,
+  "flags": {},
+  "_key": "!items!aJKTuq1Ja5o9lB16"
+}

--- a/src/packs/subclasses/feature_Invigorating_ewgpPblJAcHCHPUO.json
+++ b/src/packs/subclasses/feature_Invigorating_ewgpPblJAcHCHPUO.json
@@ -1,0 +1,152 @@
+{
+  "folder": "M1QUCqLVHPOiWSPz",
+  "name": "Invigorating",
+  "type": "feature",
+  "_id": "ewgpPblJAcHCHPUO",
+  "img": "icons/magic/life/cross-beam-green.webp",
+  "system": {
+    "attribution": {},
+    "description": "<p>On a successful attack, roll a d4. On a result of 4, gain a Focus.</p>",
+    "gmNotes": "",
+    "resource": null,
+    "actions": {
+      "1xtWty9JmQwHDr5p": {
+        "type": "effect",
+        "_id": "1xtWty9JmQwHDr5p",
+        "systemPath": "actions",
+        "baseAction": false,
+        "description": "",
+        "chatDisplay": true,
+        "originItem": {
+          "type": "itemCollection"
+        },
+        "actionType": "action",
+        "triggers": [],
+        "areas": [],
+        "cost": [],
+        "uses": {
+          "value": null,
+          "max": "",
+          "recovery": null,
+          "consumeOnSuccess": false
+        },
+        "effects": [
+          {
+            "_id": "ZW4pQL4QoTFKL7Ry",
+            "onSave": false
+          }
+        ],
+        "target": {
+          "type": "self",
+          "amount": null
+        },
+        "name": "Enter Stance",
+        "range": "self",
+        "img": "icons/magic/life/cross-beam-green.webp"
+      },
+      "L5Uhj2wnmfMhSCP6": {
+        "type": "attack",
+        "damage": {
+          "main": null,
+          "resources": {}
+        },
+        "_id": "L5Uhj2wnmfMhSCP6",
+        "systemPath": "actions",
+        "baseAction": false,
+        "description": "",
+        "chatDisplay": true,
+        "originItem": {
+          "type": "itemCollection"
+        },
+        "actionType": "action",
+        "triggers": [],
+        "areas": [],
+        "cost": [],
+        "uses": {
+          "value": null,
+          "max": "",
+          "recovery": null,
+          "consumeOnSuccess": false
+        },
+        "target": {
+          "type": "any",
+          "amount": null
+        },
+        "effects": [],
+        "roll": {
+          "type": "diceSet",
+          "trait": null,
+          "difficulty": null,
+          "bonus": null,
+          "advState": "neutral",
+          "diceRolling": {
+            "multiplier": "flat",
+            "flatMultiplier": 1,
+            "dice": "d6",
+            "compare": "aboveEqual",
+            "treshold": 4
+          },
+          "useDefault": false
+        },
+        "save": {
+          "trait": null,
+          "difficulty": null,
+          "damageMod": "none"
+        },
+        "name": "Roll D4",
+        "range": "",
+        "img": "icons/magic/life/cross-beam-green.webp"
+      }
+    },
+    "granter": null,
+    "featureForm": "passive"
+  },
+  "effects": [
+    {
+      "name": "Stance: Invigorating",
+      "disabled": false,
+      "img": "icons/magic/life/cross-beam-green.webp",
+      "description": "<p>On a successful attack, roll a d4. On a result of 4, gain a Focus.</p>",
+      "transfer": false,
+      "statuses": [],
+      "system": {
+        "changes": [],
+        "duration": {
+          "description": "",
+          "type": "scene"
+        },
+        "rangeDependence": null,
+        "stacking": null,
+        "targetDispositions": []
+      },
+      "_id": "ZW4pQL4QoTFKL7Ry",
+      "type": "base",
+      "start": {
+        "time": 0,
+        "combat": null,
+        "combatant": null,
+        "initiative": null,
+        "round": null,
+        "turn": null
+      },
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "tint": "#ffffff",
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!items.effects!ewgpPblJAcHCHPUO.ZW4pQL4QoTFKL7Ry"
+    }
+  ],
+  "sort": 0,
+  "flags": {},
+  "_key": "!items!ewgpPblJAcHCHPUO"
+}

--- a/src/packs/subclasses/feature_Isolating_QVKgnF8eUwbX8K9H.json
+++ b/src/packs/subclasses/feature_Isolating_QVKgnF8eUwbX8K9H.json
@@ -1,0 +1,106 @@
+{
+  "folder": "lWpkV14I1qmLrVHt",
+  "name": "Isolating",
+  "type": "feature",
+  "_id": "QVKgnF8eUwbX8K9H",
+  "img": "icons/magic/control/control-influence-rally-purple.webp",
+  "system": {
+    "attribution": {},
+    "description": "<p>Gain advantage on attack rolls when there are no other creatures within Very Close range of you or your target.</p>",
+    "gmNotes": "",
+    "resource": null,
+    "actions": {
+      "ZqZgI5Pc2qFFBt5o": {
+        "type": "effect",
+        "_id": "ZqZgI5Pc2qFFBt5o",
+        "systemPath": "actions",
+        "baseAction": false,
+        "description": "",
+        "chatDisplay": true,
+        "originItem": {
+          "type": "itemCollection"
+        },
+        "actionType": "action",
+        "triggers": [],
+        "areas": [],
+        "cost": [],
+        "uses": {
+          "value": null,
+          "max": "",
+          "recovery": null,
+          "consumeOnSuccess": false
+        },
+        "effects": [
+          {
+            "_id": "GcjxmDtqCU7J0IU3",
+            "onSave": false
+          }
+        ],
+        "target": {
+          "type": "self",
+          "amount": null
+        },
+        "name": "Enter Stance",
+        "range": "self"
+      }
+    },
+    "granter": null,
+    "featureForm": "passive"
+  },
+  "effects": [
+    {
+      "name": "Stance: Isolating",
+      "disabled": false,
+      "img": "icons/magic/control/control-influence-rally-purple.webp",
+      "description": "<p>Gain advantage on attack rolls when there are no other creatures within Very Close range of you or your target.</p>",
+      "transfer": false,
+      "statuses": [],
+      "system": {
+        "changes": [
+          {
+            "key": "system.advantageSources",
+            "type": "add",
+            "value": "Attack rolls when there are no other creatures within Very Close range of you or your target",
+            "priority": null,
+            "phase": "initial"
+          }
+        ],
+        "duration": {
+          "description": "",
+          "type": "scene"
+        },
+        "rangeDependence": null,
+        "stacking": null,
+        "targetDispositions": []
+      },
+      "_id": "GcjxmDtqCU7J0IU3",
+      "type": "base",
+      "start": {
+        "time": 0,
+        "combat": null,
+        "combatant": null,
+        "initiative": null,
+        "round": null,
+        "turn": null
+      },
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "tint": "#ffffff",
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!items.effects!QVKgnF8eUwbX8K9H.GcjxmDtqCU7J0IU3"
+    }
+  ],
+  "sort": 0,
+  "flags": {},
+  "_key": "!items!QVKgnF8eUwbX8K9H"
+}

--- a/src/packs/subclasses/feature_Otherwordly_K2R2i8dhtNnY9MYR.json
+++ b/src/packs/subclasses/feature_Otherwordly_K2R2i8dhtNnY9MYR.json
@@ -1,0 +1,98 @@
+{
+  "folder": "K1Zh9uNgiR5UlOOE",
+  "name": "Otherwordly",
+  "type": "feature",
+  "_id": "K2R2i8dhtNnY9MYR",
+  "img": "icons/skills/melee/strike-weapon-polearm-ice-blue.webp",
+  "system": {
+    "attribution": {},
+    "description": "<p>On a successful attack, you can deal physical or magic damage.</p>",
+    "gmNotes": "",
+    "resource": null,
+    "actions": {
+      "R6KliyvYNNvAzMbz": {
+        "type": "effect",
+        "_id": "R6KliyvYNNvAzMbz",
+        "systemPath": "actions",
+        "baseAction": false,
+        "description": "",
+        "chatDisplay": true,
+        "originItem": {
+          "type": "itemCollection"
+        },
+        "actionType": "action",
+        "triggers": [],
+        "areas": [],
+        "cost": [],
+        "uses": {
+          "value": null,
+          "max": "",
+          "recovery": null,
+          "consumeOnSuccess": false
+        },
+        "effects": [
+          {
+            "_id": "RtscqiOS754ouvOM",
+            "onSave": false
+          }
+        ],
+        "target": {
+          "type": "self",
+          "amount": null
+        },
+        "name": "Enter Stance",
+        "range": "self"
+      }
+    },
+    "granter": null,
+    "featureForm": "passive"
+  },
+  "effects": [
+    {
+      "name": "Stance: Otherwordly",
+      "disabled": false,
+      "img": "icons/skills/melee/strike-weapon-polearm-ice-blue.webp",
+      "description": "<p>On a successful attack, you can deal physical or magic damage.</p>",
+      "transfer": false,
+      "statuses": [],
+      "system": {
+        "changes": [],
+        "duration": {
+          "description": "",
+          "type": "scene"
+        },
+        "rangeDependence": null,
+        "stacking": null,
+        "targetDispositions": []
+      },
+      "_id": "RtscqiOS754ouvOM",
+      "type": "base",
+      "start": {
+        "time": 0,
+        "combat": null,
+        "combatant": null,
+        "initiative": null,
+        "round": null,
+        "turn": null
+      },
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "tint": "#ffffff",
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!items.effects!K2R2i8dhtNnY9MYR.RtscqiOS754ouvOM"
+    }
+  ],
+  "sort": 0,
+  "flags": {},
+  "_key": "!items!K2R2i8dhtNnY9MYR"
+}

--- a/src/packs/subclasses/feature_Quick_bGXfEQV5TLujvgp7.json
+++ b/src/packs/subclasses/feature_Quick_bGXfEQV5TLujvgp7.json
@@ -1,0 +1,99 @@
+{
+  "folder": "M1QUCqLVHPOiWSPz",
+  "name": "Quick",
+  "type": "feature",
+  "_id": "bGXfEQV5TLujvgp7",
+  "img": "icons/skills/movement/arrows-up-trio-red.webp",
+  "system": {
+    "attribution": {},
+    "description": "<p>When you make an attack, you can spend a Focus or <strong>mark a Stress</strong> to target another creature within range with that attack.</p>",
+    "gmNotes": "",
+    "resource": null,
+    "actions": {
+      "PQCbbHf8YZVe6Xqr": {
+        "type": "effect",
+        "_id": "PQCbbHf8YZVe6Xqr",
+        "systemPath": "actions",
+        "baseAction": false,
+        "description": "",
+        "chatDisplay": true,
+        "originItem": {
+          "type": "itemCollection"
+        },
+        "actionType": "action",
+        "triggers": [],
+        "areas": [],
+        "cost": [],
+        "uses": {
+          "value": null,
+          "max": "",
+          "recovery": null,
+          "consumeOnSuccess": false
+        },
+        "effects": [
+          {
+            "_id": "E3nMTwKEtVGuqaqS",
+            "onSave": false
+          }
+        ],
+        "target": {
+          "type": "self",
+          "amount": null
+        },
+        "name": "Enter Stance",
+        "img": "icons/skills/movement/arrows-up-trio-red.webp",
+        "range": "self"
+      }
+    },
+    "granter": null,
+    "featureForm": "passive"
+  },
+  "effects": [
+    {
+      "name": "Stance: Quick",
+      "disabled": false,
+      "img": "icons/skills/movement/arrows-up-trio-red.webp",
+      "description": "<p>When you make an attack, you can spend a Focus or <strong>mark a Stress</strong> to target another creature within range with that attack.</p>",
+      "transfer": false,
+      "statuses": [],
+      "system": {
+        "changes": [],
+        "duration": {
+          "description": "",
+          "type": "scene"
+        },
+        "rangeDependence": null,
+        "stacking": null,
+        "targetDispositions": []
+      },
+      "_id": "E3nMTwKEtVGuqaqS",
+      "type": "base",
+      "start": {
+        "time": 0,
+        "combat": null,
+        "combatant": null,
+        "initiative": null,
+        "round": null,
+        "turn": null
+      },
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "tint": "#ffffff",
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!items.effects!bGXfEQV5TLujvgp7.E3nMTwKEtVGuqaqS"
+    }
+  ],
+  "sort": 0,
+  "flags": {},
+  "_key": "!items!bGXfEQV5TLujvgp7"
+}

--- a/src/packs/subclasses/feature_Reliable_zNyqL7wzm1W4dUjN.json
+++ b/src/packs/subclasses/feature_Reliable_zNyqL7wzm1W4dUjN.json
@@ -1,0 +1,106 @@
+{
+  "folder": "M1QUCqLVHPOiWSPz",
+  "name": "Reliable",
+  "type": "feature",
+  "_id": "zNyqL7wzm1W4dUjN",
+  "img": "icons/skills/melee/unarmed-punch-fist-yellow-red.webp",
+  "system": {
+    "attribution": {},
+    "description": "<p>Gain a +1 bonus to your attack rolls.</p>",
+    "gmNotes": "",
+    "resource": null,
+    "actions": {
+      "xjwcxV47Ms9zuZdy": {
+        "type": "effect",
+        "_id": "xjwcxV47Ms9zuZdy",
+        "systemPath": "actions",
+        "baseAction": false,
+        "description": "",
+        "chatDisplay": true,
+        "originItem": {
+          "type": "itemCollection"
+        },
+        "actionType": "action",
+        "triggers": [],
+        "areas": [],
+        "cost": [],
+        "uses": {
+          "value": null,
+          "max": "",
+          "recovery": null,
+          "consumeOnSuccess": false
+        },
+        "effects": [
+          {
+            "_id": "fwzWT0E4TeDptHek",
+            "onSave": false
+          }
+        ],
+        "target": {
+          "type": "self",
+          "amount": null
+        },
+        "name": "Enter Stance",
+        "range": "self"
+      }
+    },
+    "granter": null,
+    "featureForm": "passive"
+  },
+  "effects": [
+    {
+      "name": "Stance: Reliable",
+      "disabled": false,
+      "img": "icons/skills/melee/unarmed-punch-fist-yellow-red.webp",
+      "description": "<p>Gain a +1 bonus to your attack rolls.</p>",
+      "transfer": false,
+      "statuses": [],
+      "system": {
+        "changes": [
+          {
+            "key": "system.bonuses.roll.attack.bonus",
+            "type": "add",
+            "value": 1,
+            "priority": null,
+            "phase": "initial"
+          }
+        ],
+        "duration": {
+          "description": "",
+          "type": "scene"
+        },
+        "rangeDependence": null,
+        "stacking": null,
+        "targetDispositions": []
+      },
+      "_id": "fwzWT0E4TeDptHek",
+      "type": "base",
+      "start": {
+        "time": 0,
+        "combat": null,
+        "combatant": null,
+        "initiative": null,
+        "round": null,
+        "turn": null
+      },
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "tint": "#ffffff",
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!items.effects!zNyqL7wzm1W4dUjN.fwzWT0E4TeDptHek"
+    }
+  ],
+  "sort": 0,
+  "flags": {},
+  "_key": "!items!zNyqL7wzm1W4dUjN"
+}

--- a/src/packs/subclasses/feature_Scary_b16QLSE6UYZExF76.json
+++ b/src/packs/subclasses/feature_Scary_b16QLSE6UYZExF76.json
@@ -1,0 +1,158 @@
+{
+  "folder": "pwYRu6UvwBmqS8L1",
+  "name": "Scary",
+  "type": "feature",
+  "_id": "b16QLSE6UYZExF76",
+  "img": "icons/magic/death/skull-horned-worn-fire-blue.webp",
+  "system": {
+    "attribution": {},
+    "description": "<p>On a successful attack, the target must mark a Stress.</p>",
+    "gmNotes": "",
+    "resource": null,
+    "actions": {
+      "00D4ZUNKiBYvwgL6": {
+        "type": "effect",
+        "_id": "00D4ZUNKiBYvwgL6",
+        "systemPath": "actions",
+        "baseAction": false,
+        "description": "",
+        "chatDisplay": true,
+        "originItem": {
+          "type": "itemCollection"
+        },
+        "actionType": "action",
+        "triggers": [],
+        "areas": [],
+        "cost": [],
+        "uses": {
+          "value": null,
+          "max": "",
+          "recovery": null,
+          "consumeOnSuccess": false
+        },
+        "effects": [
+          {
+            "_id": "r0feAH80Gh2x6Hta",
+            "onSave": false
+          }
+        ],
+        "target": {
+          "type": "self",
+          "amount": null
+        },
+        "name": "Enter Stance",
+        "range": "self"
+      },
+      "8RhhH4QorYXMAGOj": {
+        "type": "damage",
+        "damage": {
+          "main": null,
+          "resources": {
+            "stress": {
+              "base": false,
+              "applyTo": "stress",
+              "resultBased": false,
+              "fullRestore": false,
+              "value": {
+                "multiplier": "flat",
+                "flatMultiplier": 0,
+                "dice": "d6",
+                "bonus": 1,
+                "custom": {
+                  "enabled": false,
+                  "formula": ""
+                }
+              },
+              "valueAlt": {
+                "multiplier": "flat",
+                "flatMultiplier": 1,
+                "dice": "d6",
+                "bonus": null,
+                "custom": {
+                  "enabled": false,
+                  "formula": ""
+                }
+              }
+            }
+          }
+        },
+        "_id": "8RhhH4QorYXMAGOj",
+        "systemPath": "actions",
+        "baseAction": false,
+        "description": "",
+        "chatDisplay": true,
+        "originItem": {
+          "type": "itemCollection"
+        },
+        "actionType": "action",
+        "triggers": [],
+        "areas": [],
+        "cost": [],
+        "uses": {
+          "value": null,
+          "max": "",
+          "recovery": null,
+          "consumeOnSuccess": false
+        },
+        "target": {
+          "type": "any",
+          "amount": null
+        },
+        "effects": [],
+        "name": "Stress Damage",
+        "range": "",
+        "img": "icons/magic/death/skull-energy-light-white.webp"
+      }
+    },
+    "granter": null,
+    "featureForm": "passive"
+  },
+  "effects": [
+    {
+      "name": "Stance: Scary",
+      "disabled": false,
+      "img": "icons/magic/death/skull-horned-worn-fire-blue.webp",
+      "description": "<p>On a successful attack, the target must mark a Stress.</p>",
+      "transfer": false,
+      "statuses": [],
+      "system": {
+        "changes": [],
+        "duration": {
+          "description": "",
+          "type": "scene"
+        },
+        "rangeDependence": null,
+        "stacking": null,
+        "targetDispositions": []
+      },
+      "_id": "r0feAH80Gh2x6Hta",
+      "type": "base",
+      "start": {
+        "time": 0,
+        "combat": null,
+        "combatant": null,
+        "initiative": null,
+        "round": null,
+        "turn": null
+      },
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "tint": "#ffffff",
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!items.effects!b16QLSE6UYZExF76.r0feAH80Gh2x6Hta"
+    }
+  ],
+  "sort": 0,
+  "flags": {},
+  "_key": "!items!b16QLSE6UYZExF76"
+}

--- a/src/packs/subclasses/feature_Stable_mfuYkv8RpcSh8SfG.json
+++ b/src/packs/subclasses/feature_Stable_mfuYkv8RpcSh8SfG.json
@@ -1,0 +1,98 @@
+{
+  "folder": "pwYRu6UvwBmqS8L1",
+  "name": "Stable",
+  "type": "feature",
+  "_id": "mfuYkv8RpcSh8SfG",
+  "img": "icons/magic/defensive/shield-barrier-blue.webp",
+  "system": {
+    "attribution": {},
+    "description": "<p>You can spend a Focus instead of an Armor Slot to reduce damage.</p>",
+    "gmNotes": "",
+    "resource": null,
+    "actions": {
+      "txkpaqhmPRDGtFV2": {
+        "type": "effect",
+        "_id": "txkpaqhmPRDGtFV2",
+        "systemPath": "actions",
+        "baseAction": false,
+        "description": "",
+        "chatDisplay": true,
+        "originItem": {
+          "type": "itemCollection"
+        },
+        "actionType": "action",
+        "triggers": [],
+        "areas": [],
+        "cost": [],
+        "uses": {
+          "value": null,
+          "max": "",
+          "recovery": null,
+          "consumeOnSuccess": false
+        },
+        "effects": [
+          {
+            "_id": "td74xw7ic4NbaYl0",
+            "onSave": false
+          }
+        ],
+        "target": {
+          "type": "self",
+          "amount": null
+        },
+        "name": "Enter Stance",
+        "range": "self"
+      }
+    },
+    "granter": null,
+    "featureForm": "passive"
+  },
+  "effects": [
+    {
+      "name": "Stance: Stable",
+      "disabled": false,
+      "img": "icons/magic/defensive/shield-barrier-blue.webp",
+      "description": "<p>You can spend a Focus instead of an Armor Slot to reduce damage.</p>",
+      "transfer": false,
+      "statuses": [],
+      "system": {
+        "changes": [],
+        "duration": {
+          "description": "",
+          "type": "scene"
+        },
+        "rangeDependence": null,
+        "stacking": null,
+        "targetDispositions": []
+      },
+      "_id": "td74xw7ic4NbaYl0",
+      "type": "base",
+      "start": {
+        "time": 0,
+        "combat": null,
+        "combatant": null,
+        "initiative": null,
+        "round": null,
+        "turn": null
+      },
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "tint": "#ffffff",
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!items.effects!mfuYkv8RpcSh8SfG.td74xw7ic4NbaYl0"
+    }
+  ],
+  "sort": 0,
+  "flags": {},
+  "_key": "!items!mfuYkv8RpcSh8SfG"
+}

--- a/src/packs/subclasses/feature_Stance_Fighter_EVEP9G6lNF8nR5f3.json
+++ b/src/packs/subclasses/feature_Stance_Fighter_EVEP9G6lNF8nR5f3.json
@@ -9,7 +9,7 @@
       "source": "Daggerheart SRD",
       "page": null
     },
-    "description": "<p>You can channel your inner resolve to shift into martial stances that grant you special benefits in combat.</p><p>Take the Martial Stances sheet and choose two martial stances from Tier 1. Each time you level up your character, choose an additional stance from your tier or lower.</p>",
+    "description": "<p>You can channel your inner resolve to shift into martial stances that grant you special benefits in combat.</p><p>Take the Martial Stances sheet and choose two martial stances from Tier 1. Each time you level up your character, choose an additional stance from your tier or lower.</p><hr><p><em>Currently the implementation for this is to simply grab the stances you want from the compendium <strong>Subclasses —&gt; Subclass Features —&gt; Martial Stances</strong></em></p>",
     "gmNotes": "",
     "resource": {
       "type": "simple",

--- a/src/packs/subclasses/feature_Vigilant_4bLcpljjJylzM5xg.json
+++ b/src/packs/subclasses/feature_Vigilant_4bLcpljjJylzM5xg.json
@@ -1,0 +1,136 @@
+{
+  "folder": "pwYRu6UvwBmqS8L1",
+  "name": "Vigilant",
+  "type": "feature",
+  "_id": "4bLcpljjJylzM5xg",
+  "img": "icons/magic/perception/eye-ringed-green.webp",
+  "system": {
+    "attribution": {},
+    "description": "<p>When you are targeted by an attack, you can <strong>mark a Stress</strong> to gain a <strong>[[/r d6]]</strong> bonus to your Evasion against the attack.</p>",
+    "gmNotes": "",
+    "resource": null,
+    "actions": {
+      "4oZ4pFro1PnCoENs": {
+        "type": "effect",
+        "_id": "4oZ4pFro1PnCoENs",
+        "systemPath": "actions",
+        "baseAction": false,
+        "description": "",
+        "chatDisplay": true,
+        "originItem": {
+          "type": "itemCollection"
+        },
+        "actionType": "action",
+        "triggers": [],
+        "areas": [],
+        "cost": [],
+        "uses": {
+          "value": null,
+          "max": "",
+          "recovery": null,
+          "consumeOnSuccess": false
+        },
+        "effects": [
+          {
+            "_id": "3ywLEf7h2TaVzOCf",
+            "onSave": false
+          }
+        ],
+        "target": {
+          "type": "any",
+          "amount": null
+        },
+        "name": "Enter Stance",
+        "range": ""
+      },
+      "akBB4AYAAZBpxLxA": {
+        "type": "effect",
+        "_id": "akBB4AYAAZBpxLxA",
+        "systemPath": "actions",
+        "baseAction": false,
+        "description": "",
+        "chatDisplay": true,
+        "originItem": {
+          "type": "itemCollection"
+        },
+        "actionType": "action",
+        "triggers": [],
+        "areas": [],
+        "cost": [
+          {
+            "scalable": false,
+            "key": "stress",
+            "value": 1,
+            "itemId": null,
+            "step": null,
+            "consumeOnSuccess": false
+          }
+        ],
+        "uses": {
+          "value": null,
+          "max": "",
+          "recovery": null,
+          "consumeOnSuccess": false
+        },
+        "effects": [],
+        "target": {
+          "type": "any",
+          "amount": null
+        },
+        "name": "Spend Stress",
+        "range": "",
+        "img": "icons/magic/defensive/illusion-evasion-echo-purple.webp"
+      }
+    },
+    "granter": null,
+    "featureForm": "passive"
+  },
+  "effects": [
+    {
+      "name": "Stance: Vigilant",
+      "disabled": false,
+      "img": "icons/magic/perception/eye-ringed-green.webp",
+      "description": "<p>When you are targeted by an attack, you can <strong>mark a Stress</strong> to gain a <strong>d6</strong> bonus to your Evasion against the attack.</p>",
+      "transfer": false,
+      "statuses": [],
+      "system": {
+        "changes": [],
+        "duration": {
+          "description": "",
+          "type": "scene"
+        },
+        "rangeDependence": null,
+        "stacking": null,
+        "targetDispositions": []
+      },
+      "_id": "3ywLEf7h2TaVzOCf",
+      "type": "base",
+      "start": {
+        "time": 0,
+        "combat": null,
+        "combatant": null,
+        "initiative": null,
+        "round": null,
+        "turn": null
+      },
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "tint": "#ffffff",
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!items.effects!4bLcpljjJylzM5xg.3ywLEf7h2TaVzOCf"
+    }
+  ],
+  "sort": 0,
+  "flags": {},
+  "_key": "!items!4bLcpljjJylzM5xg"
+}

--- a/src/packs/subclasses/folders_Martial_Stances_bFwam9n0uUCfs619.json
+++ b/src/packs/subclasses/folders_Martial_Stances_bFwam9n0uUCfs619.json
@@ -1,0 +1,16 @@
+{
+  "type": "Item",
+  "folder": "Sfpr4iK1cGrmncok",
+  "name": "Martial Stances",
+  "color": "#000000",
+  "flags": {
+    "daggerheart": {
+      "defaultEntity": "feature"
+    }
+  },
+  "sorting": "a",
+  "_id": "bFwam9n0uUCfs619",
+  "description": "",
+  "sort": 0,
+  "_key": "!folders!bFwam9n0uUCfs619"
+}

--- a/src/packs/subclasses/folders_Tier_1_M1QUCqLVHPOiWSPz.json
+++ b/src/packs/subclasses/folders_Tier_1_M1QUCqLVHPOiWSPz.json
@@ -1,0 +1,16 @@
+{
+  "type": "Item",
+  "folder": "bFwam9n0uUCfs619",
+  "name": "Tier 1",
+  "color": null,
+  "flags": {
+    "daggerheart": {
+      "defaultEntity": ""
+    }
+  },
+  "sorting": "a",
+  "_id": "M1QUCqLVHPOiWSPz",
+  "description": "",
+  "sort": 0,
+  "_key": "!folders!M1QUCqLVHPOiWSPz"
+}

--- a/src/packs/subclasses/folders_Tier_2_K1Zh9uNgiR5UlOOE.json
+++ b/src/packs/subclasses/folders_Tier_2_K1Zh9uNgiR5UlOOE.json
@@ -1,0 +1,16 @@
+{
+  "type": "Item",
+  "folder": "bFwam9n0uUCfs619",
+  "name": "Tier 2",
+  "color": null,
+  "flags": {
+    "daggerheart": {
+      "defaultEntity": ""
+    }
+  },
+  "sorting": "a",
+  "_id": "K1Zh9uNgiR5UlOOE",
+  "description": "",
+  "sort": 0,
+  "_key": "!folders!K1Zh9uNgiR5UlOOE"
+}

--- a/src/packs/subclasses/folders_Tier_3_pwYRu6UvwBmqS8L1.json
+++ b/src/packs/subclasses/folders_Tier_3_pwYRu6UvwBmqS8L1.json
@@ -1,0 +1,16 @@
+{
+  "type": "Item",
+  "folder": "bFwam9n0uUCfs619",
+  "name": "Tier 3",
+  "color": null,
+  "flags": {
+    "daggerheart": {
+      "defaultEntity": ""
+    }
+  },
+  "sorting": "a",
+  "_id": "pwYRu6UvwBmqS8L1",
+  "description": "",
+  "sort": 0,
+  "_key": "!folders!pwYRu6UvwBmqS8L1"
+}

--- a/src/packs/subclasses/folders_Tier_4_lWpkV14I1qmLrVHt.json
+++ b/src/packs/subclasses/folders_Tier_4_lWpkV14I1qmLrVHt.json
@@ -1,0 +1,16 @@
+{
+  "type": "Item",
+  "folder": "bFwam9n0uUCfs619",
+  "name": "Tier 4",
+  "color": null,
+  "flags": {
+    "daggerheart": {
+      "defaultEntity": ""
+    }
+  },
+  "sorting": "a",
+  "_id": "lWpkV14I1qmLrVHt",
+  "description": "",
+  "sort": 0,
+  "_key": "!folders!lWpkV14I1qmLrVHt"
+}


### PR DESCRIPTION
Added all martial stances in a subfolder in the Subclasses compendium
**Subclasses --> Subclass Features --> Martial Stances**

- The current thing a user would have to do is to pull in the stances they select onto the character sheet. I added a text stating this in the `Stance Fighter` feature.
- All stances are currently set up with a `Enter Stance` action that applies a marker effect on self, so you keep track of which stance you are in.