### PR TITLE
[Feature] Active Effect Path Viewer

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -338,6 +338,10 @@
                         "hint": "Ignore burden rules"
                     }
                 },
+                "comboDieIndex": {
+                    "label": "Combo Die Index",
+                    "hint": "The number of dice sizes your combo die has been raised from 1d4. Add +1 to increase it one size."
+                },
                 "companionFeatures": "Companion Features",
                 "connections": "Connections",
                 "contextMenu": {
@@ -479,7 +483,9 @@
         },
         "APPLICATIONS": {
             "ActiveEffectPathViewer": {
-                "title": "Active Effect Path Viewer"
+                "title": "Active Effect Path Viewer",
+                "searchLabel": "Search Paths",
+                "copyPathNotification": "Copied ActiveEffect path for {name} to clipboard"
             },
             "Attribution": {
                 "title": "Attribution"
@@ -971,6 +977,12 @@
                 "longRest": "Next Long Rest",
                 "session": "Next Session",
                 "custom": "Custom"
+            },
+            "ActiveEffectExtraPaths": {
+                "allCategory": "All Actors",
+                "cast": { "label": "Spellcasting Modifier" },
+                "fear": { "label": "Fear Amount" },
+                "partySize": { "label": "Party Size" }
             },
             "ActionAutomationChoices": {
                 "never": "Never",

--- a/lang/en.json
+++ b/lang/en.json
@@ -478,6 +478,9 @@
             }
         },
         "APPLICATIONS": {
+            "ActiveEffectPathViewer": {
+                "title": "Active Effect Path Viewer"
+            },
             "Attribution": {
                 "title": "Attribution"
             },
@@ -646,7 +649,8 @@
                     "text": "There is no active Party actor in the world or it's empty. Manually input the number of player characters."
                  },
                  "chatMessageTitle": "GM Consequences",
-                 "chatMessageText": "The GM gains fear"
+                 "chatMessageText": "The GM gains fear",
+                 "activeEffectPathViewer": "Active Effect Path Viewer"
             },
             "DeleteConfirmation": {
                 "title": "Delete {type} - {name}",

--- a/lang/en.json
+++ b/lang/en.json
@@ -485,7 +485,9 @@
             "ActiveEffectPathViewer": {
                 "title": "Active Effect Path Viewer",
                 "searchLabel": "Search Paths",
-                "copyPathNotification": "Copied ActiveEffect path for {name} to clipboard"
+                "copyPathNotification": "Copied ActiveEffect path for {name} to clipboard",
+                "macroButtonLabel": "Open Macro",
+                "macroCopyNotification": "A macro to open the Path Viewer has been copied to your clipboard. Paste it in a macro on your hotbar."
             },
             "Attribution": {
                 "title": "Attribution"

--- a/module/applications/dialogs/_module.mjs
+++ b/module/applications/dialogs/_module.mjs
@@ -18,3 +18,4 @@ export { default as RiskItAllDialog } from './riskItAllDialog.mjs';
 export { default as CompendiumBrowserSettingsDialog } from './CompendiumBrowserSettings.mjs';
 export { default as LevelupOptionsDialog } from './levelupOptionsDialog.mjs';
 export { default as MultiActionSelectionDialog } from './multiActionSelectionDialog.mjs';
+export { default as ActiveEffectPathViewer } from './activeEffectPathViewerDialog.mjs';

--- a/module/applications/dialogs/activeEffectPathViewerDialog.mjs
+++ b/module/applications/dialogs/activeEffectPathViewerDialog.mjs
@@ -1,0 +1,30 @@
+const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
+
+export default class ActiveEffectPathViewer extends HandlebarsApplicationMixin(ApplicationV2) {
+    static DEFAULT_OPTIONS = {
+        classes: ['daggerheart', 'dialog', 'dh-style', 'active-effect-change-paths-dialog'],
+        position: {
+            width: 612,
+            height: 800
+        },
+        window: {
+            icon: 'fa-solid fa-scroll',
+            title: 'DAGGERHEART.APPLICATIONS.ActiveEffectPathViewer.title'
+        }
+    };
+
+    /** @override */
+    static PARTS = {
+        main: {
+            template: 'systems/daggerheart/templates/dialogs/activeEffectPathViewer.hbs',
+            scrollable: ['.paths-container']
+        }
+    };
+
+    async _prepareContext(_options) {
+        const context = await super._prepareContext(_options);
+        context.paths = game.system.api.applications.sheetConfigs.ActiveEffectConfig.getChangeChoices();
+
+        return context;
+    }
+}

--- a/module/applications/dialogs/activeEffectPathViewerDialog.mjs
+++ b/module/applications/dialogs/activeEffectPathViewerDialog.mjs
@@ -11,7 +11,7 @@ export default class ActiveEffectPathViewer extends HandlebarsApplicationMixin(A
             if (!acc[curr.group]) acc[curr.group] = { name: curr.group, paths: [] };
             acc[curr.group].paths.push({
                 ...curr,
-                value: curr.fullPath ? curr.value : `@system.${curr.value}`
+                value: curr.isFullPath ? curr.value : `@system.${curr.value}`
             });
 
             return acc;

--- a/module/applications/dialogs/activeEffectPathViewerDialog.mjs
+++ b/module/applications/dialogs/activeEffectPathViewerDialog.mjs
@@ -25,6 +25,7 @@ export default class ActiveEffectPathViewer extends HandlebarsApplicationMixin(A
             height: 640
         },
         window: {
+            resizable: true,
             icon: 'fa-solid fa-scroll',
             title: 'DAGGERHEART.APPLICATIONS.ActiveEffectPathViewer.title'
         },

--- a/module/applications/dialogs/activeEffectPathViewerDialog.mjs
+++ b/module/applications/dialogs/activeEffectPathViewerDialog.mjs
@@ -29,7 +29,8 @@ export default class ActiveEffectPathViewer extends HandlebarsApplicationMixin(A
             title: 'DAGGERHEART.APPLICATIONS.ActiveEffectPathViewer.title'
         },
         actions: {
-            copyPath: ActiveEffectPathViewer.#onCopyPath
+            copyPath: ActiveEffectPathViewer.#onCopyPath,
+            copyOpenMacro: ActiveEffectPathViewer.#onCopyOpenMacro
         }
     };
 
@@ -40,6 +41,17 @@ export default class ActiveEffectPathViewer extends HandlebarsApplicationMixin(A
             scrollable: ['.paths-container']
         }
     };
+
+    /** @inheritDoc */
+    _getFrameButtons(options) {
+        const buttons = super._getFrameButtons(options);
+        buttons.push({
+            icon: 'fa-solid fa-scroll',
+            label: 'DAGGERHEART.APPLICATIONS.ActiveEffectPathViewer.macroButtonLabel',
+            action: 'copyOpenMacro'
+        });
+        return buttons;
+    }
 
     _attachPartListeners(partId, htmlElement, options) {
         super._attachPartListeners(partId, htmlElement, options);
@@ -85,6 +97,13 @@ export default class ActiveEffectPathViewer extends HandlebarsApplicationMixin(A
         game.clipboard.copyPlainText(value);
         ui.notifications.info(
             _loc('DAGGERHEART.APPLICATIONS.ActiveEffectPathViewer.copyPathNotification', { name: name })
+        );
+    }
+
+    static #onCopyOpenMacro() {
+        game.clipboard.copyPlainText('game.system.api.macros.showActiveEffectPathViewer();');
+        ui.notifications.info(
+            _loc('DAGGERHEART.APPLICATIONS.ActiveEffectPathViewer.macroCopyNotification')
         );
     }
 }

--- a/module/applications/dialogs/activeEffectPathViewerDialog.mjs
+++ b/module/applications/dialogs/activeEffectPathViewerDialog.mjs
@@ -1,15 +1,35 @@
 const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
 export default class ActiveEffectPathViewer extends HandlebarsApplicationMixin(ApplicationV2) {
+    constructor(options) {
+        super(options);
+
+        this.searchValue = '';
+
+        const pathData = game.system.api.applications.sheetConfigs.ActiveEffectConfig.getChangeChoices();
+        this.pathGroups = pathData.reduce((acc, curr) => {
+            if (!acc[curr.group]) acc[curr.group] = { name: curr.group, paths: [] };
+            acc[curr.group].paths.push({
+                ...curr,
+                value: curr.fullPath ? curr.value : `@system.${curr.value}`
+            });
+
+            return acc;
+        }, {});
+    }
+
     static DEFAULT_OPTIONS = {
         classes: ['daggerheart', 'dialog', 'dh-style', 'active-effect-change-paths-dialog'],
         position: {
             width: 612,
-            height: 800
+            height: 640
         },
         window: {
             icon: 'fa-solid fa-scroll',
             title: 'DAGGERHEART.APPLICATIONS.ActiveEffectPathViewer.title'
+        },
+        actions: {
+            copyPath: ActiveEffectPathViewer.#onCopyPath
         }
     };
 
@@ -21,10 +41,50 @@ export default class ActiveEffectPathViewer extends HandlebarsApplicationMixin(A
         }
     };
 
+    _attachPartListeners(partId, htmlElement, options) {
+        super._attachPartListeners(partId, htmlElement, options);
+    
+        htmlElement.querySelector('.path-search-input')
+            .addEventListener('keydown', this.debouncedUpdateSearchValue.bind(this));
+    }
+
     async _prepareContext(_options) {
         const context = await super._prepareContext(_options);
-        context.paths = game.system.api.applications.sheetConfigs.ActiveEffectConfig.getChangeChoices();
+        context.searchValue = this.searchValue;
+        context.pathGroups = this.pathGroups;
 
         return context;
+    }
+
+    debouncedUpdateSearchValue = foundry.utils.debounce(this.onUpdateSearchValue, 200);
+
+    onUpdateSearchValue(event) {
+        this.searchValue = event.target.value.toLowerCase();
+
+        for (const groupElement of this.element.querySelectorAll('.group-container')) {
+            let anyVisible = false;
+            for (const element of groupElement.querySelectorAll('.path-container')) {
+                if (element.dataset.name.toLowerCase().includes(this.searchValue)) {
+                    anyVisible = true;
+                    element.classList.remove('hidden');
+                } else {
+                    element.classList.add('hidden');
+                }
+            }
+
+            if (anyVisible) {
+                groupElement.classList.remove('hidden');
+            } else {
+                groupElement.classList.add('hidden');
+            }
+        }
+    }
+
+    static #onCopyPath(_event, button) {
+        const { value, name } = button.closest('.path-container').dataset;
+        game.clipboard.copyPlainText(value);
+        ui.notifications.info(
+            _loc('DAGGERHEART.APPLICATIONS.ActiveEffectPathViewer.copyPathNotification', { name: name })
+        );
     }
 }

--- a/module/applications/sheets-configs/activeEffectConfig.mjs
+++ b/module/applications/sheets-configs/activeEffectConfig.mjs
@@ -46,14 +46,15 @@ export default class DhActiveEffectConfig extends foundry.applications.sheets.Ac
      */
     static getChangeChoices() { 
         const ignoredActorKeys = ['config', 'DhEnvironment', 'DhParty', 'DhNPC'];
+        const ignoredRuleKeys = ['standardAttack'];
 
-        const getAllLeaves = (root, group, parentPath = '') => {
+        const getAllLeaves = (root, group, ignoredKeys = [], parentPath = '') => {
             const leaves = [];
             const rootKey = `${parentPath ? `${parentPath}.` : ''}${root.name}`;
             for (const field of Object.values(root.fields)) {
                 if (field instanceof foundry.data.fields.SchemaField)
-                    leaves.push(...getAllLeaves(field, group, rootKey));
-                else
+                    leaves.push(...getAllLeaves(field, group, ignoredKeys, rootKey));
+                else if (!ignoredKeys.includes(field.name))
                     leaves.push({
                         value: `${rootKey}.${field.name}`,
                         label: game.i18n.localize(field.label),
@@ -64,6 +65,19 @@ export default class DhActiveEffectConfig extends foundry.applications.sheets.Ac
 
             return leaves;
         };
+
+        const extraChoices = Object.entries(CONFIG.DH.ACTOR.activeEffectExtraPaths).reduce((acc, [key, paths]) => {
+            acc[key] = paths.map(x => ({
+                ...x,
+                label: _loc(x.label),
+                hint: x.hint ? _loc(x.hint) : null,
+                group: _loc(x.group),
+                fullPath: true
+            }));
+
+            return acc;
+        }, {});
+
         return Object.keys(game.system.api.models.actors).reduce((acc, key) => {
             if (ignoredActorKeys.includes(key)) return acc;
 
@@ -95,12 +109,13 @@ export default class DhActiveEffectConfig extends foundry.applications.sheets.Ac
             });
 
             const bonuses = getAllLeaves(model.schema.fields.bonuses, group);
-            const rules = getAllLeaves(model.schema.fields.rules, group);
+            const rules = getAllLeaves(model.schema.fields.rules, group, ignoredRuleKeys);
+            const extra = extraChoices[model.metadata.type];
 
-            acc.push(...bars, ...values, ...rules, ...bonuses);
+            acc.push(...extra, ...bars, ...values, ...rules, ...bonuses);
 
             return acc;
-        }, []);
+        }, extraChoices.allActors);
     }
 
     _attachPartListeners(partId, htmlElement, options) {
@@ -145,7 +160,7 @@ export default class DhActiveEffectConfig extends foundry.applications.sheets.Ac
                     return itemElement;
                 },
                 onSelect: function (item) {
-                    element.value = `system.${item.value}`;
+                    element.value = item.fullPath ? item.value : `system.${item.value}`;
                 },
                 click: e => e.fetch(),
                 customize: function (_input, _inputRect, container) {

--- a/module/applications/sheets-configs/activeEffectConfig.mjs
+++ b/module/applications/sheets-configs/activeEffectConfig.mjs
@@ -72,7 +72,7 @@ export default class DhActiveEffectConfig extends foundry.applications.sheets.Ac
                 label: _loc(x.label),
                 hint: x.hint ? _loc(x.hint) : null,
                 group: _loc(x.group),
-                fullPath: true
+                isFullPath: true
             }));
 
             return acc;
@@ -160,7 +160,7 @@ export default class DhActiveEffectConfig extends foundry.applications.sheets.Ac
                     return itemElement;
                 },
                 onSelect: function (item) {
-                    element.value = item.fullPath ? item.value : `system.${item.value}`;
+                    element.value = item.isFullPath ? item.value : `system.${item.value}`;
                 },
                 click: e => e.fetch(),
                 customize: function (_input, _inputRect, container) {

--- a/module/applications/sheets-configs/activeEffectConfig.mjs
+++ b/module/applications/sheets-configs/activeEffectConfig.mjs
@@ -44,7 +44,7 @@ export default class DhActiveEffectConfig extends foundry.applications.sheets.Ac
      * Get ChangeChoices for the changes autocomplete. Static for use in this class aswell as in settings-active-effect-config.mjs
      * @returns {ChangeChoice { value: string, label: string, hint: string, group: string }[]}
      */
-    static getChangeChoices() {
+    static getChangeChoices() { 
         const ignoredActorKeys = ['config', 'DhEnvironment', 'DhParty', 'DhNPC'];
 
         const getAllLeaves = (root, group, parentPath = '') => {

--- a/module/applications/sheets-configs/activeEffectConfig.mjs
+++ b/module/applications/sheets-configs/activeEffectConfig.mjs
@@ -44,7 +44,7 @@ export default class DhActiveEffectConfig extends foundry.applications.sheets.Ac
      * Get ChangeChoices for the changes autocomplete. Static for use in this class aswell as in settings-active-effect-config.mjs
      * @returns {ChangeChoice { value: string, label: string, hint: string, group: string }[]}
      */
-    static getChangeChoices() { 
+    static getChangeChoices() {
         const ignoredActorKeys = ['config', 'DhEnvironment', 'DhParty', 'DhNPC'];
         const ignoredRuleKeys = ['standardAttack'];
 

--- a/module/applications/sidebar/tabs/daggerheartMenu.mjs
+++ b/module/applications/sidebar/tabs/daggerheartMenu.mjs
@@ -33,7 +33,8 @@ export default class DaggerheartMenu extends HandlebarsApplicationMixin(Abstract
             selectRefreshable: DaggerheartMenu.#onSelectRefreshable,
             refreshActors: DaggerheartMenu.#onRefreshActors,
             createFallCollisionDamage: DaggerheartMenu.#onCreateFallCollisionDamage,
-            rollDowntimeFear: DaggerheartMenu.#onRollDowntimeFear
+            rollDowntimeFear: DaggerheartMenu.#onRollDowntimeFear,
+            showEffectChangePaths: DaggerheartMenu.#onShowEffectChangePaths
         }
     };
 
@@ -126,6 +127,10 @@ export default class DaggerheartMenu extends HandlebarsApplicationMixin(Abstract
         if (automation.gm) {
             ui.resources.updateFear(ui.resources.currentFear + fearRoll.total);
         }
+    }
+
+    static async #onShowEffectChangePaths() {
+        game.system.api.macros.showActiveEffectChangePaths();
     }
 
     async getFallbackPartySize() {

--- a/module/applications/sidebar/tabs/daggerheartMenu.mjs
+++ b/module/applications/sidebar/tabs/daggerheartMenu.mjs
@@ -130,7 +130,7 @@ export default class DaggerheartMenu extends HandlebarsApplicationMixin(Abstract
     }
 
     static async #onShowEffectChangePaths() {
-        game.system.api.macros.showActiveEffectChangePaths();
+        game.system.api.macros.showActiveEffectPathViewer();
     }
 
     async getFallbackPartySize() {

--- a/module/config/actorConfig.mjs
+++ b/module/config/actorConfig.mjs
@@ -231,6 +231,19 @@ export const tokenSize = {
     }
 };
 
+export const activeEffectExtraPaths = {
+    adversary: [],
+    character: [
+        { value: '@prof', label: 'DAGGERHEART.GENERAL.proficiency', group: 'TYPES.Actor.character' },
+        { value: '@cast', label: 'DAGGERHEART.CONFIG.ActiveEffectExtraPaths.cast.label', group: 'TYPES.Actor.character' }
+    ],
+    companion: [],
+    allActors: [
+        { value: '@fear', label: 'DAGGERHEART.CONFIG.ActiveEffectExtraPaths.fear.label', group: 'DAGGERHEART.CONFIG.ActiveEffectExtraPaths.allCategory' },
+        { value: '@partySize', label: 'DAGGERHEART.CONFIG.ActiveEffectExtraPaths.partySize.label', group: 'DAGGERHEART.CONFIG.ActiveEffectExtraPaths.allCategory' }
+    ]
+}
+
 export const levelChoices = {
     attributes: {
         name: 'attributes',

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -317,7 +317,9 @@ export default class DhCharacter extends DhCreature {
                         integer: true,
                         min: 0,
                         max: 5,
-                        initial: 0
+                        initial: 0,
+                        label: 'DAGGERHEART.ACTORS.Character.comboDieIndex.label',
+                        hint: 'DAGGERHEART.ACTORS.Character.comboDieIndex.hint'
                     })
                 })
             }, { persisted: false }),

--- a/module/macros/_modules.mjs
+++ b/module/macros/_modules.mjs
@@ -1,2 +1,2 @@
 export { default as spotlightCombatant } from './spotlightCombatant.mjs';
-export { default as showActiveEffectChangePaths } from './showActiveEffectChangePaths.mjs';
+export { default as showActiveEffectPathViewer } from './showActiveEffectPathViewer.mjs';

--- a/module/macros/_modules.mjs
+++ b/module/macros/_modules.mjs
@@ -1,1 +1,2 @@
 export { default as spotlightCombatant } from './spotlightCombatant.mjs';
+export { default as showActiveEffectChangePaths } from './showActiveEffectChangePaths.mjs';

--- a/module/macros/showActiveEffectChangePaths.mjs
+++ b/module/macros/showActiveEffectChangePaths.mjs
@@ -1,0 +1,5 @@
+function showActiveEffectChangePaths () {
+    (new game.system.api.applications.dialogs.ActiveEffectPathViewer).render(true);
+}
+
+export default showActiveEffectChangePaths

--- a/module/macros/showActiveEffectPathViewer.mjs
+++ b/module/macros/showActiveEffectPathViewer.mjs
@@ -1,5 +1,5 @@
-function showActiveEffectChangePaths () {
+function showActiveEffectPathViewer () {
     (new game.system.api.applications.dialogs.ActiveEffectPathViewer).render(true);
 }
 
-export default showActiveEffectChangePaths
+export default showActiveEffectPathViewer;

--- a/styles/less/dialog/active-effect-paths-viewer/index.less
+++ b/styles/less/dialog/active-effect-paths-viewer/index.less
@@ -1,0 +1,1 @@
+@import './sheet.less';

--- a/styles/less/dialog/active-effect-paths-viewer/sheet.less
+++ b/styles/less/dialog/active-effect-paths-viewer/sheet.less
@@ -1,9 +1,17 @@
 .daggerheart.dh-style.dialog.active-effect-change-paths-dialog {
+    .window-content {
+        padding-inline: 0;
+    }
+
     .paths-main-container {
         display: flex;
         flex-direction: column;
         gap: 16px;
         overflow: hidden;
+
+        > * {
+            padding-inline: var(--spacer-16);
+        }
 
         .search-label {
             font-size: var(--font-size-18);
@@ -17,6 +25,9 @@
             flex-direction: column;
             gap: 8px;
             overflow: auto;
+            font-family: var(--font-sans);
+            padding-right: max(0px, calc(var(--spacer-16) - var(--scrollbar-width)));
+            scrollbar-gutter: stable;
 
             .group-container {
                 display: flex;
@@ -25,6 +36,7 @@
 
                 .group-label {
                     font-size: var(--font-size-18);
+                    font-weight: bold;
                 }
 
                 .path-container {
@@ -32,19 +44,36 @@
                     align-items: center;
                     justify-content: space-between;
                     color: @input-color-text;
+                    overflow: hidden;
+
+                    &:has(.key-field:hover) {
+                        .name-container,
+                        .key-field {
+                            color: @color-text-emphatic;
+                        }
+                        a {
+                            text-shadow: unset;
+                        }
+                    }
+
+                    .name-container {
+                        flex: 0 0 17rem;
+                    }
 
                     .key-container {
                         display: flex;
                         align-items: center;
+                        flex: 1 0 0;
+                        overflow: hidden;
 
                         .key-field {
                             height: 24px;
-                            width: 260px;
                             border: 1px solid @input-color-border;
                             padding: 2px 4px;
                             border-radius: 6px 0 0 6px;
                             overflow: hidden;
                             text-overflow: ellipsis;
+                            flex: 1;
                         }
 
                         .key-icon {
@@ -62,10 +91,6 @@
                             color: @button-color-text;
                             background-color: @button-color-bg;
                         }
-                    }
-
-                    .name-container {
-
                     }
                 }
             }

--- a/styles/less/dialog/active-effect-paths-viewer/sheet.less
+++ b/styles/less/dialog/active-effect-paths-viewer/sheet.less
@@ -1,32 +1,77 @@
 .daggerheart.dh-style.dialog.active-effect-change-paths-dialog {
-    .paths-container {
+    .paths-main-container {
         display: flex;
         flex-direction: column;
-        gap: 8px;
-        .stable-scroll-container();
+        gap: 16px;
+        overflow: hidden;
 
-        .path-container {
+        .search-label {
+            font-size: var(--font-size-18);
             display: flex;
             align-items: center;
-            justify-content: space-between;
-            color: @input-color-text;
+            gap: 4px;
+        }
 
-            .key-container {
+        .paths-container {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            overflow: auto;
+
+            .group-container {
                 display: flex;
-                align-items: center;
-                
-                .key-button {
-                    width: 320px;
-                    border: 1px solid @input-color-border;
-                    padding: 2px 4px;
-                    border-radius: 6px 0 0 6px;
-                    overflow: hidden;
-                    text-overflow: ellipsis;
+                flex-direction: column;
+                gap: 4px;
+
+                .group-label {
+                    font-size: var(--font-size-18);
+                }
+
+                .path-container {
+                    display: flex;
+                    align-items: center;
+                    justify-content: space-between;
+                    color: @input-color-text;
+
+                    .key-container {
+                        display: flex;
+                        align-items: center;
+
+                        .key-field {
+                            height: 24px;
+                            width: 260px;
+                            border: 1px solid @input-color-border;
+                            padding: 2px 4px;
+                            border-radius: 6px 0 0 6px;
+                            overflow: hidden;
+                            text-overflow: ellipsis;
+                        }
+
+                        .key-icon {
+                            left: -1px;
+                            position: relative;
+                            height: 24px;
+                            padding: 2px;
+                            display: flex;
+                            align-items: center;
+                            justify-content: center;
+                            border-radius: 0 4px 4px 0;
+                            border-top: 1px solid @input-color-border;
+                            border-right: 1px solid @input-color-border;
+                            border-bottom: 1px solid @input-color-border;
+                            color: @button-color-text;
+                            background-color: @button-color-bg;
+                        }
+                    }
+
+                    .name-container {
+
+                    }
                 }
             }
 
-            .name-container {
-
+            .hidden {
+                display: none;
             }
         }
     }

--- a/styles/less/dialog/active-effect-paths-viewer/sheet.less
+++ b/styles/less/dialog/active-effect-paths-viewer/sheet.less
@@ -1,0 +1,33 @@
+.daggerheart.dh-style.dialog.active-effect-change-paths-dialog {
+    .paths-container {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        .stable-scroll-container();
+
+        .path-container {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            color: @input-color-text;
+
+            .key-container {
+                display: flex;
+                align-items: center;
+                
+                .key-button {
+                    width: 320px;
+                    border: 1px solid @input-color-border;
+                    padding: 2px 4px;
+                    border-radius: 6px 0 0 6px;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                }
+            }
+
+            .name-container {
+
+            }
+        }
+    }
+}

--- a/styles/less/dialog/index.less
+++ b/styles/less/dialog/index.less
@@ -20,3 +20,4 @@
 @import './risk-it-all/index.less';
 @import './levelup-options-dialog/sheet.less';
 @import './multi-action-select/sheet.less';
+@import './active-effect-paths-viewer/index.less';

--- a/templates/dialogs/activeEffectPathViewer.hbs
+++ b/templates/dialogs/activeEffectPathViewer.hbs
@@ -1,15 +1,32 @@
-<div class="paths-container">
-    {{#each paths}}
-        <div class="path-container">
-            <div class="key-container">
-                <div class="key-button">
-                    {{this.value}}
-                </div>
-                <button><i class="fa-solid fa-copy"></i></button>
-            </div>
-            <div class="name-container">
-                {{this.label}}
-            </div>
+<div class="paths-main-container">
+    <div class="two-columns">
+        <div class="search-label">
+            <i class="fa-solid fa-magnifying-glass"></i>
+            <span>{{localize "DAGGERHEART.APPLICATIONS.ActiveEffectPathViewer.searchLabel"}}</span>
         </div>
-    {{/each}}
+        <input type="text" value="{{searchValue}}" class="path-search-input" />
+    </div>
+
+    <div class="paths-container">
+        {{#each pathGroups}}
+            <div class="group-container" data-group="{{this.name}}">
+                <div class="group-label">{{this.name}}</div>
+
+                {{#each this.paths}}
+                    <div class="path-container" data-value="{{this.value}}" data-name="{{this.label}}">
+                        <div class="name-container" {{#if this.hint}}data-tooltip="{{this.hint}}"{{/if}}>
+                            {{this.label}}
+                            {{#if this.hint}}<i class="fa-solid fa-circle-question"></i>{{/if}}
+                        </div>
+                        <a class="key-container" data-action="copyPath">
+                            <div class="key-field">
+                                {{this.value}}
+                            </div>
+                            <div class="key-icon"><i class="fa-solid fa-copy"></i></div>
+                        </a>
+                    </div>
+                {{/each}}
+            </div>
+        {{/each}}
+    </div>
 </div>

--- a/templates/dialogs/activeEffectPathViewer.hbs
+++ b/templates/dialogs/activeEffectPathViewer.hbs
@@ -1,0 +1,15 @@
+<div class="paths-container">
+    {{#each paths}}
+        <div class="path-container">
+            <div class="key-container">
+                <div class="key-button">
+                    {{this.value}}
+                </div>
+                <button><i class="fa-solid fa-copy"></i></button>
+            </div>
+            <div class="name-container">
+                {{this.label}}
+            </div>
+        </div>
+    {{/each}}
+</div>

--- a/templates/dialogs/activeEffectPathViewer.hbs
+++ b/templates/dialogs/activeEffectPathViewer.hbs
@@ -14,11 +14,11 @@
 
                 {{#each this.paths}}
                     <div class="path-container" data-value="{{this.value}}" data-name="{{this.label}}">
-                        <div class="name-container" {{#if this.hint}}data-tooltip="{{this.hint}}"{{/if}}>
+                        <label class="name-container" {{#if this.hint}}data-tooltip="{{this.hint}}"{{/if}}>
                             {{this.label}}
                             {{#if this.hint}}<i class="fa-solid fa-circle-question"></i>{{/if}}
-                        </div>
-                        <a class="key-container" data-action="copyPath">
+                        </label>
+                        <a class="key-container" data-action="copyPath" id="{{@root.id}}">
                             <div class="key-field">
                                 {{this.value}}
                             </div>

--- a/templates/sidebar/daggerheart-menu/main.hbs
+++ b/templates/sidebar/daggerheart-menu/main.hbs
@@ -47,4 +47,6 @@
             </div>
         </div>
     </fieldset>
+
+    <button data-action="showEffectChangePaths">{{localize "DAGGERHEART.APPLICATIONS.DaggerheartMenu.activeEffectPathViewer"}}</button>
 </div>

--- a/templates/sidebar/daggerheart-menu/main.hbs
+++ b/templates/sidebar/daggerheart-menu/main.hbs
@@ -48,5 +48,8 @@
         </div>
     </fieldset>
 
-    <button data-action="showEffectChangePaths">{{localize "DAGGERHEART.APPLICATIONS.DaggerheartMenu.activeEffectPathViewer"}}</button>
+    <button data-action="showEffectChangePaths">
+        <i class="fa-solid fa-scroll"></i>
+        {{localize "DAGGERHEART.APPLICATIONS.DaggerheartMenu.activeEffectPathViewer"}}
+    </button>
 </div>


### PR DESCRIPTION
It's been requested a lot of times by now, so I went ahead and added in a dialog where a user can see the same ActiveEffect change paths that are displayed in the autocomplete of the ActiveEffect sheet.

There's a button in the Daggerheart Menu, but I set it up so it's available as a macro:
`game.system.api.macros.showActiveEffectPathViewer()`

There's a dialog frame button in the dialog that copies that macro to the clipboard so it's easy to set up such a macro if desired.
<img width="783" height="820" alt="image" src="https://github.com/user-attachments/assets/c7f0b082-0030-4bdb-87fc-1eecdc846ceb" />
