### PR TITLE
[Fix] FearTrigger On Reactions

### DIFF
--- a/module/dice/dualityRoll.mjs
+++ b/module/dice/dualityRoll.mjs
@@ -285,7 +285,7 @@ export default class DualityRoll extends D20Roll {
         );
         if (dualityUpdates?.length) updates.push(...dualityUpdates);
 
-        if (config.roll.result.duality === -1) {
+        if (config.roll.result.duality === -1 && config.actionType === 'action') {
             const fearUpdates = await game.system.registeredTriggers.runTrigger(
                 CONFIG.DH.TRIGGER.triggers.fearRoll.id,
                 roll.data?.parent,


### PR DESCRIPTION
Fixes #2330 
Changed so that `Triggers` triggering onFear only occur on 'action' rolls