### PR TITLE
[Fix] ActiveEffect Displaying

### DIFF
--- a/module/canvas/placeables/token.mjs
+++ b/module/canvas/placeables/token.mjs
@@ -51,7 +51,7 @@ export default class DhTokenPlaceable extends foundry.canvas.placeables.Token {
         this.effects.overlay = null;
 
         // Categorize effects
-        const activeEffects = getIconVisibleActiveEffects(Array.from(this.actor?.allApplicableEffects() ?? []));
+        const activeEffects = getIconVisibleActiveEffects(this.actor?.getActiveEffects() ?? [])
         const overlayEffect = activeEffects.findLast(e => e.img && e.getFlag?.('core', 'overlay'));
 
         // Draw effects
@@ -82,7 +82,7 @@ export default class DhTokenPlaceable extends foundry.canvas.placeables.Token {
         const icon = new PIXI.Sprite(tex);
         icon.tint = tint ?? 0xffffff;
 
-        if (effect.system.stacking?.value > 1) {
+        if (effect.system?.stacking?.value > 1) {
             const stackOverlay = new PIXI.Text(effect.system.stacking.value, {
                 fill: '#f3c267',
                 stroke: '#000000',

--- a/module/documents/activeEffect.mjs
+++ b/module/documents/activeEffect.mjs
@@ -281,4 +281,23 @@ export default class DhActiveEffect extends foundry.documents.ActiveEffect {
             }
         }
     }
+
+    /** @inheritdoc */
+    _displayScrollingStatus(enabled) {
+        const actor = this.target;
+        const tokens = actor.getActiveTokens(true);
+        const text = `${enabled ? '+' : '−'}(${this.name})`;
+        for (const token of tokens) {
+            if (!token.visible || token.document.isSecret) continue;
+            canvas.interface.createScrollingText(token.center, text, {
+                anchor: CONST.TEXT_ANCHOR_POINTS.CENTER,
+                direction: enabled ? CONST.TEXT_ANCHOR_POINTS.TOP : CONST.TEXT_ANCHOR_POINTS.BOTTOM,
+                distance: (2 * token.h),
+                fontSize: 28,
+                stroke: 0x000000,
+                strokeThickness: 4,
+                jitter: 0.25
+            });
+        }
+    }
 }


### PR DESCRIPTION
**1)** Fixed so that statuses applied from another effect will be displayed on the canvas token. This had become since we added stacking for effects, since the simple objects generated for statuses would error out on a conditional.
<img width="856" height="435" alt="image" src="https://github.com/user-attachments/assets/97a62083-37e2-4180-b75a-fb5ae059d0a6" />

----
Fixes #2340 
**2)** This one I'm not 100% on, but I -think- it's good?
When an ActiveEffect is created/deleted enabled/disabled Foundry typically generates a scroll text on the canvas token showing that:
<img width="110" height="103" alt="image" src="https://github.com/user-attachments/assets/20967cdb-33a0-4d1c-9fb8-42107a5d42ed" />

Foundry's standard logic does this check though:
`if ( !(this.statuses.size || this.system.changes.length) ) return;`
I'm not sure I agree with that. There are a lot of ActiveEffects being applied that don't have any mechanical things attached to them, but that serve as markers for something that's handled narratively. I think these should still generate the text.
I copied the Foundry function and removed that conditional.