### PR TITLE
Split DSN settings from appearance and convert to user setting

### DIFF
--- a/daggerheart.d.ts
+++ b/daggerheart.d.ts
@@ -16,6 +16,7 @@ import DhAutomation from './module/data/settings/Automation.mjs';
 import FearTracker from './module/applications/ui/fearTracker.mjs';
 import DhCountdowns from './module/data/countdowns.mjs';
 import DhEffectsDisplay from './module/applications/ui/effectsDisplay.mjs';
+import { DhDiceSoNice } from './module/data/settings/DiceSoNice.mjs';
 
 // Foundry's use of `Object.assign(globalThis) means many globally available objects are not read as such
 // This declare global hopefully fixes that
@@ -122,6 +123,7 @@ declare module '@client/helpers/client-settings.mjs' {
         get(namespace: 'daggerheart', key: typeof gameSettings.Automation): DhAutomation;
         get(namespace: 'daggerheart', key: typeof gameSettings.Homebrew): DhHomebrew;
         get(namespace: 'daggerheart', key: typeof gameSettings.Countdowns): DhCountdowns;
+        get(namespace: 'daggerheart', key: typeof gameSettings.diceSoNice): DhDiceSoNice;
         get(namespace: 'daggerheart', key: string): unknown;
     }
 }

--- a/daggerheart.mjs
+++ b/daggerheart.mjs
@@ -383,7 +383,6 @@ Hooks.on('ready', async () => {
         });
     }
 
-
     runMigrations();
 });
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -3951,26 +3951,27 @@
                 "appearance": {
                     "label": "Appearance Settings",
                     "hint": "Modify the look of various parts of the system",
-                    "duality": "Duality Rolls",
-                    "diceSoNice": {
-                        "title": "Dice So Nice",
-                        "hint": "Coloration of Duality dice if the Dice So Nice module is used.",
-                        "foreground": "Foreground",
-                        "background": "Background",
-                        "outline": "Outline",
-                        "edge": "Edge",
-                        "texture": "Texture",
-                        "colorset": "Theme",
-                        "material": "Material",
-                        "system": "Dice Preset",
-                        "font": "Font",
-                        "critical": "Duality Critical Animation",
-                        "muted": "Muted",
-                        "diceAppearance": "Dice Appearance",
-                        "animations": "Animations",
-                        "defaultAnimations": "Set Animations As Player Defaults",
-                        "previewAnimation": "Preview Animation"
-                    }
+                    "duality": "Duality Rolls"
+                },
+                "diceSoNice": {
+                    "label": "Dice So Nice (Daggerheart)",
+                    "hint": "Configure duality and advantage 3D dice animations in the Dice So Nice module.",
+                    "title": "Dice So Nice",
+                    "foreground": "Foreground",
+                    "background": "Background",
+                    "outline": "Outline",
+                    "edge": "Edge",
+                    "texture": "Texture",
+                    "colorset": "Theme",
+                    "material": "Material",
+                    "system": "Dice Preset",
+                    "font": "Font",
+                    "critical": "Duality Critical Animation",
+                    "muted": "Muted",
+                    "diceAppearance": "Dice Appearance",
+                    "animations": "Animations",
+                    "defaultAnimations": "Set Animations As Player Defaults",
+                    "previewAnimation": "Preview Animation"
                 },
                 "variantRules": {
                     "title": "Variant Rules",

--- a/module/applications/settings/_module.mjs
+++ b/module/applications/settings/_module.mjs
@@ -3,3 +3,4 @@ export { default as DhAutomationSettings } from './automationSettings.mjs';
 export { default as DhHomebrewSettings } from './homebrewSettings.mjs';
 export { default as DhMetagamingSettings } from './metagamingSettings.mjs';
 export { default as DhVariantRuleSettings } from './variantRuleSettings.mjs';
+export { DhDiceSoNiceSettings } from './diceSoNiceSettings.mjs';

--- a/module/applications/settings/appearanceSettings.mjs
+++ b/module/applications/settings/appearanceSettings.mjs
@@ -1,5 +1,3 @@
-import { getDiceSoNicePreset } from '../../config/generalConfig.mjs';
-
 const { HandlebarsApplicationMixin, ApplicationV2 } = foundry.applications.api;
 
 /**
@@ -20,8 +18,7 @@ export default class DHAppearanceSettings extends HandlebarsApplicationMixin(App
             icon: 'fa-solid fa-gears'
         },
         actions: {
-            reset: DHAppearanceSettings.#onReset,
-            preview: DHAppearanceSettings.#onPreview
+            reset: DHAppearanceSettings.#onReset
         },
         form: {
             closeOnSubmit: true,
@@ -31,30 +28,8 @@ export default class DHAppearanceSettings extends HandlebarsApplicationMixin(App
 
     static PARTS = {
         header: { template: 'systems/daggerheart/templates/settings/appearance-settings/header.hbs' },
-        tabs: { template: 'systems/daggerheart/templates/sheets/global/tabs/tab-navigation.hbs' },
         main: { template: 'systems/daggerheart/templates/settings/appearance-settings/main.hbs' },
-        diceSoNice: { template: 'systems/daggerheart/templates/settings/appearance-settings/diceSoNice.hbs' },
         footer: { template: 'templates/generic/form-footer.hbs' }
-    };
-
-    /** @inheritdoc */
-    static TABS = {
-        general: {
-            tabs: [
-                { id: 'main', label: 'DAGGERHEART.GENERAL.Tabs.general' },
-                { id: 'diceSoNice', label: 'DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.title' }
-            ],
-            initial: 'main'
-        },
-        diceSoNice: {
-            tabs: [
-                { id: 'hope', label: 'DAGGERHEART.GENERAL.hope' },
-                { id: 'fear', label: 'DAGGERHEART.GENERAL.fear' },
-                { id: 'advantage', label: 'DAGGERHEART.GENERAL.Advantage.full' },
-                { id: 'disadvantage', label: 'DAGGERHEART.GENERAL.Disadvantage.full' }
-            ],
-            initial: 'hope'
-        }
     };
 
     /**@type {DhAppearance}*/
@@ -71,39 +46,15 @@ export default class DHAppearanceSettings extends HandlebarsApplicationMixin(App
         }
     }
 
-    _attachPartListeners(partId, htmlElement, options) {
-        super._attachPartListeners(partId, htmlElement, options);
-
-        htmlElement
-            .querySelector('.default-animations-input')
-            ?.addEventListener('change', this.toggleSFXOverride.bind(this));
-    }
-
-    /** @inheritdoc */
-    _configureRenderParts(options) {
-        const parts = super._configureRenderParts(options);
-        if (!game.dice3d) {
-            delete parts.diceSoNice;
-            delete parts.tabs;
-        }
-        return parts;
-    }
-
     /**@inheritdoc */
     async _prepareContext(options) {
         const context = await super._prepareContext(options);
         if (options.isFirstRender) {
             this.setting = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.appearance);
-            this.globalOverrides = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.GlobalOverrides);
         }
 
         context.setting = this.setting;
-        context.globalOverrides = this.globalOverrides;
         context.fields = this.setting.schema.fields;
-
-        context.tabs = this._prepareTabs('general');
-        context.dsnTabs = this._prepareTabs('diceSoNice');
-
         context.isGM = game.user.isGM;
 
         return context;
@@ -112,13 +63,7 @@ export default class DHAppearanceSettings extends HandlebarsApplicationMixin(App
     /**@inheritdoc */
     async _preparePartContext(partId, context, options) {
         const partContext = await super._preparePartContext(partId, context, options);
-        if (partId in context.tabs) partContext.tab = partContext.tabs[partId];
         switch (partId) {
-            case 'diceSoNice':
-                if (game.dice3d)
-                    await this.prepareDiceSoNiceContext(partContext);
-
-                break;
             case 'footer':
                 partContext.buttons = [
                     {
@@ -132,65 +77,6 @@ export default class DHAppearanceSettings extends HandlebarsApplicationMixin(App
                 break;
         }
         return partContext;
-    }
-
-    /**
-     * Prepare render context for the DSN part.
-     * @param {ApplicationRenderContext} context
-     * @returns {Promise<void>}
-     * @protected
-     */
-    async prepareDiceSoNiceContext(context) {
-        context.animationEvents = CONFIG.DH.GENERAL.daggerheartDiceAnimationEvents;
-        context.previewAnimation = this.previewAnimation;
-
-        context.diceSoNiceTextures = Object.entries(game.dice3d.exports.TEXTURELIST).reduce(
-            (acc, [k, v]) => ({
-                ...acc,
-                [k]: v.name
-            }),
-            {}
-        );
-        context.diceSoNiceColorsets = Object.values(game.dice3d.exports.COLORSETS).reduce(
-            (acc, v) => ({
-                ...acc,
-                [v.id]: v.description
-            }),
-            {}
-        );
-        context.diceSoNiceMaterials = Object.keys(game.dice3d.DiceFactory.material_options).reduce(
-            (acc, key) => ({
-                ...acc,
-                [key]: `DICESONICE.Material${key.capitalize()}`
-            }),
-            {}
-        );
-        context.diceSoNiceSystems = Object.fromEntries(
-            [...game.dice3d.DiceFactory.systems].map(([k, v]) => [k, v.name])
-        );
-        context.diceSoNiceFonts = game.dice3d.exports.Utils.prepareFontList();
-
-        const getAnimationsOptions = key => {
-            const fields = context.fields.diceSoNice.fields[key].fields.sfx.fields;
-            return {
-                higher: fields.higher.fields.class.choices
-            };
-        };
-
-        foundry.utils.mergeObject(
-            context.dsnTabs,
-            ['hope', 'fear', 'advantage', 'disadvantage'].reduce(
-                (acc, key) => ({
-                    ...acc,
-                    [key]: {
-                        values: this.setting.diceSoNice[key],
-                        fields: this.setting.schema.getField(`diceSoNice.${key}`).fields,
-                        animations: ['hope', 'fear'].includes(key) ? getAnimationsOptions(key) : {}
-                    }
-                }),
-                {}
-            )
-        );
     }
 
     /**
@@ -208,41 +94,6 @@ export default class DHAppearanceSettings extends HandlebarsApplicationMixin(App
     }
 
     /* -------------------------------------------- */
-
-    async toggleSFXOverride(event) {
-        await this.globalOverrides.diceSoNiceSFXUpdate(this.setting, event.target.checked);
-        this.globalOverrides = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.GlobalOverrides);
-        this.render();
-    }
-
-    /**
-     * Submit the configuration form.
-     * @this {DHAppearanceSettings}
-     * @type {ApplicationClickAction}
-     */
-    static async #onPreview(_, target) {
-        const formData = new foundry.applications.ux.FormDataExtended(target.closest('form'));
-        const { diceSoNice, ...rest } = foundry.utils.expandObject(formData.object);
-        const { key } = target.dataset;
-        const faces = ['advantage', 'disadvantage'].includes(key) ? 'd6' : 'd12';
-        const preset = await getDiceSoNicePreset(diceSoNice[key], faces);
-        const diceSoNiceRoll = await new foundry.dice.Roll(`1${faces}`).evaluate();
-        diceSoNiceRoll.dice[0].options.appearance = preset.appearance;
-        diceSoNiceRoll.dice[0].options.modelFile = preset.modelFile;
-
-        const previewAnimation = rest[`${key}PreviewAnimation`];
-        const events = CONFIG.DH.GENERAL.daggerheartDiceAnimationEvents;
-        if (previewAnimation) {
-            if (previewAnimation === events.critical.id && diceSoNice.sfx.critical.class) {
-                diceSoNiceRoll.dice[0].options.sfx = { specialEffect: diceSoNice.sfx.critical.class };
-            }
-            if (previewAnimation === events.higher.id && diceSoNice[key].sfx.higher) {
-                diceSoNiceRoll.dice[0].options.sfx = { specialEffect: diceSoNice[key].sfx.higher.class };
-            }
-        }
-
-        await game.dice3d.showForRoll(diceSoNiceRoll, game.user, false);
-    }
 
     /**
      * Reset the form back to default values.

--- a/module/applications/settings/diceSoNiceSettings.mjs
+++ b/module/applications/settings/diceSoNiceSettings.mjs
@@ -1,0 +1,267 @@
+import { getDiceSoNicePreset } from '../../config/generalConfig.mjs';
+
+const { HandlebarsApplicationMixin, ApplicationV2 } = foundry.applications.api;
+
+const fields = foundry.data.fields;
+
+/** 
+ * A base settings config that can handle multiple settings in the same form.
+ * Currently only used by the DSN settings, which don't need multi setting support (at least not in-form).
+ * TODO: should merge with existing settings to prevent overwrite
+ */
+class BaseSettingsConfig extends HandlebarsApplicationMixin(ApplicationV2) {
+    static DEFAULT_OPTIONS = {
+        actions: {
+            reset: this.#onReset
+        },
+        form: {
+            closeOnSubmit: true,
+            handler: this.#onSubmit
+        }
+    }
+    
+    static get SETTINGS() {
+        return [];
+    }
+
+    /** @inheritdoc */
+    async _prepareContext(options = {}) {
+        const context = await super._prepareContext(options);
+        if (options.isFirstRender) {
+            this.setting = this._prepareSettingData();
+            this.mergedSchema = this._prepareSettingSchema();
+        }
+
+        context.setting = this.setting;
+        context.fields = this.mergedSchema.fields;
+        context.isGM = game.user.isGM;
+        return context;
+    }
+    
+    /** Prepares a merged view of all settings indexed by the setting key */
+    _prepareSettingData() {
+        const values = {};
+        for (const key of this.constructor.SETTINGS) {
+            values[key] = game.settings.get(CONFIG.DH.id, key);
+        }
+        return values;
+    }
+
+    /** Prepares a merge schemafield of all settings */
+    _prepareSettingSchema() {
+        const schema = {};
+        for (const key of this.constructor.SETTINGS) {
+            const metadata = game.settings.settings.get(`${CONFIG.DH.id}.${key}`);
+            const isModel = foundry.abstract.DataModel.isPrototypeOf(metadata.type);
+            if (!isModel) throw Error('Primitives not supported yet'); // todo: support, pull hint and label from metadata
+            schema[key] = new fields.SchemaField(metadata.type.defineSchema());
+        }
+        return new fields.SchemaField(schema);
+    }
+
+    /**
+     * Reset the form back to default values.
+     * @this {BaseSettingsConfig}
+     * @type {ApplicationClickAction}
+     */
+    static async #onReset() {
+        this.setting = this.mergedSchema.getInitialValue();
+        this.render({ force: false });
+    }
+
+    /**
+     * Submit the configuration form.
+     * @this {BaseSettingsConfig}
+     * @param {SubmitEvent} event
+     * @param {HTMLFormElement} form
+     * @param {foundry.applications.ux.FormDataExtended} formData
+     * @returns {Promise<void>}
+     */
+    static async #onSubmit(_event, _form, formData) {
+        const expanded = foundry.utils.expandObject(formData.object);
+        const data = this.mergedSchema.clean(expanded);
+        for (const [key, value] of Object.entries(data)) {
+            await game.settings.set(CONFIG.DH.id, key, value);
+        }
+    }
+}
+
+/**
+ * Main config for dice so nice settings.
+ * This also attempts a more generic approach at multi-setting configs, which should be considered for adoption in others.
+ */
+export class DhDiceSoNiceSettings extends BaseSettingsConfig {
+    /** @inheritdoc */
+    static DEFAULT_OPTIONS = {
+        tag: 'form',
+        id: 'daggerheart-dsn-settings',
+        classes: ['daggerheart', 'dialog', 'dh-style', 'setting', 'dsn-settings'],
+        position: { width: '600', height: 'auto' },
+        window: {
+            title: 'DAGGERHEART.SETTINGS.Menu.title',
+            icon: 'fa-solid fa-gears'
+        },
+        actions: {
+            preview: this.#onPreview
+        }
+    }
+    
+    static get SETTINGS() {
+        return [CONFIG.DH.SETTINGS.gameSettings.diceSoNice];
+    }
+
+    static PARTS = {
+        diceSoNice: { template: 'systems/daggerheart/templates/settings/dice-so-nice/main.hbs' },
+        footer: { template: 'templates/generic/form-footer.hbs' }
+    };
+
+    /** @inheritdoc */
+    static TABS = {
+        diceSoNice: {
+            tabs: [
+                { id: 'hope', label: 'DAGGERHEART.GENERAL.hope' },
+                { id: 'fear', label: 'DAGGERHEART.GENERAL.fear' },
+                { id: 'advantage', label: 'DAGGERHEART.GENERAL.Advantage.full' },
+                { id: 'disadvantage', label: 'DAGGERHEART.GENERAL.Disadvantage.full' }
+            ],
+            initial: 'hope'
+        }
+    };
+
+    async _prepareContext(options) {
+        const context = await super._prepareContext(options);
+        if (options.isFirstRender) {
+            this.globalOverrides = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.GlobalOverrides);
+        }
+
+        context.globalOverrides = this.globalOverrides;
+        context.dsnTabs = this._prepareTabs('diceSoNice');
+        return context;
+    }
+
+    /**@inheritdoc */
+    async _preparePartContext(partId, context, options) {
+        const partContext = await super._preparePartContext(partId, context, options);
+        if (partId in context.tabs) partContext.tab = partContext.tabs[partId];
+        switch (partId) {
+            case 'diceSoNice':
+                await this.prepareDiceSoNiceContext(partContext);
+                break;
+            case 'footer':
+                partContext.buttons = [
+                    {
+                        type: 'button',
+                        action: 'reset',
+                        icon: 'fa-solid fa-arrow-rotate-left',
+                        label: game.i18n.localize('SETTINGS.UI.ACTIONS.Reset')
+                    },
+                    { type: 'submit', icon: 'fa-solid fa-floppy-disk', label: game.i18n.localize('EDITOR.Save') }
+                ];
+                break;
+        }
+        return partContext;
+    }
+
+    /** @inheritdoc */
+    _attachPartListeners(partId, htmlElement, options) {
+        super._attachPartListeners(partId, htmlElement, options);
+
+        htmlElement
+            .querySelector('.default-animations-input')
+            ?.addEventListener('change', this.toggleSFXOverride.bind(this));
+    }
+    
+    /**
+     * Prepare render context for the DSN part.
+     * @param {ApplicationRenderContext} context
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async prepareDiceSoNiceContext(context) {
+        context.animationEvents = CONFIG.DH.GENERAL.daggerheartDiceAnimationEvents;
+        context.previewAnimation = this.previewAnimation;
+
+        context.diceSoNiceTextures = Object.entries(game.dice3d.exports.TEXTURELIST).reduce(
+            (acc, [k, v]) => ({
+                ...acc,
+                [k]: v.name
+            }),
+            {}
+        );
+        context.diceSoNiceColorsets = Object.values(game.dice3d.exports.COLORSETS).reduce(
+            (acc, v) => ({
+                ...acc,
+                [v.id]: v.description
+            }),
+            {}
+        );
+        context.diceSoNiceMaterials = Object.keys(game.dice3d.DiceFactory.material_options).reduce(
+            (acc, key) => ({
+                ...acc,
+                [key]: `DICESONICE.Material${key.capitalize()}`
+            }),
+            {}
+        );
+        context.diceSoNiceSystems = Object.fromEntries(
+            [...game.dice3d.DiceFactory.systems].map(([k, v]) => [k, v.name])
+        );
+        context.diceSoNiceFonts = game.dice3d.exports.Utils.prepareFontList();
+
+        const getAnimationsOptions = key => {
+            const fields = context.fields.diceSoNice.fields[key].fields.sfx.fields;
+            return {
+                higher: fields.higher.fields.class.choices
+            };
+        };
+
+        foundry.utils.mergeObject(
+            context.dsnTabs,
+            ['hope', 'fear', 'advantage', 'disadvantage'].reduce(
+                (acc, key) => ({
+                    ...acc,
+                    [key]: {
+                        values: this.setting.diceSoNice[key],
+                        fields: this.mergedSchema.getField(`diceSoNice.${key}`).fields,
+                        animations: ['hope', 'fear'].includes(key) ? getAnimationsOptions(key) : {}
+                    }
+                }),
+                {}
+            )
+        );
+    }
+    
+    async toggleSFXOverride(event) {
+        await this.globalOverrides.diceSoNiceSFXUpdate(this.setting.diceSoNice, event.target.checked);
+        this.globalOverrides = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.GlobalOverrides);
+        this.render();
+    }
+
+    /**
+     * Submit the configuration form.
+     * @this {DhDiceSoNiceSettings}
+     * @type {ApplicationClickAction}
+     */
+    static async #onPreview(_, target) {
+        const formData = new foundry.applications.ux.FormDataExtended(target.closest('form'));
+        const { diceSoNice, ...rest } = foundry.utils.expandObject(formData.object);
+        const { key } = target.dataset;
+        const faces = ['advantage', 'disadvantage'].includes(key) ? 'd6' : 'd12';
+        const preset = await getDiceSoNicePreset(diceSoNice[key], faces);
+        const diceSoNiceRoll = await new foundry.dice.Roll(`1${faces}`).evaluate();
+        diceSoNiceRoll.dice[0].options.appearance = preset.appearance;
+        diceSoNiceRoll.dice[0].options.modelFile = preset.modelFile;
+
+        const previewAnimation = rest[`${key}PreviewAnimation`];
+        const events = CONFIG.DH.GENERAL.daggerheartDiceAnimationEvents;
+        if (previewAnimation) {
+            if (previewAnimation === events.critical.id && diceSoNice.sfx.critical.class) {
+                diceSoNiceRoll.dice[0].options.sfx = { specialEffect: diceSoNice.sfx.critical.class };
+            }
+            if (previewAnimation === events.higher.id && diceSoNice[key].sfx.higher) {
+                diceSoNiceRoll.dice[0].options.sfx = { specialEffect: diceSoNice[key].sfx.higher.class };
+            }
+        }
+
+        await game.dice3d.showForRoll(diceSoNiceRoll, game.user, false);
+    }
+}

--- a/module/config/generalConfig.mjs
+++ b/module/config/generalConfig.mjs
@@ -734,7 +734,7 @@ export const daggerheartDiceAnimationEvents = {
 };
 
 export const getDiceSoNiceSFX = sfxOptions => {
-    const diceSoNice = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.appearance).diceSoNiceData;
+    const diceSoNice = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.diceSoNice).diceSoNiceData;
     const criticalAnimationData = diceSoNice.sfx.critical;
     if (sfxOptions.critical && criticalAnimationData.class) {
         return {

--- a/module/config/settingsConfig.mjs
+++ b/module/config/settingsConfig.mjs
@@ -29,9 +29,12 @@ export const menu = {
 export const gameSettings = {
     /** @type {'Automation'} */
     Automation: 'Automation',
+    /** @type {'diceSoNice'} */
+    diceSoNice: 'diceSoNice',
     Metagaming: 'Metagaming',
     /** @type {'Homebrew'} */
     Homebrew: 'Homebrew',
+    /** @type {'Appearance'} */
     appearance: 'Appearance',
     GlobalOverrides: 'GlobalOverrides',
     variantRules: 'VariantRules',

--- a/module/data/settings/Appearance.mjs
+++ b/module/data/settings/Appearance.mjs
@@ -3,38 +3,8 @@ import { resetAndRerenderActors } from '../../helpers/utils.mjs';
 export default class DhAppearance extends foundry.abstract.DataModel {
     static LOCALIZATION_PREFIXES = ['DAGGERHEART.SETTINGS.Appearance'];
 
-    static sfxSchema = () =>
-        new foundry.data.fields.SchemaField({
-            class: new foundry.data.fields.StringField({
-                nullable: true,
-                initial: null,
-                blank: true,
-                choices: CONFIG.DH.GENERAL.diceSoNiceSFXClasses
-            }),
-            options: new foundry.data.fields.SchemaField({
-                muteSound: new foundry.data.fields.BooleanField()
-            })
-        });
-
     static defineSchema() {
-        const { StringField, ColorField, BooleanField, SchemaField } = foundry.data.fields;
-
-        // helper to create dice style schema
-        const diceStyle = ({ fg, bg, outline, edge }) =>
-            new SchemaField({
-                foreground: new ColorField({ required: true, initial: fg }),
-                background: new ColorField({ required: true, initial: bg }),
-                outline: new ColorField({ required: true, initial: outline }),
-                edge: new ColorField({ required: true, initial: edge }),
-                texture: new StringField({ initial: 'astralsea', required: true, blank: false }),
-                colorset: new StringField({ initial: 'inspired', required: true, blank: false }),
-                material: new StringField({ initial: 'metal', required: true, blank: false }),
-                system: new StringField({ initial: 'standard', required: true, blank: false }),
-                font: new StringField({ initial: 'auto', required: true, blank: false }),
-                sfx: new SchemaField({
-                    higher: DhAppearance.sfxSchema()
-                })
-            });
+        const { StringField, BooleanField, SchemaField } = foundry.data.fields;
 
         return {
             useResourcePips: new BooleanField({ initial: false }),
@@ -49,15 +19,6 @@ export default class DhAppearance extends foundry.abstract.DataModel {
                 initial: CONFIG.DH.GENERAL.fearPosition.topCenter.value
             }),
             displayCountdownUI: new BooleanField({ initial: true }),
-            diceSoNice: new SchemaField({
-                hope: diceStyle({ fg: '#ffffff', bg: '#ffe760', outline: '#000000', edge: '#ffffff' }),
-                fear: diceStyle({ fg: '#000000', bg: '#0032b1', outline: '#ffffff', edge: '#000000' }),
-                advantage: diceStyle({ fg: '#ffffff', bg: '#008000', outline: '#000000', edge: '#ffffff' }),
-                disadvantage: diceStyle({ fg: '#000000', bg: '#b30000', outline: '#ffffff', edge: '#000000' }),
-                sfx: new SchemaField({
-                    critical: DhAppearance.sfxSchema()
-                })
-            }),
             extendCharacterDescriptions: new BooleanField(),
             extendAdversaryDescriptions: new BooleanField(),
             extendEnvironmentDescriptions: new BooleanField(),
@@ -99,37 +60,6 @@ export default class DhAppearance extends foundry.abstract.DataModel {
         };
     }
 
-    get diceSoNiceData() {
-        const globalOverrides = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.GlobalOverrides);
-        const getSFX = (baseClientData, overrideKey) => {
-            if (!globalOverrides.diceSoNice.sfx.overrideEnabled) return baseClientData;
-            const overrideData = globalOverrides.diceSoNice.sfx[overrideKey];
-            const clientData = foundry.utils.deepClone(baseClientData);
-            return Object.keys(clientData).reduce((acc, key) => {
-                const data = clientData[key];
-                acc[key] = Object.keys(data).reduce((acc, dataKey) => {
-                    const value = data[dataKey];
-                    acc[dataKey] = value ? value : overrideData[key][dataKey];
-                    return acc;
-                }, {});
-                return acc;
-            }, {});
-        };
-
-        return {
-            ...this.diceSoNice,
-            sfx: getSFX(this.diceSoNice.sfx, 'global'),
-            hope: {
-                ...this.diceSoNice.hope,
-                sfx: getSFX(this.diceSoNice.hope.sfx, 'hope')
-            },
-            fear: {
-                ...this.diceSoNice.fear,
-                sfx: getSFX(this.diceSoNice.fear.sfx, 'fear')
-            }
-        };
-    }
-
     /** Invoked by the setting when data changes */
     handleChange() {
         if (ui.resources) {
@@ -140,8 +70,6 @@ export default class DhAppearance extends foundry.abstract.DataModel {
             }
         }
 
-        const globalOverrides = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.GlobalOverrides);
-        globalOverrides.diceSoNiceSFXUpdate(this);
         resetAndRerenderActors();
     }
 }

--- a/module/data/settings/Appearance.mjs
+++ b/module/data/settings/Appearance.mjs
@@ -1,3 +1,5 @@
+import { resetAndRerenderActors } from '../../helpers/utils.mjs';
+
 export default class DhAppearance extends foundry.abstract.DataModel {
     static LOCALIZATION_PREFIXES = ['DAGGERHEART.SETTINGS.Appearance'];
 
@@ -140,5 +142,6 @@ export default class DhAppearance extends foundry.abstract.DataModel {
 
         const globalOverrides = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.GlobalOverrides);
         globalOverrides.diceSoNiceSFXUpdate(this);
+        resetAndRerenderActors();
     }
 }

--- a/module/data/settings/DiceSoNice.mjs
+++ b/module/data/settings/DiceSoNice.mjs
@@ -1,0 +1,83 @@
+/** Data model to store the setting for dice so nice hope/fear configuration. */
+export class DhDiceSoNice extends foundry.abstract.DataModel {
+    static sfxSchema = () =>
+        new foundry.data.fields.SchemaField({
+            class: new foundry.data.fields.StringField({
+                nullable: true,
+                initial: null,
+                blank: true,
+                choices: CONFIG.DH.GENERAL.diceSoNiceSFXClasses
+            }),
+            options: new foundry.data.fields.SchemaField({
+                muteSound: new foundry.data.fields.BooleanField()
+            })
+        });
+    
+    static defineSchema() {
+        const { StringField, ColorField, SchemaField } = foundry.data.fields;
+        
+        // helper to create dice style schema
+        const diceStyle = ({ fg, bg, outline, edge }) =>
+            new SchemaField({
+                foreground: new ColorField({ required: true, initial: fg }),
+                background: new ColorField({ required: true, initial: bg }),
+                outline: new ColorField({ required: true, initial: outline }),
+                edge: new ColorField({ required: true, initial: edge }),
+                texture: new StringField({ initial: 'astralsea', required: true, blank: false }),
+                colorset: new StringField({ initial: 'inspired', required: true, blank: false }),
+                material: new StringField({ initial: 'metal', required: true, blank: false }),
+                system: new StringField({ initial: 'standard', required: true, blank: false }),
+                font: new StringField({ initial: 'auto', required: true, blank: false }),
+                sfx: new SchemaField({
+                    higher: DhDiceSoNice.sfxSchema()
+                })
+            });
+
+        return {
+            hope: diceStyle({ fg: '#ffffff', bg: '#ffe760', outline: '#000000', edge: '#ffffff' }),
+            fear: diceStyle({ fg: '#000000', bg: '#0032b1', outline: '#ffffff', edge: '#000000' }),
+            advantage: diceStyle({ fg: '#ffffff', bg: '#008000', outline: '#000000', edge: '#ffffff' }),
+            disadvantage: diceStyle({ fg: '#000000', bg: '#b30000', outline: '#ffffff', edge: '#000000' }),
+            sfx: new SchemaField({
+                critical: DhDiceSoNice.sfxSchema()
+            })
+        }
+    }
+
+    // todo find references and replace
+    get diceSoNiceData() {
+        const globalOverrides = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.GlobalOverrides);
+        const getSFX = (baseClientData, overrideKey) => {
+            if (!globalOverrides.diceSoNice.sfx.overrideEnabled) return baseClientData;
+            const overrideData = globalOverrides.diceSoNice.sfx[overrideKey];
+            const clientData = foundry.utils.deepClone(baseClientData);
+            return Object.keys(clientData).reduce((acc, key) => {
+                const data = clientData[key];
+                acc[key] = Object.keys(data).reduce((acc, dataKey) => {
+                    const value = data[dataKey];
+                    acc[dataKey] = value ? value : overrideData[key][dataKey];
+                    return acc;
+                }, {});
+                return acc;
+            }, {});
+        };
+
+        return {
+            ...this,
+            sfx: getSFX(this.sfx, 'global'),
+            hope: {
+                ...this.hope,
+                sfx: getSFX(this.hope.sfx, 'hope')
+            },
+            fear: {
+                ...this.fear,
+                sfx: getSFX(this.fear.sfx, 'fear')
+            }
+        };
+    }
+
+    handleChange() {
+        const globalOverrides = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.GlobalOverrides);
+        globalOverrides.diceSoNiceSFXUpdate(this);
+    }
+}

--- a/module/data/settings/GlobalOverrides.mjs
+++ b/module/data/settings/GlobalOverrides.mjs
@@ -1,4 +1,4 @@
-import DhAppearance from './Appearance.mjs';
+import { DhDiceSoNice } from './DiceSoNice.mjs';
 
 /**
  * A setting to handle cases where we want to allow the GM to set a global default for client settings.
@@ -11,20 +11,20 @@ export default class DhGlobalOverrides extends foundry.abstract.DataModel {
                 sfx: new fields.SchemaField({
                     overrideEnabled: new fields.BooleanField(),
                     global: new fields.SchemaField({
-                        critical: DhAppearance.sfxSchema()
+                        critical: DhDiceSoNice.sfxSchema()
                     }),
                     hope: new fields.SchemaField({
-                        higher: DhAppearance.sfxSchema()
+                        higher: DhDiceSoNice.sfxSchema()
                     }),
                     fear: new fields.SchemaField({
-                        higher: DhAppearance.sfxSchema()
+                        higher: DhDiceSoNice.sfxSchema()
                     })
                 })
             })
         };
     }
 
-    async diceSoNiceSFXUpdate(appearanceSettings, enabled) {
+    async diceSoNiceSFXUpdate(dsnSettings, enabled) {
         if (!game.user.isGM) return;
 
         const newEnabled = enabled !== undefined ? enabled : this.diceSoNice.sfx.overrideEnabled;
@@ -33,9 +33,9 @@ export default class DhGlobalOverrides extends foundry.abstract.DataModel {
                 diceSoNice: {
                     sfx: {
                         overrideEnabled: true,
-                        global: appearanceSettings.diceSoNice.sfx,
-                        hope: appearanceSettings.diceSoNice.hope.sfx,
-                        fear: appearanceSettings.diceSoNice.fear.sfx
+                        global: dsnSettings.sfx,
+                        hope: dsnSettings.hope.sfx,
+                        fear: dsnSettings.fear.sfx
                     }
                 }
             });

--- a/module/data/settings/_module.mjs
+++ b/module/data/settings/_module.mjs
@@ -4,3 +4,4 @@ export { default as DhHomebrew } from './Homebrew.mjs';
 export { default as DhMetagaming } from './Metagaming.mjs';
 export { default as DhVariantRules } from './VariantRules.mjs';
 export { default as DhGlobalOverrides } from './GlobalOverrides.mjs';
+export { DhDiceSoNice } from './DiceSoNice.mjs';

--- a/module/dice/baseRoll.mjs
+++ b/module/dice/baseRoll.mjs
@@ -19,7 +19,7 @@ export default class BaseRoll extends foundry.dice.Roll {
             const fearRoll = this.dice.find(x => x.modifiers.includes('f'));
             if (hopeRoll && fearRoll) {
                 const diceSoNice = 
-                    game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.appearance).diceSoNiceData;
+                    game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.diceSoNice).diceSoNiceData;
                 const isCritical = hopeRoll.total === fearRoll.total;
                 hopeRoll.options.sfx = getDiceSoNiceSFX({ 
                     critical: isCritical, 

--- a/module/dice/die/baseDie.mjs
+++ b/module/dice/die/baseDie.mjs
@@ -62,7 +62,7 @@ export default class BaseDie extends foundry.dice.terms.Die {
     async #setDualityDiePreset(dualityType) {
         if (!game.dice3d) return;
 
-        const diceSoNice = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.appearance).diceSoNiceData;
+        const diceSoNice = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.diceSoNice).diceSoNiceData;
         const dualityDie = diceSoNice[dualityType];
         if (!dualityDie) return;
 

--- a/module/systemRegistration/handlebars.mjs
+++ b/module/systemRegistration/handlebars.mjs
@@ -62,7 +62,7 @@ export const preloadHandlebarsTemplates = async function () {
         'systems/daggerheart/templates/ui/itemBrowser/itemContainer.hbs',
         'systems/daggerheart/templates/ui/countdowns/parts/countdowns.hbs',
         'systems/daggerheart/templates/scene/dh-config.hbs',
-        'systems/daggerheart/templates/settings/appearance-settings/diceSoNiceTab.hbs',
+        'systems/daggerheart/templates/settings/dice-so-nice/diceSoNiceTab.hbs',
         'systems/daggerheart/templates/sheets/activeEffect/typeChanges/armorChange.hbs',
         'systems/daggerheart/templates/dialogs/levelupOptionsDialog/parts/tier.hbs',
         'systems/daggerheart/templates/sheets/activeEffect/typeChanges/standardAttack.hbs',

--- a/module/systemRegistration/migrations.mjs
+++ b/module/systemRegistration/migrations.mjs
@@ -6,6 +6,29 @@ import { Migration_2_8_0_hotfix } from './migration-handlers/2_8_0-hotfix.mjs';
 import { Migration_2_9_1 } from './migration-handlers/2_9_1.mjs';
 
 export async function runMigrations() {
+    // Handle client setting migrations. There is only dice so nice, so no splitting it up for now
+    // Client settings are personalized and cannot be resolved by the GM
+    const systemId = CONFIG.DH.id;
+    const settingKeys = CONFIG.DH.SETTINGS.gameSettings;
+    const storage = game.settings.storage;
+    const dsnSettingId = `${systemId}.${settingKeys.diceSoNice}`;
+    const hasDiceSettings = !!storage.get('user').getSetting(dsnSettingId, game.user.id);
+    if (!hasDiceSettings) {
+        try {
+            const rawData = storage.get('client').getItem(`${systemId}.${settingKeys.appearance}`);
+            const newData = rawData 
+                ? JSON.parse(rawData ?? '{}')?.diceSoNice
+                : game.settings.settings.get(dsnSettingId).type.schema.getInitialValue();
+            game.settings.set(systemId, settingKeys.diceSoNice, newData);
+        } catch {}
+    }
+
+    if (game.user.isActiveGM) {
+        await runGamemasterMigrations();
+    }
+}
+
+async function runGamemasterMigrations() {
     let lastMigrationVersion = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.LastMigrationVersion);
     if (!lastMigrationVersion) lastMigrationVersion = game.system.version;
 

--- a/module/systemRegistration/settings.mjs
+++ b/module/systemRegistration/settings.mjs
@@ -6,14 +6,16 @@ import {
     DhGlobalOverrides,
     DhHomebrew,
     DhMetagaming,
-    DhVariantRules
+    DhVariantRules,
+    DhDiceSoNice
 } from '../data/settings/_module.mjs';
 import {
     DhAppearanceSettings,
     DhAutomationSettings,
     DhHomebrewSettings,
     DhMetagamingSettings,
-    DhVariantRuleSettings
+    DhVariantRuleSettings,
+    DhDiceSoNiceSettings
 } from '../applications/settings/_module.mjs';
 import { CompendiumBrowserSettings } from '../data/_module.mjs';
 import SpotlightTracker from '../data/spotlightTracker.mjs';
@@ -120,6 +122,15 @@ const registerMenuSettings = () => {
             value.handleChange();
         }
     });
+
+    game.settings.register(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.diceSoNice, {
+        scope: 'user',
+        config: false,
+        type: DhDiceSoNice,
+        onChange: value => {
+            value.handleChange();
+        }
+    });
 };
 
 const registerMenus = () => {
@@ -158,6 +169,17 @@ const registerMenus = () => {
         type: DhAppearanceSettings,
         restricted: false
     });
+
+    if (game.modules.get('dice-so-nice')?.active) {
+        game.settings.registerMenu(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.diceSoNice, {
+            name: game.i18n.localize('DAGGERHEART.SETTINGS.Menu.diceSoNice.label'),
+            label: game.i18n.localize('DAGGERHEART.SETTINGS.Menu.diceSoNice.label'),
+            hint: game.i18n.localize('DAGGERHEART.SETTINGS.Menu.diceSoNice.hint'),
+            icon: 'fa-solid fa-palette',
+            type: DhDiceSoNiceSettings,
+            restricted: false
+        });
+    }
 
     game.settings.registerMenu(CONFIG.DH.id, CONFIG.DH.SETTINGS.menu.VariantRules.Name, {
         name: game.i18n.localize('DAGGERHEART.SETTINGS.Menu.variantRules.title'),

--- a/styles/less/ui/settings/appearance-settings/index.less
+++ b/styles/less/ui/settings/appearance-settings/index.less
@@ -1,1 +1,0 @@
-@import './diceSoNice.less';

--- a/styles/less/ui/settings/diceSoNice.less
+++ b/styles/less/ui/settings/diceSoNice.less
@@ -1,4 +1,4 @@
-.daggerheart.dh-style.setting.appearance-settings {
+.daggerheart.dh-style.setting.dsn-settings {
     .tab.active[data-tab='diceSoNice'] {
         display: flex;
         flex-direction: column;
@@ -6,26 +6,18 @@
         gap: 0.5rem;
     }
 
-    .diceSoNice-footer {
-        display: grid;
-        align-items: center;
-        grid-template-columns: 1fr 1fr 1fr 1fr;
-        gap: 8px;
-        margin-top: 32px;
-
-        label {
-            text-align: center;
-        }
-
-        select {
-            grid-column: span 2;
-        }
+    .general {
+        padding: 0 8px;
     }
 
-    .title-hint {
-        font-size: var(--font-size-14);
-        font-variant: small-caps;
-        text-align: center;
+    .form-fields label {
+        display: flex;
+        align-items: center;
+        line-height: unset;
+    }
+
+    .tab-navigation {
+        margin-top: var(--spacer-16);
     }
 
     .split-section {
@@ -53,7 +45,7 @@
     .label-container {
         display: grid;
         grid-template-columns: 1fr 1fr;
-        gap: 10px;
+        gap: 2rem;
 
         &.full-width {
             grid-template-columns: 1fr 1fr 1fr 1fr;
@@ -65,7 +57,7 @@
 
         label {
             align-self: center;
-            text-align: center;
+            text-align: end;
             white-space: nowrap;
         }
 
@@ -91,6 +83,22 @@
                 align-items: center;
                 gap: 2px;
             }
+        }
+    }
+
+    .diceSoNice-footer {
+        display: grid;
+        align-items: center;
+        grid-template-columns: 1fr 1fr 1fr 1fr;
+        gap: 8px;
+        margin-top: 32px;
+
+        label {
+            text-align: center;
+        }
+
+        select {
+            grid-column: span 2;
         }
     }
 }

--- a/styles/less/ui/settings/index.less
+++ b/styles/less/ui/settings/index.less
@@ -1,3 +1,3 @@
 @import './settings.less';
-@import './appearance-settings/index.less';
+@import './diceSoNice.less';
 @import './homebrew-settings/index.less';

--- a/templates/settings/appearance-settings/main.hbs
+++ b/templates/settings/appearance-settings/main.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{#if tab.active}} active{{/if}}" data-group="{{tab.group}}" data-tab="{{tab.id}}">
+<section>
     {{formGroup
     fields.useResourcePips
     value=setting.useResourcePips

--- a/templates/settings/dice-so-nice/diceSoNiceTab.hbs
+++ b/templates/settings/dice-so-nice/diceSoNiceTab.hbs
@@ -1,61 +1,61 @@
 <div class="field-section">
-    <h3>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.diceAppearance"}}</h3>
+    <h3>{{localize "DAGGERHEART.SETTINGS.Menu.diceSoNice.diceAppearance"}}</h3>
 
     <div class="label-container full-width">
-        <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.system"}}</label>
+        <label>{{localize "DAGGERHEART.SETTINGS.Menu.diceSoNice.system"}}</label>
         {{formInput fields.system value=values.system localize=true choices=@root.diceSoNiceSystems}}
     </div>
     <div class="split-section">
     <div class="label-container">
-        <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.foreground"}}</label>
+        <label>{{localize "DAGGERHEART.SETTINGS.Menu.diceSoNice.foreground"}}</label>
         {{formInput fields.foreground value=values.foreground localize=true}}
     </div>
     <div class="label-container">
-        <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.background"}}</label>
+        <label>{{localize "DAGGERHEART.SETTINGS.Menu.diceSoNice.background"}}</label>
         {{formInput fields.background value=values.background localize=true}}
     </div>
     <div class="label-container">
-        <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.outline"}}</label>
+        <label>{{localize "DAGGERHEART.SETTINGS.Menu.diceSoNice.outline"}}</label>
         {{formInput fields.outline value=values.outline localize=true}}
     </div>
     <div class="label-container">
-        <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.edge"}}</label>
+        <label>{{localize "DAGGERHEART.SETTINGS.Menu.diceSoNice.edge"}}</label>
         {{formInput fields.edge value=values.edge localize=true}}
     </div>
     <div class="label-container">
-        <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.colorset"}}</label>
+        <label>{{localize "DAGGERHEART.SETTINGS.Menu.diceSoNice.colorset"}}</label>
         {{formInput fields.colorset value=values.colorset choices=@root.diceSoNiceColorsets localize=true}}
     </div>
     <div class="label-container">
-        <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.texture"}}</label>
+        <label>{{localize "DAGGERHEART.SETTINGS.Menu.diceSoNice.texture"}}</label>
         {{formInput fields.texture value=values.texture choices=@root.diceSoNiceTextures localize=true}}
     </div>
     <div class="label-container">
-        <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.material"}}</label>
+        <label>{{localize "DAGGERHEART.SETTINGS.Menu.diceSoNice.material"}}</label>
         {{formInput fields.material value=values.material choices=@root.diceSoNiceMaterials localize=true}}
     </div>
     <div class="label-container">
-        <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.font"}}</label>
+        <label>{{localize "DAGGERHEART.SETTINGS.Menu.diceSoNice.font"}}</label>
         {{formInput fields.font value=values.font choices=@root.diceSoNiceFonts localize=true}}
     </div>
     </div>
 
     {{#if animations}}
-        <h3>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.animations"}}</h3>      
+        <h3>{{localize "DAGGERHEART.SETTINGS.Menu.diceSoNice.animations"}}</h3>      
         <div class="animation-container">
             <label>{{localize "DAGGERHEART.CONFIG.DaggerheartDiceAnimationEvents.higher.name"}}</label>
             <div class="animation-inner-container">
                 {{formInput fields.sfx.fields.higher.fields.class value=values.sfx.higher.class blank="" localize=true}}
-                <div class="animation-control">
-                    <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.muted"}}</label>
+                <label class="animation-control">
+                    <span>{{localize "DAGGERHEART.SETTINGS.Menu.diceSoNice.muted"}}</span>
                     {{formInput fields.sfx.fields.higher.fields.options.fields.muteSound value=values.sfx.higher.options.muteSound localize=true}}
-                </div>
+                </label>
             </div>
         </div>
     {{/if}}
 
     <div class="diceSoNice-footer">
-        <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.previewAnimation"}}</label>
+        <label>{{localize "DAGGERHEART.SETTINGS.Menu.diceSoNice.previewAnimation"}}</label>
         <select name="{{concat id "PreviewAnimation"}}">
             {{selectOptions @root.animationEvents selected=@root.previewAnimation blank="" localize=true }}
         </select>

--- a/templates/settings/dice-so-nice/main.hbs
+++ b/templates/settings/dice-so-nice/main.hbs
@@ -1,23 +1,23 @@
-<section class="tab {{#if tab.active}} active{{/if}}" data-group="{{tab.group}}" data-tab="{{tab.id}}">
-    <div class="title-hint">{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.hint"}}</div>
-    <div class="field-section form-fields">
+<section>
+    <header class="dialog-header">
+        <h1>{{localize 'DAGGERHEART.SETTINGS.Menu.diceSoNice.label'}}</h1>
+    </header>
+    <div class="form-fields general">
         {{#if isGM}}
             <div class="form-group">
-                <label for="dsn-overrideEnabled">{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.defaultAnimations"}}</label>
+                <label for="dsn-overrideEnabled">{{localize "DAGGERHEART.SETTINGS.Menu.diceSoNice.defaultAnimations"}}</label>
                 <input id="dsn-overrideEnabled" type="checkbox" class="default-animations-input" {{checked globalOverrides.diceSoNice.sfx.overrideEnabled}} />
             </div>
         {{/if}}
         <div class="form-group"> 
-            <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.critical"}}</label>
+            <label>{{localize "DAGGERHEART.SETTINGS.Menu.diceSoNice.critical"}}</label>
             
             <div class="form-fields">
-                <div class="form-fields">
-                    {{formInput fields.diceSoNice.fields.sfx.fields.critical.fields.class value=setting.diceSoNice.sfx.critical.class blank="" localize=true}}
-                </div>      
-                <label>{{localize "DAGGERHEART.SETTINGS.Menu.appearance.diceSoNice.muted"}}</label>
-                <div class="form-fields">
+                {{formInput fields.diceSoNice.fields.sfx.fields.critical.fields.class value=setting.diceSoNice.sfx.critical.class blank="" localize=true}}
+                <label>
+                    <span>{{localize "DAGGERHEART.SETTINGS.Menu.diceSoNice.muted"}}</span>
                     {{formInput fields.diceSoNice.fields.sfx.fields.critical.fields.options.fields.muteSound value=setting.diceSoNice.sfx.critical.options.muteSound localize=true}}
-                </div>   
+                </label>
             </div>
         </div>
     </div>
@@ -38,7 +38,7 @@
     </section>
     {{#each dsnTabs as |dsnTab|}}
         <section class="tab {{#if dsnTab.active}} active{{/if}}" data-group="{{dsnTab.group}}" data-tab="{{dsnTab.id}}">
-            {{> "systems/daggerheart/templates/settings/appearance-settings/diceSoNiceTab.hbs" dsnTab }}
+            {{> "systems/daggerheart/templates/settings/dice-so-nice/diceSoNiceTab.hbs" dsnTab }}
         </section>
     {{/each}}
 </section>


### PR DESCRIPTION
This splits DSN settings into a new setting and a new menu. The new DSN settings are user settings, which means that they are specific to the world, not to the browser. This is also the case for the actual dice so nice module (which only has a client setting for the purposes of migrations, and otherwise uses user flags).

Also sneaks in the following features, that were kinda annoying to do separately:
- Updating appearance settings re-renders all open actor sheets like homebrew settings do
- Fixes regular migrations to only run for GMs (a player logging in first can trigger a migration and permission failure spam otherwise). I saw this happen when troubleshooting for someone.

There are however some things I withold on, because I didn't wanna increase the size of this with extra things.
- I would like to refactor the app files like `DHAppearanceSettings` to `AppearanceConfig`. This is the naming convention used by foundry. If we did `AppearanceSettingConfig`, this would be the 5e convention. I"m happy with either but am leaning the former.
- I would like the refactor the data models from `DhAppearance` to `AppearanceSetting`. This is the 5e convention for data models.
- I'm not sure about the migration. Basically, every world you log on, including new worlds, will be set to your user setting. We could update the appearance so it only ever happens on one world, but then that might cause issues with other worlds.

