### PR TITLE
[Feature] Featuer Resources Varriant

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1780,6 +1780,10 @@
                     "label": "Automatic"
                 }
             },
+            "Resources": {
+                "favor": "Favor",
+                "focus": "Focus"
+            },
             "RollTypes": {
                 "trait": {
                     "name": "Trait"
@@ -3517,6 +3521,7 @@
                 "activeWhenEvolved": "Active When Evolved",
                 "evolutionFeature": "Evolution Feature",
                 "evolutionLocked": "Features with an evolution action must be of evolution type",
+                "actorResources": "Actor Resources",
                 "createActorResourceTitle": "Add Actor Resource",
                 "deleteActorResourceTitle": "Delete Actor Resource",
                 "deleteActorResourceText": "Are you sure you want to delete the resource?"

--- a/module/applications/sheets/items/feature.mjs
+++ b/module/applications/sheets/items/feature.mjs
@@ -60,23 +60,41 @@ export default class FeatureSheet extends DHBaseItemSheet {
             disabled: evolutionLocked,
             tooltip: evolutionLocked ? _loc('DAGGERHEART.ITEMS.Feature.evolutionLocked') : null
         };
+
+        context.featureActorResources = Object.entries(this.document.system.actorResources)
+            .reduce((acc, [key, data]) => {
+                const resource = CONFIG.DH.RESOURCE.optionalResources[key];
+                if (!resource) return acc; // Might need to handle this better incase the global resource has been removed, so we can delete the feature part?
+                acc[key] = {
+                    ...resource,
+                    ...data
+                }
+                return acc;
+            }, {});
         
         return context;
     }
 
     static async #onAddActorResource() {
+        const choices = Object.entries(CONFIG.DH.RESOURCE.optionalResources).reduce((acc, [key, data]) => {
+            if (!this.document.system.actorResources[key])
+                acc[key] = data;
+
+            return acc;
+        }, {});
         const content = new foundry.data.fields.StringField({
-            label: game.i18n.localize('DAGGERHEART.GENERAL.name'),
+            choices: choices,
+            blank: true,
             required: true
         }).toFormGroup({}, { name: 'name', localize: true }).outerHTML;
 
         async function callback(_, button) {
             const name = button.form.elements.name.value;
-            if (!name) return;
+            const resource = choices[name];
+            if (!resource) return;
 
-            const sluggedName = name.slugify();
-            await this.document.update({ [`system.actorResources.${sluggedName}`]: {  
-                label: name
+            await this.document.update({ [`system.actorResources.${resource.id}`]: {  
+                value: resource.initial
             }})
         }
 

--- a/module/config/resourceConfig.mjs
+++ b/module/config/resourceConfig.mjs
@@ -63,6 +63,29 @@ const companionBaseResources = Object.freeze({
     }
 });
 
+export const optionalResources = Object.freeze({
+    favor: {
+        id: 'favor',
+        initial: 3,
+        max: 6,
+        label: 'DAGGERHEART.CONFIG.Resources.favor',
+        images: {
+            full: { value: 'fa-solid fa-spaghetti-monster-flying', isIcon: true, opacity: 1 },
+            empty: { value: 'fa-solid fa-spaghetti-monster-flying', isIcon: true, opacity: 0.6 }
+        }
+    },
+    focus: {
+        id: 'focus',
+        initial: 0,
+        max: 6,
+        label: 'DAGGERHEART.CONFIG.Resources.focus',
+        images: {
+            full: { value: 'fa-solid fa-yin-yang', isIcon: true, opacity: 1 },
+            empty: { value: 'fa-solid fa-yin-yang', isIcon: true, opacity: 0.6 }
+        }
+    }
+});
+
 export const character = {
     base: characterBaseResources,
     custom: {}, // module stuff goes here

--- a/module/data/actor/creature.mjs
+++ b/module/data/actor/creature.mjs
@@ -74,8 +74,12 @@ export default class DhCreature extends BaseDataActor {
     prepareDerivedData() {
         for (const feature of this.parent.items.filter(x => x.type === 'feature')) {
             for (const [key, data] of Object.entries(feature.system.actorResources)) {
+                const resource = CONFIG.DH.RESOURCE.optionalResources[key];
+                if (!resource) continue;
+
                 this.resources[key] = {
-                    ...data,
+                    ...resource,
+                    value: data.value,
                     featureParentId: feature.id
                 }
             }

--- a/module/data/item/feature.mjs
+++ b/module/data/item/feature.mjs
@@ -1,4 +1,3 @@
-import { imageIconField } from '../settings/Homebrew.mjs';
 import BaseDataItem from './base.mjs';
 
 export default class DHFeature extends BaseDataItem {
@@ -43,22 +42,10 @@ export default class DHFeature extends BaseDataItem {
             }),
             actorResources: new fields.TypedObjectField(new fields.SchemaField({
                 value: new fields.NumberField({
+                    label: 'DAGGERHEART.GENERAL.value',
                     required: true,
-                    integer: true,
-                    initial: 0,
-                    min: 0,
-                    label: 'DAGGERHEART.GENERAL.value'
-                }),
-                max: new fields.NumberField({
-                    nullable: true,
-                    initial: null,
-                    min: 0,
-                    label: 'DAGGERHEART.GENERAL.max'
-                }),
-                label: new fields.StringField({ label: 'DAGGERHEART.GENERAL.label' }),
-                images: new fields.SchemaField({
-                    full: imageIconField('fa solid fa-circle'),
-                    empty: imageIconField('fa-regular fa-circle')
+                    nullable: false,
+                    integer: true
                 })
             }))
         };

--- a/src/packs/classes/feature_Favor_OGPn7DUJoJwAXh8o.json
+++ b/src/packs/classes/feature_Favor_OGPn7DUJoJwAXh8o.json
@@ -17,22 +17,7 @@
     "granter": null,
     "actorResources": {
       "favor": {
-        "label": "Favor",
-        "value": 3,
-        "max": 6,
-        "images": {
-          "full": {
-            "value": "fa-solid fa-spaghetti-monster-flying",
-            "isIcon": true,
-            "noColorFilter": false
-          },
-          "empty": {
-            "value": "fa-solid fa-spaghetti-monster-flying",
-            "isIcon": true,
-            "noColorFilter": false,
-            "opacity": 0.6
-          }
-        }
+        "value": 3
       }
     }
   },

--- a/src/packs/subclasses/feature_Stance_Fighter_EVEP9G6lNF8nR5f3.json
+++ b/src/packs/subclasses/feature_Stance_Fighter_EVEP9G6lNF8nR5f3.json
@@ -17,22 +17,7 @@
     "granter": null,
     "actorResources": {
       "focus": {
-        "label": "Focus",
-        "value": 0,
-        "max": 6,
-        "images": {
-          "full": {
-            "value": "fa-solid fa-yin-yang",
-            "isIcon": true,
-            "noColorFilter": false
-          },
-          "empty": {
-            "value": "fa-solid fa-yin-yang",
-            "isIcon": true,
-            "noColorFilter": false,
-            "opacity": 0.6
-          }
-        }
+        "value": 0
       }
     }
   },

--- a/styles/less/sheets/items/feature.less
+++ b/styles/less/sheets/items/feature.less
@@ -7,4 +7,25 @@
     section.tab {
         overflow-y: auto;
     }
+
+    .actor-resource-container {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+
+        .inputs-container {
+            flex: 1;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        span {
+            font-size: var(--font-size-16);
+        }
+
+        span, a {
+            padding-top: 18px;
+        }
+    }
 }

--- a/templates/sheets/items/feature/settings.hbs
+++ b/templates/sheets/items/feature/settings.hbs
@@ -9,6 +9,8 @@
         <span {{#if featureFormData.tooltip}}data-tooltip="{{featureFormData.tooltip}}"{{/if}}>
             {{formInput document.system.schema.fields.featureForm value=document.system.featureForm choices=featureFormChoices disabled=featureFormData.disabled localize=true}}
         </span>
+        <span>{{localize "DAGGERHEART.ITEMS.Feature.actorResources"}}</span>
+        {{formInput document.system.schema.fields.actorResources value=document.system.actorResources localize=true}}
     </fieldset>
 
     {{> "systems/daggerheart/templates/sheets/global/partials/resource-section/resource-section.hbs" }}
@@ -19,13 +21,20 @@
             <a><i class="fa-solid fa-plus" data-action="addActorResource"></i></a>
         </legend>
 
-        {{#each document.system.actorResources as |resource key|}}
-            {{> "systems/daggerheart/templates/sheets/global/partials/custom-resource/custom-resource.hbs" 
-                resource 
-                key=key
-                fields=../document.system.schema.fields.actorResources.element.fields 
-                basePath=(concat "system.actorResources." key ".") 
-            }}
+        {{#each featureActorResources as |resource key|}}
+            <div class="actor-resource-container">
+                <span>{{localize resource.label}}</span>
+                <div class="inputs-container">
+                    {{formGroup ../document.system.schema.fields.actorResources.element.fields.value value=resource.value localize=true}}
+                    <div class="form-group">
+                        <label>{{localize "Max"}}</label>
+                        <div class="form-fields">
+                            <input type="text" value="{{resource.max}}" disabled />
+                        </div>
+                    </div>
+                </div>
+                <a><i class="fa-solid fa-trash" data-action="removeActorResource" data-resource-key="{{key}}"></i></a>
+            </div>
         {{/each}}
     </fieldset>
 </section>


### PR DESCRIPTION
Based on `feature/feature-resources`

Changed to define optional resources in ResourceConfig. Features can pick from them.
The reason for this change is that if Actions are going to be able to select these resources as Costs - then we have to be able to consistently grab a list of the available Resources.

The previous solution where the definition was -in- the Features wouldn't work well, since the features can be in compendiums, forcing us to load all compendiums to get the whole list.

This solution will let us join up: 
`CONFIG.DH.RESOURCE.<actorType>.all + CONFIG.DH.RESOURCE.optionalResources + <Homebrew Resources With some later modifications>`
This final list is what actions will pick costs from without relying on reading items.