### PR TITLE
Replace button enrichers with the content link styling

### DIFF
--- a/module/enrichers/DualityRollEnricher.mjs
+++ b/module/enrichers/DualityRollEnricher.mjs
@@ -1,5 +1,5 @@
 import { abilities } from '../config/actorConfig.mjs';
-import { getCommandTarget, rollCommandToJSON } from '../helpers/utils.mjs';
+import { createHtmlElement, getCommandTarget, rollCommandToJSON } from '../helpers/utils.mjs';
 
 export function DhDualityRollEnricher(match, _options) {
     const roll = rollCommandToJSON(match[0]);
@@ -35,26 +35,27 @@ function getDualityMessage(roll, flavor) {
                 : undefined;
 
     const dualityElement = document.createElement('span');
-    dualityElement.innerHTML = `
-        <button type="button" class="duality-roll-button${roll?.inline ? ' inline' : ''}" 
-            data-title="${label}"
-            data-label="${dataLabel}"
-            data-reaction="${roll?.reaction ? 'true' : 'false'}"
-            data-hope="${roll?.hope ?? 'd12'}" 
-            data-fear="${roll?.fear ?? 'd12'}"
-            ${advantage ? `data-advantage="${advantage}"` : ''}
-            ${roll?.difficulty !== undefined ? `data-difficulty="${roll.difficulty}"` : ''}
-            ${roll?.trait && abilities[roll.trait] ? `data-trait="${roll.trait}"` : ''}
-            ${roll?.advantage ? 'data-advantage="true"' : ''}
-            ${roll?.disadvantage ? 'data-disadvantage="true"' : ''}
-            ${roll?.grantResources ? 'data-grant-resources="true"' : ''}
-        >
-            ${roll?.reaction ? '<i class="fa-solid fa-reply"></i>' : '<i class="fa-solid fa-circle-half-stroke"></i>'}
-            ${label}
-            ${!flavor && (roll?.difficulty || advantageLabel) ? `(${[roll.difficulty, advantageLabel ? game.i18n.localize(`DAGGERHEART.GENERAL.${advantageLabel}.short`) : null].filter(x => x).join(' ')})` : ''}
-        </button>
-    `;
-
+    const anchor = createHtmlElement('a', {
+        className: 'content-link duality-roll-button',
+        data: {
+            title: label,
+            label: dataLabel,
+            reaction: `${roll?.reaction ? 'true' : 'false'}`,
+            hope: roll?.hope ?? 'd12',
+            fear: roll?.fear ?? 'd12',
+            difficulty: roll?.difficulty,
+            trait: roll?.trait && abilities[roll.trait] ? roll.trait : null,
+            advantage: roll?.advantage || null,
+            disadvantage: roll?.disadvantage || null,
+            grantResources: roll?.grantResources || null
+        },
+        html: [
+            roll?.reaction ? '<i class="fa-solid fa-reply"></i>' : '<i class="fa-solid fa-circle-half-stroke"></i>',
+            label,
+            !flavor && (roll?.difficulty || advantageLabel) ? `(${[roll.difficulty, advantageLabel ? game.i18n.localize(`DAGGERHEART.GENERAL.${advantageLabel}.short`) : null].filter(x => x).join(' ')})` : ''
+        ].join('')
+    });
+    dualityElement.append(anchor);
     return dualityElement;
 }
 

--- a/module/enrichers/EmbedTableEnricher.mjs
+++ b/module/enrichers/EmbedTableEnricher.mjs
@@ -1,5 +1,5 @@
 import { simplifyDescriptionForEmbed } from '../applications/sheets/sheet-helpers.mjs';
-import { fromUuids } from '../helpers/utils.mjs';
+import { createHtmlElement, fromUuids } from '../helpers/utils.mjs';
 import { parseInlineParams } from './parser.mjs';
 
 /** 
@@ -222,22 +222,7 @@ const rowsByItemType = {
     }
 }
 
-/**
- * 
- * @param {keyof HTMLElementTagNameMap} tagName 
- * @param {*} param1 
- * @returns 
- */
-function createHtmlElement(tagName, { text = null, html = null, className = null, attributes }) {
-    const tag = document.createElement(tagName);
-    if (text) tag.textContent = text;
-    if (html) tag.innerHTML = html;
-    if (className) tag.classList.add(className);
-    for (const [key, value] of Object.entries(attributes ?? {})) {
-        tag.setAttribute(key, value);
-    }
-    return tag;
-}
+
 
 function createErrorMessage(message) {
     const div = createHtmlElement('div', { text: message })

--- a/module/enrichers/FateRollEnricher.mjs
+++ b/module/enrichers/FateRollEnricher.mjs
@@ -1,4 +1,4 @@
-import { getCommandTarget, rollCommandToJSON } from '../helpers/utils.mjs';
+import { createHtmlElement, getCommandTarget, rollCommandToJSON } from '../helpers/utils.mjs';
 
 export function DhFateRollEnricher(match, _options) {
     const roll = rollCommandToJSON(match[0]);
@@ -29,15 +29,16 @@ function getFateMessage(roll, flavor) {
     const title = flavor ?? game.i18n.localize('DAGGERHEART.GENERAL.fateRoll');
 
     const fateElement = document.createElement('span');
-    fateElement.innerHTML = `
-        <button type="button" class="fate-roll-button${roll?.inline ? ' inline' : ''}"
-            data-title="${title}"
-            data-label="${fateTypeLabel}"
-            data-fateType="${fateType}"
-        >
-            ${title}
-        </button>
-    `;
+    const anchor = createHtmlElement('a', {
+        className: 'content-link fate-roll-button',
+        data: {
+            title,
+            label: fateTypeLabel,
+            fateType
+        },
+        html: title
+    });
+    fateElement.append(anchor);
 
     return fateElement;
 }

--- a/module/enrichers/TemplateEnricher.mjs
+++ b/module/enrichers/TemplateEnricher.mjs
@@ -1,3 +1,4 @@
+import { createHtmlElement } from '../helpers/utils.mjs';
 import { parseInlineParams } from './parser.mjs';
 
 /** Supports a template such as `@Template[type:emanation|range:far]` */
@@ -5,8 +6,7 @@ export function DhTemplateEnricher(match, _options) {
     const params = parseInlineParams(match[1]);
     const { 
         type = CONFIG.DH.GENERAL.templateTypes.circle.id,
-        angle = CONFIG.MeasuredTemplate.defaults.angle,
-        inline = false
+        angle = CONFIG.MeasuredTemplate.defaults.angle
     } = params;
     const direction = Number(params.direction) || 0;
     params.range = params.range?.toLowerCase();
@@ -43,13 +43,17 @@ export function DhTemplateEnricher(match, _options) {
     }
 
     const templateElement = document.createElement('span');
-    templateElement.innerHTML = `
-        <button type="button" class="measured-template-button${inline ? ' inline' : ''}" 
-            data-type="${type}" data-range="${range}" data-angle="${angle}" data-direction="${direction}">
-            ${label} - ${rangeDisplay}${extraDisplay}
-        </button>
-    `;
-
+    const anchor = createHtmlElement('a', {
+        className: 'content-link measured-template-button',
+        data: {
+            type,
+            range,
+            angle,
+            direction
+        },
+        html: `${label} - ${rangeDisplay}${extraDisplay}`
+    });
+    templateElement.append(anchor);
     return templateElement;
 }
 

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -218,6 +218,27 @@ export const damageKeyToNumber = key => {
     }[key];
 };
 
+/**
+ * Shorthand for creating an html element with certain properties as shorthand
+ * @template {keyof HTMLElementTagNameMap} T
+ * @param {T} tagName 
+ * @returns {HTMLElementTagNameMap[T]}
+ */
+export function createHtmlElement(tagName, { text = null, html = null, className = null, attributes, data }) {
+    const tag = document.createElement(tagName);
+    if (text) tag.textContent = text;
+    if (html) tag.innerHTML = html;
+    if (className) tag.classList.add(...className.split(' '));
+    for (const [key, value] of Object.entries(attributes ?? {})) {
+        tag.setAttribute(key, value);
+    }
+    for (const [key, value] of Object.entries(data ?? {})) {
+        if (value === null || value === undefined) continue;
+        tag.dataset[key] = String(value);
+    }
+    return tag;
+}
+
 export default function constructHTMLButton({
     label,
     dataset = {},


### PR DESCRIPTION
Replaces the yellow buttons that look awkward mid paragraph and mess up line height with the content-link styling, which is used for the regular rolling and embeds.

<img width="364" height="226" alt="image" src="https://github.com/user-attachments/assets/0e0e3ca7-d6cb-470b-a23c-0a40bd578986" />

The reason for create element refactor was because having spaces around the inner text causes some strange-ness in inline text elements where the button will be right up alongside the text. This seemed better than lines in our big string, and safer too.