### PR TITLE
[Fix] Create dialog when type is empty

### DIFF
--- a/daggerheart.mjs
+++ b/daggerheart.mjs
@@ -529,6 +529,8 @@ Hooks.on('renderDialogV2', (dialog, html) => {
             }
         });
     } else {
+        const { pack, parent } = dialog.options;
+        nameInput.placeholder = cls.defaultName({ type: defaultEntity, pack, parent });
         select.querySelector(`option[value=${defaultEntity}]`).selected = true;
     }
 });

--- a/daggerheart.mjs
+++ b/daggerheart.mjs
@@ -519,7 +519,6 @@ Hooks.on('renderDialogV2', (dialog, html) => {
     if (!defaultEntity) {
         nameInput.placeholder = cls.defaultName({});
         const emptyOption = document.createElement('option');
-        emptyOption.value = defaultEntity;
         emptyOption.selected = true;
         select.required = true;
         select.prepend(emptyOption);

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -160,6 +160,8 @@ export default class DhpActor extends Actor {
         const folder = collection?.get(data.folder) ?? null;
         options.defaultEntity = folder?.getDefaultEntity(); // used in hook
         options.classes = [options.classes ?? [], 'actor-create'].flat(); // handled in hook
+        options.parent = createOptions?.parent;
+        options.pack = createOptions?.pack;
         return super.createDialog(data, createOptions, options, renderOptions);
     }
 


### PR DESCRIPTION
Closes https://github.com/Foundryborne/daggerheart/issues/2294

defaultEntity has no value in that if branch, so setting the value only serves to make the form think that the option has a value, making the validation check pass when it shouldn't.