### PR TITLE
[Fix] Enrichers in Journals

### DIFF
--- a/daggerheart.mjs
+++ b/daggerheart.mjs
@@ -391,12 +391,11 @@ Hooks.on('renderChatMessageHTML', (document, element) => {
     if (cssClass) cssClass.split(' ').forEach(cls => element.classList.add(cls));
 });
 
-Hooks.on('renderJournalEntryPageProseMirrorSheet', (_, element) => {
-    enricherRenderSetup(element);
-});
-
-Hooks.on('renderHandlebarsApplication', (_, element) => {
-    enricherRenderSetup(element);
+Hooks.on('renderHandlebarsApplication', (_, element, data) => {
+    const enricherExcludedDocuments = [CONFIG.JournalEntryPage.documentClass];
+    if (!enricherExcludedDocuments.some(x => data.document instanceof x)) {
+        enricherRenderSetup(element);
+    }
 });
 
 Hooks.on(CONFIG.DH.HOOKS.hooksConfig.tagTeamStart, async data => {

--- a/daggerheart.mjs
+++ b/daggerheart.mjs
@@ -338,6 +338,9 @@ Hooks.on('setup', () => {
             value: [...actorCommon.value, 'evasion', 'levelData.level.current']
         }
     };
+
+    // Setup enricher on window
+    enricherRenderSetup(window.document);
 });
 
 Hooks.on('ready', async () => {
@@ -385,18 +388,9 @@ Hooks.on('ready', async () => {
 
 Hooks.once('dicesoniceready', () => {});
 
-Hooks.on('renderChatMessageHTML', (document, element) => {
-    enricherRenderSetup(element);
-    const cssClass = document.flags?.daggerheart?.cssClass;
-    if (cssClass) cssClass.split(' ').forEach(cls => element.classList.add(cls));
-});
-
-Hooks.on('renderHandlebarsApplication', (_, element, data) => {
-    const enricherExcludedDocuments = [CONFIG.JournalEntryPage.documentClass];
-    if (!enricherExcludedDocuments.some(x => data.document instanceof x)) {
-        enricherRenderSetup(element);
-    }
-});
+Hooks.on('openDetachedWindow', (_, window) => {
+    enricherRenderSetup(window.document);
+})
 
 Hooks.on(CONFIG.DH.HOOKS.hooksConfig.tagTeamStart, async data => {
     if (data.openForAllPlayers && data.partyId) {

--- a/module/documents/chatMessage.mjs
+++ b/module/documents/chatMessage.mjs
@@ -217,7 +217,7 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
         if (this.system.action) this.system.action.workflow.get('applyDamage')?.execute(config, targets, true);
         else {
             for (const target of targets) {
-                const actor = target.document.actor;
+                const actor = foundry.utils.fromUuidSync(target.actorId);
                 if (!actor) continue;
 
                 if (this.system.hasHealing) actor.takeHealing(this.system.damage);

--- a/module/enrichers/DamageEnricher.mjs
+++ b/module/enrichers/DamageEnricher.mjs
@@ -1,31 +1,35 @@
 import { parseInlineParams } from './parser.mjs';
+import { abilityCosts } from '../config/generalConfig.mjs';
 
+const { fear, resource, ...resourceTypes } = abilityCosts;
 export function DhDamageEnricher(match, _options) {
     const { value, type, inline } = parseInlineParams(match[1], { first: 'value' });
-    if (!value || !type) return match[0];
-    return getDamageMessage(value, type, inline, match[0]);
-}
-
-function getDamageMessage(damage, type, inline, defaultElement) {
-    const typeIcons = type
+    
+    const allApplicableTypes = ['physical', 'magical', ...Object.keys(resourceTypes)];
+    const types = (type ?? '')
         .replace('[', '')
         .replace(']', '')
         .split(',')
+
+    if (!value || !types.every(type => allApplicableTypes.includes(type))) return match[0];
+
+    return getDamageMessage(value, types, inline);
+}
+
+function getDamageMessage(damage, types, inline) {
+    const iconNodes = types
         .map(x => x.trim())
         .map(x => {
             return CONFIG.DH.GENERAL.damageTypes[x]?.icon ?? null;
         })
-        .filter(x => x);
-
-    if (!typeIcons.length) return defaultElement;
-
-    const iconNodes = typeIcons.map(x => `<i class="fa-solid ${x}"></i>`).join('');
+        .filter(x => x)
+        .map(x => `<i class="fa-solid ${x}"></i>`).join('');
 
     const dualityElement = document.createElement('span');
     dualityElement.innerHTML = `
         <button type="button" class="enriched-damage-button${inline ? ' inline' : ''}" 
             data-value="${damage}"
-            data-type="${type}"
+            data-type="[${types.join(',')}]"
             data-tooltip="${game.i18n.localize('DAGGERHEART.GENERAL.damage')}"
         >
             ${damage}
@@ -45,6 +49,21 @@ export const renderDamageButton = async event => {
         .split(',')
         .map(x => x.trim());
 
+    const damageTypes = types.filter(type => ['physical', 'magical'].includes(type));
+    const isDamage = Boolean(damageTypes.length);
+
+    const damageFormula = isDamage ? {
+        formula: value,
+        applyTo: CONFIG.DH.GENERAL.healingTypes.hitPoints.id,
+        damageTypes: damageTypes
+    } : null;
+
+    /* The enricher only takes 1 value, so we only use a single type even if multiples are erroneously passed in */
+    const resourceFormulas = !isDamage ? [{
+        formula: value,
+        applyTo: types[0]
+    }] : [];
+
     const config = {
         event: event,
         title: game.i18n.localize('Damage Roll'),
@@ -55,12 +74,8 @@ export const renderDamageButton = async event => {
         targets: Array.from(game.user.targets).map(t =>
             game.system.api.fields.ActionFields.TargetField.formatTarget(t)
         ),
-        damageFormula: {
-            formula: value,
-            applyTo: CONFIG.DH.GENERAL.healingTypes.hitPoints.id,
-            damageTypes: types
-        },
-        resourceFormulas: []
+        damageFormula,
+        resourceFormulas
     };
 
     CONFIG.Dice.daggerheart.DamageRoll.build(config);

--- a/module/enrichers/DamageEnricher.mjs
+++ b/module/enrichers/DamageEnricher.mjs
@@ -37,13 +37,13 @@ function getDamageMessage(damage, type, inline, defaultElement) {
 }
 
 export const renderDamageButton = async event => {
-    const button = event.currentTarget,
-        value = button.dataset.value,
-        type = button.dataset.type
-            .replace('[', '')
-            .replace(']', '')
-            .split(',')
-            .map(x => x.trim());
+    const button = event.currentTarget;
+    const value = button.dataset.value;
+    const types = button.dataset.type
+        .replace('[', '')
+        .replace(']', '')
+        .split(',')
+        .map(x => x.trim());
 
     const config = {
         event: event,
@@ -55,13 +55,12 @@ export const renderDamageButton = async event => {
         targets: Array.from(game.user.targets).map(t =>
             game.system.api.fields.ActionFields.TargetField.formatTarget(t)
         ),
-        roll: [
-            {
-                formula: value,
-                applyTo: CONFIG.DH.GENERAL.healingTypes.hitPoints.id,
-                damageTypes: type
-            }
-        ]
+        damageFormula: {
+            formula: value,
+            applyTo: CONFIG.DH.GENERAL.healingTypes.hitPoints.id,
+            damageTypes: types
+        },
+        resourceFormulas: []
     };
 
     CONFIG.Dice.daggerheart.DamageRoll.build(config);

--- a/module/enrichers/DamageEnricher.mjs
+++ b/module/enrichers/DamageEnricher.mjs
@@ -41,7 +41,7 @@ function getDamageMessage(damage, types, inline) {
 }
 
 export const renderDamageButton = async event => {
-    const button = event.currentTarget;
+    const button = event.target;
     const value = button.dataset.value;
     const types = button.dataset.type
         .replace('[', '')

--- a/module/enrichers/DualityRollEnricher.mjs
+++ b/module/enrichers/DualityRollEnricher.mjs
@@ -59,7 +59,7 @@ function getDualityMessage(roll, flavor) {
 }
 
 export const renderDualityButton = async event => {
-    const button = event.currentTarget,
+    const button = event.target,
         reaction = button.dataset.reaction === 'true',
         traitValue = button.dataset.trait?.toLowerCase(),
         target = getCommandTarget({ allowNull: true }),

--- a/module/enrichers/FateRollEnricher.mjs
+++ b/module/enrichers/FateRollEnricher.mjs
@@ -43,7 +43,7 @@ function getFateMessage(roll, flavor) {
 }
 
 export const renderFateButton = async event => {
-    const button = event.currentTarget,
+    const button = event.target,
         target = getCommandTarget({ allowNull: true });
 
     const fateTypeData = getFateTypeData(button.dataset?.fatetype);

--- a/module/enrichers/TemplateEnricher.mjs
+++ b/module/enrichers/TemplateEnricher.mjs
@@ -1,8 +1,13 @@
 import { parseInlineParams } from './parser.mjs';
 
+/** Supports a template such as `@Template[type:emanation|range:far]` */
 export function DhTemplateEnricher(match, _options) {
     const params = parseInlineParams(match[1]);
-    const { type, angle = CONFIG.MeasuredTemplate.defaults.angle, inline = false } = params;
+    const { 
+        type = CONFIG.DH.GENERAL.templateTypes.circle.id,
+        angle = CONFIG.MeasuredTemplate.defaults.angle,
+        inline = false
+    } = params;
     const direction = Number(params.direction) || 0;
     params.range = params.range?.toLowerCase();
     const range =
@@ -49,7 +54,7 @@ export function DhTemplateEnricher(match, _options) {
 }
 
 export const renderMeasuredTemplate = async event => {
-    const button = event.currentTarget,
+    const button = event.target,
         type = button.dataset.type,
         range = button.dataset.range,
         angle = button.dataset.angle,

--- a/module/enrichers/_module.mjs
+++ b/module/enrichers/_module.mjs
@@ -45,25 +45,24 @@ export const enricherConfig = [
     }
 ];
 
-export const enricherRenderSetup = element => {
-    const clickWrapper = func => event => {
-        event.stopPropagation();
-        func(event);
-    };   
-
-    element
-        .querySelectorAll('.enriched-damage-button')
-        .forEach(element => element.addEventListener('click', clickWrapper(renderDamageButton)));
-
-    element
-        .querySelectorAll('.duality-roll-button')
-        .forEach(element => element.addEventListener('click', clickWrapper(renderDualityButton)));
-
-    element
-        .querySelectorAll('.fate-roll-button')
-        .forEach(element => element.addEventListener('click', clickWrapper(renderFateButton)));
-
-    element
-        .querySelectorAll('.measured-template-button')
-        .forEach(element => element.addEventListener('click', clickWrapper(renderMeasuredTemplate)));
-};
+/** 
+ * Setups up a listener for inline roll links on the element. Should be called on window.document and any popout windows.
+ * @param {HTMLDocument} element
+ */
+export function enricherRenderSetup(element) {
+    element.addEventListener('click', event => {
+        if (event.target.closest('.enriched-damage-button')) {
+            event.stopPropagation();
+            return renderDamageButton(event);
+        } else if (event.target.closest('.duality-roll-button')) {
+            event.stopPropagation();
+            return renderDualityButton(event);
+        } else if (event.target.closest('.fate-roll-button')) {
+            event.stopPropagation();
+            return renderFateButton(event);
+        } else if (event.target.closest('.measured-template-button')) {
+            event.stopPropagation();
+            return renderMeasuredTemplate(event);
+        }
+    }, { passive: true });
+}


### PR DESCRIPTION
Fixes #2232
The hooks we had setup in `daggerheart.mjs` made a journal end up with 3 rounds of `enricherRenderSetup` run, and therefore 3 listeners triggering 3 rolls.
Fixed it by removing the `renderJournalEntryPageProseMirrorSheet` hook and limiting the `renderHandlebarsApplication` hook so it enriches once in journals (they always trigger both for the Journal and for the JournalEntryPage).

Fixes #2233 
The DamageEnricher wasn't updated to the new format after the Damage rework.

Fixes #1941
I went ahead and added so that `type` can be the resource types aswell, making it possible to deal stress/hope etc damage.
