### PR TITLE
[Fix] Downtime Cleanup

### DIFF
--- a/module/applications/sheets/actors/party.mjs
+++ b/module/applications/sheets/actors/party.mjs
@@ -98,8 +98,10 @@ export default class PartySheet extends DHBaseActorSheet {
     async _prepareContext(options) {
         const context = await super._prepareContext(options);
         const settings = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Metagaming);
+        context.isGM = game.user.isGM;
         context.showStats =
             settings.hidePartyStats === 'never' || (settings.hidePartyStats === 'players' && game.user.isGM);
+            
         return context;
     }
 

--- a/styles/less/sheets/actors/party/party-members.less
+++ b/styles/less/sheets/actors/party/party-members.less
@@ -9,11 +9,14 @@
     .actions-section {
         display: flex;
         align-items: center;
-        justify-content: center;
         padding: 10px;
         margin-bottom: 10px;
         gap: 20px;
         background-color: light-dark(@dark-blue-10, @golden-10);
+
+        &.centered {
+            justify-content: center;
+        }
 
         button {
             span {

--- a/templates/sheets/actors/party/party-members.hbs
+++ b/templates/sheets/actors/party/party-members.hbs
@@ -14,7 +14,7 @@
             <span>{{localize "DAGGERHEART.APPLICATIONS.GroupRollSelect.title"}}</span>
         </button>
         {{#if isGM}}
-            <button data-action="triggerRest"  data-action="triggerRest" data-type="shortRest">
+            <button data-action="triggerRest" data-type="shortRest">
                 <i class="fa-solid fa-utensils"></i>
                 <span>{{localize "DAGGERHEART.APPLICATIONS.Downtime.shortRest.title"}}</span>
             </button>

--- a/templates/sheets/actors/party/party-members.hbs
+++ b/templates/sheets/actors/party/party-members.hbs
@@ -4,7 +4,7 @@
     data-group='{{tabs.partyMembers.group}}'
 >
 
-    <div class="actions-section">
+    <div class="actions-section {{#if isGM}}centered{{/if}}">
         <button data-action="tagTeamRoll" class="{{#if tagTeamActive}}active-action{{/if}}">
             <i class="fa-solid fa-user-group"></i>
             <span>{{localize "DAGGERHEART.APPLICATIONS.TagTeamSelect.title"}}</span>
@@ -13,14 +13,16 @@
             <i class="fa-solid fa-users"></i>
             <span>{{localize "DAGGERHEART.APPLICATIONS.GroupRollSelect.title"}}</span>
         </button>
-        <button data-action="triggerRest"  data-action="triggerRest" data-type="shortRest">
-            <i class="fa-solid fa-utensils"></i>
-            <span>{{localize "DAGGERHEART.APPLICATIONS.Downtime.shortRest.title"}}</span>
-        </button>
-        <button data-action="triggerRest"  data-type="longRest">
-            <i class="fa-solid fa-bed"></i>
-            <span>{{localize "DAGGERHEART.APPLICATIONS.Downtime.longRest.title"}}</span>
-        </button>
+        {{#if isGM}}
+            <button data-action="triggerRest"  data-action="triggerRest" data-type="shortRest">
+                <i class="fa-solid fa-utensils"></i>
+                <span>{{localize "DAGGERHEART.APPLICATIONS.Downtime.shortRest.title"}}</span>
+            </button>
+            <button data-action="triggerRest"  data-type="longRest">
+                <i class="fa-solid fa-bed"></i>
+                <span>{{localize "DAGGERHEART.APPLICATIONS.Downtime.longRest.title"}}</span>
+            </button>
+        {{/if}}
     </div>
 
     <ul class="actors-list{{#unless @root.showStats}} limited{{/unless}}">

--- a/templates/ui/chat/downtime.hbs
+++ b/templates/ui/chat/downtime.hbs
@@ -1,5 +1,5 @@
 <div class="daggerheart chat downtime">
-    <ul class="downtime-moves-list">
+    <div class="downtime-moves-list">
         {{#each moves as | move index |}}
             <details class="downtime-move" {{@root.open}}>
                 <summary class="downtime-label">
@@ -33,5 +33,5 @@
                 </div>
             {{/each}}
         {{/each}}
-    </ul>
+    </div>
 </div>


### PR DESCRIPTION
- Fixed downtime messages in chat having left padding. The container was randomly a `ul` element, which we've added a global rule with padding for.
- Fixed so that non-GMs do not see the Short Rest and Long Rest buttons in the Party Sheet as they're used for the GM to call downtime.