### PR TITLE
Fix rolls in light mode interface

### DIFF
--- a/module/documents/chatMessage.mjs
+++ b/module/documents/chatMessage.mjs
@@ -41,6 +41,11 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
 
         this.enrichChatMessage(html);
         this.addChatListeners(html);
+        
+        // todo: move to system renderHTML once implemented
+        if (['adversaryRoll', 'damageRoll', 'dualityRoll', 'fateRoll'].includes(this.type)) {
+            html.classList.add('themed', 'theme-dark');
+        }
 
         return html;
     }

--- a/styles/less/global/chat.less
+++ b/styles/less/global/chat.less
@@ -7,15 +7,6 @@
     .chat-log .chat-message {
         background-image: url('../assets/parchments/dh-parchment-light.png');
 
-        .message-header .message-header-main .message-metadata,
-        .message-header .message-header-main .name {
-            color: @dark;
-        }
-
-        .message-header .message-header-main h4 {
-            color: @dark-blue;
-        }
-
         .message-content {
             .table-draw {
                 .table-description {
@@ -75,7 +66,7 @@
                         font-weight: bold;
                         margin-bottom: 0;
                         font-family: @font-subtitle;
-                        color: @golden;
+                        color: light-dark(@dark-blue, @golden);
                         white-space: nowrap;
                         text-overflow: ellipsis;
                         flex: 1;
@@ -85,12 +76,16 @@
                     
                     .message-metadata {
                         font-family: @font-body;
-                        color: @beige;
                         white-space: nowrap;
                         align-items: baseline;
+                        color: light-dark(@dark, @beige);
                         .message-timestamp {
                             font-size: var(--font-size-11);
                         }
+                    }
+
+                    .name {
+                        color: light-dark(@dark, @color-text-primary);
                     }
                     
                     .subtitle {
@@ -98,7 +93,7 @@
                         flex: 1;
                         display: flex;
                         justify-content: space-between;
-                        color: @beige;
+                        color: light-dark(@dark, @beige);
                         gap: 4px;
                         align-items: baseline;
                         line-height: 1;


### PR DESCRIPTION
The scope change is for molilo's char sheet stuff, it prevents any nested themed elements from getting style meant for the application (it was getting the sheet parchment).

But while testing it caught some regressions in chat in light mode.