### PR TITLE
[Feature] Implement refresh from compendium

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3403,7 +3403,16 @@
             },
             "Base": {
                 "addGMNote": "Add GM Note",
-                "viewReference": "View Full Details"
+                "viewReference": "View Full Details",
+                "Refresh": {
+                    "Title": "Refresh From Compendium",
+                    "AreYouSure": "Are you sure you want to refresh this item with new contents?",
+                    "Error": {
+                        "doesNotExist": "This document does not have a copy in the compendium",
+                        "invalidTier": "This document is of a different tier than the source, and was likely re-tiered",
+                        "invalidType": "The source document is the incorrect type"
+                    }
+                }
             },
             "Beastform": {
                 "FIELDS": {

--- a/module/applications/sheets/api/base-actor.mjs
+++ b/module/applications/sheets/api/base-actor.mjs
@@ -25,7 +25,8 @@ export default class DHBaseActorSheet extends DHApplicationMixin(ActorSheetV2) {
             openSettings: DHBaseActorSheet.#openSettings,
             sendExpToChat: DHBaseActorSheet.#sendExpToChat,
             increaseActionUses: event => DHBaseActorSheet.#modifyActionUses(event, true),
-            groupActionSelect: DHBaseActorSheet.#groupActionSelect
+            groupActionSelect: DHBaseActorSheet.#groupActionSelect,
+            refreshFromCompendium: DHBaseActorSheet.#onRefreshFromCompendium
         },
         contextMenus: [
             {
@@ -60,6 +61,20 @@ export default class DHBaseActorSheet extends DHApplicationMixin(ActorSheetV2) {
         const viewPermission = this.document.testUserPermission(game.user, this.options.viewPermission);
         const limitedOnly = this.document.testUserPermission(game.user, this.options.viewPermission, { exact: true });
         return limitedOnly ? this.document.system.metadata.hasLimitedView : viewPermission;
+    }
+
+    /** @inheritdoc */
+    _getHeaderControls() {
+        const controls = super._getHeaderControls();
+        if (this.actor.refreshSourceUuid) {
+            controls.push({
+                label: _loc('DAGGERHEART.ITEMS.Base.Refresh.Title'),
+                icon: 'fa-solid fa-arrow-rotate-left',
+                action: 'refreshFromCompendium'
+            });
+        }
+
+        return controls;
     }
 
     /* -------------------------------------------- */
@@ -304,6 +319,19 @@ export default class DHBaseActorSheet extends DHApplicationMixin(ActorSheetV2) {
     static async #groupActionSelect(event, button) {
         const action = await fromUuid(button.dataset.itemUuid);
         action.use(event, { groupAction: { forceSelect: true }});
+    }
+
+    /** @this DHBaseActorSheet */
+    static async #onRefreshFromCompendium() {
+        const refresh = await foundry.applications.api.DialogV2.confirm({
+            window: {
+                title: _loc('DAGGERHEART.ITEMS.Base.Refresh.Title')
+            },
+            content: _loc('DAGGERHEART.ITEMS.Base.Refresh.AreYouSure')
+        });
+        if (refresh) {
+            this.document.refreshFromCompendium();
+        }
     }
 
     /* -------------------------------------------- */

--- a/module/applications/sheets/api/base-item.mjs
+++ b/module/applications/sheets/api/base-item.mjs
@@ -35,7 +35,8 @@ export default class DHBaseItemSheet extends DHApplicationMixin(ItemSheetV2) {
             deleteFeature: DHBaseItemSheet.#deleteFeature,
             addResource: DHBaseItemSheet.#addResource,
             removeResource: DHBaseItemSheet.#removeResource,
-            editGMNote: DHBaseItemSheet.#onEditGMNote
+            editGMNote: DHBaseItemSheet.#onEditGMNote,
+            refreshFromCompendium: DHBaseItemSheet.#onRefreshFromCompendium
         },
         dragDrop: [
             { dragSelector: null, dropSelector: '.drop-section' },
@@ -64,6 +65,20 @@ export default class DHBaseItemSheet extends DHApplicationMixin(ItemSheetV2) {
             labelPrefix: 'DAGGERHEART.GENERAL.Tabs'
         }
     };
+
+    /** @inheritdoc */
+    _getHeaderControls() {
+        const controls = super._getHeaderControls();
+        if (this.item.refreshSourceUuid) {
+            controls.push({
+                label: _loc('DAGGERHEART.ITEMS.Base.Refresh.Title'),
+                icon: 'fa-solid fa-arrow-rotate-left',
+                action: 'refreshFromCompendium'
+            });
+        }
+
+        return controls;
+    }
 
     /* -------------------------------------------- */
     /*  Prepare Context                             */
@@ -416,6 +431,19 @@ export default class DHBaseItemSheet extends DHApplicationMixin(ItemSheetV2) {
         window.setTimeout(() => {
             if (wasHidden) editor.classList.add('hide-if-inactive');
         }, 0);
+    }
+
+    /** @this DHBaseItemSheet */
+    static async #onRefreshFromCompendium() {
+        const refresh = await foundry.applications.api.DialogV2.confirm({
+            window: {
+                title: _loc('DAGGERHEART.ITEMS.Base.Refresh.Title')
+            },
+            content: _loc('DAGGERHEART.ITEMS.Base.Refresh.AreYouSure')
+        });
+        if (refresh) {
+            this.document.refreshFromCompendium();
+        }
     }
 
     /** @inheritdoc */

--- a/module/documents/_types.d.ts
+++ b/module/documents/_types.d.ts
@@ -31,5 +31,9 @@ declare module './item.mjs' {
         actor: DhpActor;
         system: T;
         effects: EmbeddedCollection<DhActiveEffect>;
+        _stats: {
+            compendiumSource?: string;
+            duplicateSource?: string;
+        }
     }
 }

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1205,7 +1205,7 @@ export default class DhpActor extends Actor {
      */
     async refreshFromCompendium({ save = true } = {}) {
         const latest = await fromUuid(this.refreshSourceUuid);
-        if (!latest || !this._stats.compendiumSource?.startsWith('Compendium.')) {
+        if (!latest) {
             return ui.notifications.error(_loc('DAGGERHEART.ITEMS.Base.Refresh.Error.doesNotExist'));
         }
         if (latest.type !== this.type) {

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1216,9 +1216,6 @@ export default class DhpActor extends Actor {
             return ui.notifications.error(_loc('DAGGERHEART.ITEMS.Base.Refresh.Error.invalidTier'));
         }
 
-        // @todo defer preserved properties to system data somehow
-        // should gm notes be preserved or ko'd?
-        // what do we do about flags?
         const currentSource = this.toObject(true);
         const latestSource = latest.toObject(true);
         const system = foundry.utils.mergeObject(latestSource.system, {

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1,7 +1,7 @@
 import { emitGMUpdate, GMUpdateEvent } from '../systemRegistration/socket.mjs';
 import { LevelOptionType } from '../data/levelTier.mjs';
 import DHFeature from '../data/item/feature.mjs';
-import { createScrollText, damageKeyToNumber, getDamageKey, createShallowProxy } from '../helpers/utils.mjs';
+import { createScrollText, damageKeyToNumber, getDamageKey, createShallowProxy, pick } from '../helpers/utils.mjs';
 import DhCompanionLevelUp from '../applications/levelup/companionLevelup.mjs';
 import { ResourceUpdateMap } from '../data/action/baseAction.mjs';
 import { abilities } from '../config/actorConfig.mjs';
@@ -28,6 +28,18 @@ export default class DhpActor extends Actor {
      */
     get isNPC() {
         return this.system.metadata.isNPC;
+    }
+
+    /**
+     * Returns the uuid of the actor that is used for refreshing.
+     * This isn't necessarily the sourceUuid. Compendium items don't have a refresh source.
+     * @returns {string | null} the uuid to refresh from, or null if it can't be refreshed
+     */
+    get refreshSourceUuid() {
+        const hasCompendiumSource = this._stats.compendiumSource?.startsWith('Compendium.');
+        return !this.pack && hasCompendiumSource && ['adversary', 'environment'].includes(this.type)
+            ? this._stats.compendiumSource
+            : null;
     }
 
     /** @inheritDoc */
@@ -1186,7 +1198,117 @@ export default class DhpActor extends Actor {
         }
     }
 
-    applyActiveEffects(phase) {
-        super.applyActiveEffects(phase);
+    /** 
+     * Refreshes this actor's data, effects, and items using information from the compendium.
+     * @param {options} [options]
+     * @param {boolean} [options.save] if set to false, returns the batch data to perform the operation instead of doing it
+     */
+    async refreshFromCompendium({ save = true } = {}) {
+        const latest = await fromUuid(this.refreshSourceUuid);
+        if (!latest || !this._stats.compendiumSource?.startsWith('Compendium.')) {
+            return ui.notifications.error(_loc('DAGGERHEART.ITEMS.Base.Refresh.Error.doesNotExist'));
+        }
+        if (latest.type !== this.type) {
+            return ui.notifications.error(_loc('DAGGERHEART.ITEMS.Base.Refresh.Error.invalidType'));
+        }
+        if (latest.system.tier !== this.system.tier) {
+            // An adversary that has been re-tiered is not eligible for refresh
+            return ui.notifications.error(_loc('DAGGERHEART.ITEMS.Base.Refresh.Error.invalidTier'));
+        }
+
+        // @todo defer preserved properties to system data somehow
+        // should gm notes be preserved or ko'd?
+        // what do we do about flags?
+        const currentSource = this.toObject(true);
+        const latestSource = latest.toObject(true);
+        const system = foundry.utils.mergeObject(latestSource.system, {
+            notes: currentSource.system.notes || latestSource.system.notes
+        });
+
+        // Handle Effects
+        const effectsToDelete = this.effects.filter(e => !latest.effects.has(e.id)).map(i => i.id);
+        const effectUpdates = [];
+        const effectCreates = [];
+        for (const effectSource of latestSource.effects) {
+            const existingEffect = this.effects.get(effectSource._id)?.toObject(true);
+            if (!existingEffect) {
+                effectCreates.push(effectSource);
+            } else {
+                effectUpdates.push(foundry.utils.mergeObject(effectSource, pick(existingEffect, ['disabled'])))
+            }
+        }
+
+        // Hnadle Items
+        const itemsToDelete = this.items.filter(e => !latest.items.has(e.id)).map(i => i.id);
+        const itemCreates = latestSource.items.filter(i => !this.items.has(i._id));
+        const batchFromItems = (await Promise.all(
+            this.items
+                .filter(i => latest.items.has(i.id))
+                .map(i => i.refreshFromCompendium({ save: false, latest: latest.items.get(i.id) }))
+        )).flat();
+
+        /** @type {foundry.abstract.types.DatabaseWriteOperation[]} */
+        const batch = [{
+            parent: this.parent,
+            documentName: this.documentName,
+            pack: this.pack,
+            action: 'update',
+            updates: [{
+                _id: this._id,
+                name: latestSource.name,
+                img: latestSource.img,
+                system: _replace(system)
+            }]
+        }];
+        if (effectCreates.length) {
+            batch.push({
+                parent: this,
+                documentName: 'ActiveEffect',
+                action: 'create',
+                data: effectCreates,
+                keepId: true
+            });
+        }
+        if (effectUpdates.length) {
+            batch.push({
+                parent: this,
+                documentName: 'ActiveEffect',
+                action: 'update',
+                updates: effectUpdates,
+                recursive: false,
+                diff: false
+            });
+        }
+        if (effectsToDelete.length) {
+            batch.push({
+                parent: this,
+                documentName: 'ActiveEffect',
+                action: 'delete',
+                ids: effectsToDelete
+            });
+        }
+        if (itemCreates.length) {
+            batch.push({
+                parent: this,
+                documentName: 'Item',
+                action: 'create',
+                data: itemCreates,
+                keepId: true
+            });
+        }
+        if (itemsToDelete.length) {
+            batch.push({
+                parent: this,
+                documentName: 'Item',
+                action: 'delete',
+                ids: itemsToDelete
+            });
+        }
+        batch.push(...batchFromItems);
+        if (save) {
+            if (batch.length) await foundry.documents.modifyBatch(batch);
+        } else {
+            return batch;
+        }
     }
 }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1,5 +1,5 @@
 import ActionSelectionDialog from '../applications/dialogs/actionSelectionDialog.mjs';
-import { fromUuids, keyBy } from '../helpers/utils.mjs';
+import { fromUuids, keyBy, pick } from '../helpers/utils.mjs';
 
 /**
  * Override and extend the basic Item implementation.
@@ -14,6 +14,52 @@ export default class DHItem extends foundry.documents.Item {
     get sourceUuid() {
         const isCompendium = this._id && this.pack && !this.isEmbedded;
         return isCompendium ? this.uuid : this._stats.compendiumSource ?? this._stats.duplicateSource ?? this.uuid;
+    }
+
+    /**
+     * Returns the uuid of the item that is used for refreshing.
+     * This isn't necessarily the sourceUuid. Compendium items don't have a refresh source.
+     * @returns {string | null} the uuid to refresh from, or null if it can't be refreshed
+     */
+    get refreshSourceUuid() {
+        // no refreshing compendium items
+        // ancestry items also aren't refreshable
+        if (this.pack || this.type === 'ancestry') return null;
+
+        const actor = this.actor;
+        if (['adversary', 'environment'].includes(actor.type)) {
+            const uuid = `${actor.refreshSourceUuid}.Item.${this.id}`;
+            return uuid.startsWith('Compendium.') ? uuid : null;
+        }
+        
+        return this._stats.compendiumSource?.startsWith('Compendium.') ? this._stats.compendiumSource : null;
+    }
+
+    /**
+     * Determine if this item is classified as an inventory item based on its metadata.
+     * @returns {boolean} Returns `true` if the item is an inventory item.
+     */
+    get isInventoryItem() {
+        return this.system.metadata.isInventoryItem ?? false;
+    }
+
+    /** 
+     * Returns true if the item can be used
+     * @returns {boolean}
+     */
+    get usable() {
+        const actor = this.actor;
+        const pack = actor?.pack ? game.packs.get(actor.pack) : null;
+        const hasActions = this.system.actionsList?.size || this.system.actionsList?.length;
+        const isValidType = actor?.type === 'character' || this.type === 'feature';
+        return !pack?.locked && this.isOwner && isValidType && hasActions;
+    }
+
+    /** Returns true if the item has a description, usually if there is a description field, or if there are item features */
+    get hasDescription() {
+        return Boolean(this.system.description) 
+            || Boolean(this.system.itemFeatures?.length)
+            || (Boolean(this.system.gmNotes) && game.user.isGM);
     }
 
     /** @inheritDoc */
@@ -126,26 +172,6 @@ export default class DHItem extends foundry.documents.Item {
         return data;
     }
 
-    /**
-     * Determine if this item is classified as an inventory item based on its metadata.
-     * @returns {boolean} Returns `true` if the item is an inventory item.
-     */
-    get isInventoryItem() {
-        return this.system.metadata.isInventoryItem ?? false;
-    }
-
-    /** Returns true if the item can be used */
-    get usable() {
-        const actor = this.actor;
-        const pack = actor?.pack ? game.packs.get(actor.pack) : null;
-        const hasActions = this.system.actionsList?.size || this.system.actionsList?.length;
-        const isValidType = actor?.type === 'character' || this.type === 'feature';
-        return !pack?.locked && this.isOwner && isValidType && hasActions;
-    }
-
-    get hasDescription() {
-        return Boolean(this.system.description) || Boolean(this.system.itemFeatures?.length);
-    }
 
     /** @inheritdoc */
     static async createDialog(data = {}, createOptions = {}, options = {}, renderOptions) {
@@ -316,5 +342,97 @@ export default class DHItem extends foundry.documents.Item {
         }
 
         return super.migrateData(source);
+    }
+
+    /** 
+     * Refreshes this item's data and effects using information from the compendium.
+     * @param {options} [options]
+     * @param {boolean} [options.save] if set to false, returns the batch data to perform the operation instead of doing it
+     */
+    async refreshFromCompendium({ save = true, latest } = {}) {
+        latest ??= await fromUuid(this.refreshSourceUuid);
+        if (!latest || !latest.pack) {
+            return ui.notifications.error(_loc('DAGGERHEART.ITEMS.Base.Refresh.Error.doesNotExist'));
+        }
+        if (latest.type !== this.type) {
+            return ui.notifications.error(_loc('DAGGERHEART.ITEMS.Base.Refresh.Error.invalidType'));
+        }
+
+        // @todo defer preserved properties to system data somehow
+        // should gm notes be preserved or ko'd?
+        // what do we do about flags?
+        const currentSource = this.toObject(true);
+        const latestSource = latest.toObject(true);
+        const system = foundry.utils.mergeObject(latestSource.system, pick(currentSource.system, [
+            // domain cards
+            'inVault',
+            // inventory items
+            'quantity',
+            'equipped',
+            // features
+            'granter',
+            // subclass (and class)
+            'featureState',
+            'isMulticlass'
+        ]), { recursive: false });
+
+        // todo: effects
+        const effectsToDelete = this.effects.filter(e => !latest.effects.has(e.id)).map(i => i.id);
+        const effectUpdates = [];
+        const effectCreates = [];
+        for (const effectSource of latestSource.effects) {
+            const existingEffect = this.effects.get(effectSource._id)?.toObject(true);
+            if (!existingEffect) {
+                effectCreates.push(effectSource);
+            } else {
+                effectUpdates.push(foundry.utils.mergeObject(effectSource, pick(existingEffect, ['disabled'])))
+            }
+        }
+
+        /** @type {foundry.abstract.types.DatabaseWriteOperation[]} */
+        const batch = [{
+            parent: this.parent,
+            documentName: this.documentName,
+            pack: this.pack,
+            action: 'update',
+            updates: [{
+                _id: this._id,
+                name: latestSource.name,
+                img: latestSource.img,
+                system: _replace(system)
+            }]
+        }];
+        if (effectCreates.length) {
+            batch.push({
+                parent: this,
+                documentName: 'ActiveEffect',
+                action: 'create',
+                data: effectCreates,
+                keepId: true
+            });
+        }
+        if (effectUpdates.length) {
+            batch.push({
+                parent: this,
+                documentName: 'ActiveEffect',
+                action: 'update',
+                updates: effectUpdates,
+                recursive: false,
+                diff: false
+            });
+        }
+        if (effectsToDelete.length) {
+            batch.push({
+                parent: this,
+                documentName: 'ActiveEffect',
+                action: 'delete',
+                ids: effectsToDelete
+            });
+        }
+        if (save) {
+            if (batch.length) await foundry.documents.modifyBatch(batch);
+        } else {
+            return batch;
+        }
     }
 }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -351,7 +351,7 @@ export default class DHItem extends foundry.documents.Item {
      */
     async refreshFromCompendium({ save = true, latest } = {}) {
         latest ??= await fromUuid(this.refreshSourceUuid);
-        if (!latest || !latest.pack) {
+        if (!latest) {
             return ui.notifications.error(_loc('DAGGERHEART.ITEMS.Base.Refresh.Error.doesNotExist'));
         }
         if (latest.type !== this.type) {

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -27,7 +27,7 @@ export default class DHItem extends foundry.documents.Item {
         if (this.pack || this.type === 'ancestry') return null;
 
         const actor = this.actor;
-        if (['adversary', 'environment'].includes(actor.type)) {
+        if (['adversary', 'environment'].includes(actor?.type)) {
             const uuid = `${actor.refreshSourceUuid}.Item.${this.id}`;
             return uuid.startsWith('Compendium.') ? uuid : null;
         }
@@ -358,12 +358,12 @@ export default class DHItem extends foundry.documents.Item {
             return ui.notifications.error(_loc('DAGGERHEART.ITEMS.Base.Refresh.Error.invalidType'));
         }
 
-        // @todo defer preserved properties to system data somehow
-        // should gm notes be preserved or ko'd?
-        // what do we do about flags?
+        // Get system data, preserving certain properties
         const currentSource = this.toObject(true);
         const latestSource = latest.toObject(true);
         const system = foundry.utils.mergeObject(latestSource.system, pick(currentSource.system, [
+            // General
+            'gmNotes',
             // domain cards
             'inVault',
             // inventory items
@@ -376,7 +376,7 @@ export default class DHItem extends foundry.documents.Item {
             'isMulticlass'
         ]), { recursive: false });
 
-        // todo: effects
+        // Handle Effects
         const effectsToDelete = this.effects.filter(e => !latest.effects.has(e.id)).map(i => i.id);
         const effectUpdates = [];
         const effectCreates = [];


### PR DESCRIPTION
Closes https://github.com/Foundryborne/daggerheart/issues/913

This adds a button in the window header menu for adversaries/environments/most item types. On an adversary/environment actor, refresh an item instead checks the actor's copy of that item, rather than assuming that the adversary feature has some source feature to pull from.

I have some uncertainties about it.
* This is an inherently dangerous operation. We may want to further restrict it early on
* A lot of it is document level, not system level. We should maybe defer some of its operation to the system level to avoid some checks, but I'm not sure which parts. Maybe we put stuff in metadata.
* How do we handle mixed ancestries? We really shouldn't refresh those.
* Should we handle changes in features in ancestry/community/subclasses? In what ways? I haven't touched feature

molilo was uncertain about calling it refresh, if others share the same opinion, we can rename it.