### PR TITLE
[Feature] Actor Sheets Image Popout

### DIFF
--- a/module/applications/sheets/api/base-actor.mjs
+++ b/module/applications/sheets/api/base-actor.mjs
@@ -66,6 +66,12 @@ export default class DHBaseActorSheet extends DHApplicationMixin(ActorSheetV2) {
     /** @inheritdoc */
     _getHeaderControls() {
         const controls = super._getHeaderControls();
+        controls.push({
+            icon: 'fa-solid fa-image',
+            label: 'SIDEBAR.CharArt',
+            action: 'showPortraitArtwork'
+        });
+
         if (this.actor.refreshSourceUuid) {
             controls.push({
                 label: _loc('DAGGERHEART.ITEMS.Base.Refresh.Title'),

--- a/module/applications/sheets/api/base-actor.mjs
+++ b/module/applications/sheets/api/base-actor.mjs
@@ -157,6 +157,9 @@ export default class DHBaseActorSheet extends DHApplicationMixin(ActorSheetV2) {
     _attachPartListeners(partId, htmlElement, options) {
         super._attachPartListeners(partId, htmlElement, options);
 
+        htmlElement.querySelector('.portrait > img, img.profile')
+            ?.addEventListener('contextmenu', DHBaseActorSheet.#onDisplayPortraitArtwork.bind(this));
+
         htmlElement.querySelectorAll('.inventory-item-quantity').forEach(element => {
             element.addEventListener('change', this.updateItemQuantity.bind(this));
             element.addEventListener('click', e => e.stopPropagation());
@@ -248,6 +251,12 @@ export default class DHBaseActorSheet extends DHApplicationMixin(ActorSheetV2) {
     /* -------------------------------------------- */
     /*  Application Listener Actions                */
     /* -------------------------------------------- */
+
+    static #onDisplayPortraitArtwork() {
+        const { ImagePopout } = foundry.applications.apps;
+        const {img, name, uuid} = this.document;
+        new ImagePopout({src: img, uuid, window: {title: name}}).render({force: true});
+    }
 
     async updateItemQuantity(event) {
         const item = await getDocFromElement(event.currentTarget);

--- a/module/applications/sheets/api/base-item.mjs
+++ b/module/applications/sheets/api/base-item.mjs
@@ -31,6 +31,7 @@ export default class DHBaseItemSheet extends DHApplicationMixin(ItemSheetV2) {
             submitOnChange: true
         },
         actions: {
+            showPortraitArtwork: DHBaseItemSheet.#onShowPortraitArtwork,
             addFeature: DHBaseItemSheet.#addFeature,
             deleteFeature: DHBaseItemSheet.#deleteFeature,
             addResource: DHBaseItemSheet.#addResource,
@@ -69,6 +70,12 @@ export default class DHBaseItemSheet extends DHApplicationMixin(ItemSheetV2) {
     /** @inheritdoc */
     _getHeaderControls() {
         const controls = super._getHeaderControls();
+        controls.push({
+            icon: 'fa-solid fa-image',
+            label: 'ITEM.ViewArt',
+            action: 'showPortraitArtwork'
+        });
+
         if (this.item.refreshSourceUuid) {
             controls.push({
                 label: _loc('DAGGERHEART.ITEMS.Base.Refresh.Title'),
@@ -131,6 +138,10 @@ export default class DHBaseItemSheet extends DHApplicationMixin(ItemSheetV2) {
     /** @inheritdoc */
     _attachPartListeners(partId, htmlElement, options) {
         super._attachPartListeners(partId, htmlElement, options);
+
+        
+        htmlElement.querySelector('img.profile')
+            ?.addEventListener('contextmenu', DHBaseItemSheet.#onShowPortraitArtwork.bind(this));
 
         // If the item supports lore references, add autocomplete
         const loreRefElement = htmlElement.querySelector('input[name="system.loreReference"]');
@@ -200,6 +211,12 @@ export default class DHBaseItemSheet extends DHApplicationMixin(ItemSheetV2) {
     /* -------------------------------------------- */
     /*  Application Clicks Actions                  */
     /* -------------------------------------------- */
+
+    static #onShowPortraitArtwork() {
+        const { ImagePopout } = foundry.applications.apps;
+        const {img, name, uuid} = this.document;
+        new ImagePopout({src: img, uuid, window: {title: name}}).render({force: true});
+    }
 
     /**
      * Add a new feature to the item, prompting the user for its type.


### PR DESCRIPTION
Added image popout for all actor sheets on rightclick of the portrait and in the context menu.
<img width="2043" height="1028" alt="image" src="https://github.com/user-attachments/assets/bccd712f-546a-419f-a10d-e172b6523e8f" />

<img width="808" height="500" alt="image" src="https://github.com/user-attachments/assets/ec23b79b-f6a7-44f2-af07-429b0e07a626" />
