### PR TITLE
[Fix] Healing Improvements

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -190,7 +190,8 @@
                 },
                 "fullRestore": {
                     "label": "Fully restore the resource.",
-                    "inChatRoll": "Full"
+                    "inChatRoll": "Full",
+                    "inFormula": "Full Restore"
                 },
                 "applyTo": {
                     "label": "Targeted Resource"
@@ -3986,6 +3987,7 @@
                     "applyEffect": "Apply Effects"
                 },
                 "clearResource": "Clear {quantity} {resource}",
+                "clearResourceFully": "Fully Clear {resource}",
                 "damageSummary": {
                     "title": "Damage Applied",
                     "healingTitle": "Healing Applied"

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -923,7 +923,7 @@ export default class DhpActor extends Actor {
                 };
             } else {
                 const valueFunc = (base, resource, baseMax) => {
-                    if (resource.clear) return baseMax && base.inverted ? baseMax : 0;
+                    if (resource.clear) return baseMax && !base.isReversed ? baseMax : 0;
 
                     return (base.value ?? base) + resource.value;
                 };
@@ -932,7 +932,8 @@ export default class DhpActor extends Actor {
                         ui.resources.updateFear(
                             valueFunc(
                                 game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Resources.Fear),
-                                r
+                                r,
+                                game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Homebrew).maxFear
                             )
                         );
                         break;

--- a/src/packs/adversaries/adversary_Entombed_Stonemason_cugsaVxMi9UCUNku.json
+++ b/src/packs/adversaries/adversary_Entombed_Stonemason_cugsaVxMi9UCUNku.json
@@ -285,9 +285,9 @@
         "gmNotes": "",
         "resource": null,
         "actions": {
-          "w90DAmISboUMZs6R": {
-            "type": "effect",
-            "_id": "w90DAmISboUMZs6R",
+          "76WAmsO9THiGRB1u": {
+            "type": "healing",
+            "_id": "76WAmsO9THiGRB1u",
             "systemPath": "actions",
             "baseAction": false,
             "description": "",
@@ -314,10 +314,82 @@
               "recovery": null,
               "consumeOnSuccess": false
             },
-            "effects": [],
+            "damage": {
+              "main": null,
+              "resources": {
+                "hitPoints": {
+                  "base": false,
+                  "applyTo": "hitPoints",
+                  "resultBased": false,
+                  "fullRestore": true,
+                  "value": {
+                    "multiplier": "flat",
+                    "flatMultiplier": 1,
+                    "dice": "d6",
+                    "bonus": null,
+                    "custom": {
+                      "enabled": false,
+                      "formula": ""
+                    }
+                  },
+                  "valueAlt": {
+                    "multiplier": "flat",
+                    "flatMultiplier": 1,
+                    "dice": "d6",
+                    "bonus": null,
+                    "custom": {
+                      "enabled": false,
+                      "formula": ""
+                    }
+                  }
+                },
+                "stress": {
+                  "base": false,
+                  "applyTo": "stress",
+                  "resultBased": false,
+                  "fullRestore": true,
+                  "value": {
+                    "multiplier": "flat",
+                    "flatMultiplier": 1,
+                    "dice": "d6",
+                    "bonus": null,
+                    "custom": {
+                      "enabled": false,
+                      "formula": ""
+                    }
+                  },
+                  "valueAlt": {
+                    "multiplier": "flat",
+                    "flatMultiplier": 1,
+                    "dice": "d6",
+                    "bonus": null,
+                    "custom": {
+                      "enabled": false,
+                      "formula": ""
+                    }
+                  }
+                }
+              }
+            },
             "target": {
               "type": "self",
               "amount": null
+            },
+            "effects": [],
+            "roll": {
+              "type": null,
+              "trait": null,
+              "difficulty": null,
+              "bonus": null,
+              "advState": "neutral",
+              "diceRolling": {
+                "multiplier": "prof",
+                "flatMultiplier": 1,
+                "dice": "d6",
+                "compare": null,
+                "treshold": null
+              },
+              "useDefault": false
             },
             "name": "Spend Fear",
             "range": "self"

--- a/src/packs/adversaries/adversary_Fungispunj_Sporophore_5BKK7pDRjRAgN3Nm.json
+++ b/src/packs/adversaries/adversary_Fungispunj_Sporophore_5BKK7pDRjRAgN3Nm.json
@@ -325,7 +325,60 @@
             },
             "damage": {
               "main": null,
-              "resources": {}
+              "resources": {
+                "hitPoints": {
+                  "base": false,
+                  "applyTo": "hitPoints",
+                  "resultBased": false,
+                  "fullRestore": true,
+                  "value": {
+                    "multiplier": "flat",
+                    "flatMultiplier": 1,
+                    "dice": "d6",
+                    "bonus": null,
+                    "custom": {
+                      "enabled": false,
+                      "formula": ""
+                    }
+                  },
+                  "valueAlt": {
+                    "multiplier": "flat",
+                    "flatMultiplier": 1,
+                    "dice": "d6",
+                    "bonus": null,
+                    "custom": {
+                      "enabled": false,
+                      "formula": ""
+                    }
+                  }
+                },
+                "stress": {
+                  "base": false,
+                  "applyTo": "stress",
+                  "resultBased": false,
+                  "fullRestore": true,
+                  "value": {
+                    "multiplier": "flat",
+                    "flatMultiplier": 1,
+                    "dice": "d6",
+                    "bonus": null,
+                    "custom": {
+                      "enabled": false,
+                      "formula": ""
+                    }
+                  },
+                  "valueAlt": {
+                    "multiplier": "flat",
+                    "flatMultiplier": 1,
+                    "dice": "d6",
+                    "bonus": null,
+                    "custom": {
+                      "enabled": false,
+                      "formula": ""
+                    }
+                  }
+                }
+              }
             },
             "target": {
               "type": "any",

--- a/src/packs/adversaries/adversary_Phantom_T2kyHFC68VKtIXir.json
+++ b/src/packs/adversaries/adversary_Phantom_T2kyHFC68VKtIXir.json
@@ -408,6 +408,80 @@
               "consumeOnSuccess": false
             },
             "range": ""
+          },
+          "eLEuZWbjMcwd1Zw5": {
+            "type": "healing",
+            "_id": "eLEuZWbjMcwd1Zw5",
+            "systemPath": "actions",
+            "baseAction": false,
+            "description": "<p>When it triggers, clear the @Lookup[@name]'s HP and immediately spotlight them.</p>",
+            "chatDisplay": true,
+            "originItem": {
+              "type": "itemCollection"
+            },
+            "actionType": "action",
+            "triggers": [],
+            "areas": [],
+            "cost": [],
+            "uses": {
+              "value": null,
+              "max": "",
+              "recovery": null,
+              "consumeOnSuccess": false
+            },
+            "damage": {
+              "main": null,
+              "resources": {
+                "hitPoints": {
+                  "base": false,
+                  "applyTo": "hitPoints",
+                  "resultBased": false,
+                  "fullRestore": true,
+                  "value": {
+                    "multiplier": "flat",
+                    "flatMultiplier": 1,
+                    "dice": "d6",
+                    "bonus": null,
+                    "custom": {
+                      "enabled": false,
+                      "formula": ""
+                    }
+                  },
+                  "valueAlt": {
+                    "multiplier": "flat",
+                    "flatMultiplier": 1,
+                    "dice": "d6",
+                    "bonus": null,
+                    "custom": {
+                      "enabled": false,
+                      "formula": ""
+                    }
+                  }
+                }
+              }
+            },
+            "target": {
+              "type": "self",
+              "amount": null
+            },
+            "effects": [],
+            "roll": {
+              "type": null,
+              "trait": null,
+              "difficulty": null,
+              "bonus": null,
+              "advState": "neutral",
+              "diceRolling": {
+                "multiplier": "prof",
+                "flatMultiplier": 1,
+                "dice": "d6",
+                "compare": null,
+                "treshold": null
+              },
+              "useDefault": false
+            },
+            "name": "Trigger Countdown",
+            "range": "self"
           }
         },
         "granter": null

--- a/src/packs/adversaries/adversary_Rabble_Mawb_lKmBNV3Sgpq9sTtp.json
+++ b/src/packs/adversaries/adversary_Rabble_Mawb_lKmBNV3Sgpq9sTtp.json
@@ -169,9 +169,9 @@
         "gmNotes": "",
         "resource": null,
         "actions": {
-          "Fdp9ERscvRPKVzPD": {
-            "type": "effect",
-            "_id": "Fdp9ERscvRPKVzPD",
+          "BfxTYVkuJNrK9ola": {
+            "type": "healing",
+            "_id": "BfxTYVkuJNrK9ola",
             "systemPath": "actions",
             "baseAction": false,
             "description": "",
@@ -198,15 +198,87 @@
               "recovery": null,
               "consumeOnSuccess": false
             },
-            "effects": [
-              {
-                "_id": "jsSpZ9WaB1NdAhO4",
-                "onSave": false
+            "damage": {
+              "main": null,
+              "resources": {
+                "hitPoints": {
+                  "base": false,
+                  "applyTo": "hitPoints",
+                  "resultBased": false,
+                  "fullRestore": true,
+                  "value": {
+                    "multiplier": "flat",
+                    "flatMultiplier": 1,
+                    "dice": "d6",
+                    "bonus": null,
+                    "custom": {
+                      "enabled": false,
+                      "formula": ""
+                    }
+                  },
+                  "valueAlt": {
+                    "multiplier": "flat",
+                    "flatMultiplier": 1,
+                    "dice": "d6",
+                    "bonus": null,
+                    "custom": {
+                      "enabled": false,
+                      "formula": ""
+                    }
+                  }
+                },
+                "stress": {
+                  "base": false,
+                  "applyTo": "stress",
+                  "resultBased": false,
+                  "fullRestore": true,
+                  "value": {
+                    "multiplier": "flat",
+                    "flatMultiplier": 1,
+                    "dice": "d6",
+                    "bonus": null,
+                    "custom": {
+                      "enabled": false,
+                      "formula": ""
+                    }
+                  },
+                  "valueAlt": {
+                    "multiplier": "flat",
+                    "flatMultiplier": 1,
+                    "dice": "d6",
+                    "bonus": null,
+                    "custom": {
+                      "enabled": false,
+                      "formula": ""
+                    }
+                  }
+                }
               }
-            ],
+            },
             "target": {
               "type": "self",
               "amount": null
+            },
+            "effects": [
+              {
+                "_id": "iLgfMc5nYu56Cgqa",
+                "onSave": false
+              }
+            ],
+            "roll": {
+              "type": null,
+              "trait": null,
+              "difficulty": null,
+              "bonus": null,
+              "advState": "neutral",
+              "diceRolling": {
+                "multiplier": "prof",
+                "flatMultiplier": 1,
+                "dice": "d6",
+                "compare": null,
+                "treshold": null
+              },
+              "useDefault": false
             },
             "name": "Spend Fear",
             "range": "self"
@@ -291,6 +363,81 @@
             "compendiumSource": null
           },
           "_key": "!actors.items.effects!lKmBNV3Sgpq9sTtp.jC4ngCoNcUSTuJv9.jsSpZ9WaB1NdAhO4"
+        },
+        {
+          "name": "Came Back Worse",
+          "disabled": false,
+          "img": "icons/creatures/magical/spirit-poison-smoke-green.webp",
+          "description": "<p>The Rabble Mawb gains a bonus to all rolls equal to the number of times this feature has been used by this Rabble Mawb.</p>",
+          "transfer": false,
+          "statuses": [],
+          "system": {
+            "changes": [
+              {
+                "key": "system.bonuses.roll.action.bonus",
+                "type": "add",
+                "value": "@stacks",
+                "priority": null,
+                "phase": "initial"
+              },
+              {
+                "key": "system.bonuses.roll.reaction.bonus",
+                "type": "add",
+                "value": "@stacks",
+                "priority": null,
+                "phase": "initial"
+              },
+              {
+                "key": "system.bonuses.damage.physical.bonus",
+                "type": "add",
+                "value": "@stacks",
+                "priority": null,
+                "phase": "initial"
+              },
+              {
+                "key": "system.bonuses.damage.magical.bonus",
+                "type": "add",
+                "value": "@stacks",
+                "priority": null,
+                "phase": "initial"
+              }
+            ],
+            "duration": {
+              "description": "",
+              "type": ""
+            },
+            "rangeDependence": null,
+            "stacking": {
+              "value": 1,
+              "max": null
+            },
+            "targetDispositions": []
+          },
+          "_id": "iLgfMc5nYu56Cgqa",
+          "type": "base",
+          "start": {
+            "time": 0,
+            "combat": null,
+            "combatant": null,
+            "initiative": null,
+            "round": null,
+            "turn": null
+          },
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "tint": "#ffffff",
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!lKmBNV3Sgpq9sTtp.jC4ngCoNcUSTuJv9.iLgfMc5nYu56Cgqa"
         }
       ],
       "folder": null,

--- a/src/packs/environments/environment_Hallowed_Temple_dsA6j69AnaJhUyqH.json
+++ b/src/packs/environments/environment_Hallowed_Temple_dsA6j69AnaJhUyqH.json
@@ -149,8 +149,8 @@
                 "hitPoints": {
                   "value": {
                     "custom": {
-                      "enabled": true,
-                      "formula": "@system.resources.hitPoints.max"
+                      "enabled": false,
+                      "formula": ""
                     },
                     "multiplier": "flat",
                     "flatMultiplier": 1,
@@ -170,7 +170,7 @@
                       "formula": ""
                     }
                   },
-                  "fullRestore": false
+                  "fullRestore": true
                 }
               }
             },

--- a/src/packs/items/consumables/consumable_Feast_of_Xuria_aX6NyxkNzu0LcJpt.json
+++ b/src/packs/items/consumables/consumable_Feast_of_Xuria_aX6NyxkNzu0LcJpt.json
@@ -36,8 +36,8 @@
             "hitPoints": {
               "value": {
                 "custom": {
-                  "enabled": true,
-                  "formula": "@system.resources.hitPoints.max"
+                  "enabled": false,
+                  "formula": ""
                 },
                 "multiplier": "prof",
                 "flatMultiplier": 1,
@@ -57,13 +57,13 @@
                   "formula": ""
                 }
               },
-              "fullRestore": false
+              "fullRestore": true
             },
             "stress": {
               "value": {
                 "custom": {
-                  "enabled": true,
-                  "formula": "@system.resources.stress.max"
+                  "enabled": false,
+                  "formula": ""
                 },
                 "multiplier": "prof",
                 "flatMultiplier": 1,
@@ -83,7 +83,7 @@
                   "formula": ""
                 }
               },
-              "fullRestore": false
+              "fullRestore": true
             },
             "hope": {
               "value": {

--- a/src/packs/items/consumables/consumable_Godling_s_Pomelo_QowgtRfI0AmzGroZ.json
+++ b/src/packs/items/consumables/consumable_Godling_s_Pomelo_QowgtRfI0AmzGroZ.json
@@ -13,9 +13,9 @@
     "consumeOnUse": true,
     "gmNotes": "",
     "actions": {
-      "lLwr1Rru0C1t2cYy": {
-        "type": "effect",
-        "_id": "lLwr1Rru0C1t2cYy",
+      "KYnbdh2UTxw5Xr9f": {
+        "type": "healing",
+        "_id": "KYnbdh2UTxw5Xr9f",
         "systemPath": "actions",
         "baseAction": false,
         "description": "",
@@ -42,10 +42,82 @@
           "recovery": null,
           "consumeOnSuccess": false
         },
-        "effects": [],
+        "damage": {
+          "main": null,
+          "resources": {
+            "hitPoints": {
+              "base": false,
+              "applyTo": "hitPoints",
+              "resultBased": false,
+              "fullRestore": true,
+              "value": {
+                "multiplier": "flat",
+                "flatMultiplier": 1,
+                "dice": "d6",
+                "bonus": null,
+                "custom": {
+                  "enabled": false,
+                  "formula": ""
+                }
+              },
+              "valueAlt": {
+                "multiplier": "flat",
+                "flatMultiplier": 1,
+                "dice": "d6",
+                "bonus": null,
+                "custom": {
+                  "enabled": false,
+                  "formula": ""
+                }
+              }
+            },
+            "stress": {
+              "base": false,
+              "applyTo": "stress",
+              "resultBased": false,
+              "fullRestore": true,
+              "value": {
+                "multiplier": "flat",
+                "flatMultiplier": 1,
+                "dice": "d6",
+                "bonus": null,
+                "custom": {
+                  "enabled": false,
+                  "formula": ""
+                }
+              },
+              "valueAlt": {
+                "multiplier": "flat",
+                "flatMultiplier": 1,
+                "dice": "d6",
+                "bonus": null,
+                "custom": {
+                  "enabled": false,
+                  "formula": ""
+                }
+              }
+            }
+          }
+        },
         "target": {
           "type": "any",
           "amount": null
+        },
+        "effects": [],
+        "roll": {
+          "type": null,
+          "trait": null,
+          "difficulty": null,
+          "bonus": null,
+          "advState": "neutral",
+          "diceRolling": {
+            "multiplier": "prof",
+            "flatMultiplier": 1,
+            "dice": "d6",
+            "compare": null,
+            "treshold": null
+          },
+          "useDefault": false
         },
         "name": "Eat",
         "range": ""

--- a/src/packs/items/consumables/consumable_Sleeping_Sap_XZavUVlHEvE2srEt.json
+++ b/src/packs/items/consumables/consumable_Sleeping_Sap_XZavUVlHEvE2srEt.json
@@ -36,8 +36,8 @@
             "stress": {
               "value": {
                 "custom": {
-                  "enabled": true,
-                  "formula": "@system.resources.stress.max"
+                  "enabled": false,
+                  "formula": ""
                 },
                 "multiplier": "prof",
                 "flatMultiplier": 1,
@@ -57,7 +57,7 @@
                   "formula": ""
                 }
               },
-              "fullRestore": false
+              "fullRestore": true
             }
           }
         },

--- a/src/packs/items/consumables/consumable_Sprite_Bottle_4VcsFnUD9VHm9ie8.json
+++ b/src/packs/items/consumables/consumable_Sprite_Bottle_4VcsFnUD9VHm9ie8.json
@@ -13,9 +13,9 @@
     "consumeOnUse": true,
     "gmNotes": "",
     "actions": {
-      "wUImqyDPQpkiZ97K": {
-        "type": "effect",
-        "_id": "wUImqyDPQpkiZ97K",
+      "OaeTodiubEfIhiZe": {
+        "type": "healing",
+        "_id": "OaeTodiubEfIhiZe",
         "systemPath": "actions",
         "baseAction": false,
         "description": "",
@@ -42,10 +42,56 @@
           "recovery": null,
           "consumeOnSuccess": false
         },
-        "effects": [],
+        "damage": {
+          "main": null,
+          "resources": {
+            "hitPoints": {
+              "base": false,
+              "applyTo": "hitPoints",
+              "resultBased": false,
+              "fullRestore": true,
+              "value": {
+                "multiplier": "flat",
+                "flatMultiplier": 1,
+                "dice": "d6",
+                "bonus": null,
+                "custom": {
+                  "enabled": false,
+                  "formula": ""
+                }
+              },
+              "valueAlt": {
+                "multiplier": "flat",
+                "flatMultiplier": 1,
+                "dice": "d6",
+                "bonus": null,
+                "custom": {
+                  "enabled": false,
+                  "formula": ""
+                }
+              }
+            }
+          }
+        },
         "target": {
           "type": "any",
           "amount": null
+        },
+        "effects": [],
+        "roll": {
+          "type": null,
+          "trait": null,
+          "difficulty": null,
+          "bonus": null,
+          "advState": "neutral",
+          "diceRolling": {
+            "multiplier": "prof",
+            "flatMultiplier": 1,
+            "dice": "d6",
+            "compare": null,
+            "treshold": null
+          },
+          "useDefault": false
         },
         "name": "Use",
         "range": ""

--- a/templates/actionTypes/damage.hbs
+++ b/templates/actionTypes/damage.hbs
@@ -52,9 +52,8 @@
                             <a data-action="removeDamageResource" data-key="{{key}}"><i class="fas fa-trash"></i></a>
                         {{/unless}}
                     </legend>
-                    {{#if (eq dmg.applyTo 'weaponResource')}}
-                        {{formField ../fields.resources.element.fields.fullRestore value=dmg.fullRestore name=(concat ../path "damage.resources." dmg.applyTo ".fullRestore") localize=true classes="checkbox"}}
-                    {{/if}}
+
+                    {{formField ../fields.resources.element.fields.fullRestore value=dmg.fullRestore name=(concat ../path "damage.resources." dmg.applyTo ".fullRestore") localize=true classes="checkbox"}}
                     {{#unless dmg.fullRestore}}
                         {{> damageData damage=dmg fields=../fields.resources.element.fields basePath=(concat ../path "damage.resources." dmg.applyTo)}}
                     {{/unless}}

--- a/templates/dialogs/dice-roll/damageSelection.hbs
+++ b/templates/dialogs/dice-roll/damageSelection.hbs
@@ -60,16 +60,21 @@
 
     {{#each @root.resourceFormulas}}
         <div class="damage-formula">
-            <span class="damage-resource"><b>{{localize "DAGGERHEART.GENERAL.formula"}}:</b> {{roll.formula}}</span>
+            <span class="damage-resource">
+                <b>{{localize "DAGGERHEART.GENERAL.formula"}}:</b> 
+                {{#if fullRestore}}{{localize "DAGGERHEART.ACTIONS.Settings.fullRestore.inFormula"}}{{else}}{{roll.formula}}{{/if}}
+            </span>
             <span class="damage-details">
                 {{#with (lookup @root.config.GENERAL.healingTypes applyTo)}}
                     {{localize label}}
                 {{/with}}
             </span>
         </div>
-        <div class="bonuses form-group flexrow">
-            <input type="text" value="{{extraFormula}}" name={{concat "resourceFormulas." @key ".extraFormula"}} placeholder="{{localize "DAGGERHEART.GENERAL.situationalBonus"}}">
-        </div>
+        {{#unless fullRestore}}
+            <div class="bonuses form-group flexrow">
+                <input type="text" value="{{extraFormula}}" name={{concat "resourceFormulas." @key ".extraFormula"}} placeholder="{{localize "DAGGERHEART.GENERAL.situationalBonus"}}">
+            </div>
+        {{/unless}}
     {{/each}}
 
     {{#unless (empty @root.modifiers)}}

--- a/templates/ui/chat/damageSummary.hbs
+++ b/templates/ui/chat/damageSummary.hbs
@@ -22,20 +22,27 @@
                                     {{localize "DAGGERHEART.UI.Chat.restoreWeaponResource" quantity=this.value weapon=this.target.name}}
                                 {{/if}}
                             </span>
+                        {{else if this.clear}}
+                            <span>
+                                {{
+                                    localize "DAGGERHEART.UI.Chat.clearResourceFully"
+                                    resource=(localize (concat "DAGGERHEART.CONFIG.HealingType." this.key ".name"))
+                                }}
+                            </span>
                         {{else if (gte this.value 0)}}
                             <span>
                                 {{
-                                localize "DAGGERHEART.UI.Chat.markResource"
-                                quantity=this.value
-                                resource=(localize (concat "DAGGERHEART.CONFIG.HealingType." this.key ".name"))
+                                    localize "DAGGERHEART.UI.Chat.markResource"
+                                    quantity=this.value
+                                    resource=(localize (concat "DAGGERHEART.CONFIG.HealingType." this.key ".name"))
                                 }}
                             </span>
                         {{else}}
                             <span>
                                 {{
-                                localize "DAGGERHEART.UI.Chat.clearResource"
-                                quantity=(positive this.value)
-                                resource=(localize (concat "DAGGERHEART.CONFIG.HealingType." this.key ".name"))
+                                    localize "DAGGERHEART.UI.Chat.clearResource"
+                                    quantity=(positive this.value)
+                                    resource=(localize (concat "DAGGERHEART.CONFIG.HealingType." this.key ".name"))
                                 }}
                             </span>
                         {{/if}}


### PR DESCRIPTION
- Unlocked the hidden Full Restore option for healing actions so any resource can use that checkbox.
- Fixed the `Clear` logic in `Actor.modifyResource`, it was always ending up picking 0 to restore to. Now it correctly sets `isReverse` resources to 0 and "normal" resources to their max. So `Full Restore` on hope gets you to 6 hope for instance.
- Updated relevant SRD entries to make use of it.
- Fixed so chat messages don't just show 0 as healing value when FullRestore is true.

<img width="960" height="795" alt="image" src="https://github.com/user-attachments/assets/ab7936a8-5bbd-46b0-ab06-71482c653a5f" />
