### PR TITLE
[Fix] Default DowntimeMoves Migration

### DIFF
--- a/module/systemRegistration/migration-handlers/2_9_1.mjs
+++ b/module/systemRegistration/migration-handlers/2_9_1.mjs
@@ -1,0 +1,28 @@
+import { defaultRestOptions } from '../../config/generalConfig.mjs';
+import { MigrationHandlerBase } from './base.mjs';
+
+export class Migration_2_9_1 extends MigrationHandlerBase {
+    /** @inheritdoc */
+    version = '2.9.1';
+
+    async migrate() {
+        const homebrew = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Homebrew);
+        const shortMoves = defaultRestOptions.shortRest();
+        const longMoves = defaultRestOptions.longRest();
+
+        const updateMoves = (currentList, updatedMoves) => {
+            return Object.entries(currentList).reduce((acc, [key, move]) => {
+                acc[key] = updatedMoves[key] ?? move;
+                return acc;
+            }, {});
+        };
+
+        await homebrew.updateSource({
+            restMoves: {
+                shortMoves: { moves: updateMoves(homebrew.restMoves.shortRest.moves, shortMoves) },
+                longMoves: { moves: updateMoves(homebrew.restMoves.longRest.moves, longMoves) }
+            }
+        });
+        game.settings.set(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Homebrew, homebrew.toObject());
+    }
+}

--- a/module/systemRegistration/migrations.mjs
+++ b/module/systemRegistration/migrations.mjs
@@ -3,6 +3,7 @@ import { getAllResources } from '../helpers/utils.mjs';
 import { Migration_2_5_2 } from './migration-handlers/2_5_2.mjs';
 import { Migration_2_6_0 } from './migration-handlers/2_6_0.mjs';
 import { Migration_2_8_0_hotfix } from './migration-handlers/2_8_0-hotfix.mjs';
+import { Migration_2_9_1 } from './migration-handlers/2_9_1.mjs';
 
 export async function runMigrations() {
     let lastMigrationVersion = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.LastMigrationVersion);
@@ -334,7 +335,8 @@ export async function runMigrations() {
     const migrations = [
         new Migration_2_5_2(),
         new Migration_2_6_0(),
-        new Migration_2_8_0_hotfix()
+        new Migration_2_8_0_hotfix(),
+        new Migration_2_9_1()
     ].filter(m => m.version && foundry.utils.isNewerVersion(m.version, lastMigrationVersion));
 
     for (const handler of migrations) {

--- a/src/packs/subclasses/feature_Deathless_Embrace_pEPIud1nwUb8wxiL.json
+++ b/src/packs/subclasses/feature_Deathless_Embrace_pEPIud1nwUb8wxiL.json
@@ -38,8 +38,8 @@
         ],
         "uses": {
           "value": null,
-          "max": "",
-          "recovery": null,
+          "max": "1",
+          "recovery": "shortRest",
           "consumeOnSuccess": false
         },
         "effects": [],


### PR DESCRIPTION
Added a migration to force set all default downtime moves to their defaults. Appearantly some users -still- don't get the automation in chat messages, so this should make that go away while keeping any custom downtime moves.