### PR TITLE
[Feature] Conditionals - Roll & Damage

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2862,7 +2862,7 @@
                     "actionTypes": "Action Types"
                 },
                 "damageType": {
-                    "damageTypes": "Damage Types"
+                    "damageType": "Damage Type"
                 }
             },
             "Duration": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -1632,7 +1632,8 @@
             "ConditionalType": {
                 "dataCompare": "Data Compare",
                 "weaponRestriction": "Weapon Restriction",
-                "actionType": "Action Type"
+                "actionType": "Action Type",
+                "damageType": "Damage Type"
             },
             "ConditionalWeaponRestrictionType": {
                 "sameWeapon": "Same Weapon"
@@ -2858,7 +2859,10 @@
                     "weaponType": "Weapon Type"
                 },
                 "actionType": {
-                    "actionType": "Action Type"
+                    "actionTypes": "Action Types"
+                },
+                "damageType": {
+                    "damageTypes": "Damage Types"
                 }
             },
             "Duration": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -1636,7 +1636,8 @@
                 "damageType": "Damage Type"
             },
             "ConditionalWeaponRestrictionType": {
-                "sameWeapon": "Same Weapon"
+                "sameWeapon": "Same Weapon",
+                "anyWeapon": "Any Weapon"
             },
             "CountdownProgressType": {
                 "actionRoll": "Action Roll",

--- a/module/applications/sheets/actors/adversary.mjs
+++ b/module/applications/sheets/actors/adversary.mjs
@@ -251,11 +251,18 @@ export default class AdversarySheet extends DHBaseActorSheet {
      * Performs a reaction roll for an Adversary.
      * @type {ApplicationClickAction}
      */
-    static #reactionRoll(event) {
+    static async #reactionRoll(event) {
         const config = {
             event,
             title: game.i18n.localize('DAGGERHEART.GENERAL.reactionRoll'),
             headerTitle: game.i18n.localize('DAGGERHEART.ACTORS.Adversary.adversaryReactionRoll.headerTitle'),
+            effects: await game.system.api.data.actions.actionsTypes.base.getActionRelevantEffects(
+                {
+                    actionType: 'reaction', 
+                    roll: {}
+                }, 
+                this.document
+            ),
             roll: {
                 type: 'trait'
             },

--- a/module/applications/sheets/actors/adversary.mjs
+++ b/module/applications/sheets/actors/adversary.mjs
@@ -258,8 +258,10 @@ export default class AdversarySheet extends DHBaseActorSheet {
             headerTitle: game.i18n.localize('DAGGERHEART.ACTORS.Adversary.adversaryReactionRoll.headerTitle'),
             effects: await game.system.api.data.actions.actionsTypes.base.getActionRelevantEffects(
                 {
-                    actionType: 'reaction', 
-                    roll: {}
+                    action: {
+                        actionType: 'reaction', 
+                        roll: {}
+                    }
                 }, 
                 this.document
             ),

--- a/module/applications/sheets/api/application-mixin.mjs
+++ b/module/applications/sheets/api/application-mixin.mjs
@@ -523,12 +523,12 @@ export default function DHApplicationMixin(Base) {
                         return doc?.isOwner && hasDamage;
                     },
                     onClick: async (event, target) => {
-                        const doc = await getDocFromElement(target),
-                            action = doc?.system?.attack ?? doc;
+                        const doc = await getDocFromElement(target);
+                        const action = doc.system.attack;
                         const config = action.prepareConfig(event);
                         config.effects = await game.system.api.data.actions.actionsTypes.base.getActionRelevantEffects(
-                            this.document,
-                            doc
+                            action,
+                            this.document
                         );
                         config.hasRoll = false;
                         return action && action.workflow.get('damage').execute(config, null, true);

--- a/module/applications/sheets/api/application-mixin.mjs
+++ b/module/applications/sheets/api/application-mixin.mjs
@@ -527,7 +527,7 @@ export default function DHApplicationMixin(Base) {
                         const action = doc.system.attack;
                         const config = action.prepareConfig(event);
                         config.effects = await game.system.api.data.actions.actionsTypes.base.getActionRelevantEffects(
-                            action,
+                            action.getRollData(),
                             this.document
                         );
                         config.hasRoll = false;

--- a/module/applications/sheets/api/base-actor.mjs
+++ b/module/applications/sheets/api/base-actor.mjs
@@ -239,8 +239,8 @@ export default class DHBaseActorSheet extends DHApplicationMixin(ActorSheetV2) {
                         action = doc?.system?.attack ?? doc;
                     const config = action.prepareConfig(event);
                     config.effects = await game.system.api.data.actions.actionsTypes.base.getActionRelevantEffects(
-                        this.document,
-                        doc
+                        doc,
+                        this.document
                     );
                     config.hasRoll = false;
                     return action && action.workflow.get('damage').execute(config, null, true);

--- a/module/applications/sheets/api/base-actor.mjs
+++ b/module/applications/sheets/api/base-actor.mjs
@@ -239,7 +239,7 @@ export default class DHBaseActorSheet extends DHApplicationMixin(ActorSheetV2) {
                         action = doc?.system?.attack ?? doc;
                     const config = action.prepareConfig(event);
                     config.effects = await game.system.api.data.actions.actionsTypes.base.getActionRelevantEffects(
-                        doc,
+                        doc.getRollData(),
                         this.document
                     );
                     config.hasRoll = false;

--- a/module/config/effectConfig.mjs
+++ b/module/config/effectConfig.mjs
@@ -132,6 +132,10 @@ export const weaponRestrictionType = {
     secondary: {
         id: 'secondary',
         label: 'DAGGERHEART.ITEMS.Weapon.secondaryWeapon.full'
+    },
+    anyWeapon: {
+        id: 'anyWeapon',
+        label: 'DAGGERHEART.CONFIG.ConditionalWeaponRestrictionType.anyWeapon'
     }
 };
 

--- a/module/config/effectConfig.mjs
+++ b/module/config/effectConfig.mjs
@@ -80,6 +80,10 @@ export const conditionalTypes = {
     actionType: {
         id: 'actionType',
         label: 'DAGGERHEART.CONFIG.ConditionalType.actionType'
+    },
+    damageType: {
+        id: 'damageType',
+        label: 'DAGGERHEART.CONFIG.ConditionalType.damageType'
     }
 };
 

--- a/module/config/itemConfig.mjs
+++ b/module/config/itemConfig.mjs
@@ -2324,11 +2324,15 @@ export const weaponFeatures = {
                 system: {
                     changes: [
                         {
-                            key: 'system.bonuses.roll.primaryWeapon.bonus',
+                            key: 'system.bonuses.roll.bonus',
                             type: 'add',
                             value: 1
                         }
-                    ]
+                    ],
+                    conditionals: [{
+                        type: 'weaponRestriction',
+                        weaponType: 'sameWeapon'    
+                    }]
                 }
             }
         ]

--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -250,8 +250,7 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
         let config = this.prepareConfig(event, configOptions);
         if (!config) return;
 
-        config.effects =
-            await game.system.api.data.actions.actionsTypes.base.getActionRelevantEffects(this.actor, this.item);
+        config.effects = await DHBaseAction.getActionRelevantEffects(this, this.actor);
 
         if (Hooks.call(`${CONFIG.DH.id}.preUseAction`, this, config) === false) return;
 
@@ -361,40 +360,21 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
      * @param {DHItem|DhActor} effectParent The parent of the effect
      * @returns {DhActiveEffect[]}
      */
-    static async getActionRelevantEffects(actor, effectParent) {
+    static async getActionRelevantEffects(action, actor) {
         if (!actor) return [];
 
-        // Changes on weapon effects are not typically only applicable to show in the roll dialog for the weapon itself 
-        // The exemptions to this rule are listed below
-        const weaponTransferredEffectKeys = [
-            'system.bonuses.roll.spellcast.bonus'
-        ];
-
-        const results = [];
         const applicableEffects = await actor.allApplicableEffects({ noTransferArmor: true, noSelfArmor: true });
-        for (const effect of [...applicableEffects].filter(e => !e.isSuppressed)) {
-            if (effect.parent.type === 'weapon') {
-                // Effects on weapons only ever apply for the weapon itself (with a few exceptions)
-                const restricted =
-                    effect.parent.system.secondary
-                        // Secondary applies only to other primary weapons
-                        ? effectParent?.type !== 'weapon' || effectParent?.system.secondary
-                        // Primary only applies to itself
-                        : effectParent?.id !== effect.parent.id;
-                if (restricted) {
-                    const sourceChanges = effect._source.system.changes;
-                    const changes = sourceChanges.filter(x => weaponTransferredEffectKeys.includes(x.key));
-                    if (changes.length) {
-                        results.push(effect.clone({ 'system.changes': changes }));
-                    }
-                    continue;
-                }
-            }
+        return [...applicableEffects].filter(e => !e.isSuppressed).reduce((acc, effect) => {
+            const conditionalPassed = !effect.system.conditionals.some(x => 
+                x.constructor.metadata.phase === CONFIG.DH.EFFECTS.conditionalPhases.roll.id &&    
+                !x.doesConditionalPass(action)
+            );
 
-            results.push(effect);
-        }
+            if (conditionalPassed)
+                acc.push(effect);
 
-        return results;
+            return acc;
+        }, []);
     }
 
     /**

--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -367,7 +367,7 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
         return [...applicableEffects].filter(e => !e.isSuppressed).reduce((acc, effect) => {
             const conditionalPassed = !effect.system.conditionals.some(x => 
                 x.constructor.metadata.phase === CONFIG.DH.EFFECTS.conditionalPhases.roll.id &&    
-                !x.doesConditionalPass(action)
+                !x.test(action)
             );
 
             if (conditionalPassed)

--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -223,6 +223,11 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
             ? (data.costs.find(c => c.scalable)?.total ?? 1)
             : 1;
         actorData.roll = {};
+        actorData.action = {
+            actionType: this.actionType,
+            damage: this.damage,
+            roll: this.roll
+        };
 
         return actorData;
     }
@@ -250,7 +255,7 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
         let config = this.prepareConfig(event, configOptions);
         if (!config) return;
 
-        config.effects = await DHBaseAction.getActionRelevantEffects(this, this.actor);
+        config.effects = await DHBaseAction.getActionRelevantEffects(this.getRollData(), this.actor);
 
         if (Hooks.call(`${CONFIG.DH.id}.preUseAction`, this, config) === false) return;
 
@@ -356,18 +361,18 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
 
     /**
      * Get the all potentially applicable effects on the actor for the action's RollDialog
+     * @param {RollData} rollData The rolldata of the action being performed
      * @param {DHActor} actor The actor performing the action
-     * @param {DHItem|DhActor} effectParent The parent of the effect
      * @returns {DhActiveEffect[]}
      */
-    static async getActionRelevantEffects(action, actor) {
+    static async getActionRelevantEffects(rollData, actor) {
         if (!actor) return [];
 
         const applicableEffects = await actor.allApplicableEffects({ noTransferArmor: true, noSelfArmor: true });
         return [...applicableEffects].filter(e => !e.isSuppressed).reduce((acc, effect) => {
             const conditionalPassed = !effect.system.conditionals.some(x => 
                 x.constructor.metadata.phase === CONFIG.DH.EFFECTS.conditionalPhases.roll.id &&    
-                !x.test(action)
+                !x.test(rollData)
             );
 
             if (conditionalPassed)

--- a/module/data/action/baseAction.mjs
+++ b/module/data/action/baseAction.mjs
@@ -362,19 +362,17 @@ export default class DHBaseAction extends ActionMixin(foundry.abstract.DataModel
     /**
      * Get the all potentially applicable effects on the actor for the action's RollDialog
      * @param {RollData} rollData The rolldata of the action being performed
-     * @param {DHActor} actor The actor performing the action
+     * @param {DhpActor} actor The actor performing the action
      * @returns {DhActiveEffect[]}
      */
     static async getActionRelevantEffects(rollData, actor) {
         if (!actor) return [];
 
-        const applicableEffects = await actor.allApplicableEffects({ noTransferArmor: true, noSelfArmor: true });
+        const applicableEffects = actor.allApplicableEffects({ noTransferArmor: true, noSelfArmor: true });
         return [...applicableEffects].filter(e => !e.isSuppressed).reduce((acc, effect) => {
-            const conditionalPassed = !effect.system.conditionals.some(x => 
-                x.constructor.metadata.phase === CONFIG.DH.EFFECTS.conditionalPhases.roll.id &&    
-                !x.test(rollData)
-            );
-
+            const conditionalPassed = effect.system.testConditionals(rollData, { 
+                phase: CONFIG.DH.EFFECTS.conditionalPhases.roll.id 
+            });
             if (conditionalPassed)
                 acc.push(effect);
 

--- a/module/data/activeEffect/baseEffect.mjs
+++ b/module/data/activeEffect/baseEffect.mjs
@@ -15,6 +15,7 @@
 import { getScrollTextData } from '../../helpers/utils.mjs';
 import { changeTypes } from './changeTypes/_module.mjs'
 import { conditionalTypes } from './conditionalTypes/_module.mjs';
+import { migrations } from './migrations/_module.mjs';
 
 export default class BaseEffect extends foundry.data.ActiveEffectTypeDataModel {
     static defineSchema() {
@@ -187,9 +188,9 @@ export default class BaseEffect extends foundry.data.ActiveEffectTypeDataModel {
     }
 
     static migrateData(source) {
-        if (source.rangeDependence?.enabled === false) {
-            source.rangeDependence = null;
-        }
+        for (const migration of migrations) {
+            migration(source);
+        } 
 
         return super.migrateData(source);
     }

--- a/module/data/activeEffect/baseEffect.mjs
+++ b/module/data/activeEffect/baseEffect.mjs
@@ -118,16 +118,18 @@ export default class BaseEffect extends foundry.data.ActiveEffectTypeDataModel {
         return true;
     }
 
-    testIsSuppressed(rollData) {
+    testConditionals(rollData) {
         for (const change of this.changes) {
-            if (change.isSuppressed) return true;
+            if (change.isSuppressed) return false;
         }
 
-        return rollData && this.conditionals.some(x => 
+        const conditionalFailed = rollData && this.conditionals.some(x => 
             x.constructor.metadata.phase === CONFIG.DH.EFFECTS.conditionalPhases.preparation.id && 
             x.constructor.metadata.failureMode === CONFIG.DH.EFFECTS.conditionalFailureModes.suppress.id &&
             !x.test(rollData)
         );
+
+        return !rollData || !conditionalFailed; 
     }
 
     get armorChange() {

--- a/module/data/activeEffect/baseEffect.mjs
+++ b/module/data/activeEffect/baseEffect.mjs
@@ -118,14 +118,25 @@ export default class BaseEffect extends foundry.data.ActiveEffectTypeDataModel {
         return true;
     }
 
-    testConditionals(rollData) {
+    /** 
+     * Tests all conditionals of a specific phase and returns if there are no failures
+     * @param {object} rollData
+     * @param {object} [options]
+     * @param {keyof typeof CONFIG.DH.EFFECTS.conditionalPhases} [options.phase] the phase to run on, by default its preparation
+     * @param {(keyof typeof CONFIG.DH.EFFECTS.conditionalFailureModes) | null} [options.failureMode] the failure mode to check, by default its all
+     * @returns if the conditionals of the phase pass
+     */
+    testConditionals(rollData, { 
+        phase = CONFIG.DH.EFFECTS.conditionalPhases.preparation.id, 
+        failureMode = null
+    } = {}) {
         for (const change of this.changes) {
             if (change.isSuppressed) return false;
         }
 
         const conditionalFailed = rollData && this.conditionals.some(x => 
-            x.constructor.metadata.phase === CONFIG.DH.EFFECTS.conditionalPhases.preparation.id && 
-            x.constructor.metadata.failureMode === CONFIG.DH.EFFECTS.conditionalFailureModes.suppress.id &&
+            x.constructor.metadata.phase === phase && 
+            (!failureMode || x.constructor.metadata.failureMode === failureMode) &&
             !x.test(rollData)
         );
 

--- a/module/data/activeEffect/conditionalTypes/_module.mjs
+++ b/module/data/activeEffect/conditionalTypes/_module.mjs
@@ -1,10 +1,12 @@
 import DataCompareConditional from './dataCompareConditional.mjs';
 import WeaponRestrictionConditional from './weaponRestrictionConditional.mjs';
 import ActionTypeConditional from './actionTypeConditional.mjs';
+import DamageTypeConditional from './damageTypeConditional.mjs';
 import { conditionalTypes as types } from '../../../config/effectConfig.mjs';
 
 export const conditionalTypes = {
     [types.dataCompare.id]: DataCompareConditional,
     [types.weaponRestriction.id]: WeaponRestrictionConditional,
-    [types.actionType.id]: ActionTypeConditional
+    [types.actionType.id]: ActionTypeConditional,
+    [types.damageType.id]: DamageTypeConditional
 }

--- a/module/data/activeEffect/conditionalTypes/actionTypeConditional.mjs
+++ b/module/data/activeEffect/conditionalTypes/actionTypeConditional.mjs
@@ -20,11 +20,10 @@ export default class ActionTypeConditional extends foundry.abstract.DataModel {
                 initial: conditionalTypes.actionType.id 
             }),
             actionTypes: new fields.SetField(new fields.StringField({
-                label: 'DAGGERHEART.EFFECTS.Conditionals.actionType.actionType',
                 nullable: true,
                 choices: CONFIG.DH.EFFECTS.actionType,
                 initial: null
-            }))
+            }), { label: 'DAGGERHEART.EFFECTS.Conditionals.actionType.actionTypes' })
         }
     }
 

--- a/module/data/activeEffect/conditionalTypes/actionTypeConditional.mjs
+++ b/module/data/activeEffect/conditionalTypes/actionTypeConditional.mjs
@@ -27,16 +27,17 @@ export default class ActionTypeConditional extends foundry.abstract.DataModel {
         }
     }
 
-    test(dhRollData) {
+    test(rollData) {
         if (!this.actionTypes.size) return true;
-        if (!dhRollData.roll || !dhRollData.actionType) return false;
+
+        const actionType = rollData.action?.actionType;
+        if (!rollData.action?.roll || !actionType) return false;
         
-        const actionType = dhRollData.actionType;
         if (actionType === 'action' && this.actionTypes.has(CONFIG.DH.EFFECTS.actionType.action.id))
             return true;
         if (actionType === 'reaction' && this.actionTypes.has(CONFIG.DH.EFFECTS.actionType.reaction.id))
             return true;
 
-        return this.actionTypes.has(dhRollData.roll.type);
+        return this.actionTypes.has(rollData.action.roll.type);
     }
 }

--- a/module/data/activeEffect/conditionalTypes/actionTypeConditional.mjs
+++ b/module/data/activeEffect/conditionalTypes/actionTypeConditional.mjs
@@ -30,13 +30,14 @@ export default class ActionTypeConditional extends foundry.abstract.DataModel {
 
     test(dhRollData) {
         if (!this.actionTypes.size) return true;
-
-        const actionType = dhRollData.options.actionType;
+        if (!dhRollData.roll || !dhRollData.actionType) return false;
+        
+        const actionType = dhRollData.actionType;
         if (actionType === 'action' && this.actionTypes.has(CONFIG.DH.EFFECTS.actionType.action.id))
             return true;
         if (actionType === 'reaction' && this.actionTypes.has(CONFIG.DH.EFFECTS.actionType.reaction.id))
             return true;
 
-        return this.actionTypes.has(dhRollData.options.roll.type);
+        return this.actionTypes.has(dhRollData.roll.type);
     }
 }

--- a/module/data/activeEffect/conditionalTypes/damageTypeConditional.mjs
+++ b/module/data/activeEffect/conditionalTypes/damageTypeConditional.mjs
@@ -28,7 +28,7 @@ export default class DamageTypeConditional extends foundry.abstract.DataModel {
         }
     }
 
-    doesConditionalPass(actionData) { 
+    test(actionData) { 
         if (!actionData.damage) return false;
         
         return actionData.damage.main.type.has(this.damageType)

--- a/module/data/activeEffect/conditionalTypes/damageTypeConditional.mjs
+++ b/module/data/activeEffect/conditionalTypes/damageTypeConditional.mjs
@@ -1,5 +1,5 @@
 import { conditionalTypes, conditionalFailureModes, conditionalPhases } from '../../../config/effectConfig.mjs';
-
+// TODO: Possibly add something to handle Otherwordly's case when it's implemented.
 export default class DamageTypeConditional extends foundry.abstract.DataModel {
     static get metadata() {
         return {
@@ -19,16 +19,18 @@ export default class DamageTypeConditional extends foundry.abstract.DataModel {
                 blank: false, 
                 initial: conditionalTypes.damageType.id 
             }),
-            damageTypes: new fields.SetField(new fields.StringField({
+            damageType: new fields.StringField({
+                label: 'DAGGERHEART.EFFECTS.Conditionals.damageType.damageType',
                 required: true,
-                choices: CONFIG.DH.GENERAL.damageTypes
-            }), { label: 'DAGGERHEART.EFFECTS.Conditionals.damageType.damageTypes' })
+                choices: CONFIG.DH.GENERAL.damageTypes,
+                initial: CONFIG.DH.GENERAL.damageTypes.physical.id
+            })
         }
     }
 
     doesConditionalPass(actionData) { 
         if (!actionData.damage) return false;
         
-        return Boolean(actionData.damage.main.type.intersection(this.damageTypes).size);
+        return actionData.damage.main.type.has(this.damageType)
     }
 }

--- a/module/data/activeEffect/conditionalTypes/damageTypeConditional.mjs
+++ b/module/data/activeEffect/conditionalTypes/damageTypeConditional.mjs
@@ -1,0 +1,34 @@
+import { conditionalTypes, conditionalFailureModes, conditionalPhases } from '../../../config/effectConfig.mjs';
+
+export default class DamageTypeConditional extends foundry.abstract.DataModel {
+    static get metadata() {
+        return {
+            phase: conditionalPhases.roll.id,
+            failureMode: conditionalFailureModes.remove.id
+        }
+    }
+
+    static defineSchema() {
+        const fields = foundry.data.fields;
+
+        return {
+            type: new fields.StringField({ 
+                label: 'DAGGERHEART.GENERAL.type',
+                required: true, 
+                nullable: false, 
+                blank: false, 
+                initial: conditionalTypes.damageType.id 
+            }),
+            damageTypes: new fields.SetField(new fields.StringField({
+                required: true,
+                choices: CONFIG.DH.GENERAL.damageTypes
+            }), { label: 'DAGGERHEART.EFFECTS.Conditionals.damageType.damageTypes' })
+        }
+    }
+
+    doesConditionalPass(actionData) { 
+        if (!actionData.damage) return false;
+        
+        return Boolean(actionData.damage.main.type.intersection(this.damageTypes).size);
+    }
+}

--- a/module/data/activeEffect/conditionalTypes/damageTypeConditional.mjs
+++ b/module/data/activeEffect/conditionalTypes/damageTypeConditional.mjs
@@ -28,9 +28,9 @@ export default class DamageTypeConditional extends foundry.abstract.DataModel {
         }
     }
 
-    test(actionData) { 
-        if (!actionData.damage) return false;
+    test(rollData) { 
+        if (!rollData.action?.damage) return false;
         
-        return actionData.damage.main.type.has(this.damageType)
+        return rollData.action.damage.main.type.has(this.damageType)
     }
 }

--- a/module/data/activeEffect/conditionalTypes/damageTypeConditional.mjs
+++ b/module/data/activeEffect/conditionalTypes/damageTypeConditional.mjs
@@ -4,7 +4,7 @@ export default class DamageTypeConditional extends foundry.abstract.DataModel {
     static get metadata() {
         return {
             phase: conditionalPhases.roll.id,
-            failureMode: conditionalFailureModes.remove.id
+            failureMode: conditionalFailureModes.hide.id
         }
     }
 

--- a/module/data/activeEffect/conditionalTypes/weaponRestrictionConditional.mjs
+++ b/module/data/activeEffect/conditionalTypes/weaponRestrictionConditional.mjs
@@ -35,10 +35,11 @@ export default class WeaponRestrictionConditional extends foundry.abstract.DataM
         if (!item) return true;
 
         const rollData = actionData.item.getRollData();
-        const { secondary, primary, sameWeapon } = CONFIG.DH.EFFECTS.weaponRestrictionType;
+        const { secondary, primary, sameWeapon, anyWeapon } = CONFIG.DH.EFFECTS.weaponRestrictionType;
 
         /* TODO: Replace this.parent.parent with getNearestDocument in Stable 10 */
         const weaponTypeValid = 
+            (this.weaponType === anyWeapon) ||
             (this.weaponType === sameWeapon.id && rollData.item?.parent.id === this.parent.parent?.parent.id) ||
             (this.weaponType === secondary.id && rollData.item.secondary) ||
             (this.weaponType === primary.id && !rollData.item.secondary);

--- a/module/data/activeEffect/conditionalTypes/weaponRestrictionConditional.mjs
+++ b/module/data/activeEffect/conditionalTypes/weaponRestrictionConditional.mjs
@@ -28,23 +28,20 @@ export default class WeaponRestrictionConditional extends foundry.abstract.DataM
         }
     }
 
-    test(dhRollData) {
-        if (!dhRollData.options.source.item) return true;
+    test(actionData) {
+        if (!actionData.options.source.item) return true;
         
-        const item = dhRollData.options.data.parent?.items?.get?.(dhRollData.options.source.item);
+        const item = actionData.options.data.parent?.items?.get?.(actionData.options.source.item);
         if (!item) return true;
 
-        if (item.type !== 'weapon') return false;
-
-        const rollData = item.getRollData();
+        const rollData = actionData.item.getRollData();
         const { secondary, primary, sameWeapon } = CONFIG.DH.EFFECTS.weaponRestrictionType;
 
         /* TODO: Replace this.parent.parent with getNearestDocument in Stable 10 */
-        const weaponTypeValid = !this.weaponType || (
+        const weaponTypeValid = 
             (this.weaponType === sameWeapon.id && rollData.item?.parent.id === this.parent.parent?.parent.id) ||
             (this.weaponType === secondary.id && rollData.item.secondary) ||
-            (this.weaponType === primary.id && !rollData.item.secondary) 
-        );
+            (this.weaponType === primary.id && !rollData.item.secondary);
 
         return weaponTypeValid;
     }

--- a/module/data/activeEffect/conditionalTypes/weaponRestrictionConditional.mjs
+++ b/module/data/activeEffect/conditionalTypes/weaponRestrictionConditional.mjs
@@ -28,18 +28,14 @@ export default class WeaponRestrictionConditional extends foundry.abstract.DataM
         }
     }
 
-    test(actionData) {
-        if (!actionData.options.source.item) return true;
-        
-        const item = actionData.options.data.parent?.items?.get?.(actionData.options.source.item);
-        if (!item) return true;
+    test(rollData) {
+        if (!rollData.item) return true;
 
-        const rollData = actionData.item.getRollData();
         const { secondary, primary, sameWeapon, anyWeapon } = CONFIG.DH.EFFECTS.weaponRestrictionType;
 
         /* TODO: Replace this.parent.parent with getNearestDocument in Stable 10 */
         const weaponTypeValid = 
-            (this.weaponType === anyWeapon) ||
+            (this.weaponType === anyWeapon.id) ||
             (this.weaponType === sameWeapon.id && rollData.item?.parent.id === this.parent.parent?.parent.id) ||
             (this.weaponType === secondary.id && rollData.item.secondary) ||
             (this.weaponType === primary.id && !rollData.item.secondary);

--- a/module/data/activeEffect/migrations/_module.mjs
+++ b/module/data/activeEffect/migrations/_module.mjs
@@ -1,0 +1,7 @@
+import RangeDependenceMigration from './rangeDependenceMigration.mjs';
+import ConditionalsMigration from './conditionalsMigration.mjs';
+
+export const migrations = [
+    RangeDependenceMigration,
+    ConditionalsMigration
+];

--- a/module/data/activeEffect/migrations/conditionalsMigration.mjs
+++ b/module/data/activeEffect/migrations/conditionalsMigration.mjs
@@ -1,0 +1,93 @@
+const weaponKeys = ['primaryWeapon', 'secondaryWeapon'];
+
+export default function conditionalsMigration(source) {
+    if (!source.conditionals) {
+        source.conditionals = [];
+
+        const damageTypes = new Set();
+        const weaponTypes = new Set();
+        const actionTypes = new Set();
+
+        /* Damage Bonus: Gather conditional data and replace outdated changes  */
+        const damageTypeIndexes = source.changes.reduce((acc, change, index) => {
+            if (change.key.startsWith('system.bonuses.damage.'))
+                acc.push(index);
+
+            return acc;
+        }, []);
+
+        const newDamageData = damageTypeIndexes.length ? 
+            { ...source.changes[damageTypeIndexes[0]], key: 'system.bonuses.damage' } : null;
+        for (const index of damageTypeIndexes) {
+            const change = source.changes[index];
+            const match = change.key.match(/system\.bonuses\.damage\.(.*)\./);
+            if (!match?.length) continue;
+
+            const rollDamageType = match[1];
+            if (CONFIG.DH.GENERAL.damageTypes[rollDamageType]) {
+                damageTypes.add(rollDamageType);
+            } else if (weaponKeys.includes(rollDamageType)) {
+                weaponTypes.add(rollDamageType);
+            }
+        }
+        for (let i = damageTypeIndexes.length - 1; i >= 0; i--) {
+            source.changes.splice(damageTypeIndexes[i], 1);
+        }
+
+        /* Roll Bonus: Gather conditional data and replace outdated changes  */
+        const rollChangeIndexes = source.changes.reduce((acc, change, index) => {
+            if (change.key.startsWith('system.bonuses.roll.'))
+                acc.push(index);
+
+            return acc;
+        }, []);
+        
+        const newRollData = rollChangeIndexes.length ? 
+            { ...source.changes[rollChangeIndexes[0]], key: 'system.bonuses.roll' } : null;
+        for (const index of rollChangeIndexes) {
+            const change = source.changes[index];
+            const match = change.key.match(/system\.bonuses\.roll\.(.*)\./);
+            if (!match?.length) continue;
+
+            const rollBonusType = match[1];
+            if (CONFIG.DH.EFFECTS.actionType[rollBonusType]) {
+                actionTypes.add(rollBonusType);
+            } else if (weaponKeys.includes(rollBonusType)) {
+                weaponTypes.add(rollBonusType);
+            }
+        }
+        for (let i = rollChangeIndexes.length - 1; i >= 0; i--) {
+            source.changes.splice(rollChangeIndexes[i], 1);
+        }
+
+        /* Add the new replacement changes */
+        if (newDamageData) source.changes.push(newDamageData);
+        if (newRollData) source.changes.push(newRollData);
+
+        /* Add the conditionals */
+        if (damageTypes.size === 1) {
+            source.conditionals.push({
+                type: CONFIG.DH.EFFECTS.conditionalTypes.damageType.id,
+                damageType: damageTypes.first()
+            });
+        }
+
+        if (weaponTypes.size) {
+            const { primary, secondary, anyWeapon } = CONFIG.DH.EFFECTS.weaponRestrictionType
+            const weaponType = 
+                weaponTypes.size > 1 ? anyWeapon.id : 
+                    (weaponTypes.first() === 'primaryWeapon' ? primary.id : secondary.id); 
+            source.conditionals.push({
+                type: CONFIG.DH.EFFECTS.conditionalTypes.weaponRestriction.id,
+                weaponType: weaponType
+            });
+        }
+
+        if (actionTypes.size) {
+            source.conditionals.push({
+                type: CONFIG.DH.EFFECTS.conditionalTypes.actionType.id,
+                actionTypes: [...actionTypes]
+            });
+        }
+    }
+}

--- a/module/data/activeEffect/migrations/rangeDependenceMigration.mjs
+++ b/module/data/activeEffect/migrations/rangeDependenceMigration.mjs
@@ -1,0 +1,5 @@
+export default function rangeDependenceMigration(source) {
+    if (source.rangeDependence?.enabled === false) {
+        source.rangeDependence = null;
+    }
+}

--- a/module/data/actor/adversary.mjs
+++ b/module/data/actor/adversary.mjs
@@ -103,15 +103,8 @@ export default class DhpAdversary extends DhCreature {
                 })
             ),
             bonuses: new fields.SchemaField({
-                roll: new fields.SchemaField({
-                    attack: bonusField('DAGGERHEART.GENERAL.Roll.attack'),
-                    action: bonusField('DAGGERHEART.GENERAL.Roll.action'),
-                    reaction: bonusField('DAGGERHEART.GENERAL.Roll.reaction')
-                }),
-                damage: new fields.SchemaField({
-                    physical: bonusField('DAGGERHEART.GENERAL.Damage.physicalDamage'),
-                    magical: bonusField('DAGGERHEART.GENERAL.Damage.magicalDamage')
-                })
+                roll: bonusField('DAGGERHEART.GENERAL.roll'),
+                damage: bonusField('DAGGERHEART.GENERAL.damage')
             }, { persisted: false })
         };
     }

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -119,22 +119,9 @@ export default class DhCharacter extends DhCreature {
             }),
             levelData: new fields.EmbeddedDataField(DhLevelData),
             bonuses: new fields.SchemaField({
-                roll: new fields.SchemaField({
-                    attack: bonusField('DAGGERHEART.GENERAL.Roll.attack'),
-                    spellcast: bonusField('DAGGERHEART.GENERAL.Roll.spellcast'),
-                    trait: bonusField('DAGGERHEART.GENERAL.Roll.trait'),
-                    action: bonusField('DAGGERHEART.GENERAL.Roll.action'),
-                    reaction: bonusField('DAGGERHEART.GENERAL.Roll.reaction'),
-                    primaryWeapon: bonusField('DAGGERHEART.GENERAL.Roll.primaryWeaponAttack'),
-                    secondaryWeapon: bonusField('DAGGERHEART.GENERAL.Roll.secondaryWeaponAttack')
-                }),
-                damage: new fields.SchemaField({
-                    physical: bonusField('DAGGERHEART.GENERAL.Damage.physicalDamage'),
-                    magical: bonusField('DAGGERHEART.GENERAL.Damage.magicalDamage'),
-                    primaryWeapon: bonusField('DAGGERHEART.GENERAL.Damage.primaryWeapon'),
-                    secondaryWeapon: bonusField('DAGGERHEART.GENERAL.Damage.secondaryWeapon')
-                }),
-                healing: bonusField('DAGGERHEART.GENERAL.Healing.healingAmount'),
+                roll: bonusField('DAGGERHEART.GENERAL.roll'),
+                damage: bonusField('DAGGERHEART.GENERAL.damage'),
+                healing: bonusField('DAGGERHEART.GENERAL.healing'),
                 range: new fields.SchemaField({
                     weapon: new fields.NumberField({
                         integer: true,

--- a/module/data/actor/companion.mjs
+++ b/module/data/actor/companion.mjs
@@ -112,10 +112,7 @@ export default class DhCompanion extends DhCreature {
             }),
             levelData: new fields.EmbeddedDataField(DhLevelData),
             bonuses: new fields.SchemaField({
-                damage: new fields.SchemaField({
-                    physical: bonusField('DAGGERHEART.GENERAL.Damage.physicalDamage'),
-                    magical: bonusField('DAGGERHEART.GENERAL.Damage.magicalDamage')
-                })
+                damage: bonusField('DAGGERHEART.GENERAL.damage')
             }, { persisted: false })
         };
     }

--- a/module/dice/d20Roll.mjs
+++ b/module/dice/d20Roll.mjs
@@ -134,54 +134,18 @@ export default class D20Roll extends DHRoll {
 
     applyBaseBonus() {
         const modifiers = foundry.utils.deepClone(this.options.roll.baseModifiers) ?? [];
-
         modifiers.push(
             ...this.getBonus(
-                `system.bonuses.roll.${this.options.actionType}`,
-                `${this.options.actionType?.capitalize()} Bonus`
+                'system.bonuses.roll',
+                'Roll Bonus'
             )
         );
-
-        if (this.options.roll.type !== CONFIG.DH.GENERAL.rollTypes.attack.id) {
-            modifiers.push(
-                ...this.getBonus(
-                    `system.bonuses.roll.${this.options.roll.type}`,
-                    `${this.options.roll.type?.capitalize()} Bonus`
-                )
-            );
-        }
-
-        if (
-            this.options.roll.type === CONFIG.DH.GENERAL.rollTypes.attack.id ||
-            (this.options.roll.type === CONFIG.DH.GENERAL.rollTypes.spellcast.id && this.options.hasDamage)
-        ) {
-            modifiers.push(
-                ...this.getBonus(`system.bonuses.roll.attack`, `${this.options.roll.type?.capitalize()} Bonus`)
-            );
-        }
 
         return modifiers;
     }
 
     getActionChangeKeys() {
-        const changeKeys = new Set([`system.bonuses.roll.${this.options.actionType}`]);
-
-        if (this.options.roll.type !== CONFIG.DH.GENERAL.rollTypes.attack.id) {
-            changeKeys.add(`system.bonuses.roll.${this.options.roll.type}`);
-        }
-
-        if (
-            this.options.roll.type === CONFIG.DH.GENERAL.rollTypes.attack.id ||
-            (this.options.roll.type === CONFIG.DH.GENERAL.rollTypes.spellcast.id && this.options.hasDamage)
-        ) {
-            changeKeys.add(`system.bonuses.roll.attack`);
-        }
-
-        if (this.options.roll.trait && this.data.traits?.[this.options.roll.trait]) {
-            if (this.options.roll.type !== CONFIG.DH.GENERAL.rollTypes.spellcast.id)
-                changeKeys.add('system.bonuses.roll.trait');
-        }
-
+        const changeKeys = new Set(['system.bonuses.roll']);
         return changeKeys;
     }
 

--- a/module/dice/damageRoll.mjs
+++ b/module/dice/damageRoll.mjs
@@ -121,21 +121,9 @@ export default class DamageRoll extends DHRoll {
         return { formula, total };
     }
 
-    applyBaseBonus(part) {
-        const modifiers = [],
-            type = this.options.messageType ?? (this.options.hasHealing ? 'healing' : 'damage'),
-            options = part ?? this.options;
-
-        if (!this.options.hasHealing) {
-            options.damageTypes?.forEach(t => {
-                modifiers.push(...this.getBonus(`${type}.${t}`, `${t.capitalize()} ${type.capitalize()} Bonus`));
-            });
-            const weapons = ['primaryWeapon', 'secondaryWeapon'];
-            weapons.forEach(w => {
-                if (this.options.source.item && this.options.source.item === this.data[w]?.id)
-                    modifiers.push(...this.getBonus(`${type}.${w}`, 'Weapon Bonus'));
-            });
-        }
+    applyBaseBonus() {
+        const type = this.options.messageType ?? (this.options.hasHealing ? 'healing' : 'damage');
+        const modifiers = [...this.getBonus(`system.bonuses.${type}`)];
 
         return modifiers;
     }
@@ -143,24 +131,9 @@ export default class DamageRoll extends DHRoll {
     getActionChangeKeys() {
         const type = this.options.messageType ?? (this.options.hasHealing ? 'healing' : 'damage');
         const changeKeys = [
-            'system.rules.attack.damage.hpDamageMultiplier'
+            'system.rules.attack.damage.hpDamageMultiplier',
+            `system.bonuses.${type}`
         ];
-
-        for (const damageType of this.options.damageFormula?.damageTypes?.values?.() ?? []) {
-            changeKeys.push(`system.bonuses.${type}.${damageType}`);
-        }
-        
-        const item = this.data.parent?.items?.get(this.options.source.item);
-        if (item) {
-            switch (item.type) {
-                case 'weapon':
-                    if (!this.options.hasHealing)
-                        ['primaryWeapon', 'secondaryWeapon'].forEach(w =>
-                            changeKeys.push(`system.bonuses.damage.${w}`)
-                        );
-                    break;
-            }
-        }
 
         return changeKeys;
     }

--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -355,7 +355,14 @@ export default class DHRoll extends BaseRoll {
         const changeKeys = this.getActionChangeKeys();
         return (
             this.options.effects?.reduce((acc, effect) => {
-                const isConditionalBlocked = 
+                const item = this.options.data.parent?.items?.get?.(this.options.source.item) ?? null;
+                const actions = item ? [
+                    ...item.system.actions,
+                    ...(item.system.attack?.id === this.options.source.action ? [item.system.attack] : [])
+                ] : [];
+                const action = actions.find(x => x.id === this.options.source.action);
+
+                const isConditionalBlocked = action &&
                     (effect.system.conditionals ?? []).some(x => x.constructor.metadata.phase === 'roll' && !x.test(this));
                 // Some old v13 messages don't have system data and will cause errors here during roll construction otherwise. TODO. See if message.roll.options.effects can be saved/instantiated as actual ActiveEffects, then this can be removed.
                 if (

--- a/module/dice/dhRoll.mjs
+++ b/module/dice/dhRoll.mjs
@@ -363,7 +363,7 @@ export default class DHRoll extends BaseRoll {
                 const action = actions.find(x => x.id === this.options.source.action);
 
                 const isConditionalBlocked = action &&
-                    (effect.system.conditionals ?? []).some(x => x.constructor.metadata.phase === 'roll' && !x.test(this));
+                    (effect.system.conditionals ?? []).some(x => x.constructor.metadata.phase === 'roll' && !x.test(action.getRollData()));
                 // Some old v13 messages don't have system data and will cause errors here during roll construction otherwise. TODO. See if message.roll.options.effects can be saved/instantiated as actual ActiveEffects, then this can be removed.
                 if (
                     !isConditionalBlocked && 

--- a/module/dice/dualityRoll.mjs
+++ b/module/dice/dualityRoll.mjs
@@ -205,30 +205,7 @@ export default class DualityRoll extends D20Roll {
     }
 
     getActionChangeKeys() {
-        const changeKeys = new Set([`system.bonuses.roll.${this.options.actionType}`]);
-
-        if (this.options.roll.type !== CONFIG.DH.GENERAL.rollTypes.attack.id) {
-            changeKeys.add(`system.bonuses.roll.${this.options.roll.type}`);
-        }
-
-        if (
-            this.options.roll.type === CONFIG.DH.GENERAL.rollTypes.attack.id ||
-            (this.options.roll.type === CONFIG.DH.GENERAL.rollTypes.spellcast.id && this.options.hasDamage)
-        ) {
-            changeKeys.add(`system.bonuses.roll.attack`);
-        }
-
-        if (this.options.roll.trait && this.data.traits?.[this.options.roll.trait]) {
-            if (this.options.roll.type !== CONFIG.DH.GENERAL.rollTypes.spellcast.id)
-                changeKeys.add('system.bonuses.roll.trait');
-        }
-
-        const weapons = ['primaryWeapon', 'secondaryWeapon'];
-        weapons.forEach(w => {
-            if (this.options.source.item && this.options.source.item === this.data[w]?.id)
-                changeKeys.add(`system.bonuses.roll.${w}`);
-        });
-
+        const changeKeys = new Set(['system.bonuses.roll']);
         return changeKeys;
     }
 

--- a/module/documents/_types.d.ts
+++ b/module/documents/_types.d.ts
@@ -6,6 +6,7 @@ import EmbeddedCollection from '@common/abstract/embedded-collection.mjs';
 import DHToken from './token.mjs';
 import Actor from '@client/documents/actor.mjs';
 import Item from '@client/documents/item.mjs';
+import BaseEffect from '../data/activeEffect/baseEffect.mjs';
 
 declare module './actor.mjs' {
     export default interface DhpActor<T extends BaseDataActor = BaseDataActor> extends Actor {
@@ -35,5 +36,11 @@ declare module './item.mjs' {
             compendiumSource?: string;
             duplicateSource?: string;
         }
+    }
+}
+
+declare module './activeEffect.mjs' {
+    export default interface DhActiveEffect extends foundry.documents.ActiveEffect {
+        system: BaseEffect;
     }
 }

--- a/module/documents/activeEffect.mjs
+++ b/module/documents/activeEffect.mjs
@@ -7,7 +7,7 @@ export default class DhActiveEffect extends foundry.documents.ActiveEffect {
 
     /**@override */
     get isSuppressed() {
-        if (this.system.testIsSuppressed(this.actor?.getRollData()) === true) return true;
+        if (!this.system.testConditionals(this.actor?.getRollData())) return true;
 
         // If this is a copied effect from an attachment, never suppress it
         // (These effects have attachmentSource metadata)

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -754,8 +754,10 @@ export default class DhpActor extends Actor {
             headerTitle: `${game.i18n.localize('DAGGERHEART.GENERAL.dualityRoll')}: ${this.name}`,
             effects: await game.system.api.data.actions.actionsTypes.base.getActionRelevantEffects(
                 {
-                    actionType: 'action', 
-                    roll: { type: 'trait' }
+                    action: {
+                        actionType: 'action', 
+                        roll: { type: 'trait' }
+                    }
                 }, 
                 this
             ),

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -752,7 +752,13 @@ export default class DhpActor extends Actor {
                 ability: abilityLabel
             }),
             headerTitle: `${game.i18n.localize('DAGGERHEART.GENERAL.dualityRoll')}: ${this.name}`,
-            effects: await game.system.api.data.actions.actionsTypes.base.getActionRelevantEffects(this),
+            effects: await game.system.api.data.actions.actionsTypes.base.getActionRelevantEffects(
+                {
+                    actionType: 'action', 
+                    roll: { type: 'trait' }
+                }, 
+                this
+            ),
             roll: {
                 trait: trait,
                 type: 'trait'

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1277,15 +1277,12 @@ export default class DhpActor extends Actor {
 
     /**@inheritdoc */
     *allApplicableEffects({ noSelfArmor, noTransferArmor } = {}) {
+        /** @param {DhActiveEffect} effect */
         const isRemovedByConditional = effect => {
             const { preparation } = CONFIG.DH.EFFECTS.conditionalPhases;
             const { hide } = CONFIG.DH.EFFECTS.conditionalFailureModes;
             const rollData = this.getRollData();
-            return effect.system.conditionals.some(x => 
-                x.constructor.metadata.phase === preparation.id && 
-                x.constructor.metadata.failureMode === hide.id &&
-                !x.test(rollData)
-            );
+            return !effect.system.testConditionals(rollData, { phase: preparation.id, failureMode: hide.id });
         }
 
         for (const effect of this.effects) {

--- a/module/documents/chatMessage.mjs
+++ b/module/documents/chatMessage.mjs
@@ -193,7 +193,14 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
         if (this.system.action) {
             const actor = await foundry.utils.fromUuid(config.source.actor);
             const item = actor?.items.get(config.source.item) ?? null;
-            config.effects = await game.system.api.data.actions.actionsTypes.base.getActionRelevantEffects(actor, item);
+            const actions = item ? [
+                ...item.system.actions,
+                ...(item.system.attack?.id === config.source.action ? [item.system.attack] : [])
+            ] : [];
+            const action = actions.find(x => x.id === config.source.action);
+
+            config.effects = 
+                await game.system.api.data.actions.actionsTypes.base.getActionRelevantEffects(action, actor);
             await this.system.action.workflow.get('damage')?.execute(config, this._id, true);
         }
     }

--- a/module/documents/chatMessage.mjs
+++ b/module/documents/chatMessage.mjs
@@ -199,8 +199,8 @@ export default class DhpChatMessage extends foundry.documents.ChatMessage {
             ] : [];
             const action = actions.find(x => x.id === config.source.action);
 
-            config.effects = 
-                await game.system.api.data.actions.actionsTypes.base.getActionRelevantEffects(action, actor);
+            const { base } = game.system.api.data.actions.actionsTypes;
+            config.effects = await base.getActionRelevantEffects(action.getRollData(), actor);
             await this.system.action.workflow.get('damage')?.execute(config, this._id, true);
         }
     }

--- a/module/systemRegistration/handlebars.mjs
+++ b/module/systemRegistration/handlebars.mjs
@@ -69,6 +69,7 @@ export const preloadHandlebarsTemplates = async function () {
         'systems/daggerheart/templates/sheets/activeEffect/conditionals/dataCompareConditional.hbs',
         'systems/daggerheart/templates/sheets/activeEffect/conditionals/weaponRestrictionConditional.hbs',
         'systems/daggerheart/templates/sheets/activeEffect/conditionals/actionTypeConditional.hbs',
+        'systems/daggerheart/templates/sheets/activeEffect/conditionals/damageTypeConditional.hbs',
         'systems/daggerheart/templates/ui/chat/parts/target-tokens-part.hbs'
     ]);
 };

--- a/templates/sheets/activeEffect/conditionals.hbs
+++ b/templates/sheets/activeEffect/conditionals.hbs
@@ -15,6 +15,8 @@
                     {{> "systems/daggerheart/templates/sheets/activeEffect/conditionals/weaponRestrictionConditional.hbs" model=(lookup ../systemFields.conditionals.element.types conditional.type) }}
                 {{else if (eq conditional.type 'actionType')}}
                     {{> "systems/daggerheart/templates/sheets/activeEffect/conditionals/actionTypeConditional.hbs" model=(lookup ../systemFields.conditionals.element.types conditional.type) }}
+                {{else if (eq conditional.type 'damageType')}}
+                    {{> "systems/daggerheart/templates/sheets/activeEffect/conditionals/damageTypeConditional.hbs" model=(lookup ../systemFields.conditionals.element.types conditional.type) }}
                 {{/if}}
             </div>
         {{/each}}

--- a/templates/sheets/activeEffect/conditionals/damageTypeConditional.hbs
+++ b/templates/sheets/activeEffect/conditionals/damageTypeConditional.hbs
@@ -1,7 +1,7 @@
 <div class="conditional-container">
     <div class="conditional-inner-container">
         <input type="hidden" value="{{this.type}}" name="{{concat "system.conditionals." @key ".type"}}" />
-        {{formGroup model.fields.damageTypes value=this.damageTypes name=(concat "system.conditionals." @key ".damageTypes") localize=true blank=false }}
+        {{formGroup model.fields.damageType value=this.damageType name=(concat "system.conditionals." @key ".damageType") localize=true blank=false }}
     </div>
 
     <a class="form-row-icon" data-action="removeConditional" data-index="{{@key}}"><i class="fa-solid fa-trash"></i></a>

--- a/templates/sheets/activeEffect/conditionals/damageTypeConditional.hbs
+++ b/templates/sheets/activeEffect/conditionals/damageTypeConditional.hbs
@@ -1,0 +1,8 @@
+<div class="conditional-container">
+    <div class="conditional-inner-container">
+        <input type="hidden" value="{{this.type}}" name="{{concat "system.conditionals." @key ".type"}}" />
+        {{formGroup model.fields.damageTypes value=this.damageTypes name=(concat "system.conditionals." @key ".damageTypes") localize=true blank=false }}
+    </div>
+
+    <a class="form-row-icon" data-action="removeConditional" data-index="{{@key}}"><i class="fa-solid fa-trash"></i></a>
+</div>


### PR DESCRIPTION
Added a new Conditional Type
**DamageType**
_Phase:_ `Roll`
_failureMode:_ `remove`
This ensures that the the damage of the action has the correct damage types.

- I removed the separate Roll and Damage entries in `creature.system.bonuses`. Now there's only a singular entry for each and it'll be handled via conditionals.
- Cleaned up the keys and bonus handling for actions so it all works.