### PR TITLE
[Fix] Rename Loot

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -8,7 +8,7 @@
             "feature": "Feature",
             "domainCard": "Domain Card",
             "consumable": "Consumable",
-            "loot": "Loot",
+            "loot": "Item",
             "weapon": "Weapon",
             "armor": "Armor",
             "beastform": "Beastform",
@@ -4156,7 +4156,7 @@
                     "weapons": "Weapons",
                     "armors": "Armors",
                     "consumables": "Consumables",
-                    "loots": "Loot",
+                    "loots": "Items",
                     "transformations": "Transformations"
                 }
             },

--- a/system.json
+++ b/system.json
@@ -147,7 +147,7 @@
         },
         {
             "name": "loot",
-            "label": "Loot",
+            "label": "Items",
             "system": "daggerheart",
             "path": "packs/items/loot.db",
             "type": "Item",


### PR DESCRIPTION
We've hade a missunderstanding since the system's inception that general items are called `Loot`.
Such an item is actually just called an `Item`. 

I changed the translations ,but I don't see a reason to try to mess with the item type key. That'll just have to be a funny historical thing.
<img width="1207" height="696" alt="image" src="https://github.com/user-attachments/assets/964518d1-5635-4b8e-bdc6-c13189aa8cb5" />
