### PR TITLE
[Fix] Subclass Description Mastery Features

### DIFF
--- a/templates/sheets/items/subclass/description.hbs
+++ b/templates/sheets/items/subclass/description.hbs
@@ -21,7 +21,7 @@
             {{/each}}
         </div>
     {{/if}}
-    {{#if masterFeatures.length}}
+    {{#if masteryFeatures.length}}
         <div class="item-description-container">
             <h4>{{localize "DAGGERHEART.ITEMS.Subclass.masteryFeature"}}</h4>
             {{#each masteryFeatures as | feature |}}


### PR DESCRIPTION
Fixes #2338 
Fixed so mastery features are added to the Subclass descriptions. A misspelling made them not be shown.