### PR TITLE
[Fix] Translation Corrections

### DIFF
--- a/module/config/itemBrowserConfig.mjs
+++ b/module/config/itemBrowserConfig.mjs
@@ -208,7 +208,7 @@ export const typeConfig = {
             {
                 key: 'system.secondary',
                 label: 'DAGGERHEART.UI.ItemBrowser.subtype',
-                format: isSecondary => (isSecondary ? 'secondary' : isSecondary === false ? 'primary' : '-')
+                format: isSecondary => (isSecondary ? 'DAGGERHEART.ITEMS.Weapon.secondaryWeapon.short' : isSecondary === false ? 'DAGGERHEART.ITEMS.Weapon.primaryWeapon.short' : '-')
             },
             {
                 key: 'system.tier',

--- a/src/packs/adversaries/adversary_Battle_Box_dgH3fW9FTYLaIDvS.json
+++ b/src/packs/adversaries/adversary_Battle_Box_dgH3fW9FTYLaIDvS.json
@@ -237,7 +237,7 @@
       "name": "Relentless (2)",
       "type": "feature",
       "system": {
-        "description": "<p>The @Lookup[@name] can be spotlighted up to two times times per GM turn. Spend Fear as usual to spotlight them.</p>",
+        "description": "<p>The @Lookup[@name] can be spotlighted up to two times per GM turn. Spend Fear as usual to spotlight them.</p>",
         "resource": null,
         "actions": {
           "2JfPSV3pw6pv0BXd": {

--- a/src/packs/rolltables/tables_Core_Set_Consumables_tF04P02yVN1YDVel.json
+++ b/src/packs/rolltables/tables_Core_Set_Consumables_tF04P02yVN1YDVel.json
@@ -847,7 +847,7 @@
         32,
         32
       ],
-      "name": "Homet’s Secret Potion",
+      "name": "Homet's Secret Potion",
       "img": "icons/consumables/potions/conical-ornate-purple.webp",
       "documentUuid": "Compendium.daggerheart.consumables.Item.VSwa1LpQ9PjZKsWF",
       "_id": "QQsRU8GRbQeFU3KP",
@@ -861,9 +861,9 @@
         "coreVersion": "14.367",
         "systemId": "daggerheart",
         "systemVersion": "2.7.4",
-        "lastModifiedBy": "JMhdNTzd2YUj2XFj",
+        "lastModifiedBy": "ET8d2buBDDPA9J7i",
         "createdTime": 1787131648702,
-        "modifiedTime": 1787131648702
+        "modifiedTime": 1788286147034
       },
       "_key": "!tables.results!tF04P02yVN1YDVel.QQsRU8GRbQeFU3KP"
     },

--- a/src/packs/rolltables/tables_Core_Set_Items_S61Shlt2I5CbLRjz.json
+++ b/src/packs/rolltables/tables_Core_Set_Items_S61Shlt2I5CbLRjz.json
@@ -91,7 +91,7 @@
         4,
         4
       ],
-      "name": "Alistair’s Torch",
+      "name": "Alistair's Torch",
       "img": "icons/sundries/lights/torch-brown-lit.webp",
       "documentUuid": "Compendium.daggerheart.loot.Item.MeEg57T6MKpw3sme",
       "_id": "jYHROKTetnH9U1NF",
@@ -105,9 +105,9 @@
         "coreVersion": "14.367",
         "systemId": "daggerheart",
         "systemVersion": "2.7.4",
-        "lastModifiedBy": "JMhdNTzd2YUj2XFj",
+        "lastModifiedBy": "ET8d2buBDDPA9J7i",
         "createdTime": 1787131648635,
-        "modifiedTime": 1787131648635
+        "modifiedTime": 1788286051210
       },
       "_key": "!tables.results!S61Shlt2I5CbLRjz.jYHROKTetnH9U1NF"
     },
@@ -982,7 +982,7 @@
         37,
         37
       ],
-      "name": "Paragon’s Chain",
+      "name": "Paragon's Chain",
       "img": "icons/equipment/neck/choker-chain-thin-gold.webp",
       "documentUuid": "Compendium.daggerheart.loot.Item.F4hoRfvVdZq5bhhI",
       "_id": "TFgxOPNDbLYDzxrl",
@@ -996,9 +996,9 @@
         "coreVersion": "14.367",
         "systemId": "daggerheart",
         "systemVersion": "2.7.4",
-        "lastModifiedBy": "JMhdNTzd2YUj2XFj",
+        "lastModifiedBy": "ET8d2buBDDPA9J7i",
         "createdTime": 1787131648648,
-        "modifiedTime": 1787131648648
+        "modifiedTime": 1788286099490
       },
       "_key": "!tables.results!S61Shlt2I5CbLRjz.TFgxOPNDbLYDzxrl"
     },


### PR DESCRIPTION
Fixes #2308 
Fixed three curly apostrophees in the rolltable result names

Fixes #2227 
Went ahead and corrected a description in the Battlebox adversary aswell

Fixes #2203 
Fixed missing translations on the ItemBrowser's subtype column for weapon