### PR TITLE
[Fix] Character Creation Mixed Ancestries

### DIFF
--- a/templates/characterCreation/tabs/ancestry.hbs
+++ b/templates/characterCreation/tabs/ancestry.hbs
@@ -21,8 +21,8 @@
 
             <div class="selections-outer-container enlarged">
                 <div class="selections-container primary-ancestry-card">
-                    {{#> "systems/daggerheart/templates/components/card-preview.hbs" primaryAncestry altPartialBlock=true secondaryDisabled=secondaryAncestry.uuid mixedAncestry=mixedAncestry }}
-                        {{#if uuid}} 
+                    {{#> "systems/daggerheart/templates/components/card-preview.hbs" primaryAncestry altPartialBlock=true secondaryDisabled=secondaryAncestry.system mixedAncestry=mixedAncestry }}
+                        {{#if system}} 
                             <div class="ancestry-preview-info-container">
                                 <div class="ancestry-preview-label">{{name}}</div>
                                 <div class="ancestry-preview-features">
@@ -43,7 +43,7 @@
                 {{#if mixedAncestry}}
                     <div class="selections-container secondary-ancestry-card">
                             {{#> "systems/daggerheart/templates/components/card-preview.hbs" secondaryAncestry altPartialBlock=true }}
-                                {{#if uuid}}
+                                {{#if system}}
                                     <div class="ancestry-preview-info-container">
                                         <div class="ancestry-preview-label">{{name}}</div>
                                         <div class="ancestry-preview-features">


### PR DESCRIPTION
Fixed so that CharacterCreation mixed ancestry shows the features you won't be given as inactive again.
We removed `uuid` from the data a while back, and the related checks were failing because of that.