### PR TITLE
[Feature] clickable character sheet feature group headers

### DIFF
--- a/daggerheart.d.ts
+++ b/daggerheart.d.ts
@@ -24,7 +24,7 @@ declare global {
     // These are convenience types for common imported things. This allows them to be used in JSDoc directly
     // For actual use such as instanceof, an import is still required
     type DHItem<T extends BaseDataItem = BaseDataItem> = InstanceType<typeof documents.DHItem<T>>;
-    type DhpActor<T extends BaseDataItem = BaseDataItem> = InstanceType<typeof documents.DhpActor<T>>;
+    type DhpActor<T extends BaseDataActor = BaseDataActor> = InstanceType<typeof documents.DhpActor<T>>;
 
     /**
      * A simple event framework used throughout Foundry Virtual Tabletop.

--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -5,8 +5,15 @@ import DhCharacterCreation from '../../characterCreation/characterCreation.mjs';
 import FilterMenu from '../../ux/filter-menu.mjs';
 import { getArmorSources, getDocFromElement, getDocFromElementSync, itemAbleRollParse, sortBy } from '../../../helpers/utils.mjs';
 
-/**@typedef {import('@client/applications/_types.mjs').ApplicationClickAction} ApplicationClickAction */
+/** 
+ * @import DhCharacter from '../../../data/actor/character.mjs';
+ */
 
+/**
+ * @typedef {import('@client/applications/_types.mjs').ApplicationClickAction} ApplicationClickAction 
+ */
+
+/** @extends {DHBaseActorSheet<DhpActor<DhCharacter>>} */
 export default class CharacterSheet extends DHBaseActorSheet {
     /**@inheritdoc */
     static DEFAULT_OPTIONS = {
@@ -223,6 +230,7 @@ export default class CharacterSheet extends DHBaseActorSheet {
     /*  Prepare Context                             */
     /* -------------------------------------------- */
 
+    /** @inheritdoc */
     async _prepareContext(_options) {
         const context = await super._prepareContext(_options);
 
@@ -264,6 +272,9 @@ export default class CharacterSheet extends DHBaseActorSheet {
             case 'header':
                 await this._prepareHeaderContext(context, options);
                 break;
+            case 'features':
+                await this._prepareFeaturesContext(context, options);
+                break;
             case 'loadout':
                 await this._prepareLoadoutContext(context, options);
                 break;
@@ -282,6 +293,61 @@ export default class CharacterSheet extends DHBaseActorSheet {
         context.hasExtraResources = Object.keys(CONFIG.DH.RESOURCE.character.all).some(
             key => !CONFIG.DH.RESOURCE.character.base[key]
         );
+    }
+
+    async _prepareFeaturesContext(context, _options) {
+        const actor = this.actor;
+        const features = actor.itemTypes.feature;
+        const { value: classItem, subclass } = actor.system.class ?? {};
+        const { value: multiclass, subclass: multiSubclass } = actor.system.multiclass ?? {};
+        const anchorItems = [
+            ...actor.itemTypes.transformation,
+            actor.system.ancestry,
+            actor.system.community,
+            classItem,
+            subclass,
+            multiclass,
+            multiSubclass
+        ].filter(Boolean);
+
+        const groups = anchorItems.map(item => {
+            const type = item.system.isMulticlass ? (item.type === 'class' ? 'multiclass' : 'multiclassSubclass') : item.type;
+            const label = type === 'multiclass' 
+                ? 'DAGGERHEART.GENERAL.multiclass'
+                : type === 'multiclassSubclass' 
+                    ? `${game.i18n.localize('DAGGERHEART.GENERAL.multiclass')} ${game.i18n.localize('TYPES.Item.subclass')}`
+                    : `TYPES.Item.${type}`;
+            const linked = item.system.getLinkedItems();
+            return {
+                title: `${_loc(label)} - ${item.name}`,
+                type,
+                // If the item should be clickable/deletable
+                anchorItem: !['class', 'subclass'].includes(item.type) ? item : null,
+                deleteUuid: item.type === 'transformation' ? item.uuid : null,
+                values: linked.filter(i => i.type === 'feature' && actor.system.isItemAvailable(i))
+            }
+        }).filter(g => g.values.length || g.deleteUuid);
+
+        const companionFeatures = features.filter(f => 
+            f.system.granter?.type === CONFIG.DH.ITEM.featureTypes.companion.id);
+        if (companionFeatures.length) {
+            groups.push({
+                title: _loc('DAGGERHEART.ACTORS.Character.companionFeatures'),
+                type: 'companion',
+                values: companionFeatures
+            });
+        }
+
+        const assignedFeatures = groups.flatMap(g => g.values.map(f => f.id));
+        const looseFeatures = features.filter(i => !assignedFeatures.includes(i.id) && actor.system.isItemAvailable(i));
+        groups.push({ 
+            title: game.i18n.localize('DAGGERHEART.GENERAL.features'),
+            type: 'feature',
+            canCreate: true,
+            values: looseFeatures
+        })
+
+        context.featureGroups = groups;
     }
 
     /**

--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -297,11 +297,12 @@ export default class CharacterSheet extends DHBaseActorSheet {
 
     async _prepareFeaturesContext(context, _options) {
         const actor = this.actor;
-        const features = actor.itemTypes.feature;
+        const itemTypes = actor.itemTypes;
+        const features = itemTypes.feature;
         const { value: classItem, subclass } = actor.system.class ?? {};
         const { value: multiclass, subclass: multiSubclass } = actor.system.multiclass ?? {};
         const anchorItems = [
-            ...actor.itemTypes.transformation,
+            ...itemTypes.transformation,
             actor.system.ancestry,
             actor.system.community,
             classItem,

--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -297,12 +297,11 @@ export default class CharacterSheet extends DHBaseActorSheet {
 
     async _prepareFeaturesContext(context, _options) {
         const actor = this.actor;
-        const itemTypes = actor.itemTypes;
-        const features = itemTypes.feature;
+        const features = actor.itemTypes.feature;
         const { value: classItem, subclass } = actor.system.class ?? {};
         const { value: multiclass, subclass: multiSubclass } = actor.system.multiclass ?? {};
         const anchorItems = [
-            ...itemTypes.transformation,
+            ...actor.itemTypes.transformation,
             actor.system.ancestry,
             actor.system.community,
             classItem,

--- a/module/applications/sheets/api/_types.d.ts
+++ b/module/applications/sheets/api/_types.d.ts
@@ -1,9 +1,9 @@
 export {}; // top level import/export required or types don't work
 
 declare module './base-actor.mjs' {
-    export default interface DHBaseActorSheet {
-        actor: DhpActor;
-        document: DhpActor;
+    export default interface DHBaseActorSheet<T extends DhpActor> {
+        actor: T;
+        document: T;
     }
 }
 

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -348,6 +348,7 @@ export default class DhCharacter extends DhCreature {
         return this.parent.items.find(x => x.type === 'community') ?? null;
     }
 
+    /** @returns {{ value?: DHItem; subclass?: DHItem }} */
     get class() {
         const value = this.parent.items.find(x => x.type === 'class' && !x.system.isMulticlass);
         const subclass = this.parent.items.find(x => x.type === 'subclass' && !x.system.isMulticlass);
@@ -358,6 +359,7 @@ export default class DhCharacter extends DhCreature {
         };
     }
 
+    /** @returns {{ value?: DHItem; subclass?: DHItem }} */
     get multiclass() {
         const value = this.parent.items.find(x => x.type === 'class' && x.system.isMulticlass);
         const subclass = this.parent.items.find(x => x.type === 'subclass' && x.system.isMulticlass);
@@ -604,95 +606,6 @@ export default class DhCharacter extends DhCreature {
                 ]
             });
         }
-    }
-
-    get sheetLists() {
-        const transformations = {},
-            ancestryFeatures = [],
-            communityFeatures = [],
-            classFeatures = [],
-            subclassFeatures = [],
-            multiclassFeatures = [],
-            multiclassSubclassFeatures = [],
-            companionFeatures = [],
-            features = [];
-
-        for (let item of this.parent.items.filter(x => this.isItemAvailable(x))) {
-            const originItemType = item.system.granter?.type;
-
-            if (item.type === 'transformation') {
-                const features = this.parent.items.filter(x => x.type === 'feature' && x.system.granter?.id === item.id);
-                transformations[`transformation-${item.id}`] = {
-                    title: `${_loc('TYPES.Item.transformation')} - ${item.name}`,
-                    type: 'transformation',
-                    deleteUuid: item.uuid,
-                    values: features
-                };   
-            }
-            if (originItemType === CONFIG.DH.ITEM.featureTypes.transformation.id) {
-                continue; 
-            } else if (originItemType === CONFIG.DH.ITEM.featureTypes.ancestry.id) {
-                ancestryFeatures.push(item);
-            } else if (originItemType === CONFIG.DH.ITEM.featureTypes.community.id) {
-                communityFeatures.push(item);
-            } else if (originItemType === CONFIG.DH.ITEM.featureTypes.class.id) {
-                (item.system.granter?.multiclass ? multiclassFeatures : classFeatures).push(item);
-            } else if (originItemType === CONFIG.DH.ITEM.featureTypes.subclass.id) {
-                (item.system.granter?.multiclass ? multiclassSubclassFeatures : subclassFeatures).push(item);
-            } else if (originItemType === CONFIG.DH.ITEM.featureTypes.companion.id) {
-                companionFeatures.push(item);
-            } else if (item.type === 'feature' && !item.system.type) {
-                features.push(item);
-            }
-        }
-
-        return {
-            ...transformations,
-            ancestryFeatures: {
-                title: `${game.i18n.localize('TYPES.Item.ancestry')} - ${this.ancestry?.name}`,
-                type: 'ancestry',
-                values: ancestryFeatures
-            },
-            communityFeatures: {
-                title: `${game.i18n.localize('TYPES.Item.community')} - ${this.community?.name}`,
-                type: 'community',
-                values: communityFeatures
-            },
-            classFeatures: {
-                title: `${game.i18n.localize('TYPES.Item.class')} - ${this.class.value?.name}`,
-                type: 'class',
-                values: classFeatures
-            },
-            subclassFeatures: {
-                title: `${game.i18n.localize('TYPES.Item.subclass')} - ${this.class.subclass?.name}`,
-                type: 'subclass',
-                values: subclassFeatures
-            },
-            ...(multiclassFeatures.length
-                ? {
-                    multiclassFeatures: {
-                        title: `${game.i18n.localize('DAGGERHEART.GENERAL.multiclass')} - ${this.multiclass.value?.name}`,
-                        type: 'multiclass',
-                        values: multiclassFeatures
-                    }
-                }
-                : {}),
-            ...(multiclassSubclassFeatures.length
-                ? {
-                    multiclassSubclassFeatures: {
-                        title: `${game.i18n.localize('DAGGERHEART.GENERAL.multiclass')} ${game.i18n.localize('TYPES.Item.subclass')} - ${this.multiclass.subclass?.name}`,
-                        type: 'multiclassSubclass',
-                        values: multiclassSubclassFeatures
-                    }
-                }
-                : {}),
-            companionFeatures: {
-                title: game.i18n.localize('DAGGERHEART.ACTORS.Character.companionFeatures'),
-                type: 'companion',
-                values: companionFeatures
-            },
-            features: { title: game.i18n.localize('DAGGERHEART.GENERAL.features'), type: 'feature', values: features }
-        };
     }
 
     get primaryWeapon() {

--- a/templates/sheets/actors/character/features.hbs
+++ b/templates/sheets/actors/character/features.hbs
@@ -1,27 +1,37 @@
 <section class='tab {{tabs.features.cssClass}} {{tabs.features.id}}' data-tab='{{tabs.features.id}}'
     data-group='{{tabs.features.group}}'>
     <div class="features-sections">
-        {{#each document.system.sheetLists as |category|}}
-            {{#if (eq category.type 'feature' )}}
-                {{> 'daggerheart.inventory-items'
-                    title=category.title
-                    type='feature'
-                    actorType='character'
-                    collection=category.values
-                    canCreate=@root.editable
-                    showActions=@root.editable
-                }}
-            {{else if (or category.values.length category.deleteUuid)}}
-                {{> 'daggerheart.inventory-items'
-                    title=category.title
-                    type='feature'
-                    actorType='character'
-                    collection=category.values
-                    canCreate=false
-                    deleteUuid=category.deleteUuid
-                    showActions=@root.editable
-                }}
-            {{/if}}
+        {{#each featureGroups as |category|}}
+            <fieldset class="drop-section" >
+                <legend {{#if category.anchorItem}}data-tooltip="#item#{{category.anchorItem.uuid}}"{{/if}}>
+                    {{#if category.anchorItem}}
+                        <a data-action="editDoc" data-item-uuid="{{category.anchorItem.uuid}}">{{category.title}}</a>
+                    {{else}}
+                        {{category.title}}
+                    {{/if}}
+                    {{#if category.canCreate}}
+                        <a data-action="addNewItem" data-document-class="Item" data-type="feature" data-tooltip="{{localize 'DOCUMENT.Create' type=''}}">
+                            <i class="fa-solid fa-plus icon-button"></i>
+                        </a>
+                    {{/if}}
+                    {{#if category.deleteUuid}}
+                        <a data-action="deleteDoc" data-item-uuid="{{category.deleteUuid}}">
+                            <i class="fa-solid fa-trash icon-button"></i>
+                        </a>
+                    {{/if}}
+                </legend>
+                <ul class="items-list">
+                    {{#each category.values as |item|}}
+                        {{> 'daggerheart.inventory-item'
+                            item=item
+                            type="feature"
+                            actorType=@root.document.type
+                            showActions=@root.editable
+                        }}
+                    {{/each}}
+                </ul>
+            </fieldset>
+
         {{/each}}
     </div>
 </section>


### PR DESCRIPTION
Sheet modules might have to update after. This makes it so that the transformation is actually accessible.

Later on we can make subclass clickable, but for that we may want tooltips on each available rank.

<img width="604" height="528" alt="image" src="https://github.com/user-attachments/assets/780e3bc0-9f3b-4577-941d-8e3d4d23976a" />
