### PR TITLE
[Fix] Ancestry Feature Display Order

### DIFF
--- a/module/applications/sheets/actors/character.mjs
+++ b/module/applications/sheets/actors/character.mjs
@@ -3,7 +3,8 @@ import DhDeathMove from '../../dialogs/deathMove.mjs';
 import { CharacterLevelup, LevelupViewMode } from '../../levelup/_module.mjs';
 import DhCharacterCreation from '../../characterCreation/characterCreation.mjs';
 import FilterMenu from '../../ux/filter-menu.mjs';
-import { getArmorSources, getDocFromElement, getDocFromElementSync, itemAbleRollParse, sortBy } from '../../../helpers/utils.mjs';
+import { getArmorSources, getDocFromElement, getDocFromElementSync, itemAbleRollParse } from '../../../helpers/utils.mjs';
+import { sortBy } from '../../../helpers/functional.mjs';
 
 /** 
  * @import DhCharacter from '../../../data/actor/character.mjs';

--- a/module/applications/sheets/actors/party.mjs
+++ b/module/applications/sheets/actors/party.mjs
@@ -1,5 +1,6 @@
 import DHBaseActorSheet from '../api/base-actor.mjs';
-import { getDocFromElement, sortBy } from '../../../helpers/utils.mjs';
+import { getDocFromElement } from '../../../helpers/utils.mjs';
+import { sortBy } from '../../../helpers/functional.mjs';
 import { ItemBrowser } from '../../ui/itemBrowser.mjs';
 import FilterMenu from '../../ux/filter-menu.mjs';
 import DaggerheartMenu from '../../sidebar/tabs/daggerheartMenu.mjs';

--- a/module/data/item/ancestry.mjs
+++ b/module/data/item/ancestry.mjs
@@ -1,6 +1,6 @@
 import BaseDataItem from './base.mjs';
 import ItemLinkFields from '../../data/fields/itemLinkFields.mjs';
-import { fromUuids, getFeaturesHTMLData } from '../../helpers/utils.mjs';
+import { fromUuids, getFeaturesHTMLData, sortBy } from '../../helpers/utils.mjs';
 
 const fields = foundry.data.fields;
 
@@ -59,8 +59,12 @@ export default class DHAncestry extends BaseDataItem {
 
         const baseDescription = `${this.description}${referenceLink}`;
         
-        const featureData = [this.primaryFeature, this.secondaryFeature].filter(Boolean).map(x => x.uuid ?? x);
-        const features = await getFeaturesHTMLData(await fromUuids(featureData));
+        const featureSubtypes = CONFIG.DH.ITEM.featureSubTypes;
+        const featureUuids = sortBy(
+            this._source.features, 
+            f => [featureSubtypes.primary, featureSubtypes.secondary].indexOf(f.type))
+            .map(f => f.item);
+        const features = await getFeaturesHTMLData(await fromUuids(featureUuids));
 
         if (!features.length) return { prefix: null, value: baseDescription, suffix: null };
         const suffix = await foundry.applications.handlebars.renderTemplate(

--- a/module/data/item/ancestry.mjs
+++ b/module/data/item/ancestry.mjs
@@ -59,7 +59,7 @@ export default class DHAncestry extends BaseDataItem {
 
         const baseDescription = `${this.description}${referenceLink}`;
         
-        const featureData = [this.primaryFeature, this.secondaryFeature].filter(Boolean).map(x => x.uuid);
+        const featureData = [this.primaryFeature, this.secondaryFeature].filter(Boolean).map(x => x.uuid ?? x);
         const features = await getFeaturesHTMLData(await fromUuids(featureData));
 
         if (!features.length) return { prefix: null, value: baseDescription, suffix: null };

--- a/module/data/item/ancestry.mjs
+++ b/module/data/item/ancestry.mjs
@@ -58,7 +58,9 @@ export default class DHAncestry extends BaseDataItem {
             ? `<p>@UUID[${reference}]{${label}}</p>` : '';
 
         const baseDescription = `${this.description}${referenceLink}`;
-        const features = await getFeaturesHTMLData(await fromUuids(this._source.features.map(f => f.item)));
+        
+        const featureData = [this.primaryFeature, this.secondaryFeature].filter(Boolean).map(x => x.uuid);
+        const features = await getFeaturesHTMLData(await fromUuids(featureData));
 
         if (!features.length) return { prefix: null, value: baseDescription, suffix: null };
         const suffix = await foundry.applications.handlebars.renderTemplate(

--- a/module/helpers/functional.mjs
+++ b/module/helpers/functional.mjs
@@ -67,3 +67,24 @@ export function keyBy(arr, keyFn) {
         return r;
     }, {})
 }
+
+/**
+ * Returns an array sorted by a function that returns a thing to compare, or an array to compare in order
+ * Similar to lodash's sortBy function.
+ */
+export function sortBy(arr, fn) {
+    const directCompare = (a, b) => (a < b ? -1 : a > b ? 1 : 0);
+    const cmp = (a, b) => {
+        const resultA = fn(a);
+        const resultB = fn(b);
+        if (Array.isArray(resultA) && Array.isArray(resultB)) {
+            for (let idx = 0; idx < Math.min(resultA.length, resultB.length); idx++) {
+                const result = directCompare(resultA[idx], resultB[idx]);
+                if (result !== 0) return result;
+            }
+            return 0;
+        }
+        return directCompare(resultA, resultB);
+    };
+    return arr.sort(cmp);
+}

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -1,5 +1,6 @@
 import { diceTypes, range } from '../config/generalConfig.mjs';
 import Tagify from '@yaireo/tagify';
+import { sortBy } from './functional.mjs';
 export * from './functional.mjs';
 
 /**
@@ -763,27 +764,6 @@ export function resetAndRerenderActors() {
         actor.reset();
         actor.render();
     }
-}
-
-/**
- * Returns an array sorted by a function that returns a thing to compare, or an array to compare in order
- * Similar to lodash's sortBy function.
- */
-export function sortBy(arr, fn) {
-    const directCompare = (a, b) => (a < b ? -1 : a > b ? 1 : 0);
-    const cmp = (a, b) => {
-        const resultA = fn(a);
-        const resultB = fn(b);
-        if (Array.isArray(resultA) && Array.isArray(resultB)) {
-            for (let idx = 0; idx < Math.min(resultA.length, resultB.length); idx++) {
-                const result = directCompare(resultA[idx], resultB[idx]);
-                if (result !== 0) return result;
-            }
-            return 0;
-        }
-        return directCompare(resultA, resultB);
-    };
-    return arr.sort(cmp);
 }
 
 /**


### PR DESCRIPTION
Fixes #2315
Fixed so the ancestry description always displays primary and secondary feature in the correct order