### PR TITLE
[Feature] RollResolver Duality Labels

### DIFF
--- a/daggerheart.mjs
+++ b/daggerheart.mjs
@@ -533,3 +533,19 @@ Hooks.on('renderDialogV2', (dialog, html) => {
         select.querySelector(`option[value=${defaultEntity}]`).selected = true;
     }
 });
+
+Hooks.on('renderRollResolver', (document, html) => {
+    for (const [termId, data] of document.fulfillable) {
+        const dualityLabel = 
+            data.term.modifiers.includes('h') ? _loc(`DAGGERHEART.GENERAL.rollWith`, { roll: _loc(`DAGGERHEART.GENERAL.hope`) }) : 
+                data.term.modifiers.includes('f') ? _loc(`DAGGERHEART.GENERAL.rollWith`, { roll: _loc(`DAGGERHEART.GENERAL.fear`) }) : 
+                    null;
+
+        if (!dualityLabel) continue;
+        
+        const legend = html.querySelector(`.input-grid[data-term-id=${termId}] legend`);
+        if (!legend) continue;
+        
+        legend.childNodes[0].nodeValue = `${dualityLabel} `;
+    }
+});


### PR DESCRIPTION
Fixed so that the RollResolver dialog when using manual dice rolling will display Hope Roll and Fear Roll as labels when applicable.
<img width="652" height="470" alt="image" src="https://github.com/user-attachments/assets/b205b5af-9db5-47d1-87b0-5c1155656162" />

I remade the previous PR that was delayed to instead use a hook. This is much better since Duality rolls can now be made anywhere using roll syntax (`/r 1d12h + 1d12f`)
