### PR TITLE
[Feature] Conditional Active Effects

### DIFF
--- a/daggerheart.mjs
+++ b/daggerheart.mjs
@@ -254,7 +254,7 @@ Hooks.once('init', () => {
         SYSTEM.id,
         applications.sheetConfigs.ActiveEffectConfig,
         {
-            types: ['base', 'beastform', 'horde'],
+            types: ['base', 'beastform'],
             makeDefault: true,
             label: sheetLabel('DOCUMENT.ActiveEffect')
         }

--- a/lang/en.json
+++ b/lang/en.json
@@ -16,8 +16,7 @@
         },
         "ActiveEffect": {
             "base": "Standard",
-            "beastform": "Beastform",
-            "horde": "Horde"
+            "beastform": "Beastform"
         },
         "Actor": {
             "character": "Character",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1619,7 +1619,7 @@
             },
             "ConditionalFailureMode": {
                 "suppress": "Suppress",
-                "remove": "Remove"
+                "hide": "Hide"
             },
             "ConditionalPhase": {
                 "preparation": "Preparation",

--- a/lang/en.json
+++ b/lang/en.json
@@ -321,7 +321,7 @@
                     "attack": "ATK",
                     "thresholds": "Thresholds"
                 },
-                "hordeDamage": "Horde Damage",
+                "hordeDamage": "Horde Damage (Half HP)",
                 "horderHp": "Horde/HP",
                 "adversaryReactionRoll": {
                     "headerTitle": "Adversary Reaction Roll"

--- a/lang/en.json
+++ b/lang/en.json
@@ -313,6 +313,10 @@
                     }
                 },
                 "confirmDeleteAttack": "Are you sure you want to delete this adversary's attack?",
+                "changeType": {
+                    "title": "Change Adversary Type",
+                    "content": "You are changing the adversary type, which will delete type specific data. Are you sure you want to do this?"
+                },
                 "Embed": {
                     "attack": "ATK",
                     "thresholds": "Thresholds"

--- a/lang/en.json
+++ b/lang/en.json
@@ -228,6 +228,9 @@
                 "stacking": {
                     "title": "Stacking"
                 },
+                "conditionals": {
+                    "title": "Conditionals"
+                },
                 "targetDispositions": "Affected Dispositions"
             },
             "RangeDependance": {
@@ -1606,6 +1609,18 @@
                     "autoAppliedByLabel": "Max Stress"
                 }
             },
+            "ConditionalComparator": {
+                "less": "Less Than",
+                "lessEquals": "Less Or Equals",
+                "equals": "Equals",
+                "greaterEquals": "Greater Or Equals",
+                "greater": "Greater Than",
+                "truthy": "Is True",
+                "falsy": "Is False"
+            },
+            "ConditionalType": {
+                "dataCompare": "Data Compare"
+            },
             "CountdownProgressType": {
                 "actionRoll": "Action Roll",
                 "characterAttack": "Character Attack",
@@ -2815,6 +2830,11 @@
                     }
                 }
             },
+            "Conditionals": {
+                "dataCompare": {
+                    "comparator": "Comparator"
+                }
+            },
             "Duration": {
                 "passive": "Passive",
                 "temporary": "Temporary"
@@ -3195,7 +3215,8 @@
                 "triggers": "Triggers",
                 "deathMoves": "Deathmoves",
                 "sources": "Sources",
-                "packs": "Packs"
+                "packs": "Packs",
+                "conditionals": "Conditionals"
             },
             "Tiers": {
                 "singular": "Tier",
@@ -3286,6 +3307,7 @@
             "itemResource": "Item Resource",
             "itemQuantity": "Item Quantity",
             "items": "Items",
+            "key": "Key",
             "label": "Label",
             "level": "Level",
             "levelShort": "Lv",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1672,10 +1672,12 @@
             "DamageType": {
                 "physical": {
                     "name": "Physical",
+                    "lowercase": "physical",
                     "abbreviation": "Phy"
                 },
                 "magical": {
                     "name": "Magical",
+                    "lowercase": "magical",
                     "abbreviation": "Mag"
                 },
                 "direct": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -1618,8 +1618,21 @@
                 "truthy": "Is True",
                 "falsy": "Is False"
             },
+            "ConditionalFailureMode": {
+                "suppress": "Suppress",
+                "remove": "Remove"
+            },
+            "ConditionalPhase": {
+                "preparation": "Preparation",
+                "roll": "Roll"
+            },
             "ConditionalType": {
-                "dataCompare": "Data Compare"
+                "dataCompare": "Data Compare",
+                "weaponRestriction": "Weapon Restriction",
+                "actionType": "Action Type"
+            },
+            "ConditionalWeaponRestrictionType": {
+                "sameWeapon": "Same Weapon"
             },
             "CountdownProgressType": {
                 "actionRoll": "Action Roll",
@@ -2831,8 +2844,16 @@
                 }
             },
             "Conditionals": {
+                "phase": "Phase",
+                "failureMode": "Failure Mode",
                 "dataCompare": {
                     "comparator": "Comparator"
+                },
+                "weaponRestriction": {
+                    "weaponType": "Weapon Type"
+                },
+                "actionType": {
+                    "actionType": "Action Type"
                 }
             },
             "Duration": {

--- a/module/applications/sheets-configs/activeEffectConfig.mjs
+++ b/module/applications/sheets-configs/activeEffectConfig.mjs
@@ -11,7 +11,8 @@ export default class DhActiveEffectConfig extends foundry.applications.sheets.Ac
     static DEFAULT_OPTIONS = {
         classes: ['daggerheart', 'sheet', 'dh-style'],
         actions: {
-            showItem: DhActiveEffectConfig.#onShowItem
+            showItem: DhActiveEffectConfig.#onShowItem,
+            removeConditional: DhActiveEffectConfig.#onRemoveConditional
         }
     };
 
@@ -19,6 +20,7 @@ export default class DhActiveEffectConfig extends foundry.applications.sheets.Ac
         header: { template: 'systems/daggerheart/templates/sheets/activeEffect/header.hbs' },
         tabs: { template: 'templates/generic/tab-navigation.hbs' },
         details: { template: 'systems/daggerheart/templates/sheets/activeEffect/details.hbs', scrollable: [''] },
+        conditionals: { template: 'systems/daggerheart/templates/sheets/activeEffect/conditionals.hbs' },
         settings: { template: 'systems/daggerheart/templates/sheets/activeEffect/settings.hbs' },
         changes: {
             template: 'systems/daggerheart/templates/sheets/activeEffect/changes.hbs',
@@ -33,6 +35,7 @@ export default class DhActiveEffectConfig extends foundry.applications.sheets.Ac
             tabs: [
                 { id: 'details', icon: 'fa-solid fa-book' },
                 { id: 'settings', icon: 'fa-solid fa-bars', label: 'DAGGERHEART.GENERAL.Tabs.settings' },
+                { id: 'conditionals', icon: 'fa-solid fa-sliders', label: 'DAGGERHEART.GENERAL.Tabs.conditionals' },
                 { id: 'changes', icon: 'fa-solid fa-gears' }
             ],
             initial: 'details',
@@ -170,6 +173,9 @@ export default class DhActiveEffectConfig extends foundry.applications.sheets.Ac
             });
         });
 
+        htmlElement.querySelector('.conditional-select-input')
+            ?.addEventListener('change', this.#onAddConditional.bind(this));
+
         htmlElement.querySelector('.stacking-change-checkbox')
             ?.addEventListener('change', this.#onStackingChangeToggle.bind(this));
 
@@ -223,6 +229,9 @@ export default class DhActiveEffectConfig extends foundry.applications.sheets.Ac
                     group: CONST.ACTIVE_EFFECT_TIME_DURATION_UNITS.includes(value) ? groups.time : groups.combat
                 }));
                 break;
+            case 'conditionals': 
+                partContext.conditionalOptions = CONFIG.DH.EFFECTS.conditionalTypes;
+                break;
             case 'changes':
                 const typedChanges = this.document.changes.reduce((acc, change, index) => {
                     if (change.single) acc[change.type] = { ...change, index };
@@ -235,6 +244,12 @@ export default class DhActiveEffectConfig extends foundry.applications.sheets.Ac
         }
 
         return partContext;
+    }
+
+    #onAddConditional(event) {
+        const conditionals = [...this.document.system.conditionals, { type: event.target.value }];
+        event.target.value = '';
+        return this.submit({ updateData: { system: { conditionals } } });
     }
 
     #onStackingChangeToggle(event) {
@@ -353,6 +368,13 @@ export default class DhActiveEffectConfig extends foundry.applications.sheets.Ac
             if (event.target.value === 'temporary') durationDescription.classList.add('visible');
             else durationDescription.classList.remove('visible');
         }
+
+        const conditionalComparatorMatch = event.target.name.match(/system.conditionals.\d.comparator/);
+        if (conditionalComparatorMatch) {
+            const parent = event.target.closest('[data-index]');
+            const comparator = CONFIG.DH.EFFECTS.conditionalComparators[event.target.value];
+            parent.querySelector('.conditional-value').hidden = comparator.ignoresValue;
+        }
     }
 
     /** @inheritDoc */
@@ -394,10 +416,17 @@ export default class DhActiveEffectConfig extends foundry.applications.sheets.Ac
         });
     }
 
-    static #onShowItem(event, button) {
+    static #onShowItem(_event, button) {
         const { itemId } = button.dataset;
         if (!itemId) return;
         const item = fromUuidSync(itemId);
         if (item.visible) item.sheet?.render({ force: true });
+    }
+
+    static #onRemoveConditional(_event, button) {
+        const conditionals = this.document.system.conditionals
+        const index = Number(button.dataset.index);
+        conditionals.splice(index, 1);
+        return this.submit({ updateData: { system: { conditionals } } });
     }
 }

--- a/module/applications/sheets-configs/adversary-settings.mjs
+++ b/module/applications/sheets-configs/adversary-settings.mjs
@@ -66,6 +66,8 @@ export default class DHAdversarySettings extends DHBaseActorSettings {
         }));
         featureGroups[1].features.push(...features.filter(f => !featureFormsTypes.includes(f.system.featureForm)));
         context.featureGroups = featureGroups;
+        context.typeDataFields = this.document.system.typeData ? 
+            context.systemFields.typeData.types[this.document.system.typeData.type]?.fields : null;
 
         return context;
     }

--- a/module/applications/sheets-configs/adversary-settings.mjs
+++ b/module/applications/sheets-configs/adversary-settings.mjs
@@ -72,6 +72,24 @@ export default class DHAdversarySettings extends DHBaseActorSettings {
         return context;
     }
 
+    async _processSubmitData(event, form, submitData, options) {
+        // If the user is changing type, they may risk deleting certain data. Warn if that will happen.
+        const actor = this.actor;
+        if (actor.system.typeData && submitData.system?.type && submitData.system?.type !== actor.system.type) {
+            const confirm = await foundry.applications.api.DialogV2.confirm({
+                window: {
+                    title: _loc('DAGGERHEART.ACTORS.Adversary.changeType.title')
+                },
+                content: _loc('DAGGERHEART.ACTORS.Adversary.changeType.content')
+            });
+            if (!confirm) {
+                this.render();
+                return;
+            }
+        }
+        return super._processSubmitData(event, form, submitData, options);
+    }
+
     /* -------------------------------------------- */
 
     /**

--- a/module/config/actorConfig.mjs
+++ b/module/config/actorConfig.mjs
@@ -1,3 +1,5 @@
+import { HordeAdversaryType } from '../data/actor/adversaryTypes/_module.mjs';
+
 export const abilities = {
     agility: {
         id: 'agility',
@@ -150,6 +152,10 @@ export const adversaryTypes = {
         bpCost: 1
     }
 };
+
+export const adversaryTypeModels = {
+    horde: HordeAdversaryType
+}
 
 export const allAdversaryTypes = () => ({
     ...adversaryTypes,

--- a/module/config/effectConfig.mjs
+++ b/module/config/effectConfig.mjs
@@ -46,10 +46,40 @@ export const activeEffectDurations = {
     }
 };
 
+export const conditionalPhases = {
+    preparation: {
+        id: 'preparation',
+        label: 'DAGGERHEART.CONFIG.ConditionalPhase.preparation'
+    },
+    roll: {
+        id: 'roll',
+        label: 'DAGGERHEART.CONFIG.ConditionalPhase.roll'
+    }
+}
+
+export const conditionalFailureModes = {
+    suppress: {
+        id: 'suppress',
+        label: 'DAGGERHEART.CONFIG.ConditionalFailureMode.suppress'
+    },
+    remove: {
+        id: 'remove',
+        label: 'DAGGERHEART.CONFIG.ConditionalFailureMode.remove'
+    }
+}
+
 export const conditionalTypes = {
     dataCompare: {
         id: 'dataCompare',
         label: 'DAGGERHEART.CONFIG.ConditionalType.dataCompare'
+    },
+    weaponRestriction: {
+        id: 'weaponRestriction',
+        label: 'DAGGERHEART.CONFIG.ConditionalType.weaponRestriction' 
+    },
+    actionType: {
+        id: 'actionType',
+        label: 'DAGGERHEART.CONFIG.ConditionalType.actionType'
     }
 };
 
@@ -85,3 +115,41 @@ export const conditionalComparators = {
         ignoresValue: true
     }
 };
+
+export const weaponRestrictionType = {
+    sameWeapon: {
+        id: 'sameWeapon',
+        label: 'DAGGERHEART.CONFIG.ConditionalWeaponRestrictionType.sameWeapon'
+    },
+    primary: {
+        id: 'primary',
+        label: 'DAGGERHEART.ITEMS.Weapon.primaryWeapon.full'
+    },
+    secondary: {
+        id: 'secondary',
+        label: 'DAGGERHEART.ITEMS.Weapon.secondaryWeapon.full'
+    }
+};
+
+export const actionType = {
+    action: {
+        id: 'action',
+        label: 'DAGGERHEART.GENERAL.Roll.action'
+    },
+    reaction: {
+        id: 'reaction',
+        label: 'DAGGERHEART.GENERAL.Roll.reaction'
+    },
+    attack: {
+        id: 'attack',
+        label: 'DAGGERHEART.GENERAL.Roll.attack'
+    },
+    trait: {
+        id: 'trait',
+        label: 'DAGGERHEART.GENERAL.Roll.trait'
+    },
+    spellcast: {
+        id: 'spellcast',
+        label: 'DAGGERHEART.GENERAL.Roll.spellcast'
+    }
+}

--- a/module/config/effectConfig.mjs
+++ b/module/config/effectConfig.mjs
@@ -45,3 +45,43 @@ export const activeEffectDurations = {
         label: 'DAGGERHEART.CONFIG.ActiveEffectDuration.custom'
     }
 };
+
+export const conditionalTypes = {
+    dataCompare: {
+        id: 'dataCompare',
+        label: 'DAGGERHEART.CONFIG.ConditionalType.dataCompare'
+    }
+};
+
+export const conditionalComparators = {
+    less: {
+        id: 'less',
+        label: 'DAGGERHEART.CONFIG.ConditionalComparator.less'
+    },
+    lessEquals: {
+        id: 'lessEquals',
+        label: 'DAGGERHEART.CONFIG.ConditionalComparator.lessEquals'
+    },
+    equals: {
+        id: 'equals',
+        label: 'DAGGERHEART.CONFIG.ConditionalComparator.equals'
+    },
+    greaterEquals: {
+        id: 'greaterEquals',
+        label: 'DAGGERHEART.CONFIG.ConditionalComparator.greaterEquals'
+    },
+    greater: {
+        id: 'greater',
+        label: 'DAGGERHEART.CONFIG.ConditionalComparator.greater'
+    },
+    truthy: {
+        id: 'truthy',
+        label: 'DAGGERHEART.CONFIG.ConditionalComparator.truthy',
+        ignoresValue: true
+    },
+    falsy: {
+        id: 'falsy',
+        label: 'DAGGERHEART.CONFIG.ConditionalComparator.falsy',
+        ignoresValue: true
+    }
+};

--- a/module/config/effectConfig.mjs
+++ b/module/config/effectConfig.mjs
@@ -62,9 +62,9 @@ export const conditionalFailureModes = {
         id: 'suppress',
         label: 'DAGGERHEART.CONFIG.ConditionalFailureMode.suppress'
     },
-    remove: {
-        id: 'remove',
-        label: 'DAGGERHEART.CONFIG.ConditionalFailureMode.remove'
+    hide: {
+        id: 'hide',
+        label: 'DAGGERHEART.CONFIG.ConditionalFailureMode.hide'
     }
 }
 

--- a/module/config/flagsConfig.mjs
+++ b/module/config/flagsConfig.mjs
@@ -37,5 +37,5 @@ export const activeEffectFlags = {
 };
 
 export const actorFlags = {
-    hordeEffect: 'hordeEffect'
+    hordeFeature: 'hordeFeature'
 };

--- a/module/config/flagsConfig.mjs
+++ b/module/config/flagsConfig.mjs
@@ -35,3 +35,7 @@ export const folderFlags = {
 export const activeEffectFlags = {
     evolutionMarker: 'evolutionMarker'
 };
+
+export const actorFlags = {
+    hordeEffect: 'hordeEffect'
+};

--- a/module/config/generalConfig.mjs
+++ b/module/config/generalConfig.mjs
@@ -155,12 +155,14 @@ export const damageTypes = {
     physical: {
         id: 'physical',
         label: 'DAGGERHEART.CONFIG.DamageType.physical.name',
+        lowercase: 'DAGGERHEART.CONFIG.DamageType.physical.lowercase',
         abbreviation: 'DAGGERHEART.CONFIG.DamageType.physical.abbreviation',
         icon: 'fa-hand-fist'
     },
     magical: {
         id: 'magical',
         label: 'DAGGERHEART.CONFIG.DamageType.magical.name',
+        lowercase: 'DAGGERHEART.CONFIG.DamageType.magical.lowercase',
         abbreviation: 'DAGGERHEART.CONFIG.DamageType.magical.abbreviation',
         icon: 'fa-wand-sparkles'
     }

--- a/module/data/action/attackAction.mjs
+++ b/module/data/action/attackAction.mjs
@@ -23,13 +23,6 @@ export default class DHAttackAction extends DHDamageAction {
         return hitPointsPart.value.getFormula();
     }
 
-    get altDamageFormula() {
-        const hitPointsPart = this.damage.main;
-        if (!hitPointsPart) return '0';
-
-        return hitPointsPart.valueAlt.getFormula();
-    }
-
     async use(event, options) {
         if (this.item?.system.needsReload) {
             return ui.notifications.error(_loc('DAGGERHEART.UI.Notifications.reloadRequired', { weapon: this.item.name }));
@@ -73,10 +66,8 @@ export default class DHAttackAction extends DHDamageAction {
         if (roll.trait) labels.push(game.i18n.localize(`DAGGERHEART.CONFIG.Traits.${roll.trait}.short`));
         if (range) labels.push(game.i18n.localize(`DAGGERHEART.CONFIG.Range.${range}.short`));
 
-        const useAltDamage = this.actor?.effects?.find(x => x.type === 'horde')?.active;
-        for (const { value, valueAlt, type } of [damage.main, ...damage.resources].filter(d => !!d)) {
-            const usedValue = useAltDamage ? valueAlt : value;
-            const damageString = Roll.replaceFormulaData(usedValue.getFormula(), this.actor?.getRollData() ?? {});
+        for (const { value, type } of [damage.main, ...damage.resources].filter(d => !!d)) {
+            const damageString = Roll.replaceFormulaData(value.getFormula(), this.actor?.getRollData() ?? {});
             const str = damageString
                 ? damageString
                 : game.i18n.format('DAGGERHEART.GENERAL.missingX', {

--- a/module/data/action/attackAction.mjs
+++ b/module/data/action/attackAction.mjs
@@ -1,3 +1,4 @@
+import { nestedReplaceFormulaData } from '../../helpers/utils.mjs';
 import DHDamageAction from './damageAction.mjs';
 
 export default class DHAttackAction extends DHDamageAction {
@@ -67,7 +68,7 @@ export default class DHAttackAction extends DHDamageAction {
         if (range) labels.push(game.i18n.localize(`DAGGERHEART.CONFIG.Range.${range}.short`));
 
         for (const { value, type } of [damage.main, ...damage.resources].filter(d => !!d)) {
-            const damageString = Roll.replaceFormulaData(value.getFormula(), this.actor?.getRollData() ?? {});
+            const damageString = nestedReplaceFormulaData(value.getFormula(), this.actor?.getRollData() ?? {});
             const str = damageString
                 ? damageString
                 : game.i18n.format('DAGGERHEART.GENERAL.missingX', {

--- a/module/data/action/damageAction.mjs
+++ b/module/data/action/damageAction.mjs
@@ -1,3 +1,4 @@
+import { nestedReplaceFormulaData } from '../../helpers/utils.mjs';
 import DHBaseAction from './baseAction.mjs';
 
 export default class DHDamageAction extends DHBaseAction {
@@ -36,6 +37,7 @@ export default class DHDamageAction extends DHBaseAction {
     getDamageFormula() {
         if (!this.damage.main) return '';
 
-        return Roll.replaceFormulaData(this.damage.main.value.getFormula(), this.actor?.getRollData() ?? {});
+        const rollData = this.actor?.getRollData() ?? {};
+        return nestedReplaceFormulaData(this.damage.main.value.getFormula(), rollData);
     }
 }

--- a/module/data/activeEffect/_module.mjs
+++ b/module/data/activeEffect/_module.mjs
@@ -2,6 +2,7 @@ import BaseEffect from './baseEffect.mjs';
 import BeastformEffect from './beastformEffect.mjs';
 import HordeEffect from './hordeEffect.mjs';
 export { changeTypes, changeEffects } from './changeTypes/_module.mjs';
+export { conditionalTypes as ActiveEffectConditionalTypes } from './conditionalTypes/_module.mjs';
 
 export { BaseEffect, BeastformEffect, HordeEffect };
 

--- a/module/data/activeEffect/_module.mjs
+++ b/module/data/activeEffect/_module.mjs
@@ -1,13 +1,11 @@
 import BaseEffect from './baseEffect.mjs';
 import BeastformEffect from './beastformEffect.mjs';
-import HordeEffect from './hordeEffect.mjs';
 export { changeTypes, changeEffects } from './changeTypes/_module.mjs';
 export { conditionalTypes as ActiveEffectConditionalTypes } from './conditionalTypes/_module.mjs';
 
-export { BaseEffect, BeastformEffect, HordeEffect };
+export { BaseEffect, BeastformEffect };
 
 export const config = {
     base: BaseEffect,
-    beastform: BeastformEffect,
-    horde: HordeEffect
+    beastform: BeastformEffect
 };

--- a/module/data/activeEffect/baseEffect.mjs
+++ b/module/data/activeEffect/baseEffect.mjs
@@ -125,8 +125,8 @@ export default class BaseEffect extends foundry.data.ActiveEffectTypeDataModel {
         }
 
         return rollData && this.conditionals.some(x => 
-            x.phase === CONFIG.DH.EFFECTS.conditionalPhases.preparation.id && 
-            x.failureMode === CONFIG.DH.EFFECTS.conditionalFailureModes.suppress.id &&
+            x.constructor.metadata.phase === CONFIG.DH.EFFECTS.conditionalPhases.preparation.id && 
+            x.constructor.metadata.failureMode === CONFIG.DH.EFFECTS.conditionalFailureModes.suppress.id &&
             !x.doesConditionalPass(rollData)
         );
     }

--- a/module/data/activeEffect/baseEffect.mjs
+++ b/module/data/activeEffect/baseEffect.mjs
@@ -127,7 +127,7 @@ export default class BaseEffect extends foundry.data.ActiveEffectTypeDataModel {
         return rollData && this.conditionals.some(x => 
             x.constructor.metadata.phase === CONFIG.DH.EFFECTS.conditionalPhases.preparation.id && 
             x.constructor.metadata.failureMode === CONFIG.DH.EFFECTS.conditionalFailureModes.suppress.id &&
-            !x.doesConditionalPass(rollData)
+            !x.test(rollData)
         );
     }
 

--- a/module/data/activeEffect/baseEffect.mjs
+++ b/module/data/activeEffect/baseEffect.mjs
@@ -124,7 +124,11 @@ export default class BaseEffect extends foundry.data.ActiveEffectTypeDataModel {
             if (change.isSuppressed) return true;
         }
 
-        return rollData && this.conditionals.some(x => !x.doesConditionalPass(rollData));
+        return rollData && this.conditionals.some(x => 
+            x.phase === CONFIG.DH.EFFECTS.conditionalPhases.preparation.id && 
+            x.failureMode === CONFIG.DH.EFFECTS.conditionalFailureModes.suppress.id &&
+            !x.doesConditionalPass(rollData)
+        );
     }
 
     get armorChange() {

--- a/module/data/activeEffect/baseEffect.mjs
+++ b/module/data/activeEffect/baseEffect.mjs
@@ -14,6 +14,7 @@
 
 import { getScrollTextData } from '../../helpers/utils.mjs';
 import { changeTypes } from './changeTypes/_module.mjs'
+import { conditionalTypes } from './conditionalTypes/_module.mjs';
 
 export default class BaseEffect extends foundry.data.ActiveEffectTypeDataModel {
     static defineSchema() {
@@ -40,6 +41,8 @@ export default class BaseEffect extends foundry.data.ActiveEffectTypeDataModel {
             return r;
         }, {});
 
+        
+
         return {
             ...super.defineSchema(),
             changes: new fields.ArrayField(
@@ -56,6 +59,7 @@ export default class BaseEffect extends foundry.data.ActiveEffectTypeDataModel {
                 }),
                 description: new fields.HTMLField({ label: 'DAGGERHEART.GENERAL.description' })
             }),
+            conditionals: new fields.ArrayField(new fields.TypedSchemaField(conditionalTypes)),
             rangeDependence: new fields.SchemaField({
                 type: new fields.StringField({
                     required: true,
@@ -115,11 +119,12 @@ export default class BaseEffect extends foundry.data.ActiveEffectTypeDataModel {
         return true;
     }
 
-    get isSuppressed() {
+    getIsSuppressed(rollData) {
         for (const change of this.changes) {
             if (change.isSuppressed) return true;
         }
-        return false;
+
+        return rollData && this.conditionals.some(x => !x.doesConditionalPass(rollData));
     }
 
     get armorChange() {

--- a/module/data/activeEffect/baseEffect.mjs
+++ b/module/data/activeEffect/baseEffect.mjs
@@ -41,8 +41,6 @@ export default class BaseEffect extends foundry.data.ActiveEffectTypeDataModel {
             return r;
         }, {});
 
-        
-
         return {
             ...super.defineSchema(),
             changes: new fields.ArrayField(

--- a/module/data/activeEffect/baseEffect.mjs
+++ b/module/data/activeEffect/baseEffect.mjs
@@ -117,7 +117,7 @@ export default class BaseEffect extends foundry.data.ActiveEffectTypeDataModel {
         return true;
     }
 
-    getIsSuppressed(rollData) {
+    testIsSuppressed(rollData) {
         for (const change of this.changes) {
             if (change.isSuppressed) return true;
         }

--- a/module/data/activeEffect/changeTypes/standardAttack.mjs
+++ b/module/data/activeEffect/changeTypes/standardAttack.mjs
@@ -81,7 +81,7 @@ export default class StandardAttackChange extends foundry.abstract.DataModel {
                 );
             }
 
-            if (change.value.damageTypes) {
+            if (change.value.damageTypes.size) {
                 foundry.utils.setProperty(
                     actor,
                     'system.attack.damage.main.type',

--- a/module/data/activeEffect/changeTypes/standardAttack.mjs
+++ b/module/data/activeEffect/changeTypes/standardAttack.mjs
@@ -56,7 +56,7 @@ export default class StandardAttackChange extends foundry.abstract.DataModel {
     static changeEffect = {
         label: 'Standard Attack',
         defaultPriority: 20,
-        handler: (actor, change, _options, _field, replacementData) => {
+        handler: (actor, change, _options) => {
             if (change.value.name) {
                 foundry.utils.setProperty(
                     actor,

--- a/module/data/activeEffect/conditionalTypes/_module.mjs
+++ b/module/data/activeEffect/conditionalTypes/_module.mjs
@@ -1,0 +1,6 @@
+import DataCompareConditional from './dataCompareConditional.mjs';
+import { conditionalTypes as types } from '../../../config/effectConfig.mjs';
+
+export const conditionalTypes = {
+    [types.dataCompare.id]: DataCompareConditional
+}

--- a/module/data/activeEffect/conditionalTypes/_module.mjs
+++ b/module/data/activeEffect/conditionalTypes/_module.mjs
@@ -1,6 +1,10 @@
 import DataCompareConditional from './dataCompareConditional.mjs';
+import WeaponRestrictionConditional from './weaponRestrictionConditional.mjs';
+import ActionTypeConditional from './actionTypeConditional.mjs';
 import { conditionalTypes as types } from '../../../config/effectConfig.mjs';
 
 export const conditionalTypes = {
-    [types.dataCompare.id]: DataCompareConditional
+    [types.dataCompare.id]: DataCompareConditional,
+    [types.weaponRestriction.id]: WeaponRestrictionConditional,
+    [types.actionType.id]: ActionTypeConditional
 }

--- a/module/data/activeEffect/conditionalTypes/actionTypeConditional.mjs
+++ b/module/data/activeEffect/conditionalTypes/actionTypeConditional.mjs
@@ -28,7 +28,7 @@ export default class ActionTypeConditional extends foundry.abstract.DataModel {
         }
     }
 
-    doesConditionalPass(dhRollData) {
+    test(dhRollData) {
         if (!this.actionTypes.size) return true;
 
         const actionType = dhRollData.options.actionType;

--- a/module/data/activeEffect/conditionalTypes/actionTypeConditional.mjs
+++ b/module/data/activeEffect/conditionalTypes/actionTypeConditional.mjs
@@ -34,6 +34,8 @@ export default class ActionTypeConditional extends foundry.abstract.DataModel {
         const actionType = dhRollData.options.actionType;
         if (actionType === 'action' && this.actionTypes.has(CONFIG.DH.EFFECTS.actionType.action.id))
             return true;
+        if (actionType === 'reaction' && this.actionTypes.has(CONFIG.DH.EFFECTS.actionType.reaction.id))
+            return true;
 
         return this.actionTypes.has(dhRollData.options.roll.type);
     }

--- a/module/data/activeEffect/conditionalTypes/actionTypeConditional.mjs
+++ b/module/data/activeEffect/conditionalTypes/actionTypeConditional.mjs
@@ -1,0 +1,40 @@
+import { conditionalTypes, conditionalFailureModes, conditionalPhases } from '../../../config/effectConfig.mjs';
+
+export default class ActionTypeConditional extends foundry.abstract.DataModel {
+    static get metadata() {
+        return {
+            phase: conditionalPhases.roll.id,
+            failureMode: conditionalFailureModes.remove.id
+        }
+    }
+
+    static defineSchema() {
+        const fields = foundry.data.fields;
+
+        return {
+            type: new fields.StringField({ 
+                label: 'DAGGERHEART.GENERAL.type',
+                required: true, 
+                nullable: false, 
+                blank: false, 
+                initial: conditionalTypes.actionType.id 
+            }),
+            actionTypes: new fields.SetField(new fields.StringField({
+                label: 'DAGGERHEART.EFFECTS.Conditionals.actionType.actionType',
+                nullable: true,
+                choices: CONFIG.DH.EFFECTS.actionType,
+                initial: null
+            }))
+        }
+    }
+
+    doesConditionalPass(dhRollData) {
+        if (!this.actionTypes.size) return true;
+
+        const actionType = dhRollData.options.actionType;
+        if (actionType === 'action' && this.actionTypes.has(CONFIG.DH.EFFECTS.actionType.action.id))
+            return true;
+
+        return this.actionTypes.has(dhRollData.options.roll.type);
+    }
+}

--- a/module/data/activeEffect/conditionalTypes/actionTypeConditional.mjs
+++ b/module/data/activeEffect/conditionalTypes/actionTypeConditional.mjs
@@ -4,7 +4,7 @@ export default class ActionTypeConditional extends foundry.abstract.DataModel {
     static get metadata() {
         return {
             phase: conditionalPhases.roll.id,
-            failureMode: conditionalFailureModes.remove.id
+            failureMode: conditionalFailureModes.hide.id
         }
     }
 

--- a/module/data/activeEffect/conditionalTypes/dataCompareConditional.mjs
+++ b/module/data/activeEffect/conditionalTypes/dataCompareConditional.mjs
@@ -1,6 +1,15 @@
+import { conditionalFailureModes, conditionalPhases } from '../../../config/effectConfig.mjs';
 import FormulaField from '../../fields/formulaField.mjs';
+import { conditionalTypes } from './_module.mjs';
 
 export default class DataCompareConditional extends foundry.abstract.DataModel {
+    static get metadata() {
+        return {
+            phase: conditionalPhases.preparation.id,
+            failureMode: conditionalFailureModes.suppress.id
+        }
+    }
+
     static defineSchema() {
         const fields = foundry.data.fields;
 
@@ -10,7 +19,7 @@ export default class DataCompareConditional extends foundry.abstract.DataModel {
                 required: true, 
                 nullable: false, 
                 blank: false, 
-                initial: 'dataCompare' 
+                initial: conditionalTypes.dataCompare.id
             }),
             key: new fields.StringField({
                 label: 'DAGGERHEART.GENERAL.key'

--- a/module/data/activeEffect/conditionalTypes/dataCompareConditional.mjs
+++ b/module/data/activeEffect/conditionalTypes/dataCompareConditional.mjs
@@ -1,0 +1,56 @@
+import FormulaField from '../../fields/formulaField.mjs';
+
+export default class DataCompareConditional extends foundry.abstract.DataModel {
+    static defineSchema() {
+        const fields = foundry.data.fields;
+
+        return {
+            type: new fields.StringField({ 
+                label: 'DAGGERHEART.GENERAL.type',
+                required: true, 
+                nullable: false, 
+                blank: false, 
+                initial: 'dataCompare' 
+            }),
+            key: new fields.StringField({
+                label: 'DAGGERHEART.GENERAL.key'
+            }),
+            comparator: new fields.StringField({ 
+                label: 'DAGGERHEART.EFFECTS.Conditionals.dataCompare.comparator',
+                required: true, 
+                nullable: false, 
+                choices: CONFIG.DH.EFFECTS.conditionalComparators, 
+                initial: CONFIG.DH.EFFECTS.conditionalComparators.equals.id
+            }),
+            value: new FormulaField({
+                label: 'DAGGERHEART.GENERAL.value'
+            })
+        }
+    }
+
+    doesConditionalPass(rollData) {
+        if (!this.key || this.value === undefined) return true;
+
+        const comparator = CONFIG.DH.EFFECTS.conditionalComparators[this.comparator];
+        const data = foundry.utils.getProperty(rollData, this.key);
+        const value = Roll.replaceFormulaData(this.value, rollData);
+        if (!data || (!comparator.ignoresValue && !value)) return true;
+
+        switch (this.comparator) {
+            case CONFIG.DH.EFFECTS.conditionalComparators.less.id:
+                return data < value;
+            case CONFIG.DH.EFFECTS.conditionalComparators.lessEquals.id:
+                return data <= value;
+            case CONFIG.DH.EFFECTS.conditionalComparators.equals.id:
+                return data == value;
+            case CONFIG.DH.EFFECTS.conditionalComparators.greaterEquals.id:
+                return data >= value;
+            case CONFIG.DH.EFFECTS.conditionalComparators.greater.id:
+                return data > value;
+            case CONFIG.DH.EFFECTS.conditionalComparators.truthy.id:
+                return Boolean(data);
+            case CONFIG.DH.EFFECTS.conditionalComparators.falsy.id:
+                return !data;
+        }
+    }
+}

--- a/module/data/activeEffect/conditionalTypes/dataCompareConditional.mjs
+++ b/module/data/activeEffect/conditionalTypes/dataCompareConditional.mjs
@@ -33,9 +33,10 @@ export default class DataCompareConditional extends foundry.abstract.DataModel {
         if (!this.key || (!comparator.ignoresValue && this.value === undefined)) return true;
 
         const data = foundry.utils.getProperty(rollData, this.key);
-        if (!data) return true;
+        if (data === undefined) return true;
 
-        const value = this.value ? Roll.replaceFormulaData(this.value, rollData) : null;
+        const replacedValue = this.value ? Roll.replaceFormulaData(this.value, rollData) : null;
+        const value = replacedValue ? (new Roll(replacedValue)).evaluateSync().total : null;
         switch (this.comparator) {
             case CONFIG.DH.EFFECTS.conditionalComparators.less.id:
                 return data < value;

--- a/module/data/activeEffect/conditionalTypes/dataCompareConditional.mjs
+++ b/module/data/activeEffect/conditionalTypes/dataCompareConditional.mjs
@@ -37,7 +37,7 @@ export default class DataCompareConditional extends foundry.abstract.DataModel {
         }
     }
 
-    doesConditionalPass(rollData) {
+    test(rollData) {
         const comparator = CONFIG.DH.EFFECTS.conditionalComparators[this.comparator];
         if (!this.key || (!comparator.ignoresValue && this.value === undefined)) return true;
 

--- a/module/data/activeEffect/conditionalTypes/dataCompareConditional.mjs
+++ b/module/data/activeEffect/conditionalTypes/dataCompareConditional.mjs
@@ -29,13 +29,13 @@ export default class DataCompareConditional extends foundry.abstract.DataModel {
     }
 
     doesConditionalPass(rollData) {
-        if (!this.key || this.value === undefined) return true;
-
         const comparator = CONFIG.DH.EFFECTS.conditionalComparators[this.comparator];
-        const data = foundry.utils.getProperty(rollData, this.key);
-        const value = Roll.replaceFormulaData(this.value, rollData);
-        if (!data || (!comparator.ignoresValue && !value)) return true;
+        if (!this.key || (!comparator.ignoresValue && this.value === undefined)) return true;
 
+        const data = foundry.utils.getProperty(rollData, this.key);
+        if (!data) return true;
+
+        const value = this.value ? Roll.replaceFormulaData(this.value, rollData) : null;
         switch (this.comparator) {
             case CONFIG.DH.EFFECTS.conditionalComparators.less.id:
                 return data < value;

--- a/module/data/activeEffect/conditionalTypes/weaponRestrictionConditional.mjs
+++ b/module/data/activeEffect/conditionalTypes/weaponRestrictionConditional.mjs
@@ -1,0 +1,47 @@
+import { conditionalTypes, conditionalFailureModes, conditionalPhases } from '../../../config/effectConfig.mjs';
+
+export default class WeaponRestrictionConditional extends foundry.abstract.DataModel {
+    static get metadata() {
+        return {
+            phase: conditionalPhases.roll.id,
+            failureMode: conditionalFailureModes.remove.id
+        }
+    }
+
+    static defineSchema() {
+        const fields = foundry.data.fields;
+
+        return {
+            type: new fields.StringField({ 
+                label: 'DAGGERHEART.GENERAL.type',
+                required: true, 
+                nullable: false, 
+                blank: false, 
+                initial: conditionalTypes.weaponRestriction.id 
+            }),
+            weaponType: new fields.StringField({
+                label: 'DAGGERHEART.EFFECTS.Conditionals.weaponRestriction.weaponType',
+                nullable: true,
+                choices: CONFIG.DH.EFFECTS.weaponRestrictionType,
+                initial: null
+            })
+        }
+    }
+
+    doesConditionalPass(dhRollData) {
+        const item = dhRollData.options.data.parent?.items?.get?.(dhRollData.options.source.item);
+        if (!item) return true;
+
+        const rollData = item.getRollData();
+        const { secondary, primary, sameWeapon } = CONFIG.DH.EFFECTS.weaponRestrictionType;
+
+        /* TODO: Replace this.parent.parent with getNearestDocument in Stable 10 */
+        const weaponTypeValid = !this.weaponType || (
+            (this.weaponType === sameWeapon.id && rollData.item?.parent.id === this.parent.parent?.parent.id) ||
+            (this.weaponType === secondary.id && rollData.item.secondary) ||
+            (this.weaponType === primary.id && !rollData.item.secondary) 
+        );
+
+        return weaponTypeValid;
+    }
+}

--- a/module/data/activeEffect/conditionalTypes/weaponRestrictionConditional.mjs
+++ b/module/data/activeEffect/conditionalTypes/weaponRestrictionConditional.mjs
@@ -29,8 +29,12 @@ export default class WeaponRestrictionConditional extends foundry.abstract.DataM
     }
 
     doesConditionalPass(dhRollData) {
+        if (!dhRollData.options.source.item) return true;
+        
         const item = dhRollData.options.data.parent?.items?.get?.(dhRollData.options.source.item);
         if (!item) return true;
+
+        if (item.type !== 'weapon') return false;
 
         const rollData = item.getRollData();
         const { secondary, primary, sameWeapon } = CONFIG.DH.EFFECTS.weaponRestrictionType;

--- a/module/data/activeEffect/conditionalTypes/weaponRestrictionConditional.mjs
+++ b/module/data/activeEffect/conditionalTypes/weaponRestrictionConditional.mjs
@@ -28,7 +28,7 @@ export default class WeaponRestrictionConditional extends foundry.abstract.DataM
         }
     }
 
-    doesConditionalPass(dhRollData) {
+    test(dhRollData) {
         if (!dhRollData.options.source.item) return true;
         
         const item = dhRollData.options.data.parent?.items?.get?.(dhRollData.options.source.item);

--- a/module/data/activeEffect/conditionalTypes/weaponRestrictionConditional.mjs
+++ b/module/data/activeEffect/conditionalTypes/weaponRestrictionConditional.mjs
@@ -4,7 +4,7 @@ export default class WeaponRestrictionConditional extends foundry.abstract.DataM
     static get metadata() {
         return {
             phase: conditionalPhases.roll.id,
-            failureMode: conditionalFailureModes.remove.id
+            failureMode: conditionalFailureModes.hide.id
         }
     }
 

--- a/module/data/activeEffect/hordeEffect.mjs
+++ b/module/data/activeEffect/hordeEffect.mjs
@@ -1,3 +1,0 @@
-import BaseEffect from './baseEffect.mjs';
-
-export default class HordeEffect extends BaseEffect {}

--- a/module/data/actor/adversary.mjs
+++ b/module/data/actor/adversary.mjs
@@ -138,56 +138,6 @@ export default class DhpAdversary extends DhCreature {
         return super.isItemValid(source) || source.type === 'feature';
     }
 
-    async _preUpdate(changes, options, user) {
-        const allowed = await super._preUpdate(changes, options, user);
-        if (allowed === false) return false;
-
-        if (this.type === CONFIG.DH.ACTOR.adversaryTypes.horde.id) {
-            const autoHordeDamage = game.settings.get(
-                CONFIG.DH.id,
-                CONFIG.DH.SETTINGS.gameSettings.Automation
-            ).hordeDamage;
-            if (autoHordeDamage && changes.system?.resources?.hitPoints?.value !== undefined) {
-                const hordeActiveEffect = this.parent.effects.find(x => x.type === 'horde');
-                if (hordeActiveEffect) {
-                    const halfHP = Math.ceil(this.resources.hitPoints.max / 2);
-                    const newHitPoints = changes.system.resources.hitPoints.value;
-                    const previouslyAboveHalf = this.resources.hitPoints.value < halfHP;
-                    const loweredBelowHalf = previouslyAboveHalf && newHitPoints >= halfHP;
-                    const raisedAboveHalf = !previouslyAboveHalf && newHitPoints < halfHP;
-                    if (loweredBelowHalf) {
-                        await hordeActiveEffect.update({ disabled: false });
-                    } else if (raisedAboveHalf) {
-                        await hordeActiveEffect.update({ disabled: true });
-                    }
-                }
-            }
-        }
-    }
-
-    _onUpdate(changes, options, userId) {
-        super._onUpdate(changes, options, userId);
-
-        if (game.user.id === userId) {
-            if (changes.system?.type) {
-                const existingHordeEffect = this.parent.effects.find(x => x.type === 'horde');
-                if (changes.system.type === CONFIG.DH.ACTOR.adversaryTypes.horde.id) {
-                    if (!existingHordeEffect)
-                        this.parent.createEmbeddedDocuments('ActiveEffect', [
-                            {
-                                type: 'horde',
-                                name: game.i18n.localize('DAGGERHEART.CONFIG.AdversaryType.horde.label'),
-                                img: 'icons/magic/movement/chevrons-down-yellow.webp',
-                                disabled: true
-                            }
-                        ]);
-                } else {
-                    existingHordeEffect?.delete();
-                }
-            }
-        }
-    }
-
     prepareDerivedData() {
         super.prepareDerivedData();
         if (this.attack) {

--- a/module/data/actor/adversary.mjs
+++ b/module/data/actor/adversary.mjs
@@ -163,6 +163,7 @@ export default class DhpAdversary extends DhCreature {
                         const hordeEffectData = {
                             name: _loc('DAGGERHEART.CONFIG.AdversaryType.horde.label'),
                             img: 'icons/magic/movement/chevrons-down-yellow.webp',
+                            showIcon: 2,
                             system: {
                                 conditionals: [{
                                     type: 'dataCompare',

--- a/module/data/actor/adversary.mjs
+++ b/module/data/actor/adversary.mjs
@@ -140,6 +140,97 @@ export default class DhpAdversary extends DhCreature {
         return super.isItemValid(source) || source.type === 'feature';
     }
 
+    _getTags() {
+        const tags = [
+            game.i18n.localize(`DAGGERHEART.GENERAL.Tiers.${this.tier}`),
+            `${game.i18n.localize(`DAGGERHEART.CONFIG.AdversaryType.${this.type}.label`)}`,
+            `${game.i18n.localize('DAGGERHEART.GENERAL.difficulty')}: ${this.difficulty}`
+        ];
+        return tags;
+    }
+
+    /** Returns source data for this actor adjusted to a new tier, which can be used to create a new actor. */
+    adjustForTier(tier) {
+        const source = this.parent.toObject(true);
+        return getTierAdjustedAdversary(source, tier);
+    }
+
+    /** @inheritdoc */
+    async _prepareEmbedContext(options) {
+        const adversaryTypes = CONFIG.DH.ACTOR.allAdversaryTypes();
+        const attack = this.attack ? {
+            name: this.attack.name,
+            range: _loc(CONFIG.DH.GENERAL.range[this.attack.range]?.label),
+            bonus: signedNumber(this.attack.roll?.bonus),
+            damage: this.attack.getDamageFormula()
+        } : null;
+
+        return {
+            ...(await super._prepareEmbedContext(options)),
+            actor: this.parent,
+            type: _loc(adversaryTypes[this.type]?.label),
+            attack,
+            experiences: Object.values(this.experiences).map(e => ({ name: e.name, value: signedNumber(e.value) }))
+        }
+    }
+
+    /* -------------------------------------------- */
+    /*  Data Preparation                            */
+    /* -------------------------------------------- */
+
+    /** @inheritdoc */
+    prepareBaseData() {
+        super.prepareBaseData();
+        if (this.attack) {
+            this.attack.roll.isStandardAttack = true;
+        }
+
+        // Ensure type data exists in case it got somehow removed (ex: modules).
+        // Updating the source allows updates not to break when we add the prepared data
+        const typeModel = CONFIG.DH.ACTOR.adversaryTypeModels[this.type];
+        if (typeModel && !this.typeData) {
+            this.typeData = new typeModel();
+            this.updateSource({ typeData: this.typeData.toObject() });
+        }
+
+        if (this.type === 'horde') {
+            // Add backwards compatibility. Consider a deprecation warning at a later date
+            Object.defineProperty(this.attack, 'altDamageFormula', {
+                get: () => {
+                    return Roll.replaceFormulaData(this.typeData.hordeDamage, this.getRollData());
+                }
+            })
+        }
+    }
+
+    /** @inheritdoc */
+    prepareDerivedData() {
+        super.prepareDerivedData();
+
+        // Evolution features may set other features as inactive
+        for (const feature of this.features.filter(x => x.system.featureForm === 'evolution')) {
+            const evolutionActions = feature.system.actions.filter(x => x.type === 'evolution');
+            for (const action of evolutionActions) {
+                const evolutionActive = action.evolution.active;
+                for (const [id, state] of Object.entries(action.evolution.evolutionFeatures)) {
+                    const isEvolvedFeature = state === CONFIG.DH.ACTIONS.evolutionStates.evolved.id;
+                    const isUnevolvedFeature = state === CONFIG.DH.ACTIONS.evolutionStates.unevolved.id;
+                    const feature = this.parent.items.get(id);
+                    feature.system.inactive = 
+                        (isEvolvedFeature && !evolutionActive) || (isUnevolvedFeature && evolutionActive);
+                }
+            }
+        }
+
+        // Clamp resources (must be done last to ensure all updates occur)
+        this.clampResources();
+    }
+
+    /* -------------------------------------------- */
+    /*  Event Handlers                              */
+    /* -------------------------------------------- */
+
+    /** @inheritdoc */
     async _preUpdate(changes, options, user) {
         const allowed = await super._preUpdate(changes, options, user);
         if (allowed === false) return false;
@@ -151,6 +242,7 @@ export default class DhpAdversary extends DhCreature {
         }
     }
 
+    /** @inheritdoc */
     _onUpdate(changes, options, userId) {
         super._onUpdate(changes, options, userId);
 
@@ -199,65 +291,6 @@ export default class DhpAdversary extends DhCreature {
             } else {
                 existingHordeFeature?.delete();
             }
-        }
-    }
-
-    prepareDerivedData() {
-        super.prepareDerivedData();
-        if (this.attack) {
-            this.attack.roll.isStandardAttack = true;
-        }
-
-        // Evolution features may set other features as inactive
-        for (const feature of this.features.filter(x => x.system.featureForm === 'evolution')) {
-            const evolutionActions = feature.system.actions.filter(x => x.type === 'evolution');
-            for (const action of evolutionActions) {
-                const evolutionActive = action.evolution.active;
-                for (const [id, state] of Object.entries(action.evolution.evolutionFeatures)) {
-                    const isEvolvedFeature = state === CONFIG.DH.ACTIONS.evolutionStates.evolved.id;
-                    const isUnevolvedFeature = state === CONFIG.DH.ACTIONS.evolutionStates.unevolved.id;
-                    const feature = this.parent.items.get(id);
-                    feature.system.inactive = 
-                        (isEvolvedFeature && !evolutionActive) || (isUnevolvedFeature && evolutionActive);
-                }
-            }
-        }
-
-        // Clamp resources (must be done last to ensure all updates occur)
-        this.clampResources();
-    }
-
-    _getTags() {
-        const tags = [
-            game.i18n.localize(`DAGGERHEART.GENERAL.Tiers.${this.tier}`),
-            `${game.i18n.localize(`DAGGERHEART.CONFIG.AdversaryType.${this.type}.label`)}`,
-            `${game.i18n.localize('DAGGERHEART.GENERAL.difficulty')}: ${this.difficulty}`
-        ];
-        return tags;
-    }
-
-    /** Returns source data for this actor adjusted to a new tier, which can be used to create a new actor. */
-    adjustForTier(tier) {
-        const source = this.parent.toObject(true);
-        return getTierAdjustedAdversary(source, tier);
-    }
-
-    /** @inheritdoc */
-    async _prepareEmbedContext(options) {
-        const adversaryTypes = CONFIG.DH.ACTOR.allAdversaryTypes();
-        const attack = this.attack ? {
-            name: this.attack.name,
-            range: _loc(CONFIG.DH.GENERAL.range[this.attack.range]?.label),
-            bonus: signedNumber(this.attack.roll?.bonus),
-            damage: this.attack.getDamageFormula()
-        } : null;
-
-        return {
-            ...(await super._prepareEmbedContext(options)),
-            actor: this.parent,
-            type: _loc(adversaryTypes[this.type]?.label),
-            attack,
-            experiences: Object.values(this.experiences).map(e => ({ name: e.name, value: signedNumber(e.value) }))
         }
     }
 }

--- a/module/data/actor/adversary.mjs
+++ b/module/data/actor/adversary.mjs
@@ -154,52 +154,50 @@ export default class DhpAdversary extends DhCreature {
     _onUpdate(changes, options, userId) {
         super._onUpdate(changes, options, userId);
 
-        if (game.user.id === userId) {
-            if (changes.system?.type) {
-                const existingHordeFeature = 
-                    this.parent.items.find(x => x.getFlag(CONFIG.DH.id, CONFIG.DH.FLAGS.actorFlags.hordeFeature));
-                if (changes.system.type === CONFIG.DH.ACTOR.adversaryTypes.horde.id) {
-                    if (!existingHordeFeature) {
-                        const hordeEffectData = {
-                            name: _loc('DAGGERHEART.CONFIG.AdversaryType.horde.label'),
-                            img: 'icons/magic/movement/chevrons-down-yellow.webp',
-                            showIcon: 2,
-                            system: {
-                                conditionals: [{
-                                    type: 'dataCompare',
-                                    key: 'system.resources.hitPoints.value',
-                                    comparator: 'greaterEquals',
-                                    value: '@system.resources.hitPoints.max / 2'
-                                }],
-                                changes: [{
-                                    type: 'standardAttack',
-                                    value: {
-                                        name: '',
-                                        damageTypes: [],
-                                        attackRange: null,
-                                        trait: null,
-                                        damageFormula: '@system.typeData.hordeDamage',
-                                        img: null
-                                    },
-                                    priority: 0
-                                }]
-                            }
-                        };
-                        this.parent.createEmbeddedDocuments('Item', [{
-                            type: 'feature',
-                            featureForm: CONFIG.DH.ITEM.featureForm.passive,
-                            name: _loc('DAGGERHEART.CONFIG.AdversaryType.horde.label'),
-                            img: 'icons/creatures/magical/humanoid-silhouette-aliens-green.webp',
-                            system: {
-                                description: `When the @Lookup[@name] have marked half or more of their HP, their standard attack deals @Lookup[@system.typeData.hordeDamage] @Lookup[@system.attackDamageType] damage instead.`
-                            },
-                            flags: { [CONFIG.DH.id]: { [CONFIG.DH.FLAGS.actorFlags.hordeFeature]: true } },
-                            effects: [hordeEffectData]
-                        }]);
-                    }
-                } else {
-                    existingHordeFeature?.delete();
+        if (game.user.id === userId && changes.system?.type) {
+            const existingHordeFeature = 
+                this.parent.items.find(x => x.getFlag(CONFIG.DH.id, CONFIG.DH.FLAGS.actorFlags.hordeFeature));
+            if (changes.system.type === CONFIG.DH.ACTOR.adversaryTypes.horde.id) {
+                if (!existingHordeFeature) {
+                    const hordeEffectData = {
+                        name: _loc('DAGGERHEART.CONFIG.AdversaryType.horde.label'),
+                        img: 'icons/magic/movement/chevrons-down-yellow.webp',
+                        showIcon: 2,
+                        system: {
+                            conditionals: [{
+                                type: 'dataCompare',
+                                key: 'system.resources.hitPoints.value',
+                                comparator: 'greaterEquals',
+                                value: '@system.resources.hitPoints.max / 2'
+                            }],
+                            changes: [{
+                                type: 'standardAttack',
+                                value: {
+                                    name: '',
+                                    damageTypes: [],
+                                    attackRange: null,
+                                    trait: null,
+                                    damageFormula: '@system.typeData.hordeDamage',
+                                    img: null
+                                },
+                                priority: 0
+                            }]
+                        }
+                    };
+                    this.parent.createEmbeddedDocuments('Item', [{
+                        type: 'feature',
+                        featureForm: CONFIG.DH.ITEM.featureForm.passive,
+                        name: _loc('DAGGERHEART.CONFIG.AdversaryType.horde.label'),
+                        img: 'icons/creatures/magical/humanoid-silhouette-aliens-green.webp',
+                        system: {
+                            description: `When the @Lookup[@name] have marked half or more of their HP, their standard attack deals @Lookup[@system.typeData.hordeDamage] @Lookup[@system.attackDamageType] damage instead.`
+                        },
+                        flags: { [CONFIG.DH.id]: { [CONFIG.DH.FLAGS.actorFlags.hordeFeature]: true } },
+                        effects: [hordeEffectData]
+                    }]);
                 }
+            } else {
+                existingHordeFeature?.delete();
             }
         }
     }

--- a/module/data/actor/adversary.mjs
+++ b/module/data/actor/adversary.mjs
@@ -246,7 +246,7 @@ export default class DhpAdversary extends DhCreature {
     _onUpdate(changes, options, userId) {
         super._onUpdate(changes, options, userId);
 
-        if (game.user.id === userId && changes.system?.type) {
+        if (game.user.id === userId && changes.system?.type && !options?.isRefresh) {
             const existingHordeFeature = 
                 this.parent.items.find(x => x.getFlag(CONFIG.DH.id, CONFIG.DH.FLAGS.actorFlags.hordeFeature));
             if (changes.system.type === CONFIG.DH.ACTOR.adversaryTypes.horde.id) {

--- a/module/data/actor/adversary.mjs
+++ b/module/data/actor/adversary.mjs
@@ -36,15 +36,12 @@ export default class DhpAdversary extends DhCreature {
                 choices: CONFIG.DH.ACTOR.allAdversaryTypes,
                 initial: CONFIG.DH.ACTOR.adversaryTypes.standard.id
             }),
+            typeData: new fields.TypedSchemaField(CONFIG.DH.ACTOR.adversaryTypeModels, 
+                { nullable: true, initial: null }
+            ),
             motivesAndTactics: new fields.StringField(),
             notes: new fields.HTMLField(),
             difficulty: new fields.NumberField({ required: true, initial: 1, integer: true }),
-            hordeHp: new fields.NumberField({
-                required: true,
-                initial: 1,
-                integer: true,
-                label: 'DAGGERHEART.GENERAL.hordeHp'
-            }),
             criticalThreshold: new fields.NumberField({
                 required: true,
                 integer: true,
@@ -136,6 +133,60 @@ export default class DhpAdversary extends DhCreature {
 
     isItemValid(source) {
         return super.isItemValid(source) || source.type === 'feature';
+    }
+
+    async _preUpdate(changes, options, user) {
+        const allowed = await super._preUpdate(changes, options, user);
+        if (allowed === false) return false;
+
+        if (changes.system?.type && changes.system.type !== this.type) {
+            const newType = CONFIG.DH.ACTOR.adversaryTypeModels[changes.system.type] ?? null;
+            const newTypeData = newType ? (new newType()).toObject() : null;
+            changes.system.typeData = newTypeData;
+        }
+    }
+
+    _onUpdate(changes, options, userId) {
+        super._onUpdate(changes, options, userId);
+
+        if (game.user.id === userId) {
+            if (changes.system?.type) {
+                const existingHordeEffect = 
+                    this.parent.effects.find(x => x.getFlag(CONFIG.DH.id, CONFIG.DH.FLAGS.actorFlags.hordeEffect));
+                if (changes.system.type === CONFIG.DH.ACTOR.adversaryTypes.horde.id) {
+                    if (!existingHordeEffect)
+                        this.parent.createEmbeddedDocuments('ActiveEffect', [
+                            {
+                                type: 'base',
+                                flags: { [CONFIG.DH.id]: { [CONFIG.DH.FLAGS.actorFlags.hordeEffect]: true } },
+                                name: _loc('DAGGERHEART.CONFIG.AdversaryType.horde.label'),
+                                img: 'icons/magic/movement/chevrons-down-yellow.webp',
+                                conditionals: [{
+                                    type: 'dataCompare',
+                                    key: 'system.resources.hitPoints.value',
+                                    comparator: 'greaterEquals',
+                                    value: '@system.resources.hitPoints.max / 2'
+                                }],
+                                changes: [{
+                                    type: 'standardAttack',
+                                    value: {
+                                        name: '',
+                                        damageTypes: [],
+                                        attackRange: null,
+                                        trait: null,
+                                        damageFormula: '@system.typeData.hordeDamage',
+                                        img: null
+                                    },
+                                    priority: 0
+                                }],
+                                disabled: true
+                            }
+                        ]);
+                } else {
+                    existingHordeEffect?.delete();
+                }
+            }
+        }
     }
 
     prepareDerivedData() {

--- a/module/data/actor/adversary.mjs
+++ b/module/data/actor/adversary.mjs
@@ -127,6 +127,11 @@ export default class DhpAdversary extends DhCreature {
         return this.attack?.roll.bonus ?? null;
     }
 
+    get attackDamageType() {
+        const type = this.attack?.damage.main.type.first();
+        return type ? _loc(CONFIG.DH.GENERAL.damageTypes[type].lowercase) : '<No Damage Type>';
+    }
+
     get features() {
         return this.parent.items.filter(x => x.type === 'feature');
     }
@@ -151,16 +156,14 @@ export default class DhpAdversary extends DhCreature {
 
         if (game.user.id === userId) {
             if (changes.system?.type) {
-                const existingHordeEffect = 
-                    this.parent.effects.find(x => x.getFlag(CONFIG.DH.id, CONFIG.DH.FLAGS.actorFlags.hordeEffect));
+                const existingHordeFeature = 
+                    this.parent.items.find(x => x.getFlag(CONFIG.DH.id, CONFIG.DH.FLAGS.actorFlags.hordeFeature));
                 if (changes.system.type === CONFIG.DH.ACTOR.adversaryTypes.horde.id) {
-                    if (!existingHordeEffect)
-                        this.parent.createEmbeddedDocuments('ActiveEffect', [
-                            {
-                                type: 'base',
-                                flags: { [CONFIG.DH.id]: { [CONFIG.DH.FLAGS.actorFlags.hordeEffect]: true } },
-                                name: _loc('DAGGERHEART.CONFIG.AdversaryType.horde.label'),
-                                img: 'icons/magic/movement/chevrons-down-yellow.webp',
+                    if (!existingHordeFeature) {
+                        const hordeEffectData = {
+                            name: _loc('DAGGERHEART.CONFIG.AdversaryType.horde.label'),
+                            img: 'icons/magic/movement/chevrons-down-yellow.webp',
+                            system: {
                                 conditionals: [{
                                     type: 'dataCompare',
                                     key: 'system.resources.hitPoints.value',
@@ -178,12 +181,23 @@ export default class DhpAdversary extends DhCreature {
                                         img: null
                                     },
                                     priority: 0
-                                }],
-                                disabled: true
+                                }]
                             }
-                        ]);
+                        };
+                        this.parent.createEmbeddedDocuments('Item', [{
+                            type: 'feature',
+                            featureForm: CONFIG.DH.ITEM.featureForm.passive,
+                            name: _loc('DAGGERHEART.CONFIG.AdversaryType.horde.label'),
+                            img: 'icons/creatures/magical/humanoid-silhouette-aliens-green.webp',
+                            system: {
+                                description: `When the @Lookup[@name] have marked half or more of their HP, their standard attack deals @Lookup[@system.typeData.hordeDamage] @Lookup[@system.attackDamageType] damage instead.`
+                            },
+                            flags: { [CONFIG.DH.id]: { [CONFIG.DH.FLAGS.actorFlags.hordeFeature]: true } },
+                            effects: [hordeEffectData]
+                        }]);
+                    }
                 } else {
-                    existingHordeEffect?.delete();
+                    existingHordeFeature?.delete();
                 }
             }
         }

--- a/module/data/actor/adversaryTypes/_module.mjs
+++ b/module/data/actor/adversaryTypes/_module.mjs
@@ -1,0 +1,1 @@
+export { default as HordeAdversaryType } from './hordeAdversaryType.mjs';

--- a/module/data/actor/adversaryTypes/hordeAdversaryType.mjs
+++ b/module/data/actor/adversaryTypes/hordeAdversaryType.mjs
@@ -1,0 +1,17 @@
+import FormulaField from '../../fields/formulaField.mjs';
+
+export default class HordeAdversaryType extends foundry.abstract.DataModel {
+    static defineSchema() {
+        const fields = foundry.data.fields;
+        return {
+            type: new fields.StringField({ required: true, nullable: false, blank: false, initial: 'horde' }),
+            hordeHP: new fields.NumberField({
+                required: true,
+                initial: 1,
+                integer: true,
+                label: 'DAGGERHEART.GENERAL.hordeHp'
+            }),
+            hordeDamage: new FormulaField()
+        }
+    }
+}

--- a/module/data/actor/adversaryTypes/hordeAdversaryType.mjs
+++ b/module/data/actor/adversaryTypes/hordeAdversaryType.mjs
@@ -11,7 +11,7 @@ export default class HordeAdversaryType extends foundry.abstract.DataModel {
                 integer: true,
                 label: 'DAGGERHEART.GENERAL.hordeHp'
             }),
-            hordeDamage: new FormulaField()
+            hordeDamage: new FormulaField({ initial: '1d4', label: 'DAGGERHEART.ACTORS.Adversary.hordeDamage' })
         }
     }
 }

--- a/module/data/actor/tierAdjustment.mjs
+++ b/module/data/actor/tierAdjustment.mjs
@@ -49,11 +49,14 @@ export function getTierAdjustedAdversary(source, tier) {
         const damage = source.system.attack.damage;
         if (!damage?.main) throw new Error('Unexpected missing damage in adversary');
 
-        for (const property of ['value', 'valueAlt']) {
-            const data = damage.main[property];
-            const previousFormula = getFormula(data);
-            const value = calculateAdjustedDamage(previousFormula, 'attack', damageMeta);
-            applyAdjustedDamage(data, value);
+        const previousFormula = getFormula(damage.main.value);
+        const value = calculateAdjustedDamage(previousFormula, 'attack', damageMeta);
+        applyAdjustedDamage(damage.main.value, value);
+
+        if (source.system.typeData?.hordeDamage) {
+            // Update hordes. They don't use "attack" scaling, which attempts to match tier for dice count
+            const value = calculateAdjustedDamage(source.system.typeData.hordeDamage, 'action', damageMeta);
+            source.system.typeData.hordeDamage = getFormula(value);
         }
     } catch (err) {
         ui.notifications.warn('Failed to convert attack damage of adversary');
@@ -88,15 +91,17 @@ export function getTierAdjustedAdversary(source, tier) {
                 const result = [];
                 for (const property of ['value', 'valueAlt']) {
                     const { [property]: data, type: damageType } = action.damage.main;
-                    const previousFormula = getFormula(data);
-                    const isActuallyAttack =
-                        previousFormula === initialAttack.value &&
-                        foundry.utils.equals(damageType.toSorted(), initialAttack.type) &&
-                        !descriptionFormulas.includes(previousFormula);
-                    const type = isActuallyAttack ? 'attack' : 'action';
-                    const value = calculateAdjustedDamage(previousFormula, type, damageMeta);
-                    applyAdjustedDamage(data, value);
-                    result.push({ previousFormula, formula: getFormula(value) });
+                    if (data) {
+                        const previousFormula = getFormula(data);
+                        const isActuallyAttack =
+                            previousFormula === initialAttack.value &&
+                            foundry.utils.equals(damageType.toSorted(), initialAttack.type) &&
+                            !descriptionFormulas.includes(previousFormula);
+                        const type = isActuallyAttack ? 'attack' : 'action';
+                        const value = calculateAdjustedDamage(previousFormula, type, damageMeta);
+                        applyAdjustedDamage(data, value);
+                        result.push({ previousFormula, formula: getFormula(value) });
+                    }
                 }
 
                 // Override text in the description with those values
@@ -121,6 +126,8 @@ export function getTierAdjustedAdversary(source, tier) {
 
 /**
  * Converts a damage object to a new damage range
+ * @param {string} formula the damage formula we are converting
+ * @param {'attack' | 'action'} type the use of the damage. Affects scaling, attack attempts to preserve certain things
  * @returns {{ diceQuantity: number; faces: number; bonus: number }} the adjusted result as a combined term
  * @throws error if the formula is the wrong type
  */

--- a/module/data/fields/action/damageField.mjs
+++ b/module/data/fields/action/damageField.mjs
@@ -199,13 +199,6 @@ export default class DamageField extends fields.SchemaField {
 
         if (data.hasRoll && part.resultBased && data.roll.withFear) return part.valueAlt;
 
-        const isAdversary = this.actor.type === 'adversary';
-        const isHorde = this.actor.system.type === CONFIG.DH.ACTOR.adversaryTypes.horde.id;
-        if (isAdversary && isHorde && this.roll?.isStandardAttack) {
-            const hasHordeDamage = this.actor.effects.find(x => x.type === 'horde');
-            if (hasHordeDamage && !hasHordeDamage.disabled) return part.valueAlt;
-        }
-
         return formulaValue;
     }
 

--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -356,7 +356,7 @@ export default class DHRoll extends BaseRoll {
         return (
             this.options.effects?.reduce((acc, effect) => {
                 const isConditionalBlocked = 
-                    effect.system.conditionals.some(x => x.constructor.metadata.phase === 'roll' && !x.doesConditionalPass(this));
+                    (effect.system.conditionals ?? []).some(x => x.constructor.metadata.phase === 'roll' && !x.doesConditionalPass(this));
                 // Some old v13 messages don't have system data and will cause errors here during roll construction otherwise. TODO. See if message.roll.options.effects can be saved/instantiated as actual ActiveEffects, then this can be removed.
                 if (
                     !isConditionalBlocked && 

--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -355,8 +355,13 @@ export default class DHRoll extends BaseRoll {
         const changeKeys = this.getActionChangeKeys();
         return (
             this.options.effects?.reduce((acc, effect) => {
+                const isConditionalBlocked = 
+                    effect.system.conditionals.some(x => x.constructor.metadata.phase === 'roll' && !x.doesConditionalPass(this));
                 // Some old v13 messages don't have system data and will cause errors here during roll construction otherwise. TODO. See if message.roll.options.effects can be saved/instantiated as actual ActiveEffects, then this can be removed.
-                if ((effect.system.changes ?? []).some(x => changeKeys.some(key => x.key?.includes(key)))) {
+                if (
+                    !isConditionalBlocked && 
+                    (effect.system.changes ?? []).some(x => changeKeys.some(key => x.key?.includes(key)))
+                ) {
                     acc[effect.id] = {
                         id: effect.id,
                         name: effect.name,

--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -356,7 +356,7 @@ export default class DHRoll extends BaseRoll {
         return (
             this.options.effects?.reduce((acc, effect) => {
                 const isConditionalBlocked = 
-                    (effect.system.conditionals ?? []).some(x => x.constructor.metadata.phase === 'roll' && !x.doesConditionalPass(this));
+                    (effect.system.conditionals ?? []).some(x => x.constructor.metadata.phase === 'roll' && !x.test(this));
                 // Some old v13 messages don't have system data and will cause errors here during roll construction otherwise. TODO. See if message.roll.options.effects can be saved/instantiated as actual ActiveEffects, then this can be removed.
                 if (
                     !isConditionalBlocked && 

--- a/module/documents/activeEffect.mjs
+++ b/module/documents/activeEffect.mjs
@@ -7,7 +7,7 @@ export default class DhActiveEffect extends foundry.documents.ActiveEffect {
 
     /**@override */
     get isSuppressed() {
-        if (this.system.isSuppressed === true) return true;
+        if (this.system.getIsSuppressed(this.actor?.getRollData()) === true) return true;
 
         // If this is a copied effect from an attachment, never suppress it
         // (These effects have attachmentSource metadata)

--- a/module/documents/activeEffect.mjs
+++ b/module/documents/activeEffect.mjs
@@ -7,7 +7,7 @@ export default class DhActiveEffect extends foundry.documents.ActiveEffect {
 
     /**@override */
     get isSuppressed() {
-        if (this.system.getIsSuppressed(this.actor?.getRollData()) === true) return true;
+        if (this.system.testIsSuppressed(this.actor?.getRollData()) === true) return true;
 
         // If this is a copied effect from an attachment, never suppress it
         // (These effects have attachmentSource metadata)

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1239,9 +1239,11 @@ export default class DhpActor extends Actor {
     /**@inheritdoc */
     *allApplicableEffects({ noSelfArmor, noTransferArmor } = {}) {
         const isRemovedByConditional = effect => {
+            const { preparation } = CONFIG.DH.EFFECTS.conditionalPhases;
+            const { remove } = CONFIG.DH.EFFECTS.conditionalFailureModes;
             return effect.system.conditionals.some(x => 
-                x.phase === CONFIG.DH.EFFECTS.conditionalPhases.preparation.id && 
-                x.failureMode === CONFIG.DH.EFFECTS.conditionalFailureModes.remove.id &&
+                x.constructor.metadata.phase === preparation.id && 
+                x.constructor.metadata.failureMode === remove.id &&
                 !x.doesConditionalPass(this.getRollData())
             );
         }

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1238,12 +1238,20 @@ export default class DhpActor extends Actor {
 
     /**@inheritdoc */
     *allApplicableEffects({ noSelfArmor, noTransferArmor } = {}) {
+        const isRemovedByConditional = effect => {
+            return effect.system.conditionals.some(x => 
+                x.phase === CONFIG.DH.EFFECTS.conditionalPhases.preparation.id && 
+                x.failureMode === CONFIG.DH.EFFECTS.conditionalFailureModes.remove.id &&
+                !x.doesConditionalPass(this.getRollData())
+            );
+        }
+
         for (const effect of this.effects) {
-            if (!noSelfArmor || effect.type !== 'armor') yield effect;
+            if (!isRemovedByConditional(effect) && (!noSelfArmor || effect.type !== 'armor')) yield effect;
         }
         for (const item of this.items) {
             for (const effect of item.effects) {
-                if (effect.transfer && (!noTransferArmor || effect.type !== 'armor')) yield effect;
+                if (!isRemovedByConditional(effect) && effect.transfer && (!noTransferArmor || effect.type !== 'armor')) yield effect;
             }
         }
     }

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1244,7 +1244,7 @@ export default class DhpActor extends Actor {
             return effect.system.conditionals.some(x => 
                 x.constructor.metadata.phase === preparation.id && 
                 x.constructor.metadata.failureMode === remove.id &&
-                !x.doesConditionalPass(this.getRollData())
+                !x.test(this.getRollData())
             );
         }
 

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1198,7 +1198,7 @@ export default class DhpActor extends Actor {
         const conditions = CONFIG.DH.GENERAL.conditions();
         const statusMap = new Map(foundry.CONFIG.statusEffects.map(status => [status.id, status]));
         const autoVulnerableActive = this.system.isAutoVulnerableActive;
-        return this.effects
+        return this.allApplicableEffects()
             .filter(x => !x.disabled && !x.isSuppressed)
             .reduce((acc, effect) => {
                 /* Could be generalized if needed. Currently just related to Vulnerable */

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1271,11 +1271,11 @@ export default class DhpActor extends Actor {
     *allApplicableEffects({ noSelfArmor, noTransferArmor } = {}) {
         const isRemovedByConditional = effect => {
             const { preparation } = CONFIG.DH.EFFECTS.conditionalPhases;
-            const { remove } = CONFIG.DH.EFFECTS.conditionalFailureModes;
+            const { hide } = CONFIG.DH.EFFECTS.conditionalFailureModes;
             const rollData = this.getRollData();
             return effect.system.conditionals.some(x => 
                 x.constructor.metadata.phase === preparation.id && 
-                x.constructor.metadata.failureMode === remove.id &&
+                x.constructor.metadata.failureMode === hide.id &&
                 !x.test(rollData)
             );
         }

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -5,6 +5,7 @@ import { createScrollText, damageKeyToNumber, getDamageKey, createShallowProxy, 
 import DhCompanionLevelUp from '../applications/levelup/companionLevelup.mjs';
 import { ResourceUpdateMap } from '../data/action/baseAction.mjs';
 import { abilities } from '../config/actorConfig.mjs';
+import { DHDamageData } from '../data/fields/action/damageField.mjs';
 
 export default class DhpActor extends Actor {
     parties = new Set();
@@ -134,6 +135,36 @@ export default class DhpActor extends Actor {
                     multiclass: feature.system.multiclassOrigin,
                     identifier: feature.system.identifier
                 };
+            }
+        }
+
+        if (source.type === 'adversary') {
+            for (const effect of (source.effects ?? [])) {
+                if (effect.type === 'horde') {
+                    effect.type = 'base';
+                    effect.disabled = false;
+                    const variantDamage = new DHDamageData(source.system.attack.damage.main);
+                    const hordeDamage = variantDamage.valueAlt.getFormula();
+                    effect.system.changes.push({
+                        type: 'standardAttack',
+                        value: {
+                            name: '',
+                            damageTypes: [],
+                            attackRange: null,
+                            trait: null,
+                            img: null,
+                            damageFormula: hordeDamage
+                        },
+                        phase: 'initial',
+                        priority: 0
+                    });
+                    effect.system.conditionals = [{
+                        type: 'dataCompare',
+                        key: 'system.resources.hitPoints.value',
+                        comparator: 'greaterEquals',
+                        value: '@system.resources.hitPoints.max / 2'
+                    }]
+                }
             }
         }
 
@@ -1168,7 +1199,7 @@ export default class DhpActor extends Actor {
         const statusMap = new Map(foundry.CONFIG.statusEffects.map(status => [status.id, status]));
         const autoVulnerableActive = this.system.isAutoVulnerableActive;
         return this.effects
-            .filter(x => !x.disabled)
+            .filter(x => !x.disabled && !x.isSuppressed)
             .reduce((acc, effect) => {
                 /* Could be generalized if needed. Currently just related to Vulnerable */
                 const isAutoVulnerableEffect =

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1347,7 +1347,8 @@ export default class DhpActor extends Actor {
                 name: latestSource.name,
                 img: latestSource.img,
                 system: _replace(system)
-            }]
+            }],
+            isRefresh: true
         }];
         if (effectCreates.length) {
             batch.push({

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1272,19 +1272,20 @@ export default class DhpActor extends Actor {
         const isRemovedByConditional = effect => {
             const { preparation } = CONFIG.DH.EFFECTS.conditionalPhases;
             const { remove } = CONFIG.DH.EFFECTS.conditionalFailureModes;
+            const rollData = this.getRollData();
             return effect.system.conditionals.some(x => 
                 x.constructor.metadata.phase === preparation.id && 
                 x.constructor.metadata.failureMode === remove.id &&
-                !x.test(this.getRollData())
+                !x.test(rollData)
             );
         }
 
         for (const effect of this.effects) {
-            if (!isRemovedByConditional(effect) && (!noSelfArmor || effect.type !== 'armor')) yield effect;
+            if ((!noSelfArmor || effect.type !== 'armor') && !isRemovedByConditional(effect)) yield effect;
         }
         for (const item of this.items) {
             for (const effect of item.effects) {
-                if (!isRemovedByConditional(effect) && effect.transfer && (!noTransferArmor || effect.type !== 'armor')) yield effect;
+                if (effect.transfer && (!noTransferArmor || effect.type !== 'armor') && !isRemovedByConditional(effect)) yield effect;
             }
         }
     }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -409,7 +409,8 @@ export default class DHItem extends foundry.documents.Item {
                 name: latestSource.name,
                 img: latestSource.img,
                 system: _replace(system)
-            }]
+            }],
+            isRefresh: true
         }];
         if (effectCreates.length) {
             batch.push({

--- a/module/enrichers/LookupEnricher.mjs
+++ b/module/enrichers/LookupEnricher.mjs
@@ -1,3 +1,4 @@
+import { nestedReplaceFormulaData } from '../helpers/utils.mjs';
 import { parseInlineParams } from './parser.mjs';
 
 /**
@@ -24,7 +25,7 @@ export function DhLookupEnricher(match, { rollData }) {
     }
     
     // Perform lookup/replacement, and handle lookup tables
-    const lookupText = Roll.replaceFormulaData(String(params.formula), rollData);
+    const lookupText = nestedReplaceFormulaData(String(params.formula), rollData);
     if (table && lookupText in table.entries) {
         let entry = table.entries[lookupText];
         const adjustment = params.adjustment ? Number(params.adjustment) : null;

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -950,3 +950,18 @@ export function getAllResourceLabels() {
         return acc;
     }, {});
 }
+
+/** 
+ * Performs a replace data that reruns if the new result includes @ strings
+ * It only repeats once for efficiency, full recursion would need to track previous results.
+ * This handles the case where lookup looks up a damage formula that also needs to be resolved.
+ * @param {string} formula
+ * @param {object} rollData
+ * @returns {string}
+ */
+export function nestedReplaceFormulaData(formula, rollData) {
+    const replacement = Roll.replaceFormulaData(formula, rollData);
+    return replacement !== formula && replacement.includes('@') 
+        ? Roll.replaceFormulaData(replacement, rollData)
+        : replacement;
+}

--- a/module/systemRegistration/handlebars.mjs
+++ b/module/systemRegistration/handlebars.mjs
@@ -66,6 +66,7 @@ export const preloadHandlebarsTemplates = async function () {
         'systems/daggerheart/templates/sheets/activeEffect/typeChanges/armorChange.hbs',
         'systems/daggerheart/templates/dialogs/levelupOptionsDialog/parts/tier.hbs',
         'systems/daggerheart/templates/sheets/activeEffect/typeChanges/standardAttack.hbs',
+        'systems/daggerheart/templates/sheets/activeEffect/conditionals/dataCompareConditional.hbs',
         'systems/daggerheart/templates/ui/chat/parts/target-tokens-part.hbs'
     ]);
 };

--- a/module/systemRegistration/handlebars.mjs
+++ b/module/systemRegistration/handlebars.mjs
@@ -67,6 +67,8 @@ export const preloadHandlebarsTemplates = async function () {
         'systems/daggerheart/templates/dialogs/levelupOptionsDialog/parts/tier.hbs',
         'systems/daggerheart/templates/sheets/activeEffect/typeChanges/standardAttack.hbs',
         'systems/daggerheart/templates/sheets/activeEffect/conditionals/dataCompareConditional.hbs',
+        'systems/daggerheart/templates/sheets/activeEffect/conditionals/weaponRestrictionConditional.hbs',
+        'systems/daggerheart/templates/sheets/activeEffect/conditionals/actionTypeConditional.hbs',
         'systems/daggerheart/templates/ui/chat/parts/target-tokens-part.hbs'
     ]);
 };

--- a/src/packs/adversaries/adversary_Archer_Squadron_0ts6CGd93lLqGZI5.json
+++ b/src/packs/adversaries/adversary_Archer_Squadron_0ts6CGd93lLqGZI5.json
@@ -241,7 +241,73 @@
       },
       "_id": "uPwtE9d63PHtQitG",
       "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [],
+      "effects": [
+        {
+          "name": "Horde",
+          "type": "base",
+          "system": {
+            "changes": [
+              {
+                "type": "standardAttack",
+                "phase": "initial",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "1d6 + 3",
+                  "img": null
+                },
+                "priority": 0
+              }
+            ],
+            "duration": {
+              "description": "",
+              "type": ""
+            },
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "BvL39WnKTmCYSMHT",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "disabled": false,
+          "start": {
+            "time": 0,
+            "combat": null,
+            "combatant": null,
+            "initiative": null,
+            "round": null,
+            "turn": null
+          },
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "<p>When the Archer Squadron has marked half or more of their HP, their standard attack deals <strong>1d6 + 3</strong> physical damage instead.</p>",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 2,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!0ts6CGd93lLqGZI5.uPwtE9d63PHtQitG.BvL39WnKTmCYSMHT"
+        }
+      ],
       "folder": null,
       "sort": 0,
       "flags": {},
@@ -490,49 +556,6 @@
       "_key": "!actors.items!0ts6CGd93lLqGZI5.ayGHTtyjSuIR4BrV"
     }
   ],
-  "effects": [
-    {
-      "type": "horde",
-      "name": "Horde",
-      "img": "icons/magic/movement/chevrons-down-yellow.webp",
-      "disabled": true,
-      "_id": "bq8hTzQoCXmA3xad",
-      "system": {
-        "changes": [],
-        "duration": {
-          "description": ""
-        },
-        "rangeDependence": null,
-        "stacking": null,
-        "targetDispositions": []
-      },
-      "duration": {
-        "value": null,
-        "units": "seconds",
-        "expiry": null,
-        "expired": false
-      },
-      "description": "",
-      "tint": "#ffffff",
-      "transfer": false,
-      "statuses": [],
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "start": {
-        "combat": null,
-        "time": 0,
-        "combatant": null,
-        "initiative": null,
-        "round": null,
-        "turn": null
-      },
-      "showIcon": 1,
-      "folder": null,
-      "_key": "!actors.effects!0ts6CGd93lLqGZI5.bq8hTzQoCXmA3xad"
-    }
-  ],
+  "effects": [],
   "_key": "!actors!0ts6CGd93lLqGZI5"
 }

--- a/src/packs/adversaries/adversary_Archer_Squadron_0ts6CGd93lLqGZI5.json
+++ b/src/packs/adversaries/adversary_Archer_Squadron_0ts6CGd93lLqGZI5.json
@@ -539,7 +539,7 @@
           "tint": "#ffffff",
           "transfer": true,
           "statuses": [],
-          "showIcon": 1,
+          "showIcon": 2,
           "folder": null,
           "sort": 0,
           "flags": {},

--- a/src/packs/adversaries/adversary_Archer_Squadron_0ts6CGd93lLqGZI5.json
+++ b/src/packs/adversaries/adversary_Archer_Squadron_0ts6CGd93lLqGZI5.json
@@ -129,7 +129,12 @@
     "size": "medium",
     "advantageSources": [],
     "disadvantageSources": [],
-    "criticalThreshold": 20
+    "criticalThreshold": 20,
+    "typeData": {
+      "type": "horde",
+      "hordeHP": 2,
+      "hordeDamage": "1d6+3"
+    }
   },
   "flags": {},
   "_id": "0ts6CGd93lLqGZI5",
@@ -227,95 +232,6 @@
     "depth": 1
   },
   "items": [
-    {
-      "name": "Horde",
-      "type": "feature",
-      "system": {
-        "description": "<p>When the @Lookup[@name] has marked half or more of their HP, their standard attack deals <strong>@Lookup[@system.attack.altDamageFormula]</strong> physical damage instead.</p>",
-        "resource": null,
-        "actions": {},
-        "attribution": {},
-        "gmNotes": "",
-        "featureForm": "passive",
-        "granter": null
-      },
-      "_id": "uPwtE9d63PHtQitG",
-      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [
-        {
-          "name": "Horde",
-          "type": "base",
-          "system": {
-            "changes": [
-              {
-                "type": "standardAttack",
-                "phase": "initial",
-                "value": {
-                  "name": "",
-                  "damageTypes": [],
-                  "attackRange": null,
-                  "trait": null,
-                  "damageFormula": "1d6 + 3",
-                  "img": null
-                },
-                "priority": 0
-              }
-            ],
-            "duration": {
-              "description": "",
-              "type": ""
-            },
-            "conditionals": [
-              {
-                "type": "dataCompare",
-                "key": "system.resources.hitPoints.value",
-                "comparator": "greaterEquals",
-                "value": "@system.resources.hitPoints.max / 2"
-              }
-            ],
-            "rangeDependence": null,
-            "stacking": null,
-            "targetDispositions": []
-          },
-          "_id": "BvL39WnKTmCYSMHT",
-          "img": "icons/magic/movement/chevrons-down-yellow.webp",
-          "disabled": false,
-          "start": {
-            "time": 0,
-            "combat": null,
-            "combatant": null,
-            "initiative": null,
-            "round": null,
-            "turn": null
-          },
-          "duration": {
-            "value": null,
-            "units": "seconds",
-            "expiry": null,
-            "expired": false
-          },
-          "description": "<p>When the Archer Squadron has marked half or more of their HP, their standard attack deals <strong>1d6 + 3</strong> physical damage instead.</p>",
-          "tint": "#ffffff",
-          "transfer": true,
-          "statuses": [],
-          "showIcon": 2,
-          "folder": null,
-          "sort": 0,
-          "flags": {},
-          "_stats": {
-            "compendiumSource": null
-          },
-          "_key": "!actors.items.effects!0ts6CGd93lLqGZI5.uPwtE9d63PHtQitG.BvL39WnKTmCYSMHT"
-        }
-      ],
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.items!0ts6CGd93lLqGZI5.uPwtE9d63PHtQitG"
-    },
     {
       "name": "Focused Volley",
       "type": "feature",
@@ -554,6 +470,92 @@
         "compendiumSource": null
       },
       "_key": "!actors.items!0ts6CGd93lLqGZI5.ayGHTtyjSuIR4BrV"
+    },
+    {
+      "type": "feature",
+      "name": "Horde",
+      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
+      "system": {
+        "description": "When the @Lookup[@name] have marked half or more of their HP, their standard attack deals @Lookup[@system.typeData.hordeDamage] @Lookup[@system.attackDamageType] damage instead.",
+        "attribution": {},
+        "gmNotes": "",
+        "resource": null,
+        "actions": {},
+        "granter": null,
+        "featureForm": "passive",
+        "actorResources": []
+      },
+      "flags": {
+        "daggerheart": {
+          "hordeFeature": true
+        }
+      },
+      "effects": [
+        {
+          "name": "Horde",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "system": {
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "changes": [
+              {
+                "type": "standardAttack",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "@system.typeData.hordeDamage",
+                  "img": null
+                },
+                "priority": 0,
+                "phase": "initial"
+              }
+            ],
+            "duration": {
+              "description": ""
+            },
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "m3ikBOD5aPrMmQUP",
+          "type": "base",
+          "disabled": false,
+          "start": null,
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!0ts6CGd93lLqGZI5.OzrJGZ3sC6s84Uky.m3ikBOD5aPrMmQUP"
+        }
+      ],
+      "_id": "OzrJGZ3sC6s84Uky",
+      "folder": null,
+      "sort": 0,
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!actors.items!0ts6CGd93lLqGZI5.OzrJGZ3sC6s84Uky"
     }
   ],
   "effects": [],

--- a/src/packs/adversaries/adversary_Darkweave_Swarmlings_ADiUlCE0woMcvnzv.json
+++ b/src/packs/adversaries/adversary_Darkweave_Swarmlings_ADiUlCE0woMcvnzv.json
@@ -150,7 +150,73 @@
       },
       "_id": "5Nd2SDF6BGCabSfk",
       "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [],
+      "effects": [
+        {
+          "name": "Horde",
+          "type": "base",
+          "system": {
+            "changes": [
+              {
+                "type": "standardAttack",
+                "phase": "initial",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "1d4",
+                  "img": null
+                },
+                "priority": 0
+              }
+            ],
+            "duration": {
+              "description": "",
+              "type": ""
+            },
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "wDaKPcBUPoqz41ko",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "disabled": false,
+          "start": {
+            "time": 0,
+            "combat": null,
+            "combatant": null,
+            "initiative": null,
+            "round": null,
+            "turn": null
+          },
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "<p>When the Swarmlings have marked half or more of their HP, their standard attack deals <strong>1d4</strong> physical damage instead.</p>",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!ADiUlCE0woMcvnzv.5Nd2SDF6BGCabSfk.wDaKPcBUPoqz41ko"
+        }
+      ],
       "folder": null,
       "sort": 0,
       "flags": {},
@@ -364,50 +430,7 @@
     "appendNumber": false,
     "prependAdjective": false
   },
-  "effects": [
-    {
-      "type": "horde",
-      "name": "Horde",
-      "img": "icons/magic/movement/chevrons-down-yellow.webp",
-      "disabled": true,
-      "_id": "BMhcKNOc30zdW7wj",
-      "system": {
-        "changes": [],
-        "duration": {
-          "description": ""
-        },
-        "rangeDependence": null,
-        "stacking": null,
-        "targetDispositions": []
-      },
-      "start": {
-        "time": 0,
-        "combat": null,
-        "combatant": null,
-        "initiative": null,
-        "round": null,
-        "turn": null
-      },
-      "duration": {
-        "value": null,
-        "units": "seconds",
-        "expiry": null,
-        "expired": false
-      },
-      "description": "",
-      "tint": "#ffffff",
-      "transfer": false,
-      "statuses": [],
-      "showIcon": 1,
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.effects!ADiUlCE0woMcvnzv.BMhcKNOc30zdW7wj"
-    }
-  ],
+  "effects": [],
   "sort": 0,
   "flags": {},
   "_key": "!actors!ADiUlCE0woMcvnzv"

--- a/src/packs/adversaries/adversary_Darkweave_Swarmlings_ADiUlCE0woMcvnzv.json
+++ b/src/packs/adversaries/adversary_Darkweave_Swarmlings_ADiUlCE0woMcvnzv.json
@@ -233,7 +233,7 @@
             "expired": false
           },
           "tint": "#ffffff",
-          "showIcon": 1,
+          "showIcon": 2,
           "folder": null,
           "sort": 0,
           "flags": {},

--- a/src/packs/adversaries/adversary_Darkweave_Swarmlings_ADiUlCE0woMcvnzv.json
+++ b/src/packs/adversaries/adversary_Darkweave_Swarmlings_ADiUlCE0woMcvnzv.json
@@ -133,98 +133,14 @@
     "advantageSources": [],
     "disadvantageSources": [],
     "notes": "",
-    "criticalThreshold": 20
+    "criticalThreshold": 20,
+    "typeData": {
+      "type": "horde",
+      "hordeHP": 8,
+      "hordeDamage": "1d4"
+    }
   },
   "items": [
-    {
-      "name": "Horde (1d4)",
-      "type": "feature",
-      "system": {
-        "featureForm": "passive",
-        "description": "<p>When the Swarmlings have marked half or more of their HP, their standard attack deals <strong>1d4</strong> physical damage instead.</p>",
-        "attribution": {},
-        "gmNotes": "",
-        "resource": null,
-        "actions": {},
-        "granter": null
-      },
-      "_id": "5Nd2SDF6BGCabSfk",
-      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [
-        {
-          "name": "Horde",
-          "type": "base",
-          "system": {
-            "changes": [
-              {
-                "type": "standardAttack",
-                "phase": "initial",
-                "value": {
-                  "name": "",
-                  "damageTypes": [],
-                  "attackRange": null,
-                  "trait": null,
-                  "damageFormula": "1d4",
-                  "img": null
-                },
-                "priority": 0
-              }
-            ],
-            "duration": {
-              "description": "",
-              "type": ""
-            },
-            "conditionals": [
-              {
-                "type": "dataCompare",
-                "key": "system.resources.hitPoints.value",
-                "comparator": "greaterEquals",
-                "value": "@system.resources.hitPoints.max / 2"
-              }
-            ],
-            "rangeDependence": null,
-            "stacking": null,
-            "targetDispositions": []
-          },
-          "_id": "wDaKPcBUPoqz41ko",
-          "img": "icons/magic/movement/chevrons-down-yellow.webp",
-          "disabled": false,
-          "start": {
-            "time": 0,
-            "combat": null,
-            "combatant": null,
-            "initiative": null,
-            "round": null,
-            "turn": null
-          },
-          "duration": {
-            "value": null,
-            "units": "seconds",
-            "expiry": null,
-            "expired": false
-          },
-          "description": "<p>When the Swarmlings have marked half or more of their HP, their standard attack deals <strong>1d4</strong> physical damage instead.</p>",
-          "tint": "#ffffff",
-          "transfer": true,
-          "statuses": [],
-          "showIcon": 1,
-          "folder": null,
-          "sort": 0,
-          "flags": {},
-          "_stats": {
-            "compendiumSource": null
-          },
-          "_key": "!actors.items.effects!ADiUlCE0woMcvnzv.5Nd2SDF6BGCabSfk.wDaKPcBUPoqz41ko"
-        }
-      ],
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.items!ADiUlCE0woMcvnzv.5Nd2SDF6BGCabSfk"
-    },
     {
       "name": "\"Get 'em Off , Get 'em Off !\"",
       "type": "feature",
@@ -334,6 +250,92 @@
         "compendiumSource": null
       },
       "_key": "!actors.items!ADiUlCE0woMcvnzv.ca15rqxQtas4Lx6v"
+    },
+    {
+      "type": "feature",
+      "name": "Horde",
+      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
+      "system": {
+        "description": "When the @Lookup[@name] have marked half or more of their HP, their standard attack deals @Lookup[@system.typeData.hordeDamage] @Lookup[@system.attackDamageType] damage instead.",
+        "attribution": {},
+        "gmNotes": "",
+        "resource": null,
+        "actions": {},
+        "granter": null,
+        "featureForm": "passive",
+        "actorResources": []
+      },
+      "flags": {
+        "daggerheart": {
+          "hordeFeature": true
+        }
+      },
+      "effects": [
+        {
+          "name": "Horde",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "system": {
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "changes": [
+              {
+                "type": "standardAttack",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "@system.typeData.hordeDamage",
+                  "img": null
+                },
+                "priority": 0,
+                "phase": "initial"
+              }
+            ],
+            "duration": {
+              "description": ""
+            },
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "R6bhKfhA9YUdmCCV",
+          "type": "base",
+          "disabled": false,
+          "start": null,
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!ADiUlCE0woMcvnzv.q6ZV8KODK4fD66QD.R6bhKfhA9YUdmCCV"
+        }
+      ],
+      "_id": "q6ZV8KODK4fD66QD",
+      "folder": null,
+      "sort": 0,
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!actors.items!ADiUlCE0woMcvnzv.q6ZV8KODK4fD66QD"
     }
   ],
   "_id": "ADiUlCE0woMcvnzv",

--- a/src/packs/adversaries/adversary_Demonic_Hound_Pack_NoRZ1PqB8N5wcIw0.json
+++ b/src/packs/adversaries/adversary_Demonic_Hound_Pack_NoRZ1PqB8N5wcIw0.json
@@ -247,7 +247,73 @@
       },
       "_id": "NXzJLDoJBJqCXlOm",
       "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [],
+      "effects": [
+        {
+          "name": "Horde",
+          "type": "base",
+          "system": {
+            "changes": [
+              {
+                "type": "standardAttack",
+                "phase": "initial",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "2d4 + 1",
+                  "img": null
+                },
+                "priority": 0
+              }
+            ],
+            "duration": {
+              "description": "",
+              "type": ""
+            },
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "6C1qtdD7cfcuwSo8",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "disabled": false,
+          "start": {
+            "time": 0,
+            "combat": null,
+            "combatant": null,
+            "initiative": null,
+            "round": null,
+            "turn": null
+          },
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "<p>When the Demonic Hound Pack has marked half or more of their HP, their standard attack deals <strong>2d4 + 1 </strong>physical damage instead.</p>",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!NoRZ1PqB8N5wcIw0.NXzJLDoJBJqCXlOm.6C1qtdD7cfcuwSo8"
+        }
+      ],
       "folder": null,
       "sort": 0,
       "flags": {},
@@ -449,49 +515,6 @@
       "_key": "!actors.items!NoRZ1PqB8N5wcIw0.3mOBJE5c3cP2cGP1"
     }
   ],
-  "effects": [
-    {
-      "type": "horde",
-      "name": "Horde",
-      "img": "icons/magic/movement/chevrons-down-yellow.webp",
-      "disabled": true,
-      "_id": "dPZ7PwvTERjtG92P",
-      "system": {
-        "changes": [],
-        "duration": {
-          "description": ""
-        },
-        "rangeDependence": null,
-        "stacking": null,
-        "targetDispositions": []
-      },
-      "duration": {
-        "value": null,
-        "units": "seconds",
-        "expiry": null,
-        "expired": false
-      },
-      "description": "",
-      "tint": "#ffffff",
-      "transfer": false,
-      "statuses": [],
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "start": {
-        "combat": null,
-        "time": 0,
-        "combatant": null,
-        "initiative": null,
-        "round": null,
-        "turn": null
-      },
-      "showIcon": 1,
-      "folder": null,
-      "_key": "!actors.effects!NoRZ1PqB8N5wcIw0.dPZ7PwvTERjtG92P"
-    }
-  ],
+  "effects": [],
   "_key": "!actors!NoRZ1PqB8N5wcIw0"
 }

--- a/src/packs/adversaries/adversary_Demonic_Hound_Pack_NoRZ1PqB8N5wcIw0.json
+++ b/src/packs/adversaries/adversary_Demonic_Hound_Pack_NoRZ1PqB8N5wcIw0.json
@@ -498,7 +498,7 @@
           "tint": "#ffffff",
           "transfer": true,
           "statuses": [],
-          "showIcon": 1,
+          "showIcon": 2,
           "folder": null,
           "sort": 0,
           "flags": {},

--- a/src/packs/adversaries/adversary_Demonic_Hound_Pack_NoRZ1PqB8N5wcIw0.json
+++ b/src/packs/adversaries/adversary_Demonic_Hound_Pack_NoRZ1PqB8N5wcIw0.json
@@ -135,7 +135,12 @@
     "size": "large",
     "advantageSources": [],
     "disadvantageSources": [],
-    "criticalThreshold": 20
+    "criticalThreshold": 20,
+    "typeData": {
+      "type": "horde",
+      "hordeHP": 1,
+      "hordeDamage": "2d4+1"
+    }
   },
   "flags": {},
   "_id": "NoRZ1PqB8N5wcIw0",
@@ -233,95 +238,6 @@
     "depth": 1
   },
   "items": [
-    {
-      "name": "Horde",
-      "type": "feature",
-      "system": {
-        "description": "<p>When the @Lookup[@name] has marked half or more of their HP, their standard attack deals <strong>@Lookup[@system.attack.altDamageFormula]</strong> physical damage instead.</p>",
-        "resource": null,
-        "actions": {},
-        "attribution": {},
-        "gmNotes": "",
-        "featureForm": "passive",
-        "granter": null
-      },
-      "_id": "NXzJLDoJBJqCXlOm",
-      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [
-        {
-          "name": "Horde",
-          "type": "base",
-          "system": {
-            "changes": [
-              {
-                "type": "standardAttack",
-                "phase": "initial",
-                "value": {
-                  "name": "",
-                  "damageTypes": [],
-                  "attackRange": null,
-                  "trait": null,
-                  "damageFormula": "2d4 + 1",
-                  "img": null
-                },
-                "priority": 0
-              }
-            ],
-            "duration": {
-              "description": "",
-              "type": ""
-            },
-            "conditionals": [
-              {
-                "type": "dataCompare",
-                "key": "system.resources.hitPoints.value",
-                "comparator": "greaterEquals",
-                "value": "@system.resources.hitPoints.max / 2"
-              }
-            ],
-            "rangeDependence": null,
-            "stacking": null,
-            "targetDispositions": []
-          },
-          "_id": "6C1qtdD7cfcuwSo8",
-          "img": "icons/magic/movement/chevrons-down-yellow.webp",
-          "disabled": false,
-          "start": {
-            "time": 0,
-            "combat": null,
-            "combatant": null,
-            "initiative": null,
-            "round": null,
-            "turn": null
-          },
-          "duration": {
-            "value": null,
-            "units": "seconds",
-            "expiry": null,
-            "expired": false
-          },
-          "description": "<p>When the Demonic Hound Pack has marked half or more of their HP, their standard attack deals <strong>2d4 + 1 </strong>physical damage instead.</p>",
-          "tint": "#ffffff",
-          "transfer": true,
-          "statuses": [],
-          "showIcon": 1,
-          "folder": null,
-          "sort": 0,
-          "flags": {},
-          "_stats": {
-            "compendiumSource": null
-          },
-          "_key": "!actors.items.effects!NoRZ1PqB8N5wcIw0.NXzJLDoJBJqCXlOm.6C1qtdD7cfcuwSo8"
-        }
-      ],
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.items!NoRZ1PqB8N5wcIw0.NXzJLDoJBJqCXlOm"
-    },
     {
       "name": "Dreadhowl",
       "type": "feature",
@@ -513,6 +429,92 @@
         "compendiumSource": null
       },
       "_key": "!actors.items!NoRZ1PqB8N5wcIw0.3mOBJE5c3cP2cGP1"
+    },
+    {
+      "type": "feature",
+      "name": "Horde",
+      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
+      "system": {
+        "description": "When the @Lookup[@name] have marked half or more of their HP, their standard attack deals @Lookup[@system.typeData.hordeDamage] @Lookup[@system.attackDamageType] damage instead.",
+        "attribution": {},
+        "gmNotes": "",
+        "resource": null,
+        "actions": {},
+        "granter": null,
+        "featureForm": "passive",
+        "actorResources": []
+      },
+      "flags": {
+        "daggerheart": {
+          "hordeFeature": true
+        }
+      },
+      "effects": [
+        {
+          "name": "Horde",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "system": {
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "changes": [
+              {
+                "type": "standardAttack",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "@system.typeData.hordeDamage",
+                  "img": null
+                },
+                "priority": 0,
+                "phase": "initial"
+              }
+            ],
+            "duration": {
+              "description": ""
+            },
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "H3GhjuvEU8rIfwAk",
+          "type": "base",
+          "disabled": false,
+          "start": null,
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!NoRZ1PqB8N5wcIw0.hpM5SpIOzehpszhJ.H3GhjuvEU8rIfwAk"
+        }
+      ],
+      "_id": "hpM5SpIOzehpszhJ",
+      "folder": null,
+      "sort": 0,
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!actors.items!NoRZ1PqB8N5wcIw0.hpM5SpIOzehpszhJ"
     }
   ],
   "effects": [],

--- a/src/packs/adversaries/adversary_Electric_Eels_TLzY1nDw0Bu9Ud40.json
+++ b/src/packs/adversaries/adversary_Electric_Eels_TLzY1nDw0Bu9Ud40.json
@@ -241,7 +241,73 @@
       },
       "_id": "1mNlXMyCQNg4P3n3",
       "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [],
+      "effects": [
+        {
+          "name": "Horde",
+          "type": "base",
+          "system": {
+            "changes": [
+              {
+                "type": "standardAttack",
+                "phase": "initial",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "2d4 + 1",
+                  "img": null
+                },
+                "priority": 0
+              }
+            ],
+            "duration": {
+              "description": "",
+              "type": ""
+            },
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "1CAHwyhTw4HWPTOX",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "disabled": false,
+          "start": {
+            "time": 0,
+            "combat": null,
+            "combatant": null,
+            "initiative": null,
+            "round": null,
+            "turn": null
+          },
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "<p>When the Electric Eels have marked half or more of their HP, their standard attack deals <strong>2d4 + 1</strong> physical damage instead.</p>",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!TLzY1nDw0Bu9Ud40.1mNlXMyCQNg4P3n3.1CAHwyhTw4HWPTOX"
+        }
+      ],
       "folder": null,
       "sort": 0,
       "flags": {},
@@ -368,49 +434,6 @@
       "_key": "!actors.items!TLzY1nDw0Bu9Ud40.u5NL1eUJeAkIEpgt"
     }
   ],
-  "effects": [
-    {
-      "type": "horde",
-      "name": "Horde",
-      "img": "icons/magic/movement/chevrons-down-yellow.webp",
-      "disabled": true,
-      "_id": "xoal60Ed3Ih7saBJ",
-      "system": {
-        "changes": [],
-        "duration": {
-          "description": ""
-        },
-        "rangeDependence": null,
-        "stacking": null,
-        "targetDispositions": []
-      },
-      "duration": {
-        "value": null,
-        "units": "seconds",
-        "expiry": null,
-        "expired": false
-      },
-      "description": "",
-      "tint": "#ffffff",
-      "transfer": false,
-      "statuses": [],
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "start": {
-        "combat": null,
-        "time": 0,
-        "combatant": null,
-        "initiative": null,
-        "round": null,
-        "turn": null
-      },
-      "showIcon": 1,
-      "folder": null,
-      "_key": "!actors.effects!TLzY1nDw0Bu9Ud40.xoal60Ed3Ih7saBJ"
-    }
-  ],
+  "effects": [],
   "_key": "!actors!TLzY1nDw0Bu9Ud40"
 }

--- a/src/packs/adversaries/adversary_Electric_Eels_TLzY1nDw0Bu9Ud40.json
+++ b/src/packs/adversaries/adversary_Electric_Eels_TLzY1nDw0Bu9Ud40.json
@@ -129,7 +129,12 @@
     "size": "medium",
     "advantageSources": [],
     "disadvantageSources": [],
-    "criticalThreshold": 20
+    "criticalThreshold": 20,
+    "typeData": {
+      "type": "horde",
+      "hordeHP": 2,
+      "hordeDamage": "2d4+1"
+    }
   },
   "flags": {},
   "_id": "TLzY1nDw0Bu9Ud40",
@@ -227,95 +232,6 @@
     "depth": 1
   },
   "items": [
-    {
-      "name": "Horde",
-      "type": "feature",
-      "system": {
-        "description": "<p>When the @Lookup[@name] have marked half or more of their HP, their standard attack deals <strong>@Lookup[@system.attack.altDamageFormula]</strong> physical damage instead.</p>",
-        "resource": null,
-        "actions": {},
-        "attribution": {},
-        "gmNotes": "",
-        "featureForm": "passive",
-        "granter": null
-      },
-      "_id": "1mNlXMyCQNg4P3n3",
-      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [
-        {
-          "name": "Horde",
-          "type": "base",
-          "system": {
-            "changes": [
-              {
-                "type": "standardAttack",
-                "phase": "initial",
-                "value": {
-                  "name": "",
-                  "damageTypes": [],
-                  "attackRange": null,
-                  "trait": null,
-                  "damageFormula": "2d4 + 1",
-                  "img": null
-                },
-                "priority": 0
-              }
-            ],
-            "duration": {
-              "description": "",
-              "type": ""
-            },
-            "conditionals": [
-              {
-                "type": "dataCompare",
-                "key": "system.resources.hitPoints.value",
-                "comparator": "greaterEquals",
-                "value": "@system.resources.hitPoints.max / 2"
-              }
-            ],
-            "rangeDependence": null,
-            "stacking": null,
-            "targetDispositions": []
-          },
-          "_id": "1CAHwyhTw4HWPTOX",
-          "img": "icons/magic/movement/chevrons-down-yellow.webp",
-          "disabled": false,
-          "start": {
-            "time": 0,
-            "combat": null,
-            "combatant": null,
-            "initiative": null,
-            "round": null,
-            "turn": null
-          },
-          "duration": {
-            "value": null,
-            "units": "seconds",
-            "expiry": null,
-            "expired": false
-          },
-          "description": "<p>When the Electric Eels have marked half or more of their HP, their standard attack deals <strong>2d4 + 1</strong> physical damage instead.</p>",
-          "tint": "#ffffff",
-          "transfer": true,
-          "statuses": [],
-          "showIcon": 1,
-          "folder": null,
-          "sort": 0,
-          "flags": {},
-          "_stats": {
-            "compendiumSource": null
-          },
-          "_key": "!actors.items.effects!TLzY1nDw0Bu9Ud40.1mNlXMyCQNg4P3n3.1CAHwyhTw4HWPTOX"
-        }
-      ],
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.items!TLzY1nDw0Bu9Ud40.1mNlXMyCQNg4P3n3"
-    },
     {
       "name": "Paralyzing Shock",
       "type": "feature",
@@ -432,6 +348,92 @@
         "compendiumSource": null
       },
       "_key": "!actors.items!TLzY1nDw0Bu9Ud40.u5NL1eUJeAkIEpgt"
+    },
+    {
+      "type": "feature",
+      "name": "Horde",
+      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
+      "system": {
+        "description": "When the @Lookup[@name] have marked half or more of their HP, their standard attack deals @Lookup[@system.typeData.hordeDamage] @Lookup[@system.attackDamageType] damage instead.",
+        "attribution": {},
+        "gmNotes": "",
+        "resource": null,
+        "actions": {},
+        "granter": null,
+        "featureForm": "passive",
+        "actorResources": []
+      },
+      "flags": {
+        "daggerheart": {
+          "hordeFeature": true
+        }
+      },
+      "effects": [
+        {
+          "name": "Horde",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "system": {
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "changes": [
+              {
+                "type": "standardAttack",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "@system.typeData.hordeDamage",
+                  "img": null
+                },
+                "priority": 0,
+                "phase": "initial"
+              }
+            ],
+            "duration": {
+              "description": ""
+            },
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "7ut6f3fwxSbcxij7",
+          "type": "base",
+          "disabled": false,
+          "start": null,
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!TLzY1nDw0Bu9Ud40.qNTN1aPTpXuhmCLl.7ut6f3fwxSbcxij7"
+        }
+      ],
+      "_id": "qNTN1aPTpXuhmCLl",
+      "folder": null,
+      "sort": 0,
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!actors.items!TLzY1nDw0Bu9Ud40.qNTN1aPTpXuhmCLl"
     }
   ],
   "effects": [],

--- a/src/packs/adversaries/adversary_Electric_Eels_TLzY1nDw0Bu9Ud40.json
+++ b/src/packs/adversaries/adversary_Electric_Eels_TLzY1nDw0Bu9Ud40.json
@@ -417,7 +417,7 @@
           "tint": "#ffffff",
           "transfer": true,
           "statuses": [],
-          "showIcon": 1,
+          "showIcon": 2,
           "folder": null,
           "sort": 0,
           "flags": {},

--- a/src/packs/adversaries/adversary_Entombed_Skin_Beetles_BSLBG7hQ9K1HGlU6.json
+++ b/src/packs/adversaries/adversary_Entombed_Skin_Beetles_BSLBG7hQ9K1HGlU6.json
@@ -150,7 +150,73 @@
       },
       "_id": "2yF9tTRs5Msh9WMG",
       "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [],
+      "effects": [
+        {
+          "name": "Horde",
+          "type": "base",
+          "system": {
+            "changes": [
+              {
+                "type": "standardAttack",
+                "phase": "initial",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "2d4 + 1",
+                  "img": null
+                },
+                "priority": 0
+              }
+            ],
+            "duration": {
+              "description": "",
+              "type": ""
+            },
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "9mCBdunBdbg96mGq",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "disabled": false,
+          "start": {
+            "time": 0,
+            "combat": null,
+            "combatant": null,
+            "initiative": null,
+            "round": null,
+            "turn": null
+          },
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "<p>When the Beetles have marked half or more of their HP, their standard attack deals <strong>2d4+1</strong> physical damage instead.</p>",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!BSLBG7hQ9K1HGlU6.2yF9tTRs5Msh9WMG.9mCBdunBdbg96mGq"
+        }
+      ],
       "folder": null,
       "sort": 0,
       "flags": {},
@@ -418,50 +484,7 @@
     "appendNumber": false,
     "prependAdjective": false
   },
-  "effects": [
-    {
-      "type": "horde",
-      "name": "Horde",
-      "img": "icons/magic/movement/chevrons-down-yellow.webp",
-      "disabled": true,
-      "_id": "UWVPPUrmXszrYtdv",
-      "system": {
-        "changes": [],
-        "duration": {
-          "description": ""
-        },
-        "rangeDependence": null,
-        "stacking": null,
-        "targetDispositions": []
-      },
-      "start": {
-        "time": 0,
-        "combat": null,
-        "combatant": null,
-        "initiative": null,
-        "round": null,
-        "turn": null
-      },
-      "duration": {
-        "value": null,
-        "units": "seconds",
-        "expiry": null,
-        "expired": false
-      },
-      "description": "",
-      "tint": "#ffffff",
-      "transfer": false,
-      "statuses": [],
-      "showIcon": 1,
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.effects!BSLBG7hQ9K1HGlU6.UWVPPUrmXszrYtdv"
-    }
-  ],
+  "effects": [],
   "sort": 0,
   "flags": {},
   "_key": "!actors!BSLBG7hQ9K1HGlU6"

--- a/src/packs/adversaries/adversary_Entombed_Skin_Beetles_BSLBG7hQ9K1HGlU6.json
+++ b/src/packs/adversaries/adversary_Entombed_Skin_Beetles_BSLBG7hQ9K1HGlU6.json
@@ -373,7 +373,7 @@
           "tint": "#ffffff",
           "transfer": true,
           "statuses": [],
-          "showIcon": 1,
+          "showIcon": 2,
           "folder": null,
           "sort": 0,
           "flags": {},

--- a/src/packs/adversaries/adversary_Entombed_Skin_Beetles_BSLBG7hQ9K1HGlU6.json
+++ b/src/packs/adversaries/adversary_Entombed_Skin_Beetles_BSLBG7hQ9K1HGlU6.json
@@ -133,98 +133,14 @@
     "advantageSources": [],
     "disadvantageSources": [],
     "notes": "",
-    "criticalThreshold": 20
+    "criticalThreshold": 20,
+    "typeData": {
+      "type": "horde",
+      "hordeHP": 5,
+      "hordeDamage": "2d4 + 1"
+    }
   },
   "items": [
-    {
-      "name": "Horde (2d4+1)",
-      "type": "feature",
-      "system": {
-        "featureForm": "passive",
-        "description": "<p>When the Beetles have marked half or more of their HP, their standard attack deals <strong>2d4+1</strong> physical damage instead.</p>",
-        "attribution": {},
-        "gmNotes": "",
-        "resource": null,
-        "actions": {},
-        "granter": null
-      },
-      "_id": "2yF9tTRs5Msh9WMG",
-      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [
-        {
-          "name": "Horde",
-          "type": "base",
-          "system": {
-            "changes": [
-              {
-                "type": "standardAttack",
-                "phase": "initial",
-                "value": {
-                  "name": "",
-                  "damageTypes": [],
-                  "attackRange": null,
-                  "trait": null,
-                  "damageFormula": "2d4 + 1",
-                  "img": null
-                },
-                "priority": 0
-              }
-            ],
-            "duration": {
-              "description": "",
-              "type": ""
-            },
-            "conditionals": [
-              {
-                "type": "dataCompare",
-                "key": "system.resources.hitPoints.value",
-                "comparator": "greaterEquals",
-                "value": "@system.resources.hitPoints.max / 2"
-              }
-            ],
-            "rangeDependence": null,
-            "stacking": null,
-            "targetDispositions": []
-          },
-          "_id": "9mCBdunBdbg96mGq",
-          "img": "icons/magic/movement/chevrons-down-yellow.webp",
-          "disabled": false,
-          "start": {
-            "time": 0,
-            "combat": null,
-            "combatant": null,
-            "initiative": null,
-            "round": null,
-            "turn": null
-          },
-          "duration": {
-            "value": null,
-            "units": "seconds",
-            "expiry": null,
-            "expired": false
-          },
-          "description": "<p>When the Beetles have marked half or more of their HP, their standard attack deals <strong>2d4+1</strong> physical damage instead.</p>",
-          "tint": "#ffffff",
-          "transfer": true,
-          "statuses": [],
-          "showIcon": 1,
-          "folder": null,
-          "sort": 0,
-          "flags": {},
-          "_stats": {
-            "compendiumSource": null
-          },
-          "_key": "!actors.items.effects!BSLBG7hQ9K1HGlU6.2yF9tTRs5Msh9WMG.9mCBdunBdbg96mGq"
-        }
-      ],
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.items!BSLBG7hQ9K1HGlU6.2yF9tTRs5Msh9WMG"
-    },
     {
       "name": "Omophagous",
       "type": "feature",
@@ -388,6 +304,92 @@
         "compendiumSource": null
       },
       "_key": "!actors.items!BSLBG7hQ9K1HGlU6.MyEPx0FSireKIkxb"
+    },
+    {
+      "type": "feature",
+      "name": "DAGGERHEART.CONFIG.AdversaryType.horde.label",
+      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
+      "system": {
+        "description": "When the @Lookup[@name] have marked half or more of their HP, their standard attack deals @Lookup[@system.typeData.hordeDamage] @Lookup[@system.attackDamageType] damage instead.",
+        "attribution": {},
+        "gmNotes": "",
+        "resource": null,
+        "actions": {},
+        "granter": null,
+        "featureForm": "passive",
+        "actorResources": []
+      },
+      "flags": {
+        "daggerheart": {
+          "hordeFeature": true
+        }
+      },
+      "effects": [
+        {
+          "name": "Horde",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "system": {
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "changes": [
+              {
+                "type": "standardAttack",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "@system.typeData.hordeDamage",
+                  "img": null
+                },
+                "priority": 0,
+                "phase": "initial"
+              }
+            ],
+            "duration": {
+              "description": ""
+            },
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "InJy1swvvfsLfVfL",
+          "type": "base",
+          "disabled": false,
+          "start": null,
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!BSLBG7hQ9K1HGlU6.5LVYG1lSVzMqWbjM.InJy1swvvfsLfVfL"
+        }
+      ],
+      "_id": "5LVYG1lSVzMqWbjM",
+      "folder": null,
+      "sort": 0,
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!actors.items!BSLBG7hQ9K1HGlU6.5LVYG1lSVzMqWbjM"
     }
   ],
   "_id": "BSLBG7hQ9K1HGlU6",

--- a/src/packs/adversaries/adversary_Flock_Of_Feather_Fiends_vWHynB75iGfOhTjn.json
+++ b/src/packs/adversaries/adversary_Flock_Of_Feather_Fiends_vWHynB75iGfOhTjn.json
@@ -155,7 +155,73 @@
       },
       "_id": "IoYKInzWbnhourIq",
       "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [],
+      "effects": [
+        {
+          "name": "Horde",
+          "type": "base",
+          "system": {
+            "changes": [
+              {
+                "type": "standardAttack",
+                "phase": "initial",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "1d6 + 1",
+                  "img": null
+                },
+                "priority": 0
+              }
+            ],
+            "duration": {
+              "description": "",
+              "type": ""
+            },
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "2RXmqmu76SoAfiet",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "disabled": false,
+          "start": {
+            "time": 0,
+            "combat": null,
+            "combatant": null,
+            "initiative": null,
+            "round": null,
+            "turn": null
+          },
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "<p>When the Flock has marked half or more of its HP, its standard attack deals <strong>1d6+1</strong> magic damage instead.</p>",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!vWHynB75iGfOhTjn.IoYKInzWbnhourIq.2RXmqmu76SoAfiet"
+        }
+      ],
       "folder": null,
       "sort": 0,
       "flags": {},
@@ -404,50 +470,7 @@
     "appendNumber": false,
     "prependAdjective": false
   },
-  "effects": [
-    {
-      "type": "horde",
-      "name": "Horde",
-      "img": "icons/magic/movement/chevrons-down-yellow.webp",
-      "disabled": true,
-      "_id": "ClVjs3VBhNz49qqU",
-      "system": {
-        "changes": [],
-        "duration": {
-          "description": ""
-        },
-        "rangeDependence": null,
-        "stacking": null,
-        "targetDispositions": []
-      },
-      "start": {
-        "time": 0,
-        "combat": null,
-        "combatant": null,
-        "initiative": null,
-        "round": null,
-        "turn": null
-      },
-      "duration": {
-        "value": null,
-        "units": "seconds",
-        "expiry": null,
-        "expired": false
-      },
-      "description": "",
-      "tint": "#ffffff",
-      "transfer": false,
-      "statuses": [],
-      "showIcon": 1,
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.effects!vWHynB75iGfOhTjn.ClVjs3VBhNz49qqU"
-    }
-  ],
+  "effects": [],
   "sort": 0,
   "flags": {},
   "_key": "!actors!vWHynB75iGfOhTjn"

--- a/src/packs/adversaries/adversary_Flock_Of_Feather_Fiends_vWHynB75iGfOhTjn.json
+++ b/src/packs/adversaries/adversary_Flock_Of_Feather_Fiends_vWHynB75iGfOhTjn.json
@@ -138,98 +138,14 @@
     "advantageSources": [],
     "disadvantageSources": [],
     "notes": "",
-    "criticalThreshold": 20
+    "criticalThreshold": 20,
+    "typeData": {
+      "type": "horde",
+      "hordeHP": 3,
+      "hordeDamage": "1d6+1"
+    }
   },
   "items": [
-    {
-      "name": "Horde (1d6+1)",
-      "type": "feature",
-      "system": {
-        "featureForm": "passive",
-        "description": "<p>When the Flock has marked half or more of its HP, its standard attack deals <strong>1d6+1</strong> magic damage instead.</p>",
-        "attribution": {},
-        "gmNotes": "",
-        "resource": null,
-        "actions": {},
-        "granter": null
-      },
-      "_id": "IoYKInzWbnhourIq",
-      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [
-        {
-          "name": "Horde",
-          "type": "base",
-          "system": {
-            "changes": [
-              {
-                "type": "standardAttack",
-                "phase": "initial",
-                "value": {
-                  "name": "",
-                  "damageTypes": [],
-                  "attackRange": null,
-                  "trait": null,
-                  "damageFormula": "1d6 + 1",
-                  "img": null
-                },
-                "priority": 0
-              }
-            ],
-            "duration": {
-              "description": "",
-              "type": ""
-            },
-            "conditionals": [
-              {
-                "type": "dataCompare",
-                "key": "system.resources.hitPoints.value",
-                "comparator": "greaterEquals",
-                "value": "@system.resources.hitPoints.max / 2"
-              }
-            ],
-            "rangeDependence": null,
-            "stacking": null,
-            "targetDispositions": []
-          },
-          "_id": "2RXmqmu76SoAfiet",
-          "img": "icons/magic/movement/chevrons-down-yellow.webp",
-          "disabled": false,
-          "start": {
-            "time": 0,
-            "combat": null,
-            "combatant": null,
-            "initiative": null,
-            "round": null,
-            "turn": null
-          },
-          "duration": {
-            "value": null,
-            "units": "seconds",
-            "expiry": null,
-            "expired": false
-          },
-          "description": "<p>When the Flock has marked half or more of its HP, its standard attack deals <strong>1d6+1</strong> magic damage instead.</p>",
-          "tint": "#ffffff",
-          "transfer": true,
-          "statuses": [],
-          "showIcon": 1,
-          "folder": null,
-          "sort": 0,
-          "flags": {},
-          "_stats": {
-            "compendiumSource": null
-          },
-          "_key": "!actors.items.effects!vWHynB75iGfOhTjn.IoYKInzWbnhourIq.2RXmqmu76SoAfiet"
-        }
-      ],
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.items!vWHynB75iGfOhTjn.IoYKInzWbnhourIq"
-    },
     {
       "name": "Maddening Cacophony",
       "type": "feature",
@@ -374,6 +290,92 @@
         "compendiumSource": null
       },
       "_key": "!actors.items!vWHynB75iGfOhTjn.7QZXOe4FMQDIdKhP"
+    },
+    {
+      "type": "feature",
+      "name": "Horde",
+      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
+      "system": {
+        "description": "When the @Lookup[@name] have marked half or more of their HP, their standard attack deals @Lookup[@system.typeData.hordeDamage] @Lookup[@system.attackDamageType] damage instead.",
+        "attribution": {},
+        "gmNotes": "",
+        "resource": null,
+        "actions": {},
+        "granter": null,
+        "featureForm": "passive",
+        "actorResources": []
+      },
+      "flags": {
+        "daggerheart": {
+          "hordeFeature": true
+        }
+      },
+      "effects": [
+        {
+          "name": "Horde",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "system": {
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "changes": [
+              {
+                "type": "standardAttack",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "@system.typeData.hordeDamage",
+                  "img": null
+                },
+                "priority": 0,
+                "phase": "initial"
+              }
+            ],
+            "duration": {
+              "description": ""
+            },
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "12tRQS44t6r9oz6X",
+          "type": "base",
+          "disabled": false,
+          "start": null,
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!vWHynB75iGfOhTjn.WCnGBtnsdMIje6Wu.12tRQS44t6r9oz6X"
+        }
+      ],
+      "_id": "WCnGBtnsdMIje6Wu",
+      "folder": null,
+      "sort": 0,
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!actors.items!vWHynB75iGfOhTjn.WCnGBtnsdMIje6Wu"
     }
   ],
   "_id": "vWHynB75iGfOhTjn",

--- a/src/packs/adversaries/adversary_Flock_Of_Feather_Fiends_vWHynB75iGfOhTjn.json
+++ b/src/packs/adversaries/adversary_Flock_Of_Feather_Fiends_vWHynB75iGfOhTjn.json
@@ -359,7 +359,7 @@
           "tint": "#ffffff",
           "transfer": true,
           "statuses": [],
-          "showIcon": 1,
+          "showIcon": 2,
           "folder": null,
           "sort": 0,
           "flags": {},

--- a/src/packs/adversaries/adversary_Ghastly_Legion_Tg1F1PthQWeKdLJT.json
+++ b/src/packs/adversaries/adversary_Ghastly_Legion_Tg1F1PthQWeKdLJT.json
@@ -150,7 +150,73 @@
       },
       "_id": "yt10KrDz0zvTYmQa",
       "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [],
+      "effects": [
+        {
+          "name": "Horde",
+          "type": "base",
+          "system": {
+            "changes": [
+              {
+                "type": "standardAttack",
+                "phase": "initial",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "2d6 + 5",
+                  "img": null
+                },
+                "priority": 0
+              }
+            ],
+            "duration": {
+              "description": "",
+              "type": ""
+            },
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "fCJKQMBDfmrwVZFh",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "disabled": false,
+          "start": {
+            "time": 0,
+            "combat": null,
+            "combatant": null,
+            "initiative": null,
+            "round": null,
+            "turn": null
+          },
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "<p>When the Legion has marked half or more of its HP, its standard attack deals <strong>2d6+5</strong> magic damage instead.</p>",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!Tg1F1PthQWeKdLJT.yt10KrDz0zvTYmQa.fCJKQMBDfmrwVZFh"
+        }
+      ],
       "folder": null,
       "sort": 0,
       "flags": {},
@@ -452,50 +518,7 @@
     "appendNumber": false,
     "prependAdjective": false
   },
-  "effects": [
-    {
-      "type": "horde",
-      "name": "Horde",
-      "img": "icons/magic/movement/chevrons-down-yellow.webp",
-      "disabled": true,
-      "_id": "YCaqmwiZiWnsrTrX",
-      "system": {
-        "changes": [],
-        "duration": {
-          "description": ""
-        },
-        "rangeDependence": null,
-        "stacking": null,
-        "targetDispositions": []
-      },
-      "start": {
-        "time": 0,
-        "combat": null,
-        "combatant": null,
-        "initiative": null,
-        "round": null,
-        "turn": null
-      },
-      "duration": {
-        "value": null,
-        "units": "seconds",
-        "expiry": null,
-        "expired": false
-      },
-      "description": "",
-      "tint": "#ffffff",
-      "transfer": false,
-      "statuses": [],
-      "showIcon": 1,
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.effects!Tg1F1PthQWeKdLJT.YCaqmwiZiWnsrTrX"
-    }
-  ],
+  "effects": [],
   "sort": 0,
   "flags": {},
   "_key": "!actors!Tg1F1PthQWeKdLJT"

--- a/src/packs/adversaries/adversary_Ghastly_Legion_Tg1F1PthQWeKdLJT.json
+++ b/src/packs/adversaries/adversary_Ghastly_Legion_Tg1F1PthQWeKdLJT.json
@@ -407,7 +407,7 @@
           "tint": "#ffffff",
           "transfer": true,
           "statuses": [],
-          "showIcon": 1,
+          "showIcon": 2,
           "folder": null,
           "sort": 0,
           "flags": {},

--- a/src/packs/adversaries/adversary_Ghastly_Legion_Tg1F1PthQWeKdLJT.json
+++ b/src/packs/adversaries/adversary_Ghastly_Legion_Tg1F1PthQWeKdLJT.json
@@ -133,98 +133,14 @@
     "advantageSources": [],
     "disadvantageSources": [],
     "notes": "",
-    "criticalThreshold": 20
+    "criticalThreshold": 20,
+    "typeData": {
+      "type": "horde",
+      "hordeHP": 10,
+      "hordeDamage": "2d6+5"
+    }
   },
   "items": [
-    {
-      "name": "Horde (2d6+5)",
-      "type": "feature",
-      "system": {
-        "featureForm": "passive",
-        "description": "<p>When the Legion has marked half or more of its HP, its standard attack deals <strong>2d6+5</strong> magic damage instead.</p>",
-        "attribution": {},
-        "gmNotes": "",
-        "resource": null,
-        "actions": {},
-        "granter": null
-      },
-      "_id": "yt10KrDz0zvTYmQa",
-      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [
-        {
-          "name": "Horde",
-          "type": "base",
-          "system": {
-            "changes": [
-              {
-                "type": "standardAttack",
-                "phase": "initial",
-                "value": {
-                  "name": "",
-                  "damageTypes": [],
-                  "attackRange": null,
-                  "trait": null,
-                  "damageFormula": "2d6 + 5",
-                  "img": null
-                },
-                "priority": 0
-              }
-            ],
-            "duration": {
-              "description": "",
-              "type": ""
-            },
-            "conditionals": [
-              {
-                "type": "dataCompare",
-                "key": "system.resources.hitPoints.value",
-                "comparator": "greaterEquals",
-                "value": "@system.resources.hitPoints.max / 2"
-              }
-            ],
-            "rangeDependence": null,
-            "stacking": null,
-            "targetDispositions": []
-          },
-          "_id": "fCJKQMBDfmrwVZFh",
-          "img": "icons/magic/movement/chevrons-down-yellow.webp",
-          "disabled": false,
-          "start": {
-            "time": 0,
-            "combat": null,
-            "combatant": null,
-            "initiative": null,
-            "round": null,
-            "turn": null
-          },
-          "duration": {
-            "value": null,
-            "units": "seconds",
-            "expiry": null,
-            "expired": false
-          },
-          "description": "<p>When the Legion has marked half or more of its HP, its standard attack deals <strong>2d6+5</strong> magic damage instead.</p>",
-          "tint": "#ffffff",
-          "transfer": true,
-          "statuses": [],
-          "showIcon": 1,
-          "folder": null,
-          "sort": 0,
-          "flags": {},
-          "_stats": {
-            "compendiumSource": null
-          },
-          "_key": "!actors.items.effects!Tg1F1PthQWeKdLJT.yt10KrDz0zvTYmQa.fCJKQMBDfmrwVZFh"
-        }
-      ],
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.items!Tg1F1PthQWeKdLJT.yt10KrDz0zvTYmQa"
-    },
     {
       "name": "Necroplasmic",
       "type": "feature",
@@ -300,7 +216,7 @@
         }
       ],
       "folder": null,
-      "sort": 0,
+      "sort": 200000,
       "flags": {},
       "_stats": {
         "compendiumSource": null
@@ -422,6 +338,92 @@
         "compendiumSource": null
       },
       "_key": "!actors.items!Tg1F1PthQWeKdLJT.1yuuNfi8PkpCQC0U"
+    },
+    {
+      "type": "feature",
+      "name": "Horde",
+      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
+      "system": {
+        "description": "When the @Lookup[@name] have marked half or more of their HP, their standard attack deals @Lookup[@system.typeData.hordeDamage] @Lookup[@system.attackDamageType] damage instead.",
+        "attribution": {},
+        "gmNotes": "",
+        "resource": null,
+        "actions": {},
+        "granter": null,
+        "featureForm": "passive",
+        "actorResources": []
+      },
+      "flags": {
+        "daggerheart": {
+          "hordeFeature": true
+        }
+      },
+      "effects": [
+        {
+          "name": "Horde",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "system": {
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "changes": [
+              {
+                "type": "standardAttack",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "@system.typeData.hordeDamage",
+                  "img": null
+                },
+                "priority": 0,
+                "phase": "initial"
+              }
+            ],
+            "duration": {
+              "description": ""
+            },
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "lrpEqqa9rCmkBZjF",
+          "type": "base",
+          "disabled": false,
+          "start": null,
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!Tg1F1PthQWeKdLJT.xgcAQ4hogzMiRkY8.lrpEqqa9rCmkBZjF"
+        }
+      ],
+      "_id": "xgcAQ4hogzMiRkY8",
+      "folder": null,
+      "sort": 100000,
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!actors.items!Tg1F1PthQWeKdLJT.xgcAQ4hogzMiRkY8"
     }
   ],
   "_id": "Tg1F1PthQWeKdLJT",

--- a/src/packs/adversaries/adversary_Giant_Mosquitoes_IIWV4ysJPFPnTP7W.json
+++ b/src/packs/adversaries/adversary_Giant_Mosquitoes_IIWV4ysJPFPnTP7W.json
@@ -247,7 +247,73 @@
         "featureForm": "passive",
         "granter": null
       },
-      "effects": [],
+      "effects": [
+        {
+          "name": "Horde",
+          "type": "base",
+          "system": {
+            "changes": [
+              {
+                "type": "standardAttack",
+                "phase": "initial",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "1d4 + 1",
+                  "img": null
+                },
+                "priority": 0
+              }
+            ],
+            "duration": {
+              "description": "",
+              "type": ""
+            },
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "59X0UbixSRllXr9Z",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "disabled": false,
+          "start": {
+            "time": 0,
+            "combat": null,
+            "combatant": null,
+            "initiative": null,
+            "round": null,
+            "turn": null
+          },
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "<p>When the Giant Mosquitoes have marked half or more of their HP, their standard attack deals <strong>1d4 + 1</strong> physical damage instead.</p>",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!IIWV4ysJPFPnTP7W.9RduwBLYcBaiouYk.59X0UbixSRllXr9Z"
+        }
+      ],
       "folder": null,
       "sort": 0,
       "flags": {},
@@ -386,49 +452,6 @@
       "_key": "!actors.items!IIWV4ysJPFPnTP7W.BTlMLjG65KQs0Jk2"
     }
   ],
-  "effects": [
-    {
-      "type": "horde",
-      "name": "Horde",
-      "img": "icons/magic/movement/chevrons-down-yellow.webp",
-      "disabled": true,
-      "_id": "dQgcYTz5vmV25Y6G",
-      "system": {
-        "changes": [],
-        "duration": {
-          "description": ""
-        },
-        "rangeDependence": null,
-        "stacking": null,
-        "targetDispositions": []
-      },
-      "duration": {
-        "value": null,
-        "units": "seconds",
-        "expiry": null,
-        "expired": false
-      },
-      "description": "",
-      "tint": "#ffffff",
-      "transfer": false,
-      "statuses": [],
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "start": {
-        "combat": null,
-        "time": 0,
-        "combatant": null,
-        "initiative": null,
-        "round": null,
-        "turn": null
-      },
-      "showIcon": 1,
-      "folder": null,
-      "_key": "!actors.effects!IIWV4ysJPFPnTP7W.dQgcYTz5vmV25Y6G"
-    }
-  ],
+  "effects": [],
   "_key": "!actors!IIWV4ysJPFPnTP7W"
 }

--- a/src/packs/adversaries/adversary_Giant_Mosquitoes_IIWV4ysJPFPnTP7W.json
+++ b/src/packs/adversaries/adversary_Giant_Mosquitoes_IIWV4ysJPFPnTP7W.json
@@ -304,7 +304,7 @@
           "tint": "#ffffff",
           "transfer": true,
           "statuses": [],
-          "showIcon": 1,
+          "showIcon": 2,
           "folder": null,
           "sort": 0,
           "flags": {},

--- a/src/packs/adversaries/adversary_Grimmling_Warband_lzu6TNdRtCLoo3fN.json
+++ b/src/packs/adversaries/adversary_Grimmling_Warband_lzu6TNdRtCLoo3fN.json
@@ -150,7 +150,73 @@
       },
       "_id": "mbZO7L1pr3JP3pzK",
       "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [],
+      "effects": [
+        {
+          "name": "Horde",
+          "type": "base",
+          "system": {
+            "changes": [
+              {
+                "type": "standardAttack",
+                "phase": "initial",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "1d4 + 1",
+                  "img": null
+                },
+                "priority": 0
+              }
+            ],
+            "duration": {
+              "description": "",
+              "type": ""
+            },
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "SnrjVGZTLr5HhnS8",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "disabled": false,
+          "start": {
+            "time": 0,
+            "combat": null,
+            "combatant": null,
+            "initiative": null,
+            "round": null,
+            "turn": null
+          },
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "<p>When the Warband has marked half or more of its HP, its standard attack deals <strong>1d4+1</strong> physical damage instead.</p>",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!lzu6TNdRtCLoo3fN.mbZO7L1pr3JP3pzK.SnrjVGZTLr5HhnS8"
+        }
+      ],
       "folder": null,
       "sort": 0,
       "flags": {},
@@ -330,50 +396,7 @@
     "appendNumber": false,
     "prependAdjective": false
   },
-  "effects": [
-    {
-      "type": "horde",
-      "name": "Horde",
-      "img": "icons/magic/movement/chevrons-down-yellow.webp",
-      "disabled": true,
-      "_id": "0r5JxPWsZoQpK80d",
-      "system": {
-        "changes": [],
-        "duration": {
-          "description": ""
-        },
-        "rangeDependence": null,
-        "stacking": null,
-        "targetDispositions": []
-      },
-      "start": {
-        "time": 0,
-        "combat": null,
-        "combatant": null,
-        "initiative": null,
-        "round": null,
-        "turn": null
-      },
-      "duration": {
-        "value": null,
-        "units": "seconds",
-        "expiry": null,
-        "expired": false
-      },
-      "description": "",
-      "tint": "#ffffff",
-      "transfer": false,
-      "statuses": [],
-      "showIcon": 1,
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.effects!lzu6TNdRtCLoo3fN.0r5JxPWsZoQpK80d"
-    }
-  ],
+  "effects": [],
   "sort": 0,
   "flags": {},
   "_key": "!actors!lzu6TNdRtCLoo3fN"

--- a/src/packs/adversaries/adversary_Grimmling_Warband_lzu6TNdRtCLoo3fN.json
+++ b/src/packs/adversaries/adversary_Grimmling_Warband_lzu6TNdRtCLoo3fN.json
@@ -133,98 +133,14 @@
     "advantageSources": [],
     "disadvantageSources": [],
     "notes": "",
-    "criticalThreshold": 20
+    "criticalThreshold": 20,
+    "typeData": {
+      "type": "horde",
+      "hordeHP": 4,
+      "hordeDamage": "1d4+1"
+    }
   },
   "items": [
-    {
-      "name": "Horde (1d4+1)",
-      "type": "feature",
-      "system": {
-        "featureForm": "passive",
-        "description": "<p>When the Warband has marked half or more of its HP, its standard attack deals <strong>1d4+1</strong> physical damage instead.</p>",
-        "attribution": {},
-        "gmNotes": "",
-        "resource": null,
-        "actions": {},
-        "granter": null
-      },
-      "_id": "mbZO7L1pr3JP3pzK",
-      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [
-        {
-          "name": "Horde",
-          "type": "base",
-          "system": {
-            "changes": [
-              {
-                "type": "standardAttack",
-                "phase": "initial",
-                "value": {
-                  "name": "",
-                  "damageTypes": [],
-                  "attackRange": null,
-                  "trait": null,
-                  "damageFormula": "1d4 + 1",
-                  "img": null
-                },
-                "priority": 0
-              }
-            ],
-            "duration": {
-              "description": "",
-              "type": ""
-            },
-            "conditionals": [
-              {
-                "type": "dataCompare",
-                "key": "system.resources.hitPoints.value",
-                "comparator": "greaterEquals",
-                "value": "@system.resources.hitPoints.max / 2"
-              }
-            ],
-            "rangeDependence": null,
-            "stacking": null,
-            "targetDispositions": []
-          },
-          "_id": "SnrjVGZTLr5HhnS8",
-          "img": "icons/magic/movement/chevrons-down-yellow.webp",
-          "disabled": false,
-          "start": {
-            "time": 0,
-            "combat": null,
-            "combatant": null,
-            "initiative": null,
-            "round": null,
-            "turn": null
-          },
-          "duration": {
-            "value": null,
-            "units": "seconds",
-            "expiry": null,
-            "expired": false
-          },
-          "description": "<p>When the Warband has marked half or more of its HP, its standard attack deals <strong>1d4+1</strong> physical damage instead.</p>",
-          "tint": "#ffffff",
-          "transfer": true,
-          "statuses": [],
-          "showIcon": 1,
-          "folder": null,
-          "sort": 0,
-          "flags": {},
-          "_stats": {
-            "compendiumSource": null
-          },
-          "_key": "!actors.items.effects!lzu6TNdRtCLoo3fN.mbZO7L1pr3JP3pzK.SnrjVGZTLr5HhnS8"
-        }
-      ],
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.items!lzu6TNdRtCLoo3fN.mbZO7L1pr3JP3pzK"
-    },
     {
       "name": "Cowardly",
       "type": "feature",
@@ -300,6 +216,92 @@
         "compendiumSource": null
       },
       "_key": "!actors.items!lzu6TNdRtCLoo3fN.zScKH0UIU2MiV0FC"
+    },
+    {
+      "type": "feature",
+      "name": "Horde",
+      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
+      "system": {
+        "description": "When the @Lookup[@name] have marked half or more of their HP, their standard attack deals @Lookup[@system.typeData.hordeDamage] @Lookup[@system.attackDamageType] damage instead.",
+        "attribution": {},
+        "gmNotes": "",
+        "resource": null,
+        "actions": {},
+        "granter": null,
+        "featureForm": "passive",
+        "actorResources": []
+      },
+      "flags": {
+        "daggerheart": {
+          "hordeFeature": true
+        }
+      },
+      "effects": [
+        {
+          "name": "Horde",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "system": {
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "changes": [
+              {
+                "type": "standardAttack",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "@system.typeData.hordeDamage",
+                  "img": null
+                },
+                "priority": 0,
+                "phase": "initial"
+              }
+            ],
+            "duration": {
+              "description": ""
+            },
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "TdxYxLZd9EHYRSOv",
+          "type": "base",
+          "disabled": false,
+          "start": null,
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!lzu6TNdRtCLoo3fN.YmRBZX1CJNBJscxW.TdxYxLZd9EHYRSOv"
+        }
+      ],
+      "_id": "YmRBZX1CJNBJscxW",
+      "folder": null,
+      "sort": 0,
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!actors.items!lzu6TNdRtCLoo3fN.YmRBZX1CJNBJscxW"
     }
   ],
   "_id": "lzu6TNdRtCLoo3fN",

--- a/src/packs/adversaries/adversary_Grimmling_Warband_lzu6TNdRtCLoo3fN.json
+++ b/src/packs/adversaries/adversary_Grimmling_Warband_lzu6TNdRtCLoo3fN.json
@@ -285,7 +285,7 @@
           "tint": "#ffffff",
           "transfer": true,
           "statuses": [],
-          "showIcon": 1,
+          "showIcon": 2,
           "folder": null,
           "sort": 0,
           "flags": {},

--- a/src/packs/adversaries/adversary_Hallowed_Choir_68xDUa9Ls48O825Z.json
+++ b/src/packs/adversaries/adversary_Hallowed_Choir_68xDUa9Ls48O825Z.json
@@ -150,7 +150,73 @@
       },
       "_id": "0nFNX2rIm6gAnqJY",
       "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [],
+      "effects": [
+        {
+          "name": "Horde",
+          "type": "base",
+          "system": {
+            "changes": [
+              {
+                "type": "standardAttack",
+                "phase": "initial",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "2d10",
+                  "img": null
+                },
+                "priority": 0
+              }
+            ],
+            "duration": {
+              "description": "",
+              "type": ""
+            },
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "ILMsVCdvGqH39CwY",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "disabled": false,
+          "start": {
+            "time": 0,
+            "combat": null,
+            "combatant": null,
+            "initiative": null,
+            "round": null,
+            "turn": null
+          },
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "<p>When the Choir has marked half or more of its HP, its standard attack deals <strong>2d10</strong> magic damage instead.</p>",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!68xDUa9Ls48O825Z.0nFNX2rIm6gAnqJY.ILMsVCdvGqH39CwY"
+        }
+      ],
       "folder": null,
       "sort": 0,
       "flags": {},
@@ -436,50 +502,7 @@
     "appendNumber": false,
     "prependAdjective": false
   },
-  "effects": [
-    {
-      "type": "horde",
-      "name": "Horde",
-      "img": "icons/magic/movement/chevrons-down-yellow.webp",
-      "disabled": true,
-      "_id": "W7YfP6nmraj7jgG9",
-      "system": {
-        "changes": [],
-        "duration": {
-          "description": ""
-        },
-        "rangeDependence": null,
-        "stacking": null,
-        "targetDispositions": []
-      },
-      "start": {
-        "time": 0,
-        "combat": null,
-        "combatant": null,
-        "initiative": null,
-        "round": null,
-        "turn": null
-      },
-      "duration": {
-        "value": null,
-        "units": "seconds",
-        "expiry": null,
-        "expired": false
-      },
-      "description": "",
-      "tint": "#ffffff",
-      "transfer": false,
-      "statuses": [],
-      "showIcon": 1,
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.effects!68xDUa9Ls48O825Z.W7YfP6nmraj7jgG9"
-    }
-  ],
+  "effects": [],
   "sort": 0,
   "flags": {},
   "_key": "!actors!68xDUa9Ls48O825Z"

--- a/src/packs/adversaries/adversary_Hallowed_Choir_68xDUa9Ls48O825Z.json
+++ b/src/packs/adversaries/adversary_Hallowed_Choir_68xDUa9Ls48O825Z.json
@@ -133,98 +133,14 @@
     "advantageSources": [],
     "disadvantageSources": [],
     "notes": "",
-    "criticalThreshold": 20
+    "criticalThreshold": 20,
+    "typeData": {
+      "type": "horde",
+      "hordeHP": 4,
+      "hordeDamage": "2d10"
+    }
   },
   "items": [
-    {
-      "name": "Horde (2d10)",
-      "type": "feature",
-      "system": {
-        "featureForm": "passive",
-        "description": "<p>When the Choir has marked half or more of its HP, its standard attack deals <strong>2d10</strong> magic damage instead.</p>",
-        "attribution": {},
-        "gmNotes": "",
-        "resource": null,
-        "actions": {},
-        "granter": null
-      },
-      "_id": "0nFNX2rIm6gAnqJY",
-      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [
-        {
-          "name": "Horde",
-          "type": "base",
-          "system": {
-            "changes": [
-              {
-                "type": "standardAttack",
-                "phase": "initial",
-                "value": {
-                  "name": "",
-                  "damageTypes": [],
-                  "attackRange": null,
-                  "trait": null,
-                  "damageFormula": "2d10",
-                  "img": null
-                },
-                "priority": 0
-              }
-            ],
-            "duration": {
-              "description": "",
-              "type": ""
-            },
-            "conditionals": [
-              {
-                "type": "dataCompare",
-                "key": "system.resources.hitPoints.value",
-                "comparator": "greaterEquals",
-                "value": "@system.resources.hitPoints.max / 2"
-              }
-            ],
-            "rangeDependence": null,
-            "stacking": null,
-            "targetDispositions": []
-          },
-          "_id": "ILMsVCdvGqH39CwY",
-          "img": "icons/magic/movement/chevrons-down-yellow.webp",
-          "disabled": false,
-          "start": {
-            "time": 0,
-            "combat": null,
-            "combatant": null,
-            "initiative": null,
-            "round": null,
-            "turn": null
-          },
-          "duration": {
-            "value": null,
-            "units": "seconds",
-            "expiry": null,
-            "expired": false
-          },
-          "description": "<p>When the Choir has marked half or more of its HP, its standard attack deals <strong>2d10</strong> magic damage instead.</p>",
-          "tint": "#ffffff",
-          "transfer": true,
-          "statuses": [],
-          "showIcon": 1,
-          "folder": null,
-          "sort": 0,
-          "flags": {},
-          "_stats": {
-            "compendiumSource": null
-          },
-          "_key": "!actors.items.effects!68xDUa9Ls48O825Z.0nFNX2rIm6gAnqJY.ILMsVCdvGqH39CwY"
-        }
-      ],
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.items!68xDUa9Ls48O825Z.0nFNX2rIm6gAnqJY"
-    },
     {
       "name": "Celestial Coda",
       "type": "feature",
@@ -406,6 +322,92 @@
         "compendiumSource": null
       },
       "_key": "!actors.items!68xDUa9Ls48O825Z.cOwcBvzgs3GYGxKE"
+    },
+    {
+      "type": "feature",
+      "name": "Horde",
+      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
+      "system": {
+        "description": "When the @Lookup[@name] have marked half or more of their HP, their standard attack deals @Lookup[@system.typeData.hordeDamage] @Lookup[@system.attackDamageType] damage instead.",
+        "attribution": {},
+        "gmNotes": "",
+        "resource": null,
+        "actions": {},
+        "granter": null,
+        "featureForm": "passive",
+        "actorResources": []
+      },
+      "flags": {
+        "daggerheart": {
+          "hordeFeature": true
+        }
+      },
+      "effects": [
+        {
+          "name": "Horde",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "system": {
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "changes": [
+              {
+                "type": "standardAttack",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "@system.typeData.hordeDamage",
+                  "img": null
+                },
+                "priority": 0,
+                "phase": "initial"
+              }
+            ],
+            "duration": {
+              "description": ""
+            },
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "MrlQeFY9eq8pEIyk",
+          "type": "base",
+          "disabled": false,
+          "start": null,
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!68xDUa9Ls48O825Z.G1eSLlU2Qr7ZIPTH.MrlQeFY9eq8pEIyk"
+        }
+      ],
+      "_id": "G1eSLlU2Qr7ZIPTH",
+      "folder": null,
+      "sort": 0,
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!actors.items!68xDUa9Ls48O825Z.G1eSLlU2Qr7ZIPTH"
     }
   ],
   "_id": "68xDUa9Ls48O825Z",

--- a/src/packs/adversaries/adversary_Hallowed_Choir_68xDUa9Ls48O825Z.json
+++ b/src/packs/adversaries/adversary_Hallowed_Choir_68xDUa9Ls48O825Z.json
@@ -391,7 +391,7 @@
           "tint": "#ffffff",
           "transfer": true,
           "statuses": [],
-          "showIcon": 1,
+          "showIcon": 2,
           "folder": null,
           "sort": 0,
           "flags": {},

--- a/src/packs/adversaries/adversary_Night_Children_woVws0rcFaedtW3g.json
+++ b/src/packs/adversaries/adversary_Night_Children_woVws0rcFaedtW3g.json
@@ -150,7 +150,73 @@
       },
       "_id": "ucFcfRizVkPT0w9m",
       "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [],
+      "effects": [
+        {
+          "name": "Horde",
+          "type": "base",
+          "system": {
+            "changes": [
+              {
+                "type": "standardAttack",
+                "phase": "initial",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "2d6 + 2",
+                  "img": null
+                },
+                "priority": 0
+              }
+            ],
+            "duration": {
+              "description": "",
+              "type": ""
+            },
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "5OfgmgiKnmqfz8OY",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "disabled": false,
+          "start": {
+            "time": 0,
+            "combat": null,
+            "combatant": null,
+            "initiative": null,
+            "round": null,
+            "turn": null
+          },
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "<p>When the Night Children have marked half or more of their HP, their standard attack deals <strong>2d6+2</strong> physical damage instead.</p>",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!woVws0rcFaedtW3g.ucFcfRizVkPT0w9m.5OfgmgiKnmqfz8OY"
+        }
+      ],
       "folder": null,
       "sort": 0,
       "flags": {},
@@ -477,50 +543,7 @@
     "appendNumber": false,
     "prependAdjective": false
   },
-  "effects": [
-    {
-      "type": "horde",
-      "name": "Horde",
-      "img": "icons/magic/movement/chevrons-down-yellow.webp",
-      "disabled": true,
-      "_id": "exeTICrHkoRPNpct",
-      "system": {
-        "changes": [],
-        "duration": {
-          "description": ""
-        },
-        "rangeDependence": null,
-        "stacking": null,
-        "targetDispositions": []
-      },
-      "start": {
-        "time": 0,
-        "combat": null,
-        "combatant": null,
-        "initiative": null,
-        "round": null,
-        "turn": null
-      },
-      "duration": {
-        "value": null,
-        "units": "seconds",
-        "expiry": null,
-        "expired": false
-      },
-      "description": "",
-      "tint": "#ffffff",
-      "transfer": false,
-      "statuses": [],
-      "showIcon": 1,
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.effects!woVws0rcFaedtW3g.exeTICrHkoRPNpct"
-    }
-  ],
+  "effects": [],
   "sort": 0,
   "flags": {},
   "_key": "!actors!woVws0rcFaedtW3g"

--- a/src/packs/adversaries/adversary_Night_Children_woVws0rcFaedtW3g.json
+++ b/src/packs/adversaries/adversary_Night_Children_woVws0rcFaedtW3g.json
@@ -133,98 +133,14 @@
     "advantageSources": [],
     "disadvantageSources": [],
     "notes": "",
-    "criticalThreshold": 20
+    "criticalThreshold": 20,
+    "typeData": {
+      "type": "horde",
+      "hordeHP": 2,
+      "hordeDamage": "2d6+2"
+    }
   },
   "items": [
-    {
-      "name": "Horde (2d6+2)",
-      "type": "feature",
-      "system": {
-        "featureForm": "passive",
-        "description": "<p>When the @Lookup[@name] have marked half or more of their HP, their standard attack deals <strong>2d6+2</strong> physical damage instead.</p>",
-        "attribution": {},
-        "gmNotes": "",
-        "resource": null,
-        "actions": {},
-        "granter": null
-      },
-      "_id": "ucFcfRizVkPT0w9m",
-      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [
-        {
-          "name": "Horde",
-          "type": "base",
-          "system": {
-            "changes": [
-              {
-                "type": "standardAttack",
-                "phase": "initial",
-                "value": {
-                  "name": "",
-                  "damageTypes": [],
-                  "attackRange": null,
-                  "trait": null,
-                  "damageFormula": "2d6 + 2",
-                  "img": null
-                },
-                "priority": 0
-              }
-            ],
-            "duration": {
-              "description": "",
-              "type": ""
-            },
-            "conditionals": [
-              {
-                "type": "dataCompare",
-                "key": "system.resources.hitPoints.value",
-                "comparator": "greaterEquals",
-                "value": "@system.resources.hitPoints.max / 2"
-              }
-            ],
-            "rangeDependence": null,
-            "stacking": null,
-            "targetDispositions": []
-          },
-          "_id": "5OfgmgiKnmqfz8OY",
-          "img": "icons/magic/movement/chevrons-down-yellow.webp",
-          "disabled": false,
-          "start": {
-            "time": 0,
-            "combat": null,
-            "combatant": null,
-            "initiative": null,
-            "round": null,
-            "turn": null
-          },
-          "duration": {
-            "value": null,
-            "units": "seconds",
-            "expiry": null,
-            "expired": false
-          },
-          "description": "<p>When the Night Children have marked half or more of their HP, their standard attack deals <strong>2d6+2</strong> physical damage instead.</p>",
-          "tint": "#ffffff",
-          "transfer": true,
-          "statuses": [],
-          "showIcon": 1,
-          "folder": null,
-          "sort": 0,
-          "flags": {},
-          "_stats": {
-            "compendiumSource": null
-          },
-          "_key": "!actors.items.effects!woVws0rcFaedtW3g.ucFcfRizVkPT0w9m.5OfgmgiKnmqfz8OY"
-        }
-      ],
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.items!woVws0rcFaedtW3g.ucFcfRizVkPT0w9m"
-    },
     {
       "name": "Swell Ranks",
       "type": "feature",
@@ -447,6 +363,92 @@
         "compendiumSource": null
       },
       "_key": "!actors.items!woVws0rcFaedtW3g.eXVZweQ7AoZgWMbG"
+    },
+    {
+      "type": "feature",
+      "name": "Horde",
+      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
+      "system": {
+        "description": "When the @Lookup[@name] have marked half or more of their HP, their standard attack deals @Lookup[@system.typeData.hordeDamage] @Lookup[@system.attackDamageType] damage instead.",
+        "attribution": {},
+        "gmNotes": "",
+        "resource": null,
+        "actions": {},
+        "granter": null,
+        "featureForm": "passive",
+        "actorResources": []
+      },
+      "flags": {
+        "daggerheart": {
+          "hordeFeature": true
+        }
+      },
+      "effects": [
+        {
+          "name": "Horde",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "system": {
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "changes": [
+              {
+                "type": "standardAttack",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "@system.typeData.hordeDamage",
+                  "img": null
+                },
+                "priority": 0,
+                "phase": "initial"
+              }
+            ],
+            "duration": {
+              "description": ""
+            },
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "Bz9AhciprCKb0bwI",
+          "type": "base",
+          "disabled": false,
+          "start": null,
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!woVws0rcFaedtW3g.YOI7QdUoLScj8w2k.Bz9AhciprCKb0bwI"
+        }
+      ],
+      "_id": "YOI7QdUoLScj8w2k",
+      "folder": null,
+      "sort": 0,
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!actors.items!woVws0rcFaedtW3g.YOI7QdUoLScj8w2k"
     }
   ],
   "_id": "woVws0rcFaedtW3g",

--- a/src/packs/adversaries/adversary_Night_Children_woVws0rcFaedtW3g.json
+++ b/src/packs/adversaries/adversary_Night_Children_woVws0rcFaedtW3g.json
@@ -432,7 +432,7 @@
           "tint": "#ffffff",
           "transfer": true,
           "statuses": [],
-          "showIcon": 1,
+          "showIcon": 2,
           "folder": null,
           "sort": 0,
           "flags": {},

--- a/src/packs/adversaries/adversary_Pirate_Raiders_5YgEajn0wa4i85kC.json
+++ b/src/packs/adversaries/adversary_Pirate_Raiders_5YgEajn0wa4i85kC.json
@@ -247,7 +247,73 @@
         "featureForm": "passive",
         "granter": null
       },
-      "effects": [],
+      "effects": [
+        {
+          "name": "Horde",
+          "type": "base",
+          "system": {
+            "changes": [
+              {
+                "type": "standardAttack",
+                "phase": "initial",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "1d4 + 1",
+                  "img": null
+                },
+                "priority": 0
+              }
+            ],
+            "duration": {
+              "description": "",
+              "type": ""
+            },
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "V1LEaesiC5QBMAWE",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "disabled": false,
+          "start": {
+            "time": 0,
+            "combat": null,
+            "combatant": null,
+            "initiative": null,
+            "round": null,
+            "turn": null
+          },
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "<p>When the Pirate Raiders have marked half or more of their HP, their standard attack deals <strong>1d4 + 1 </strong>physical damage instead.</p>",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!5YgEajn0wa4i85kC.Q7DRbWjHl64CNwag.V1LEaesiC5QBMAWE"
+        }
+      ],
       "folder": null,
       "sort": 0,
       "flags": {},
@@ -341,49 +407,6 @@
       "_key": "!actors.items!5YgEajn0wa4i85kC.N401rF937fLXMuMA"
     }
   ],
-  "effects": [
-    {
-      "type": "horde",
-      "name": "Horde",
-      "img": "icons/magic/movement/chevrons-down-yellow.webp",
-      "disabled": true,
-      "_id": "OU05YZwFQffawtna",
-      "system": {
-        "changes": [],
-        "duration": {
-          "description": ""
-        },
-        "rangeDependence": null,
-        "stacking": null,
-        "targetDispositions": []
-      },
-      "duration": {
-        "value": null,
-        "units": "seconds",
-        "expiry": null,
-        "expired": false
-      },
-      "description": "",
-      "tint": "#ffffff",
-      "transfer": false,
-      "statuses": [],
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "start": {
-        "combat": null,
-        "time": 0,
-        "combatant": null,
-        "initiative": null,
-        "round": null,
-        "turn": null
-      },
-      "showIcon": 1,
-      "folder": null,
-      "_key": "!actors.effects!5YgEajn0wa4i85kC.OU05YZwFQffawtna"
-    }
-  ],
+  "effects": [],
   "_key": "!actors!5YgEajn0wa4i85kC"
 }

--- a/src/packs/adversaries/adversary_Pirate_Raiders_5YgEajn0wa4i85kC.json
+++ b/src/packs/adversaries/adversary_Pirate_Raiders_5YgEajn0wa4i85kC.json
@@ -390,7 +390,7 @@
           "tint": "#ffffff",
           "transfer": true,
           "statuses": [],
-          "showIcon": 1,
+          "showIcon": 2,
           "folder": null,
           "sort": 0,
           "flags": {},

--- a/src/packs/adversaries/adversary_Pirate_Raiders_5YgEajn0wa4i85kC.json
+++ b/src/packs/adversaries/adversary_Pirate_Raiders_5YgEajn0wa4i85kC.json
@@ -135,7 +135,12 @@
     "size": "huge",
     "advantageSources": [],
     "disadvantageSources": [],
-    "criticalThreshold": 20
+    "criticalThreshold": 20,
+    "typeData": {
+      "type": "horde",
+      "hordeHP": 3,
+      "hordeDamage": "1d4+1"
+    }
   },
   "flags": {},
   "_id": "5YgEajn0wa4i85kC",
@@ -234,95 +239,6 @@
   },
   "items": [
     {
-      "name": "Horde",
-      "type": "feature",
-      "_id": "Q7DRbWjHl64CNwag",
-      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "system": {
-        "description": "<p>When the @Lookup[@name] have marked half or more of their HP, their standard attack deals <strong>@Lookup[@system.attack.altDamageFormula]</strong> physical damage instead.</p>",
-        "resource": null,
-        "actions": {},
-        "attribution": {},
-        "gmNotes": "",
-        "featureForm": "passive",
-        "granter": null
-      },
-      "effects": [
-        {
-          "name": "Horde",
-          "type": "base",
-          "system": {
-            "changes": [
-              {
-                "type": "standardAttack",
-                "phase": "initial",
-                "value": {
-                  "name": "",
-                  "damageTypes": [],
-                  "attackRange": null,
-                  "trait": null,
-                  "damageFormula": "1d4 + 1",
-                  "img": null
-                },
-                "priority": 0
-              }
-            ],
-            "duration": {
-              "description": "",
-              "type": ""
-            },
-            "conditionals": [
-              {
-                "type": "dataCompare",
-                "key": "system.resources.hitPoints.value",
-                "comparator": "greaterEquals",
-                "value": "@system.resources.hitPoints.max / 2"
-              }
-            ],
-            "rangeDependence": null,
-            "stacking": null,
-            "targetDispositions": []
-          },
-          "_id": "V1LEaesiC5QBMAWE",
-          "img": "icons/magic/movement/chevrons-down-yellow.webp",
-          "disabled": false,
-          "start": {
-            "time": 0,
-            "combat": null,
-            "combatant": null,
-            "initiative": null,
-            "round": null,
-            "turn": null
-          },
-          "duration": {
-            "value": null,
-            "units": "seconds",
-            "expiry": null,
-            "expired": false
-          },
-          "description": "<p>When the Pirate Raiders have marked half or more of their HP, their standard attack deals <strong>1d4 + 1 </strong>physical damage instead.</p>",
-          "tint": "#ffffff",
-          "transfer": true,
-          "statuses": [],
-          "showIcon": 1,
-          "folder": null,
-          "sort": 0,
-          "flags": {},
-          "_stats": {
-            "compendiumSource": null
-          },
-          "_key": "!actors.items.effects!5YgEajn0wa4i85kC.Q7DRbWjHl64CNwag.V1LEaesiC5QBMAWE"
-        }
-      ],
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.items!5YgEajn0wa4i85kC.Q7DRbWjHl64CNwag"
-    },
-    {
       "name": "Swashbuckler",
       "type": "feature",
       "_id": "N401rF937fLXMuMA",
@@ -405,6 +321,92 @@
         "compendiumSource": null
       },
       "_key": "!actors.items!5YgEajn0wa4i85kC.N401rF937fLXMuMA"
+    },
+    {
+      "type": "feature",
+      "name": "Horde",
+      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
+      "system": {
+        "description": "When the @Lookup[@name] have marked half or more of their HP, their standard attack deals @Lookup[@system.typeData.hordeDamage] @Lookup[@system.attackDamageType] damage instead.",
+        "attribution": {},
+        "gmNotes": "",
+        "resource": null,
+        "actions": {},
+        "granter": null,
+        "featureForm": "passive",
+        "actorResources": []
+      },
+      "flags": {
+        "daggerheart": {
+          "hordeFeature": true
+        }
+      },
+      "effects": [
+        {
+          "name": "Horde",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "system": {
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "changes": [
+              {
+                "type": "standardAttack",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "@system.typeData.hordeDamage",
+                  "img": null
+                },
+                "priority": 0,
+                "phase": "initial"
+              }
+            ],
+            "duration": {
+              "description": ""
+            },
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "EVtQtWuC24r0Br9T",
+          "type": "base",
+          "disabled": false,
+          "start": null,
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!5YgEajn0wa4i85kC.SiTT33vaEnoWFErO.EVtQtWuC24r0Br9T"
+        }
+      ],
+      "_id": "SiTT33vaEnoWFErO",
+      "folder": null,
+      "sort": 0,
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!actors.items!5YgEajn0wa4i85kC.SiTT33vaEnoWFErO"
     }
   ],
   "effects": [],

--- a/src/packs/adversaries/adversary_Rabble_Mawb_lKmBNV3Sgpq9sTtp.json
+++ b/src/packs/adversaries/adversary_Rabble_Mawb_lKmBNV3Sgpq9sTtp.json
@@ -150,7 +150,73 @@
       },
       "_id": "bLv6g1Lj3ygaemXp",
       "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [],
+      "effects": [
+        {
+          "name": "Horde",
+          "type": "base",
+          "system": {
+            "changes": [
+              {
+                "type": "standardAttack",
+                "phase": "initial",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "1d4 + 1",
+                  "img": null
+                },
+                "priority": 0
+              }
+            ],
+            "duration": {
+              "description": "",
+              "type": ""
+            },
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "UL1LJaPXA7B9Nopw",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "disabled": false,
+          "start": {
+            "time": 0,
+            "combat": null,
+            "combatant": null,
+            "initiative": null,
+            "round": null,
+            "turn": null
+          },
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "<p>When the Rabble Mawb has marked half or more of its HP, its standard attack deals <strong>1d4+1</strong> physical damage instead.</p>",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!lKmBNV3Sgpq9sTtp.bLv6g1Lj3ygaemXp.UL1LJaPXA7B9Nopw"
+        }
+      ],
       "folder": null,
       "sort": 0,
       "flags": {},
@@ -543,50 +609,7 @@
     "appendNumber": false,
     "prependAdjective": false
   },
-  "effects": [
-    {
-      "type": "horde",
-      "name": "Horde",
-      "img": "icons/magic/movement/chevrons-down-yellow.webp",
-      "disabled": true,
-      "_id": "2H1xiOzbdqDpRgl4",
-      "system": {
-        "changes": [],
-        "duration": {
-          "description": ""
-        },
-        "rangeDependence": null,
-        "stacking": null,
-        "targetDispositions": []
-      },
-      "start": {
-        "time": 0,
-        "combat": null,
-        "combatant": null,
-        "initiative": null,
-        "round": null,
-        "turn": null
-      },
-      "duration": {
-        "value": null,
-        "units": "seconds",
-        "expiry": null,
-        "expired": false
-      },
-      "description": "",
-      "tint": "#ffffff",
-      "transfer": false,
-      "statuses": [],
-      "showIcon": 1,
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.effects!lKmBNV3Sgpq9sTtp.2H1xiOzbdqDpRgl4"
-    }
-  ],
+  "effects": [],
   "sort": 0,
   "flags": {},
   "_key": "!actors!lKmBNV3Sgpq9sTtp"

--- a/src/packs/adversaries/adversary_Rabble_Mawb_lKmBNV3Sgpq9sTtp.json
+++ b/src/packs/adversaries/adversary_Rabble_Mawb_lKmBNV3Sgpq9sTtp.json
@@ -498,7 +498,7 @@
           "tint": "#ffffff",
           "transfer": true,
           "statuses": [],
-          "showIcon": 1,
+          "showIcon": 2,
           "folder": null,
           "sort": 0,
           "flags": {},

--- a/src/packs/adversaries/adversary_Rabble_Mawb_lKmBNV3Sgpq9sTtp.json
+++ b/src/packs/adversaries/adversary_Rabble_Mawb_lKmBNV3Sgpq9sTtp.json
@@ -133,98 +133,14 @@
     "advantageSources": [],
     "disadvantageSources": [],
     "notes": "",
-    "criticalThreshold": 20
+    "criticalThreshold": 20,
+    "typeData": {
+      "type": "horde",
+      "hordeHP": 3,
+      "hordeDamage": "1d4+1"
+    }
   },
   "items": [
-    {
-      "name": "Horde (1d4+1)",
-      "type": "feature",
-      "system": {
-        "featureForm": "passive",
-        "description": "<p>When the @Lookup[@name] has marked half or more of its HP, its standard attack deals <strong>1d4+1</strong> physical damage instead.</p>",
-        "attribution": {},
-        "gmNotes": "",
-        "resource": null,
-        "actions": {},
-        "granter": null
-      },
-      "_id": "bLv6g1Lj3ygaemXp",
-      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [
-        {
-          "name": "Horde",
-          "type": "base",
-          "system": {
-            "changes": [
-              {
-                "type": "standardAttack",
-                "phase": "initial",
-                "value": {
-                  "name": "",
-                  "damageTypes": [],
-                  "attackRange": null,
-                  "trait": null,
-                  "damageFormula": "1d4 + 1",
-                  "img": null
-                },
-                "priority": 0
-              }
-            ],
-            "duration": {
-              "description": "",
-              "type": ""
-            },
-            "conditionals": [
-              {
-                "type": "dataCompare",
-                "key": "system.resources.hitPoints.value",
-                "comparator": "greaterEquals",
-                "value": "@system.resources.hitPoints.max / 2"
-              }
-            ],
-            "rangeDependence": null,
-            "stacking": null,
-            "targetDispositions": []
-          },
-          "_id": "UL1LJaPXA7B9Nopw",
-          "img": "icons/magic/movement/chevrons-down-yellow.webp",
-          "disabled": false,
-          "start": {
-            "time": 0,
-            "combat": null,
-            "combatant": null,
-            "initiative": null,
-            "round": null,
-            "turn": null
-          },
-          "duration": {
-            "value": null,
-            "units": "seconds",
-            "expiry": null,
-            "expired": false
-          },
-          "description": "<p>When the Rabble Mawb has marked half or more of its HP, its standard attack deals <strong>1d4+1</strong> physical damage instead.</p>",
-          "tint": "#ffffff",
-          "transfer": true,
-          "statuses": [],
-          "showIcon": 1,
-          "folder": null,
-          "sort": 0,
-          "flags": {},
-          "_stats": {
-            "compendiumSource": null
-          },
-          "_key": "!actors.items.effects!lKmBNV3Sgpq9sTtp.bLv6g1Lj3ygaemXp.UL1LJaPXA7B9Nopw"
-        }
-      ],
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.items!lKmBNV3Sgpq9sTtp.bLv6g1Lj3ygaemXp"
-    },
     {
       "name": "Come Back Worse",
       "type": "feature",
@@ -513,6 +429,92 @@
         "compendiumSource": null
       },
       "_key": "!actors.items!lKmBNV3Sgpq9sTtp.jC4ngCoNcUSTuJv9"
+    },
+    {
+      "type": "feature",
+      "name": "Horde",
+      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
+      "system": {
+        "description": "When the @Lookup[@name] have marked half or more of their HP, their standard attack deals @Lookup[@system.typeData.hordeDamage] @Lookup[@system.attackDamageType] damage instead.",
+        "attribution": {},
+        "gmNotes": "",
+        "resource": null,
+        "actions": {},
+        "granter": null,
+        "featureForm": "passive",
+        "actorResources": []
+      },
+      "flags": {
+        "daggerheart": {
+          "hordeFeature": true
+        }
+      },
+      "effects": [
+        {
+          "name": "Horde",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "system": {
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "changes": [
+              {
+                "type": "standardAttack",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "@system.typeData.hordeDamage",
+                  "img": null
+                },
+                "priority": 0,
+                "phase": "initial"
+              }
+            ],
+            "duration": {
+              "description": ""
+            },
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "RZrBYUTyIeIl196x",
+          "type": "base",
+          "disabled": false,
+          "start": null,
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!lKmBNV3Sgpq9sTtp.jm7b6oWe4y3kHIZj.RZrBYUTyIeIl196x"
+        }
+      ],
+      "_id": "jm7b6oWe4y3kHIZj",
+      "folder": null,
+      "sort": 0,
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!actors.items!lKmBNV3Sgpq9sTtp.jm7b6oWe4y3kHIZj"
     }
   ],
   "_id": "lKmBNV3Sgpq9sTtp",

--- a/src/packs/adversaries/adversary_Swarm_of_Rats_qNgs3AbLyJrY19nt.json
+++ b/src/packs/adversaries/adversary_Swarm_of_Rats_qNgs3AbLyJrY19nt.json
@@ -241,7 +241,73 @@
         "featureForm": "passive",
         "granter": null
       },
-      "effects": [],
+      "effects": [
+        {
+          "name": "Horde",
+          "type": "base",
+          "system": {
+            "changes": [
+              {
+                "type": "standardAttack",
+                "phase": "initial",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "1d4 + 1",
+                  "img": null
+                },
+                "priority": 0
+              }
+            ],
+            "duration": {
+              "description": "",
+              "type": ""
+            },
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "M3PoHQoFZAH7Drlw",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "disabled": false,
+          "start": {
+            "time": 0,
+            "combat": null,
+            "combatant": null,
+            "initiative": null,
+            "round": null,
+            "turn": null
+          },
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "<p>When the Swarm of Rats has marked half or more of their HP, their standard attack deals <strong>1d4 + 1</strong> physical damage instead.</p>",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!qNgs3AbLyJrY19nt.9Zuu892SO5NmtI4w.M3PoHQoFZAH7Drlw"
+        }
+      ],
       "folder": null,
       "sort": 0,
       "flags": {},
@@ -274,49 +340,6 @@
       "_key": "!actors.items!qNgs3AbLyJrY19nt.0O6ckwZE34RBnjpB"
     }
   ],
-  "effects": [
-    {
-      "type": "horde",
-      "name": "Horde",
-      "img": "icons/magic/movement/chevrons-down-yellow.webp",
-      "disabled": true,
-      "_id": "FOV6AzngiR0PZyuN",
-      "system": {
-        "changes": [],
-        "duration": {
-          "description": ""
-        },
-        "rangeDependence": null,
-        "stacking": null,
-        "targetDispositions": []
-      },
-      "duration": {
-        "value": null,
-        "units": "seconds",
-        "expiry": null,
-        "expired": false
-      },
-      "description": "",
-      "tint": "#ffffff",
-      "transfer": false,
-      "statuses": [],
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "start": {
-        "combat": null,
-        "time": 0,
-        "combatant": null,
-        "initiative": null,
-        "round": null,
-        "turn": null
-      },
-      "showIcon": 1,
-      "folder": null,
-      "_key": "!actors.effects!qNgs3AbLyJrY19nt.FOV6AzngiR0PZyuN"
-    }
-  ],
+  "effects": [],
   "_key": "!actors!qNgs3AbLyJrY19nt"
 }

--- a/src/packs/adversaries/adversary_Swarm_of_Rats_qNgs3AbLyJrY19nt.json
+++ b/src/packs/adversaries/adversary_Swarm_of_Rats_qNgs3AbLyJrY19nt.json
@@ -323,7 +323,7 @@
           "tint": "#ffffff",
           "transfer": true,
           "statuses": [],
-          "showIcon": 1,
+          "showIcon": 2,
           "folder": null,
           "sort": 0,
           "flags": {},

--- a/src/packs/adversaries/adversary_Swarm_of_Rats_qNgs3AbLyJrY19nt.json
+++ b/src/packs/adversaries/adversary_Swarm_of_Rats_qNgs3AbLyJrY19nt.json
@@ -129,7 +129,12 @@
     "size": "medium",
     "advantageSources": [],
     "disadvantageSources": [],
-    "criticalThreshold": 20
+    "criticalThreshold": 20,
+    "typeData": {
+      "type": "horde",
+      "hordeHP": 10,
+      "hordeDamage": "1d4+1"
+    }
   },
   "flags": {},
   "_id": "qNgs3AbLyJrY19nt",
@@ -228,95 +233,6 @@
   },
   "items": [
     {
-      "name": "Horde (1d4+1)",
-      "type": "feature",
-      "_id": "9Zuu892SO5NmtI4w",
-      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "system": {
-        "description": "<p>When the @Lookup[@name] has marked half or more of their HP, their standard attack deals <strong>@Lookup[@system.attack.altDamageFormula]</strong> physical damage instead.</p>",
-        "resource": null,
-        "actions": {},
-        "attribution": {},
-        "gmNotes": "",
-        "featureForm": "passive",
-        "granter": null
-      },
-      "effects": [
-        {
-          "name": "Horde",
-          "type": "base",
-          "system": {
-            "changes": [
-              {
-                "type": "standardAttack",
-                "phase": "initial",
-                "value": {
-                  "name": "",
-                  "damageTypes": [],
-                  "attackRange": null,
-                  "trait": null,
-                  "damageFormula": "1d4 + 1",
-                  "img": null
-                },
-                "priority": 0
-              }
-            ],
-            "duration": {
-              "description": "",
-              "type": ""
-            },
-            "conditionals": [
-              {
-                "type": "dataCompare",
-                "key": "system.resources.hitPoints.value",
-                "comparator": "greaterEquals",
-                "value": "@system.resources.hitPoints.max / 2"
-              }
-            ],
-            "rangeDependence": null,
-            "stacking": null,
-            "targetDispositions": []
-          },
-          "_id": "M3PoHQoFZAH7Drlw",
-          "img": "icons/magic/movement/chevrons-down-yellow.webp",
-          "disabled": false,
-          "start": {
-            "time": 0,
-            "combat": null,
-            "combatant": null,
-            "initiative": null,
-            "round": null,
-            "turn": null
-          },
-          "duration": {
-            "value": null,
-            "units": "seconds",
-            "expiry": null,
-            "expired": false
-          },
-          "description": "<p>When the Swarm of Rats has marked half or more of their HP, their standard attack deals <strong>1d4 + 1</strong> physical damage instead.</p>",
-          "tint": "#ffffff",
-          "transfer": true,
-          "statuses": [],
-          "showIcon": 1,
-          "folder": null,
-          "sort": 0,
-          "flags": {},
-          "_stats": {
-            "compendiumSource": null
-          },
-          "_key": "!actors.items.effects!qNgs3AbLyJrY19nt.9Zuu892SO5NmtI4w.M3PoHQoFZAH7Drlw"
-        }
-      ],
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.items!qNgs3AbLyJrY19nt.9Zuu892SO5NmtI4w"
-    },
-    {
       "name": "In Your Face",
       "type": "feature",
       "_id": "0O6ckwZE34RBnjpB",
@@ -338,6 +254,92 @@
         "compendiumSource": null
       },
       "_key": "!actors.items!qNgs3AbLyJrY19nt.0O6ckwZE34RBnjpB"
+    },
+    {
+      "type": "feature",
+      "name": "Horde",
+      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
+      "system": {
+        "description": "When the @Lookup[@name] have marked half or more of their HP, their standard attack deals @Lookup[@system.typeData.hordeDamage] @Lookup[@system.attackDamageType] damage instead.",
+        "attribution": {},
+        "gmNotes": "",
+        "resource": null,
+        "actions": {},
+        "granter": null,
+        "featureForm": "passive",
+        "actorResources": []
+      },
+      "flags": {
+        "daggerheart": {
+          "hordeFeature": true
+        }
+      },
+      "effects": [
+        {
+          "name": "Horde",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "system": {
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "changes": [
+              {
+                "type": "standardAttack",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "@system.typeData.hordeDamage",
+                  "img": null
+                },
+                "priority": 0,
+                "phase": "initial"
+              }
+            ],
+            "duration": {
+              "description": ""
+            },
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "M9TexEFuniCrQfnG",
+          "type": "base",
+          "disabled": false,
+          "start": null,
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!qNgs3AbLyJrY19nt.4CID8lXEo90NtvuP.M9TexEFuniCrQfnG"
+        }
+      ],
+      "_id": "4CID8lXEo90NtvuP",
+      "folder": null,
+      "sort": -100000,
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!actors.items!qNgs3AbLyJrY19nt.4CID8lXEo90NtvuP"
     }
   ],
   "effects": [],

--- a/src/packs/adversaries/adversary_Tangle_Bramble_Swarm_PKSXFuaIHUCoH63A.json
+++ b/src/packs/adversaries/adversary_Tangle_Bramble_Swarm_PKSXFuaIHUCoH63A.json
@@ -244,7 +244,73 @@
         "featureForm": "passive",
         "granter": null
       },
-      "effects": [],
+      "effects": [
+        {
+          "name": "Horde",
+          "type": "base",
+          "system": {
+            "changes": [
+              {
+                "type": "standardAttack",
+                "phase": "initial",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "1d4 + 2",
+                  "img": null
+                },
+                "priority": 0
+              }
+            ],
+            "duration": {
+              "description": "",
+              "type": ""
+            },
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "kiLukad7Y6m8FFN8",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "disabled": false,
+          "start": {
+            "time": 0,
+            "combat": null,
+            "combatant": null,
+            "initiative": null,
+            "round": null,
+            "turn": null
+          },
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "<p>When the Tangle Bramble Swarm has marked half or more of their HP, their standard attack deals <strong>1d4 + 2 </strong>physical damage instead.</p>",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!PKSXFuaIHUCoH63A.4dSzqtYvH385r9Ng.kiLukad7Y6m8FFN8"
+        }
+      ],
       "folder": null,
       "sort": 0,
       "flags": {},
@@ -446,50 +512,7 @@
       "_key": "!actors.items!PKSXFuaIHUCoH63A.JRSGc3ozDnKCAvCj"
     }
   ],
-  "effects": [
-    {
-      "type": "horde",
-      "name": "Horde",
-      "img": "icons/magic/movement/chevrons-down-yellow.webp",
-      "disabled": true,
-      "_id": "ki4vrzrFcEYtGeJu",
-      "system": {
-        "changes": [],
-        "duration": {
-          "description": ""
-        },
-        "rangeDependence": null,
-        "stacking": null,
-        "targetDispositions": []
-      },
-      "duration": {
-        "value": null,
-        "units": "seconds",
-        "expiry": null,
-        "expired": false
-      },
-      "description": "",
-      "tint": "#ffffff",
-      "transfer": false,
-      "statuses": [],
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "start": {
-        "combat": null,
-        "time": 0,
-        "combatant": null,
-        "initiative": null,
-        "round": null,
-        "turn": null
-      },
-      "showIcon": 1,
-      "folder": null,
-      "_key": "!actors.effects!PKSXFuaIHUCoH63A.ki4vrzrFcEYtGeJu"
-    }
-  ],
+  "effects": [],
   "_id": "PKSXFuaIHUCoH63A",
   "sort": 0,
   "_key": "!actors!PKSXFuaIHUCoH63A"

--- a/src/packs/adversaries/adversary_Tangle_Bramble_Swarm_PKSXFuaIHUCoH63A.json
+++ b/src/packs/adversaries/adversary_Tangle_Bramble_Swarm_PKSXFuaIHUCoH63A.json
@@ -496,7 +496,7 @@
           "tint": "#ffffff",
           "transfer": true,
           "statuses": [],
-          "showIcon": 1,
+          "showIcon": 2,
           "folder": null,
           "sort": 0,
           "flags": {},

--- a/src/packs/adversaries/adversary_Tangle_Bramble_Swarm_PKSXFuaIHUCoH63A.json
+++ b/src/packs/adversaries/adversary_Tangle_Bramble_Swarm_PKSXFuaIHUCoH63A.json
@@ -23,7 +23,8 @@
     "experiences": {
       "WWznKZbYf1O4dcNS": {
         "name": "Camouflage",
-        "value": 2
+        "value": 2,
+        "description": ""
       }
     },
     "difficulty": 12,
@@ -134,7 +135,12 @@
     "size": "medium",
     "advantageSources": [],
     "disadvantageSources": [],
-    "criticalThreshold": 20
+    "criticalThreshold": 20,
+    "typeData": {
+      "type": "horde",
+      "hordeHP": 3,
+      "hordeDamage": "1d4+2"
+    }
   },
   "flags": {},
   "prototypeToken": {
@@ -230,95 +236,6 @@
     "depth": 1
   },
   "items": [
-    {
-      "name": "Horde",
-      "type": "feature",
-      "_id": "4dSzqtYvH385r9Ng",
-      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "system": {
-        "description": "<p>When the @Lookup[@name] has marked half or more of their HP, their standard attack deals <strong>@Lookup[@system.attack.altDamageFormula]</strong> physical damage instead.</p>",
-        "resource": null,
-        "actions": {},
-        "attribution": {},
-        "gmNotes": "",
-        "featureForm": "passive",
-        "granter": null
-      },
-      "effects": [
-        {
-          "name": "Horde",
-          "type": "base",
-          "system": {
-            "changes": [
-              {
-                "type": "standardAttack",
-                "phase": "initial",
-                "value": {
-                  "name": "",
-                  "damageTypes": [],
-                  "attackRange": null,
-                  "trait": null,
-                  "damageFormula": "1d4 + 2",
-                  "img": null
-                },
-                "priority": 0
-              }
-            ],
-            "duration": {
-              "description": "",
-              "type": ""
-            },
-            "conditionals": [
-              {
-                "type": "dataCompare",
-                "key": "system.resources.hitPoints.value",
-                "comparator": "greaterEquals",
-                "value": "@system.resources.hitPoints.max / 2"
-              }
-            ],
-            "rangeDependence": null,
-            "stacking": null,
-            "targetDispositions": []
-          },
-          "_id": "kiLukad7Y6m8FFN8",
-          "img": "icons/magic/movement/chevrons-down-yellow.webp",
-          "disabled": false,
-          "start": {
-            "time": 0,
-            "combat": null,
-            "combatant": null,
-            "initiative": null,
-            "round": null,
-            "turn": null
-          },
-          "duration": {
-            "value": null,
-            "units": "seconds",
-            "expiry": null,
-            "expired": false
-          },
-          "description": "<p>When the Tangle Bramble Swarm has marked half or more of their HP, their standard attack deals <strong>1d4 + 2 </strong>physical damage instead.</p>",
-          "tint": "#ffffff",
-          "transfer": true,
-          "statuses": [],
-          "showIcon": 1,
-          "folder": null,
-          "sort": 0,
-          "flags": {},
-          "_stats": {
-            "compendiumSource": null
-          },
-          "_key": "!actors.items.effects!PKSXFuaIHUCoH63A.4dSzqtYvH385r9Ng.kiLukad7Y6m8FFN8"
-        }
-      ],
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.items!PKSXFuaIHUCoH63A.4dSzqtYvH385r9Ng"
-    },
     {
       "name": "Crush",
       "type": "feature",
@@ -510,6 +427,92 @@
         "compendiumSource": null
       },
       "_key": "!actors.items!PKSXFuaIHUCoH63A.JRSGc3ozDnKCAvCj"
+    },
+    {
+      "type": "feature",
+      "name": "Horde",
+      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
+      "system": {
+        "description": "When the @Lookup[@name] have marked half or more of their HP, their standard attack deals @Lookup[@system.typeData.hordeDamage] @Lookup[@system.attackDamageType] damage instead.",
+        "attribution": {},
+        "gmNotes": "",
+        "resource": null,
+        "actions": {},
+        "granter": null,
+        "featureForm": "passive",
+        "actorResources": []
+      },
+      "flags": {
+        "daggerheart": {
+          "hordeFeature": true
+        }
+      },
+      "effects": [
+        {
+          "name": "Horde",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "system": {
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "changes": [
+              {
+                "type": "standardAttack",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "@system.typeData.hordeDamage",
+                  "img": null
+                },
+                "priority": 0,
+                "phase": "initial"
+              }
+            ],
+            "duration": {
+              "description": ""
+            },
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "xbpP7tkGyMzma4rO",
+          "type": "base",
+          "disabled": false,
+          "start": null,
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!PKSXFuaIHUCoH63A.345WBz3gZYgCoAhT.xbpP7tkGyMzma4rO"
+        }
+      ],
+      "_id": "345WBz3gZYgCoAhT",
+      "folder": null,
+      "sort": 0,
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!actors.items!PKSXFuaIHUCoH63A.345WBz3gZYgCoAhT"
     }
   ],
   "effects": [],

--- a/src/packs/adversaries/adversary_Vampire_Bat_Swarm_2OjMAjcG3xbbsrIV.json
+++ b/src/packs/adversaries/adversary_Vampire_Bat_Swarm_2OjMAjcG3xbbsrIV.json
@@ -150,7 +150,73 @@
       },
       "_id": "calCSfujA6x3qEaw",
       "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [],
+      "effects": [
+        {
+          "name": "Horde",
+          "type": "base",
+          "system": {
+            "changes": [
+              {
+                "type": "standardAttack",
+                "phase": "initial",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "2d6",
+                  "img": null
+                },
+                "priority": 0
+              }
+            ],
+            "duration": {
+              "description": "",
+              "type": ""
+            },
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "IIFE1N9qCBIdwGJK",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "disabled": false,
+          "start": {
+            "time": 0,
+            "combat": null,
+            "combatant": null,
+            "initiative": null,
+            "round": null,
+            "turn": null
+          },
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "<p>When the Swarm has marked half or more of its HP, its standard attack deals <strong>2d6</strong> physical damage instead.</p>",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!2OjMAjcG3xbbsrIV.calCSfujA6x3qEaw.IIFE1N9qCBIdwGJK"
+        }
+      ],
       "folder": null,
       "sort": 0,
       "flags": {},
@@ -461,50 +527,7 @@
     "appendNumber": false,
     "prependAdjective": false
   },
-  "effects": [
-    {
-      "type": "horde",
-      "name": "Horde",
-      "img": "icons/magic/movement/chevrons-down-yellow.webp",
-      "disabled": true,
-      "_id": "EmsbPsxyYL4NYNYe",
-      "system": {
-        "changes": [],
-        "duration": {
-          "description": ""
-        },
-        "rangeDependence": null,
-        "stacking": null,
-        "targetDispositions": []
-      },
-      "start": {
-        "time": 0,
-        "combat": null,
-        "combatant": null,
-        "initiative": null,
-        "round": null,
-        "turn": null
-      },
-      "duration": {
-        "value": null,
-        "units": "seconds",
-        "expiry": null,
-        "expired": false
-      },
-      "description": "",
-      "tint": "#ffffff",
-      "transfer": false,
-      "statuses": [],
-      "showIcon": 1,
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.effects!2OjMAjcG3xbbsrIV.EmsbPsxyYL4NYNYe"
-    }
-  ],
+  "effects": [],
   "sort": 0,
   "flags": {},
   "_key": "!actors!2OjMAjcG3xbbsrIV"

--- a/src/packs/adversaries/adversary_Vampire_Bat_Swarm_2OjMAjcG3xbbsrIV.json
+++ b/src/packs/adversaries/adversary_Vampire_Bat_Swarm_2OjMAjcG3xbbsrIV.json
@@ -197,7 +197,7 @@
       "img": "icons/creatures/mammals/bats-movement-flying-black.webp",
       "effects": [
         {
-          "name": "New Effect",
+          "name": "Blinding Multitude",
           "disabled": false,
           "img": "icons/creatures/mammals/bats-movement-flying-black.webp",
           "description": "<p>Creatures within Melee range have disadvantage on attacks made against adversaries other than the Swarm.</p>",
@@ -416,7 +416,7 @@
           "tint": "#ffffff",
           "transfer": true,
           "statuses": [],
-          "showIcon": 1,
+          "showIcon": 2,
           "folder": null,
           "sort": 0,
           "flags": {},

--- a/src/packs/adversaries/adversary_Vampire_Bat_Swarm_2OjMAjcG3xbbsrIV.json
+++ b/src/packs/adversaries/adversary_Vampire_Bat_Swarm_2OjMAjcG3xbbsrIV.json
@@ -133,98 +133,14 @@
     "advantageSources": [],
     "disadvantageSources": [],
     "notes": "",
-    "criticalThreshold": 20
+    "criticalThreshold": 20,
+    "typeData": {
+      "type": "horde",
+      "hordeHP": 5,
+      "hordeDamage": "2d6"
+    }
   },
   "items": [
-    {
-      "name": "Horde (2d6)",
-      "type": "feature",
-      "system": {
-        "featureForm": "passive",
-        "description": "<p>When the Swarm has marked half or more of its HP, its standard attack deals <strong>2d6</strong> physical damage instead.</p>",
-        "attribution": {},
-        "gmNotes": "",
-        "resource": null,
-        "actions": {},
-        "granter": null
-      },
-      "_id": "calCSfujA6x3qEaw",
-      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [
-        {
-          "name": "Horde",
-          "type": "base",
-          "system": {
-            "changes": [
-              {
-                "type": "standardAttack",
-                "phase": "initial",
-                "value": {
-                  "name": "",
-                  "damageTypes": [],
-                  "attackRange": null,
-                  "trait": null,
-                  "damageFormula": "2d6",
-                  "img": null
-                },
-                "priority": 0
-              }
-            ],
-            "duration": {
-              "description": "",
-              "type": ""
-            },
-            "conditionals": [
-              {
-                "type": "dataCompare",
-                "key": "system.resources.hitPoints.value",
-                "comparator": "greaterEquals",
-                "value": "@system.resources.hitPoints.max / 2"
-              }
-            ],
-            "rangeDependence": null,
-            "stacking": null,
-            "targetDispositions": []
-          },
-          "_id": "IIFE1N9qCBIdwGJK",
-          "img": "icons/magic/movement/chevrons-down-yellow.webp",
-          "disabled": false,
-          "start": {
-            "time": 0,
-            "combat": null,
-            "combatant": null,
-            "initiative": null,
-            "round": null,
-            "turn": null
-          },
-          "duration": {
-            "value": null,
-            "units": "seconds",
-            "expiry": null,
-            "expired": false
-          },
-          "description": "<p>When the Swarm has marked half or more of its HP, its standard attack deals <strong>2d6</strong> physical damage instead.</p>",
-          "tint": "#ffffff",
-          "transfer": true,
-          "statuses": [],
-          "showIcon": 1,
-          "folder": null,
-          "sort": 0,
-          "flags": {},
-          "_stats": {
-            "compendiumSource": null
-          },
-          "_key": "!actors.items.effects!2OjMAjcG3xbbsrIV.calCSfujA6x3qEaw.IIFE1N9qCBIdwGJK"
-        }
-      ],
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.items!2OjMAjcG3xbbsrIV.calCSfujA6x3qEaw"
-    },
     {
       "name": "Blinding Multitude",
       "type": "feature",
@@ -431,6 +347,92 @@
         "compendiumSource": null
       },
       "_key": "!actors.items!2OjMAjcG3xbbsrIV.BkTf2P6CnWO7dr8d"
+    },
+    {
+      "type": "feature",
+      "name": "Horde",
+      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
+      "system": {
+        "description": "When the @Lookup[@name] have marked half or more of their HP, their standard attack deals @Lookup[@system.typeData.hordeDamage] @Lookup[@system.attackDamageType] damage instead.",
+        "attribution": {},
+        "gmNotes": "",
+        "resource": null,
+        "actions": {},
+        "granter": null,
+        "featureForm": "passive",
+        "actorResources": []
+      },
+      "flags": {
+        "daggerheart": {
+          "hordeFeature": true
+        }
+      },
+      "effects": [
+        {
+          "name": "Horde",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "system": {
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "changes": [
+              {
+                "type": "standardAttack",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "@system.typeData.hordeDamage",
+                  "img": null
+                },
+                "priority": 0,
+                "phase": "initial"
+              }
+            ],
+            "duration": {
+              "description": ""
+            },
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "eEOfPTgojxX819BW",
+          "type": "base",
+          "disabled": false,
+          "start": null,
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!2OjMAjcG3xbbsrIV.M3Kid57E1OAgvmgd.eEOfPTgojxX819BW"
+        }
+      ],
+      "_id": "M3Kid57E1OAgvmgd",
+      "folder": null,
+      "sort": -100000,
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!actors.items!2OjMAjcG3xbbsrIV.M3Kid57E1OAgvmgd"
     }
   ],
   "_id": "2OjMAjcG3xbbsrIV",

--- a/src/packs/adversaries/adversary_Will_o__the_wisps_XuGDFgTjn1vFQhyA.json
+++ b/src/packs/adversaries/adversary_Will_o__the_wisps_XuGDFgTjn1vFQhyA.json
@@ -150,7 +150,73 @@
       },
       "_id": "A6LQpawx7obs9Xok",
       "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [],
+      "effects": [
+        {
+          "name": "Horde",
+          "type": "base",
+          "system": {
+            "changes": [
+              {
+                "type": "standardAttack",
+                "phase": "initial",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "1d4 - 1",
+                  "img": null
+                },
+                "priority": 0
+              }
+            ],
+            "duration": {
+              "description": "",
+              "type": ""
+            },
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "GRBDJIOldOQbBW2V",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "disabled": false,
+          "start": {
+            "time": 0,
+            "combat": null,
+            "combatant": null,
+            "initiative": null,
+            "round": null,
+            "turn": null
+          },
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "<p>When the Will-o'-the-wisps have marked half or more of their HP, their standard attack deals <strong>1d4-1</strong> magic damage instead.</p>",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!XuGDFgTjn1vFQhyA.A6LQpawx7obs9Xok.GRBDJIOldOQbBW2V"
+        }
+      ],
       "folder": null,
       "sort": 0,
       "flags": {},
@@ -486,50 +552,7 @@
     "appendNumber": false,
     "prependAdjective": false
   },
-  "effects": [
-    {
-      "type": "horde",
-      "name": "Horde",
-      "img": "icons/magic/movement/chevrons-down-yellow.webp",
-      "disabled": true,
-      "_id": "PLojodJbqujkTtDD",
-      "system": {
-        "changes": [],
-        "duration": {
-          "description": ""
-        },
-        "rangeDependence": null,
-        "stacking": null,
-        "targetDispositions": []
-      },
-      "start": {
-        "time": 0,
-        "combat": null,
-        "combatant": null,
-        "initiative": null,
-        "round": null,
-        "turn": null
-      },
-      "duration": {
-        "value": null,
-        "units": "seconds",
-        "expiry": null,
-        "expired": false
-      },
-      "description": "",
-      "tint": "#ffffff",
-      "transfer": false,
-      "statuses": [],
-      "showIcon": 1,
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.effects!XuGDFgTjn1vFQhyA.PLojodJbqujkTtDD"
-    }
-  ],
+  "effects": [],
   "sort": 0,
   "flags": {},
   "_key": "!actors!XuGDFgTjn1vFQhyA"

--- a/src/packs/adversaries/adversary_Will_o__the_wisps_XuGDFgTjn1vFQhyA.json
+++ b/src/packs/adversaries/adversary_Will_o__the_wisps_XuGDFgTjn1vFQhyA.json
@@ -133,98 +133,14 @@
     "advantageSources": [],
     "disadvantageSources": [],
     "notes": "",
-    "criticalThreshold": 20
+    "criticalThreshold": 20,
+    "typeData": {
+      "type": "horde",
+      "hordeHP": 8,
+      "hordeDamage": "1d4-1"
+    }
   },
   "items": [
-    {
-      "name": "Horde (1d4-1)",
-      "type": "feature",
-      "system": {
-        "featureForm": "passive",
-        "description": "<p>When the @Lookup[@name] have marked half or more of their HP, their standard attack deals <strong>1d4-1</strong> magic damage instead.</p>",
-        "attribution": {},
-        "gmNotes": "",
-        "resource": null,
-        "actions": {},
-        "granter": null
-      },
-      "_id": "A6LQpawx7obs9Xok",
-      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [
-        {
-          "name": "Horde",
-          "type": "base",
-          "system": {
-            "changes": [
-              {
-                "type": "standardAttack",
-                "phase": "initial",
-                "value": {
-                  "name": "",
-                  "damageTypes": [],
-                  "attackRange": null,
-                  "trait": null,
-                  "damageFormula": "1d4 - 1",
-                  "img": null
-                },
-                "priority": 0
-              }
-            ],
-            "duration": {
-              "description": "",
-              "type": ""
-            },
-            "conditionals": [
-              {
-                "type": "dataCompare",
-                "key": "system.resources.hitPoints.value",
-                "comparator": "greaterEquals",
-                "value": "@system.resources.hitPoints.max / 2"
-              }
-            ],
-            "rangeDependence": null,
-            "stacking": null,
-            "targetDispositions": []
-          },
-          "_id": "GRBDJIOldOQbBW2V",
-          "img": "icons/magic/movement/chevrons-down-yellow.webp",
-          "disabled": false,
-          "start": {
-            "time": 0,
-            "combat": null,
-            "combatant": null,
-            "initiative": null,
-            "round": null,
-            "turn": null
-          },
-          "duration": {
-            "value": null,
-            "units": "seconds",
-            "expiry": null,
-            "expired": false
-          },
-          "description": "<p>When the Will-o'-the-wisps have marked half or more of their HP, their standard attack deals <strong>1d4-1</strong> magic damage instead.</p>",
-          "tint": "#ffffff",
-          "transfer": true,
-          "statuses": [],
-          "showIcon": 1,
-          "folder": null,
-          "sort": 0,
-          "flags": {},
-          "_stats": {
-            "compendiumSource": null
-          },
-          "_key": "!actors.items.effects!XuGDFgTjn1vFQhyA.A6LQpawx7obs9Xok.GRBDJIOldOQbBW2V"
-        }
-      ],
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.items!XuGDFgTjn1vFQhyA.A6LQpawx7obs9Xok"
-    },
     {
       "name": "Kaleidoscopic",
       "type": "feature",
@@ -456,6 +372,92 @@
         "compendiumSource": null
       },
       "_key": "!actors.items!XuGDFgTjn1vFQhyA.fPWnXgxGnlfZXyto"
+    },
+    {
+      "type": "feature",
+      "name": "Horde",
+      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
+      "system": {
+        "description": "When the @Lookup[@name] have marked half or more of their HP, their standard attack deals @Lookup[@system.typeData.hordeDamage] @Lookup[@system.attackDamageType] damage instead.",
+        "attribution": {},
+        "gmNotes": "",
+        "resource": null,
+        "actions": {},
+        "granter": null,
+        "featureForm": "passive",
+        "actorResources": []
+      },
+      "flags": {
+        "daggerheart": {
+          "hordeFeature": true
+        }
+      },
+      "effects": [
+        {
+          "name": "Horde",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "system": {
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "changes": [
+              {
+                "type": "standardAttack",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "@system.typeData.hordeDamage",
+                  "img": null
+                },
+                "priority": 0,
+                "phase": "initial"
+              }
+            ],
+            "duration": {
+              "description": ""
+            },
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "bYHVkkNOwiLfZGsM",
+          "type": "base",
+          "disabled": false,
+          "start": null,
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!XuGDFgTjn1vFQhyA.ZQC4MrKxru5TzPEc.bYHVkkNOwiLfZGsM"
+        }
+      ],
+      "_id": "ZQC4MrKxru5TzPEc",
+      "folder": null,
+      "sort": -100000,
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!actors.items!XuGDFgTjn1vFQhyA.ZQC4MrKxru5TzPEc"
     }
   ],
   "_id": "XuGDFgTjn1vFQhyA",

--- a/src/packs/adversaries/adversary_Will_o__the_wisps_XuGDFgTjn1vFQhyA.json
+++ b/src/packs/adversaries/adversary_Will_o__the_wisps_XuGDFgTjn1vFQhyA.json
@@ -441,7 +441,7 @@
           "tint": "#ffffff",
           "transfer": true,
           "statuses": [],
-          "showIcon": 1,
+          "showIcon": 2,
           "folder": null,
           "sort": 0,
           "flags": {},

--- a/src/packs/adversaries/adversary_Wyrmlings_qEzuNntzQ1fRInTm.json
+++ b/src/packs/adversaries/adversary_Wyrmlings_qEzuNntzQ1fRInTm.json
@@ -150,7 +150,73 @@
       },
       "_id": "MBr2VXrxSLztwRp1",
       "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [],
+      "effects": [
+        {
+          "name": "Horde",
+          "type": "base",
+          "system": {
+            "changes": [
+              {
+                "type": "standardAttack",
+                "phase": "initial",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "2d6 + 5",
+                  "img": null
+                },
+                "priority": 0
+              }
+            ],
+            "duration": {
+              "description": "",
+              "type": ""
+            },
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "8E1Ew7XvhA9LqzdN",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "disabled": false,
+          "start": {
+            "time": 0,
+            "combat": null,
+            "combatant": null,
+            "initiative": null,
+            "round": null,
+            "turn": null
+          },
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "<p>When the Wyrmlings have marked half or more of their HP, their standard attack deals <strong>2d6+5</strong> physical damage instead.</p>",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!qEzuNntzQ1fRInTm.MBr2VXrxSLztwRp1.8E1Ew7XvhA9LqzdN"
+        }
+      ],
       "folder": null,
       "sort": 0,
       "flags": {},

--- a/src/packs/adversaries/adversary_Wyrmlings_qEzuNntzQ1fRInTm.json
+++ b/src/packs/adversaries/adversary_Wyrmlings_qEzuNntzQ1fRInTm.json
@@ -386,7 +386,7 @@
           "tint": "#ffffff",
           "transfer": true,
           "statuses": [],
-          "showIcon": 1,
+          "showIcon": 2,
           "folder": null,
           "sort": 0,
           "flags": {},

--- a/src/packs/adversaries/adversary_Wyrmlings_qEzuNntzQ1fRInTm.json
+++ b/src/packs/adversaries/adversary_Wyrmlings_qEzuNntzQ1fRInTm.json
@@ -133,98 +133,14 @@
     "advantageSources": [],
     "disadvantageSources": [],
     "notes": "",
-    "criticalThreshold": 20
+    "criticalThreshold": 20,
+    "typeData": {
+      "type": "horde",
+      "hordeHP": 3,
+      "hordeDamage": "2d6+5"
+    }
   },
   "items": [
-    {
-      "name": "Horde (2d6+5)",
-      "type": "feature",
-      "system": {
-        "featureForm": "passive",
-        "description": "<p>When the @Lookup[@name] have marked half or more of their HP, their standard attack deals <strong>2d6+5</strong> physical damage instead.</p>",
-        "attribution": {},
-        "gmNotes": "",
-        "resource": null,
-        "actions": {},
-        "granter": null
-      },
-      "_id": "MBr2VXrxSLztwRp1",
-      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [
-        {
-          "name": "Horde",
-          "type": "base",
-          "system": {
-            "changes": [
-              {
-                "type": "standardAttack",
-                "phase": "initial",
-                "value": {
-                  "name": "",
-                  "damageTypes": [],
-                  "attackRange": null,
-                  "trait": null,
-                  "damageFormula": "2d6 + 5",
-                  "img": null
-                },
-                "priority": 0
-              }
-            ],
-            "duration": {
-              "description": "",
-              "type": ""
-            },
-            "conditionals": [
-              {
-                "type": "dataCompare",
-                "key": "system.resources.hitPoints.value",
-                "comparator": "greaterEquals",
-                "value": "@system.resources.hitPoints.max / 2"
-              }
-            ],
-            "rangeDependence": null,
-            "stacking": null,
-            "targetDispositions": []
-          },
-          "_id": "8E1Ew7XvhA9LqzdN",
-          "img": "icons/magic/movement/chevrons-down-yellow.webp",
-          "disabled": false,
-          "start": {
-            "time": 0,
-            "combat": null,
-            "combatant": null,
-            "initiative": null,
-            "round": null,
-            "turn": null
-          },
-          "duration": {
-            "value": null,
-            "units": "seconds",
-            "expiry": null,
-            "expired": false
-          },
-          "description": "<p>When the Wyrmlings have marked half or more of their HP, their standard attack deals <strong>2d6+5</strong> physical damage instead.</p>",
-          "tint": "#ffffff",
-          "transfer": true,
-          "statuses": [],
-          "showIcon": 1,
-          "folder": null,
-          "sort": 0,
-          "flags": {},
-          "_stats": {
-            "compendiumSource": null
-          },
-          "_key": "!actors.items.effects!qEzuNntzQ1fRInTm.MBr2VXrxSLztwRp1.8E1Ew7XvhA9LqzdN"
-        }
-      ],
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.items!qEzuNntzQ1fRInTm.MBr2VXrxSLztwRp1"
-    },
     {
       "name": "Ravenous",
       "type": "feature",
@@ -401,6 +317,92 @@
         "compendiumSource": null
       },
       "_key": "!actors.items!qEzuNntzQ1fRInTm.4YHJFU5RYQJqHK7a"
+    },
+    {
+      "type": "feature",
+      "name": "Horde",
+      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
+      "system": {
+        "description": "When the @Lookup[@name] have marked half or more of their HP, their standard attack deals @Lookup[@system.typeData.hordeDamage] @Lookup[@system.attackDamageType] damage instead.",
+        "attribution": {},
+        "gmNotes": "",
+        "resource": null,
+        "actions": {},
+        "granter": null,
+        "featureForm": "passive",
+        "actorResources": []
+      },
+      "flags": {
+        "daggerheart": {
+          "hordeFeature": true
+        }
+      },
+      "effects": [
+        {
+          "name": "Horde",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "system": {
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "changes": [
+              {
+                "type": "standardAttack",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "@system.typeData.hordeDamage",
+                  "img": null
+                },
+                "priority": 0,
+                "phase": "initial"
+              }
+            ],
+            "duration": {
+              "description": ""
+            },
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "ocjTjNuzRvpiMGoY",
+          "type": "base",
+          "disabled": false,
+          "start": null,
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!qEzuNntzQ1fRInTm.sxBN0IiN4x5q8muo.ocjTjNuzRvpiMGoY"
+        }
+      ],
+      "_id": "sxBN0IiN4x5q8muo",
+      "folder": null,
+      "sort": 0,
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!actors.items!qEzuNntzQ1fRInTm.sxBN0IiN4x5q8muo"
     }
   ],
   "_id": "qEzuNntzQ1fRInTm",

--- a/src/packs/adversaries/adversary_Zombie_Legion_YhJrP7rTBiRdX5Fp.json
+++ b/src/packs/adversaries/adversary_Zombie_Legion_YhJrP7rTBiRdX5Fp.json
@@ -241,7 +241,73 @@
       },
       "_id": "FYwMzXwULePzFyYJ",
       "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [],
+      "effects": [
+        {
+          "name": "Horde",
+          "type": "base",
+          "system": {
+            "changes": [
+              {
+                "type": "standardAttack",
+                "phase": "initial",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "2d6 + 5",
+                  "img": null
+                },
+                "priority": 0
+              }
+            ],
+            "duration": {
+              "description": "",
+              "type": ""
+            },
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "4Hb98gh7G6V6et9R",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "disabled": false,
+          "start": {
+            "time": 0,
+            "combat": null,
+            "combatant": null,
+            "initiative": null,
+            "round": null,
+            "turn": null
+          },
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "<p>When the Zombie Legion has marked half or more of their HP, their standard attack deals <strong>2d6 + 5</strong> physical damage instead.</p>",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!YhJrP7rTBiRdX5Fp.FYwMzXwULePzFyYJ.4Hb98gh7G6V6et9R"
+        }
+      ],
       "folder": null,
       "sort": 0,
       "flags": {},
@@ -442,49 +508,6 @@
       "_key": "!actors.items!YhJrP7rTBiRdX5Fp.d5Vilu9cUub1O6TD"
     }
   ],
-  "effects": [
-    {
-      "type": "horde",
-      "name": "Horde",
-      "img": "icons/magic/movement/chevrons-down-yellow.webp",
-      "disabled": true,
-      "_id": "9D6SteWlhbfMPhvt",
-      "system": {
-        "changes": [],
-        "duration": {
-          "description": ""
-        },
-        "rangeDependence": null,
-        "stacking": null,
-        "targetDispositions": []
-      },
-      "duration": {
-        "value": null,
-        "units": "seconds",
-        "expiry": null,
-        "expired": false
-      },
-      "description": "",
-      "tint": "#ffffff",
-      "transfer": false,
-      "statuses": [],
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "start": {
-        "combat": null,
-        "time": 0,
-        "combatant": null,
-        "initiative": null,
-        "round": null,
-        "turn": null
-      },
-      "showIcon": 1,
-      "folder": null,
-      "_key": "!actors.effects!YhJrP7rTBiRdX5Fp.9D6SteWlhbfMPhvt"
-    }
-  ],
+  "effects": [],
   "_key": "!actors!YhJrP7rTBiRdX5Fp"
 }

--- a/src/packs/adversaries/adversary_Zombie_Legion_YhJrP7rTBiRdX5Fp.json
+++ b/src/packs/adversaries/adversary_Zombie_Legion_YhJrP7rTBiRdX5Fp.json
@@ -129,7 +129,12 @@
     "size": "huge",
     "advantageSources": [],
     "disadvantageSources": [],
-    "criticalThreshold": 20
+    "criticalThreshold": 20,
+    "typeData": {
+      "type": "horde",
+      "hordeHP": 3,
+      "hordeDamage": "2d6+5"
+    }
   },
   "flags": {},
   "_id": "YhJrP7rTBiRdX5Fp",
@@ -228,95 +233,6 @@
   },
   "items": [
     {
-      "name": "Horde",
-      "type": "feature",
-      "system": {
-        "description": "<p>When the @Lookup[@name] has marked half or more of their HP, their standard attack deals <strong>@Lookup[@system.attack.altDamageFormula]</strong> physical damage instead.</p>",
-        "resource": null,
-        "actions": {},
-        "attribution": {},
-        "gmNotes": "",
-        "featureForm": "passive",
-        "granter": null
-      },
-      "_id": "FYwMzXwULePzFyYJ",
-      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "effects": [
-        {
-          "name": "Horde",
-          "type": "base",
-          "system": {
-            "changes": [
-              {
-                "type": "standardAttack",
-                "phase": "initial",
-                "value": {
-                  "name": "",
-                  "damageTypes": [],
-                  "attackRange": null,
-                  "trait": null,
-                  "damageFormula": "2d6 + 5",
-                  "img": null
-                },
-                "priority": 0
-              }
-            ],
-            "duration": {
-              "description": "",
-              "type": ""
-            },
-            "conditionals": [
-              {
-                "type": "dataCompare",
-                "key": "system.resources.hitPoints.value",
-                "comparator": "greaterEquals",
-                "value": "@system.resources.hitPoints.max / 2"
-              }
-            ],
-            "rangeDependence": null,
-            "stacking": null,
-            "targetDispositions": []
-          },
-          "_id": "4Hb98gh7G6V6et9R",
-          "img": "icons/magic/movement/chevrons-down-yellow.webp",
-          "disabled": false,
-          "start": {
-            "time": 0,
-            "combat": null,
-            "combatant": null,
-            "initiative": null,
-            "round": null,
-            "turn": null
-          },
-          "duration": {
-            "value": null,
-            "units": "seconds",
-            "expiry": null,
-            "expired": false
-          },
-          "description": "<p>When the Zombie Legion has marked half or more of their HP, their standard attack deals <strong>2d6 + 5</strong> physical damage instead.</p>",
-          "tint": "#ffffff",
-          "transfer": true,
-          "statuses": [],
-          "showIcon": 1,
-          "folder": null,
-          "sort": 0,
-          "flags": {},
-          "_stats": {
-            "compendiumSource": null
-          },
-          "_key": "!actors.items.effects!YhJrP7rTBiRdX5Fp.FYwMzXwULePzFyYJ.4Hb98gh7G6V6et9R"
-        }
-      ],
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.items!YhJrP7rTBiRdX5Fp.FYwMzXwULePzFyYJ"
-    },
-    {
       "name": "Unyielding",
       "type": "feature",
       "system": {
@@ -376,7 +292,7 @@
         }
       ],
       "folder": null,
-      "sort": 0,
+      "sort": 100000,
       "flags": {},
       "_stats": {
         "compendiumSource": null
@@ -438,7 +354,7 @@
       "img": "icons/magic/unholy/silhouette-evil-horned-giant.webp",
       "effects": [],
       "folder": null,
-      "sort": 0,
+      "sort": 300000,
       "flags": {},
       "_stats": {
         "compendiumSource": null
@@ -506,6 +422,92 @@
         "compendiumSource": null
       },
       "_key": "!actors.items!YhJrP7rTBiRdX5Fp.d5Vilu9cUub1O6TD"
+    },
+    {
+      "type": "feature",
+      "name": "Horde",
+      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
+      "system": {
+        "description": "When the @Lookup[@name] have marked half or more of their HP, their standard attack deals @Lookup[@system.typeData.hordeDamage] @Lookup[@system.attackDamageType] damage instead.",
+        "attribution": {},
+        "gmNotes": "",
+        "resource": null,
+        "actions": {},
+        "granter": null,
+        "featureForm": "passive",
+        "actorResources": []
+      },
+      "flags": {
+        "daggerheart": {
+          "hordeFeature": true
+        }
+      },
+      "effects": [
+        {
+          "name": "Horde",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "system": {
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "changes": [
+              {
+                "type": "standardAttack",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "@system.typeData.hordeDamage",
+                  "img": null
+                },
+                "priority": 0,
+                "phase": "initial"
+              }
+            ],
+            "duration": {
+              "description": ""
+            },
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "wlNvZCyi0XgT3ZGH",
+          "type": "base",
+          "disabled": false,
+          "start": null,
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!YhJrP7rTBiRdX5Fp.ev6N5c7QLe5dUwqI.wlNvZCyi0XgT3ZGH"
+        }
+      ],
+      "_id": "ev6N5c7QLe5dUwqI",
+      "folder": null,
+      "sort": 0,
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!actors.items!YhJrP7rTBiRdX5Fp.ev6N5c7QLe5dUwqI"
     }
   ],
   "effects": [],

--- a/src/packs/adversaries/adversary_Zombie_Legion_YhJrP7rTBiRdX5Fp.json
+++ b/src/packs/adversaries/adversary_Zombie_Legion_YhJrP7rTBiRdX5Fp.json
@@ -491,7 +491,7 @@
           "tint": "#ffffff",
           "transfer": true,
           "statuses": [],
-          "showIcon": 1,
+          "showIcon": 2,
           "folder": null,
           "sort": 0,
           "flags": {},

--- a/src/packs/adversaries/adversary_Zombie_Pack_Nf0v43rtflV56V2T.json
+++ b/src/packs/adversaries/adversary_Zombie_Pack_Nf0v43rtflV56V2T.json
@@ -241,7 +241,73 @@
         "featureForm": "passive",
         "granter": null
       },
-      "effects": [],
+      "effects": [
+        {
+          "name": "Horde",
+          "type": "base",
+          "system": {
+            "changes": [
+              {
+                "type": "standardAttack",
+                "phase": "initial",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "1d4 + 2",
+                  "img": null
+                },
+                "priority": 0
+              }
+            ],
+            "duration": {
+              "description": "",
+              "type": ""
+            },
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "USpNpYwvbcvZWw24",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "disabled": false,
+          "start": {
+            "time": 0,
+            "combat": null,
+            "combatant": null,
+            "initiative": null,
+            "round": null,
+            "turn": null
+          },
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "<p>When the Zombie Pack have marked half or more of their HP, their standard attack deals <strong>1d4 + 2</strong> physical damage instead.</p>",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!Nf0v43rtflV56V2T.nNJGAhWu0IuS2ybn.USpNpYwvbcvZWw24"
+        }
+      ],
       "folder": null,
       "sort": 0,
       "flags": {},
@@ -313,49 +379,6 @@
       "_key": "!actors.items!Nf0v43rtflV56V2T.jQmltra0ovHE33Nx"
     }
   ],
-  "effects": [
-    {
-      "type": "horde",
-      "name": "Horde",
-      "img": "icons/magic/movement/chevrons-down-yellow.webp",
-      "disabled": true,
-      "_id": "aWWZTlNS9zYoUay7",
-      "system": {
-        "changes": [],
-        "duration": {
-          "description": ""
-        },
-        "rangeDependence": null,
-        "stacking": null,
-        "targetDispositions": []
-      },
-      "duration": {
-        "value": null,
-        "units": "seconds",
-        "expiry": null,
-        "expired": false
-      },
-      "description": "",
-      "tint": "#ffffff",
-      "transfer": false,
-      "statuses": [],
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "start": {
-        "combat": null,
-        "time": 0,
-        "combatant": null,
-        "initiative": null,
-        "round": null,
-        "turn": null
-      },
-      "showIcon": 1,
-      "folder": null,
-      "_key": "!actors.effects!Nf0v43rtflV56V2T.aWWZTlNS9zYoUay7"
-    }
-  ],
+  "effects": [],
   "_key": "!actors!Nf0v43rtflV56V2T"
 }

--- a/src/packs/adversaries/adversary_Zombie_Pack_Nf0v43rtflV56V2T.json
+++ b/src/packs/adversaries/adversary_Zombie_Pack_Nf0v43rtflV56V2T.json
@@ -129,7 +129,12 @@
     "size": "huge",
     "advantageSources": [],
     "disadvantageSources": [],
-    "criticalThreshold": 20
+    "criticalThreshold": 20,
+    "typeData": {
+      "type": "horde",
+      "hordeHP": 2,
+      "hordeDamage": "1d4+2"
+    }
   },
   "flags": {},
   "_id": "Nf0v43rtflV56V2T",
@@ -228,95 +233,6 @@
   },
   "items": [
     {
-      "name": "Horde",
-      "type": "feature",
-      "_id": "nNJGAhWu0IuS2ybn",
-      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
-      "system": {
-        "description": "<p>When the @Lookup[@name] have marked half or more of their HP, their standard attack deals <strong>@Lookup[@system.attack.altDamageFormula]</strong> physical damage instead.</p>",
-        "resource": null,
-        "actions": {},
-        "attribution": {},
-        "gmNotes": "",
-        "featureForm": "passive",
-        "granter": null
-      },
-      "effects": [
-        {
-          "name": "Horde",
-          "type": "base",
-          "system": {
-            "changes": [
-              {
-                "type": "standardAttack",
-                "phase": "initial",
-                "value": {
-                  "name": "",
-                  "damageTypes": [],
-                  "attackRange": null,
-                  "trait": null,
-                  "damageFormula": "1d4 + 2",
-                  "img": null
-                },
-                "priority": 0
-              }
-            ],
-            "duration": {
-              "description": "",
-              "type": ""
-            },
-            "conditionals": [
-              {
-                "type": "dataCompare",
-                "key": "system.resources.hitPoints.value",
-                "comparator": "greaterEquals",
-                "value": "@system.resources.hitPoints.max / 2"
-              }
-            ],
-            "rangeDependence": null,
-            "stacking": null,
-            "targetDispositions": []
-          },
-          "_id": "USpNpYwvbcvZWw24",
-          "img": "icons/magic/movement/chevrons-down-yellow.webp",
-          "disabled": false,
-          "start": {
-            "time": 0,
-            "combat": null,
-            "combatant": null,
-            "initiative": null,
-            "round": null,
-            "turn": null
-          },
-          "duration": {
-            "value": null,
-            "units": "seconds",
-            "expiry": null,
-            "expired": false
-          },
-          "description": "<p>When the Zombie Pack have marked half or more of their HP, their standard attack deals <strong>1d4 + 2</strong> physical damage instead.</p>",
-          "tint": "#ffffff",
-          "transfer": true,
-          "statuses": [],
-          "showIcon": 1,
-          "folder": null,
-          "sort": 0,
-          "flags": {},
-          "_stats": {
-            "compendiumSource": null
-          },
-          "_key": "!actors.items.effects!Nf0v43rtflV56V2T.nNJGAhWu0IuS2ybn.USpNpYwvbcvZWw24"
-        }
-      ],
-      "folder": null,
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null
-      },
-      "_key": "!actors.items!Nf0v43rtflV56V2T.nNJGAhWu0IuS2ybn"
-    },
-    {
       "name": "Overwhelm",
       "type": "feature",
       "_id": "jQmltra0ovHE33Nx",
@@ -377,6 +293,92 @@
         "compendiumSource": null
       },
       "_key": "!actors.items!Nf0v43rtflV56V2T.jQmltra0ovHE33Nx"
+    },
+    {
+      "type": "feature",
+      "name": "Horde",
+      "img": "icons/creatures/magical/humanoid-silhouette-aliens-green.webp",
+      "system": {
+        "description": "When the @Lookup[@name] have marked half or more of their HP, their standard attack deals @Lookup[@system.typeData.hordeDamage] @Lookup[@system.attackDamageType] damage instead.",
+        "attribution": {},
+        "gmNotes": "",
+        "resource": null,
+        "actions": {},
+        "granter": null,
+        "featureForm": "passive",
+        "actorResources": []
+      },
+      "flags": {
+        "daggerheart": {
+          "hordeFeature": true
+        }
+      },
+      "effects": [
+        {
+          "name": "Horde",
+          "img": "icons/magic/movement/chevrons-down-yellow.webp",
+          "system": {
+            "conditionals": [
+              {
+                "type": "dataCompare",
+                "key": "system.resources.hitPoints.value",
+                "comparator": "greaterEquals",
+                "value": "@system.resources.hitPoints.max / 2"
+              }
+            ],
+            "changes": [
+              {
+                "type": "standardAttack",
+                "value": {
+                  "name": "",
+                  "damageTypes": [],
+                  "attackRange": null,
+                  "trait": null,
+                  "damageFormula": "@system.typeData.hordeDamage",
+                  "img": null
+                },
+                "priority": 0,
+                "phase": "initial"
+              }
+            ],
+            "duration": {
+              "description": ""
+            },
+            "rangeDependence": null,
+            "stacking": null,
+            "targetDispositions": []
+          },
+          "_id": "yIOSUIAtVEY0pxG9",
+          "type": "base",
+          "disabled": false,
+          "start": null,
+          "duration": {
+            "value": null,
+            "units": "seconds",
+            "expiry": null,
+            "expired": false
+          },
+          "description": "",
+          "tint": "#ffffff",
+          "transfer": true,
+          "statuses": [],
+          "showIcon": 1,
+          "folder": null,
+          "sort": 0,
+          "flags": {},
+          "_stats": {
+            "compendiumSource": null
+          },
+          "_key": "!actors.items.effects!Nf0v43rtflV56V2T.9PpKuGD3Q6eTnaIh.yIOSUIAtVEY0pxG9"
+        }
+      ],
+      "_id": "9PpKuGD3Q6eTnaIh",
+      "folder": null,
+      "sort": 0,
+      "_stats": {
+        "compendiumSource": null
+      },
+      "_key": "!actors.items!Nf0v43rtflV56V2T.9PpKuGD3Q6eTnaIh"
     }
   ],
   "effects": [],

--- a/src/packs/adversaries/adversary_Zombie_Pack_Nf0v43rtflV56V2T.json
+++ b/src/packs/adversaries/adversary_Zombie_Pack_Nf0v43rtflV56V2T.json
@@ -362,7 +362,7 @@
           "tint": "#ffffff",
           "transfer": true,
           "statuses": [],
-          "showIcon": 1,
+          "showIcon": 2,
           "folder": null,
           "sort": 0,
           "flags": {},

--- a/styles/less/global/elements.less
+++ b/styles/less/global/elements.less
@@ -361,6 +361,14 @@
             font-weight: bold;
             color: @color-text-emphatic;
 
+            &.with-select {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+                padding-left: 8px;
+                padding-right: 8px;
+            }
+
             &.with-icon {
                 display: flex;
                 align-items: center;

--- a/styles/less/sheets/activeEffects/activeEffects.less
+++ b/styles/less/sheets/activeEffects/activeEffects.less
@@ -29,12 +29,12 @@
 
     .tab.conditionals {
         .conditional-outer-container {
-            .data-compare-container {
+            .conditional-container {
                 display: flex;
                 align-items: center;
                 gap: 4px;
 
-                .data-compare-inner-container {
+                .conditional-inner-container {
                     display: flex;
                     align-items: center;
                     gap: 4px;

--- a/styles/less/sheets/activeEffects/activeEffects.less
+++ b/styles/less/sheets/activeEffects/activeEffects.less
@@ -13,6 +13,10 @@
         }
     }
 
+    .form-row-icon {
+        margin-top: 14px;
+    }
+
     .duration-description {
         height: 0;
         overflow: hidden;
@@ -20,6 +24,31 @@
 
         &.visible {
             height: 100px;
+        }
+    }
+
+    .tab.conditionals {
+        .conditional-outer-container {
+            .data-compare-container {
+                display: flex;
+                align-items: center;
+                gap: 4px;
+
+                .data-compare-inner-container {
+                    display: flex;
+                    align-items: center;
+                    gap: 4px;
+
+                    .form-group {
+                        display: block;
+                        
+                        label {
+                            line-height: normal;
+                            color: inherit;
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/styles/less/sheets/activeEffects/activeEffects.less
+++ b/styles/less/sheets/activeEffects/activeEffects.less
@@ -28,24 +28,22 @@
     }
 
     .tab.conditionals {
-        .conditional-outer-container {
-            .conditional-container {
+        .conditional-container {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+
+            .conditional-inner-container {
                 display: flex;
                 align-items: center;
                 gap: 4px;
 
-                .conditional-inner-container {
-                    display: flex;
-                    align-items: center;
-                    gap: 4px;
-
-                    .form-group {
-                        display: block;
-                        
-                        label {
-                            line-height: normal;
-                            color: inherit;
-                        }
+                .form-group {
+                    display: block;
+                    
+                    label {
+                        line-height: normal;
+                        color: inherit;
                     }
                 }
             }

--- a/system.json
+++ b/system.json
@@ -300,8 +300,7 @@
             }
         },
         "ActiveEffect": {
-            "beastform": {},
-            "horde": {}
+            "beastform": {}
         },
         "Combat": {
             "combat": {}

--- a/templates/actionTypes/damage.hbs
+++ b/templates/actionTypes/damage.hbs
@@ -22,9 +22,6 @@
                 {{/if}}
             </div>
             {{> damageData damage=source.main fields=fields.main.fields basePath=(concat path "damage.main")}}
-            {{#if horde}}
-                {{> hordeDamage source=source.main fields=fields.main.fields basePath=(concat path "damage.main")}}
-            {{/if}}
             {{#if (ne @root.source.type 'healing')}}
                 {{formField fields.main.fields.type value=source.main.type name=(concat path "damage.main.type") localize=true}}
             {{/if}}
@@ -103,16 +100,4 @@
         {{> formula key=damage.applyTo fields=fields.value.fields type=fields.type isBase=damage.base source=damage.value basePath=(concat basePath ".value")}}
     {{/if}}
     <input type="hidden" name="{{concat basePath ".base"}}" value="{{damage.base}}">
-{{/inline}}
-
-{{#*inline "hordeDamage"}}
-    <fieldset class="one-column">
-        <legend>{{localize "DAGGERHEART.ACTORS.Adversary.hordeDamage"}}</legend>
-        <div class="nest-inputs">
-            <input type="hidden" name="{{basePath}}.valueAlt.multiplier" value="flat">
-            {{formField fields.valueAlt.fields.flatMultiplier value=source.valueAlt.flatMultiplier name=(concat basePath ".valueAlt.flatMultiplier") label="DAGGERHEART.ACTIONS.Settings.multiplier" classes="inline-child" localize=true }}
-            {{formField fields.valueAlt.fields.dice value=source.valueAlt.dice name=(concat basePath ".valueAlt.dice") classes="inline-child" localize=true}}
-            {{formField fields.valueAlt.fields.bonus value=source.valueAlt.bonus name=(concat basePath ".valueAlt.bonus") localize=true classes="inline-child"}}
-        </div>
-    </fieldset>
 {{/inline}}

--- a/templates/sheets-settings/adversary-settings/attack.hbs
+++ b/templates/sheets-settings/adversary-settings/attack.hbs
@@ -29,6 +29,6 @@
         {{/if}}
     </fieldset>
     {{#if document._source.system.attack}}
-        {{> 'systems/daggerheart/templates/actionTypes/damage.hbs' fields=systemFields.attack.fields.damage.fields source=document.system.attack.damage path="system.attack." baseFields=systemFields.attack.fields.damage.fields horde=(eq document._source.system.type 'horde')}}
+        {{> 'systems/daggerheart/templates/actionTypes/damage.hbs' fields=systemFields.attack.fields.damage.fields source=document.system.attack.damage path="system.attack." baseFields=systemFields.attack.fields.damage.fields }}
     {{/if}}
 </section>

--- a/templates/sheets-settings/adversary-settings/attack.hbs
+++ b/templates/sheets-settings/adversary-settings/attack.hbs
@@ -31,4 +31,7 @@
     {{#if document._source.system.attack}}
         {{> 'systems/daggerheart/templates/actionTypes/damage.hbs' fields=systemFields.attack.fields.damage.fields source=document.system.attack.damage path="system.attack." baseFields=systemFields.attack.fields.damage.fields }}
     {{/if}}
+    {{#if (eq document._source.system.type 'horde')}}
+        {{formGroup typeDataFields.hordeDamage value=document._source.system.typeData.hordeDamage name="system.typeData.hordeDamage" localize=true}}
+    {{/if}}
 </section>

--- a/templates/sheets-settings/adversary-settings/attack.hbs
+++ b/templates/sheets-settings/adversary-settings/attack.hbs
@@ -29,7 +29,7 @@
         {{/if}}
     </fieldset>
     {{#if document._source.system.attack}}
-        {{> 'systems/daggerheart/templates/actionTypes/damage.hbs' fields=systemFields.attack.fields.damage.fields source=document.system.attack.damage path="system.attack." baseFields=systemFields.attack.fields.damage.fields }}
+        {{> 'systems/daggerheart/templates/actionTypes/damage.hbs' fields=systemFields.attack.fields.damage.fields source=document._source.system.attack.damage path="system.attack." baseFields=systemFields.attack.fields.damage.fields }}
     {{/if}}
     {{#if (eq document._source.system.type 'horde')}}
         {{formGroup typeDataFields.hordeDamage value=document._source.system.typeData.hordeDamage name="system.typeData.hordeDamage" localize=true}}

--- a/templates/sheets-settings/adversary-settings/details.hbs
+++ b/templates/sheets-settings/adversary-settings/details.hbs
@@ -8,8 +8,8 @@
         <div class="nest-inputs">
             {{formGroup systemFields.tier value=document._source.system.tier localize=true}}
             {{formGroup systemFields.type value=document._source.system.type localize=true}}
-            {{#if (eq document._source.system.type 'horde')}}
-                {{formGroup systemFields.hordeHp value=document._source.system.hordeHp label=(localize "DAGGERHEART.ACTORS.Adversary.horderHp")}}
+            {{#if (eq document._source.system.typeData.type 'horde')}}
+                {{formGroup typeDataFields.hordeHP value=document._source.system.typeData.hordeHP name="system.typeData.hordeHP" label=(localize "DAGGERHEART.ACTORS.Adversary.horderHp")}}
             {{/if}}
             {{formGroup systemFields.difficulty value=document._source.system.difficulty localize=true}}
         </div>

--- a/templates/sheets/activeEffect/conditionals.hbs
+++ b/templates/sheets/activeEffect/conditionals.hbs
@@ -11,6 +11,10 @@
             <div class="conditional-outer-container" data-index="{{@key}}">
                 {{#if (eq conditional.type 'dataCompare')}}
                     {{> "systems/daggerheart/templates/sheets/activeEffect/conditionals/dataCompareConditional.hbs" model=(lookup ../systemFields.conditionals.element.types conditional.type) }}
+                {{else if (eq conditional.type 'weaponRestriction')}}
+                    {{> "systems/daggerheart/templates/sheets/activeEffect/conditionals/weaponRestrictionConditional.hbs" model=(lookup ../systemFields.conditionals.element.types conditional.type) }}
+                {{else if (eq conditional.type 'actionType')}}
+                    {{> "systems/daggerheart/templates/sheets/activeEffect/conditionals/actionTypeConditional.hbs" model=(lookup ../systemFields.conditionals.element.types conditional.type) }}
                 {{/if}}
             </div>
         {{/each}}

--- a/templates/sheets/activeEffect/conditionals.hbs
+++ b/templates/sheets/activeEffect/conditionals.hbs
@@ -1,0 +1,18 @@
+<section class="tab conditionals {{#if tab.active}} active{{/if}}" data-group="{{tab.group}}" data-tab="{{tab.id}}">
+    <fieldset class="one-column">
+        <legend class="with-select">
+            {{localize "DAGGERHEART.ACTIVEEFFECT.Config.conditionals.title"}} 
+            <select class="conditional-select-input">
+                {{selectOptions conditionalOptions localize=true blank=""}}
+            </select>
+        </legend>
+
+        {{#each document.system.conditionals as | conditional |}}
+            <div class="conditional-outer-container" data-index="{{@key}}">
+                {{#if (eq conditional.type 'dataCompare')}}
+                    {{> "systems/daggerheart/templates/sheets/activeEffect/conditionals/dataCompareConditional.hbs" model=(lookup ../systemFields.conditionals.element.types conditional.type) }}
+                {{/if}}
+            </div>
+        {{/each}}
+    </fieldset>
+</section>

--- a/templates/sheets/activeEffect/conditionals.hbs
+++ b/templates/sheets/activeEffect/conditionals.hbs
@@ -8,7 +8,7 @@
         </legend>
 
         {{#each document.system.conditionals as | conditional |}}
-            <div class="conditional-outer-container" data-index="{{@key}}">
+            <div>
                 {{#if (eq conditional.type 'dataCompare')}}
                     {{> "systems/daggerheart/templates/sheets/activeEffect/conditionals/dataCompareConditional.hbs" model=(lookup ../systemFields.conditionals.element.types conditional.type) }}
                 {{else if (eq conditional.type 'weaponRestriction')}}

--- a/templates/sheets/activeEffect/conditionals/actionTypeConditional.hbs
+++ b/templates/sheets/activeEffect/conditionals/actionTypeConditional.hbs
@@ -1,0 +1,8 @@
+<div class="conditional-container">
+    <div class="conditional-inner-container">
+        <input type="hidden" value="{{this.type}}" name="{{concat "system.conditionals." @key ".type"}}" />
+        {{formGroup model.fields.actionTypes value=this.actionTypes name=(concat "system.conditionals." @key ".actionTypes") localize=true blank=false }}
+    </div>
+
+    <a class="form-row-icon" data-action="removeConditional" data-index="{{@key}}"><i class="fa-solid fa-trash"></i></a>
+</div>

--- a/templates/sheets/activeEffect/conditionals/dataCompareConditional.hbs
+++ b/templates/sheets/activeEffect/conditionals/dataCompareConditional.hbs
@@ -1,5 +1,5 @@
-<div class="data-compare-container">
-    <div class="data-compare-inner-container">
+<div class="conditional-container">
+    <div class="conditional-inner-container">
         <input type="hidden" value="{{this.type}}" name="{{concat "system.conditionals." @key ".type"}}" />
         {{formGroup model.fields.key value=this.key name=(concat "system.conditionals." @key ".key") localize=true }}
         {{formGroup model.fields.comparator value=this.comparator name=(concat "system.conditionals." @key ".comparator") localize=true }}

--- a/templates/sheets/activeEffect/conditionals/dataCompareConditional.hbs
+++ b/templates/sheets/activeEffect/conditionals/dataCompareConditional.hbs
@@ -1,0 +1,10 @@
+<div class="data-compare-container">
+    <div class="data-compare-inner-container">
+        <input type="hidden" value="{{this.type}}" name="{{concat "system.conditionals." @key ".type"}}" />
+        {{formGroup model.fields.key value=this.key name=(concat "system.conditionals." @key ".key") localize=true }}
+        {{formGroup model.fields.comparator value=this.comparator name=(concat "system.conditionals." @key ".comparator") localize=true }}
+        {{formGroup model.fields.value value=this.value name=(concat "system.conditionals." @key ".value") classes="conditional-value" localize=true }}
+    </div>
+
+    <a class="form-row-icon" data-action="removeConditional" data-index="{{@key}}"><i class="fa-solid fa-trash"></i></a>
+</div>

--- a/templates/sheets/activeEffect/conditionals/weaponRestrictionConditional.hbs
+++ b/templates/sheets/activeEffect/conditionals/weaponRestrictionConditional.hbs
@@ -1,0 +1,8 @@
+<div class="conditional-container">
+    <div class="conditional-inner-container">
+        <input type="hidden" value="{{this.type}}" name="{{concat "system.conditionals." @key ".type"}}" />
+        {{formGroup model.fields.weaponType value=this.weaponType name=(concat "system.conditionals." @key ".weaponType") localize=true }}
+    </div>
+
+    <a class="form-row-icon" data-action="removeConditional" data-index="{{@key}}"><i class="fa-solid fa-trash"></i></a>
+</div>

--- a/templates/sheets/actors/adversary/header.hbs
+++ b/templates/sheets/actors/adversary/header.hbs
@@ -21,7 +21,7 @@
         </div>
         {{#if (eq source.system.type 'horde')}}
             <div class="tag">
-                <span>{{source.system.hordeHp}}</span>
+                <span>{{source.system.typeData.hordeHP}}</span>
                 <span>/{{localize "DAGGERHEART.GENERAL.HitPoints.short"}}</span>
             </div>
         {{/if}}

--- a/templates/sheets/actors/adversary/limited.hbs
+++ b/templates/sheets/actors/adversary/limited.hbs
@@ -14,7 +14,7 @@
         </div>
         {{#if (eq source.system.type 'horde')}}
             <div class="tag">
-                <span>{{source.system.hordeHp}}</span>
+                <span>{{source.system.typeData.hordeHp}}</span>
                 <span>/{{localize "DAGGERHEART.GENERAL.HitPoints.short"}}</span>
             </div>
         {{/if}}


### PR DESCRIPTION
I've added 3 ConditionalTypes:
- **DataCompare**
_Phase:_ `Preparation`
_failureMode:_ `suppress`
This compares a value in rollData to a formula via a chosen comparator method
- **ActionType**
_Phase:_ `Roll`
_failureMode:_ `remove`
This ensures that the action being used is of an allowed type. Allowed types is a SetField, so many could be allowed.
- **Weapon Requirement**
_Phase:_ `Roll`
_failureMode:_ `remove`
This ensures that the action being used is of a specific sort of weapon.

----
I updated the SRD for Horde adversaries using `DataCompare` - removed all the current logic for Horde damage using altValue and deleted the special `horde` ActiveEffect type.

----
I have not made use of `Action Type` and `Weapon Requirement` in this PR. That is handled in the stacked PR.