### PR TITLE
[Feature] Customized Sidebar Settings

### DIFF
--- a/daggerheart.mjs
+++ b/daggerheart.mjs
@@ -107,6 +107,7 @@ CONFIG.ui.hotbar = applications.ui.DhHotbar;
 CONFIG.ui.sidebar = applications.sidebar.DhSidebar;
 CONFIG.ui.actors = applications.sidebar.DhActorDirectory;
 CONFIG.ui.daggerheartMenu = applications.sidebar.DaggerheartMenu;
+CONFIG.ui.settings = applications.sidebar.DhSettings;
 CONFIG.ui.resources = applications.ui.DhFearTracker;
 CONFIG.ui.countdowns = applications.ui.DhCountdowns;
 CONFIG.ui.pause = applications.ui.DhGamePause;

--- a/lang/en.json
+++ b/lang/en.json
@@ -950,6 +950,12 @@
             },
             "MultiActionSelect": {
                 "instructionText": "Select Which Action to Use"
+            },
+            "SettingsSidebar": {
+                "systemLabel": "Game System",
+                "versionLabel": "Version {version}",
+                "wikiLink": "Wiki",
+                "discordLink": "Discord"
             }
         },
         "CLASS": {

--- a/module/applications/sidebar/_module.mjs
+++ b/module/applications/sidebar/_module.mjs
@@ -1,3 +1,4 @@
 export { default as DaggerheartMenu } from './tabs/daggerheartMenu.mjs';
 export { default as DhActorDirectory } from './tabs/actorDirectory.mjs';
 export { default as DhSidebar } from './sidebar.mjs';
+export { default as DhSettings } from './tabs/settings.mjs';

--- a/module/applications/sidebar/tabs/settings.mjs
+++ b/module/applications/sidebar/tabs/settings.mjs
@@ -1,0 +1,22 @@
+export default class DhSettings extends foundry.applications.sidebar.tabs.Settings {
+    /** @override */
+    static DEFAULT_OPTIONS = {
+        classes: ['dh-sidebar-settings']
+    }
+
+    /** @inheritDoc */
+    async _onRender(context, options) {
+        await super._onRender(context, options);
+
+        const infoSection = this.element?.querySelector('.info');
+        if (!infoSection) return;
+
+        infoSection.querySelector('.system')?.remove();
+
+        const element = await foundry.applications.handlebars.renderTemplate(
+            'systems/daggerheart/templates/sidebar/settings/info-insert.hbs',
+            { version: game.system.version }
+        );
+        infoSection.insertAdjacentHTML('afterend', element);
+    }
+}

--- a/module/applications/sidebar/tabs/settings.mjs
+++ b/module/applications/sidebar/tabs/settings.mjs
@@ -13,9 +13,17 @@ export default class DhSettings extends foundry.applications.sidebar.tabs.Settin
 
         infoSection.querySelector('.system')?.remove();
 
+        const systemUpdate = game.user.isGM && game.data.systemUpdate.hasUpdate
+            ? _loc('SETUP.UpdateAvailable', {
+                type: _loc('PACKAGE.Type.system'),
+                channel: game.data.system.title,
+                version: game.data.systemUpdate.version
+            })
+            : null;
+
         const element = await foundry.applications.handlebars.renderTemplate(
             'systems/daggerheart/templates/sidebar/settings/info-insert.hbs',
-            { version: game.system.version }
+            { version: game.system.version, systemUpdate }
         );
         infoSection.insertAdjacentHTML('afterend', element);
     }

--- a/styles/less/ui/sidebar/index.less
+++ b/styles/less/ui/sidebar/index.less
@@ -1,2 +1,3 @@
 @import './daggerheartMenu.less';
+@import './settings.less';
 @import './tabs.less';

--- a/styles/less/ui/sidebar/settings.less
+++ b/styles/less/ui/sidebar/settings.less
@@ -3,7 +3,6 @@
         display: flex;
         flex-direction: column;
         align-items: center;
-        margin-top: -16px;
 
         h4 {
             margin-bottom: 0;

--- a/styles/less/ui/sidebar/settings.less
+++ b/styles/less/ui/sidebar/settings.less
@@ -1,0 +1,23 @@
+.tab.sidebar-tab.settings-sidebar.dh-sidebar-settings {
+    .sidebar-settings-dh-info {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        margin-top: -16px;
+
+        h4 {
+            margin-bottom: 0;
+            width: 100%;
+        }
+
+        img {
+            width: 80px;
+            margin-bottom: -8px;
+        }
+
+        .links-container {
+            display: flex;
+            gap: 16px;
+        }
+    }
+}

--- a/styles/less/ui/sidebar/settings.less
+++ b/styles/less/ui/sidebar/settings.less
@@ -18,5 +18,10 @@
             display: flex;
             gap: 16px;
         }
+
+        .notification-pip {
+            position: initial;
+            color: @color-level-warning;
+        }
     }
 }

--- a/templates/sidebar/settings/info-insert.hbs
+++ b/templates/sidebar/settings/info-insert.hbs
@@ -1,0 +1,9 @@
+<div class="sidebar-settings-dh-info">
+    <h4 class="divider">{{localize "DAGGERHEART.APPLICATIONS.SettingsSidebar.systemLabel"}}</h4>
+    <img src="systems/daggerheart/assets/logos/DaggerheartLogo.webp" />
+    <span>{{localize "DAGGERHEART.APPLICATIONS.SettingsSidebar.versionLabel" version=version}}</span>
+    <div class="links-container">
+        <a href="https://github.com/Foundryborne/daggerheart/wiki" target="_blank">{{localize "DAGGERHEART.APPLICATIONS.SettingsSidebar.wikiLink"}}</a>
+        <a href="https://discord.gg/HnUt2AtwbD" target="_blank">{{localize "DAGGERHEART.APPLICATIONS.SettingsSidebar.discordLink"}}</a>
+    </div>
+</div>

--- a/templates/sidebar/settings/info-insert.hbs
+++ b/templates/sidebar/settings/info-insert.hbs
@@ -1,7 +1,13 @@
 <div class="sidebar-settings-dh-info">
     <h4 class="divider">{{localize "DAGGERHEART.APPLICATIONS.SettingsSidebar.systemLabel"}}</h4>
     <img src="systems/daggerheart/assets/logos/DaggerheartLogo.webp" />
-    <span>{{localize "DAGGERHEART.APPLICATIONS.SettingsSidebar.versionLabel" version=version}}</span>
+    <span>
+        {{localize "DAGGERHEART.APPLICATIONS.SettingsSidebar.versionLabel" version=version}}
+        {{~#if systemUpdate}}
+            <a class="notification-pip active fa-solid fa-circle-exclamation" data-tooltip-text="{{systemUpdate}}"
+                data-action="notifyUpdate" data-update="system"></a>
+        {{/if~}}
+    </span>
     <div class="links-container">
         <a href="https://github.com/Foundryborne/daggerheart/wiki" target="_blank">{{localize "DAGGERHEART.APPLICATIONS.SettingsSidebar.wikiLink"}}</a>
         <a href="https://discord.gg/HnUt2AtwbD" target="_blank">{{localize "DAGGERHEART.APPLICATIONS.SettingsSidebar.discordLink"}}</a>


### PR DESCRIPTION
Customized the sidebar settings tab in the style D&D uses. I think the link to discord is especially good to have around 🧑‍🍳 
I added the game-system section via `onRender` rather than overriding the whole template for greater stability.
<img width="430" height="1135" alt="image" src="https://github.com/user-attachments/assets/9662a6c4-ce9d-48b1-8e7c-d17d20aa3656" />
