### PR TITLE
Refine embed styling and structure

### DIFF
--- a/module/applications/sheets/sheet-helpers.mjs
+++ b/module/applications/sheets/sheet-helpers.mjs
@@ -48,5 +48,7 @@ export function prepareFeatureData(actor) {
  */
 export function simplifyDescriptionForEmbed(value) {
     // Currently only replaces standalone lines with certain embed types
-    return value.replaceAll(/<p>@(Template|Effect|UUID)\[([^[\]]*)\](?:{([^}]*)})?<\/p>/g, '')
+    return value
+        .replaceAll(/<p>@(Template|Effect|UUID)\[([^[\]]*)\](?:{([^}]*)})?<\/p>/g, '')
+        .replaceAll(/<p>\[\[\/(fr|dr)\]\]<\/p>/g, '')
 }

--- a/styles/less/global/embed.less
+++ b/styles/less/global/embed.less
@@ -44,7 +44,11 @@
     .row {
         display: flex;
         align-items: baseline;
-        padding-inline:  0.5rem;
+        padding-inline: 0.5rem;
+
+        > * {
+            white-space: nowrap;
+        }
     }
 
     .divider {
@@ -58,6 +62,7 @@
     }
 
     .experience-row {
+        display: block;
         border-top: 1px dashed var(--dh-embed-color-border);
         padding-top: 0.25rem;
         margin-top: 0.25rem;

--- a/templates/components/actor-embed/adversary.hbs
+++ b/templates/components/actor-embed/adversary.hbs
@@ -46,13 +46,11 @@
             <div class="damage">{{attack.damage}}</div>
         </div>
         {{#if experiences.length}}
-            <div class="row experience-row">
-                <div class="experiences">
-                    <strong>{{localize "DAGGERHEART.GENERAL.Experience.plural"}}:</strong>
-                    {{#each experiences as |exp index|}}
-                        <span>{{exp.name}} {{exp.value}}{{#unless @last}},{{/unless}}</span>
-                    {{/each}}
-                </div>
+            <div class="row experience-row experiences">
+                <strong>{{localize "DAGGERHEART.GENERAL.Experience.plural"}}:</strong>
+                {{#each experiences as |exp index|}}
+                    <span>{{exp.name}} {{exp.value}}{{#unless @last}},{{/unless}}</span>
+                {{/each}}
             </div>
         {{/if}}
     </section>


### PR DESCRIPTION
Fixes some styling quirks at certain sizes and also filters out full line consuming fate rolls and duality rolls. I'll refine the regex as I find more compendium examples.