### PR TITLE
[Feature] Scene Environments Always Visible

### DIFF
--- a/module/applications/ui/sceneNavigation.mjs
+++ b/module/applications/ui/sceneNavigation.mjs
@@ -31,7 +31,7 @@ export default class DhSceneNavigation extends foundry.applications.ui.SceneNavi
                 const environments = daggerheartInfo.sceneEnvironments.filter(
                     x => x && x.testUserPermission(game.user, 'LIMITED')
                 );
-                const hasEnvironments = environments.length > 0 && x.active;
+                const hasEnvironments = environments.length > 0;
                 return {
                     ...x,
                     hasEnvironments,

--- a/styles/less/ui/scene-navigation/scene-navigation.less
+++ b/styles/less/ui/scene-navigation/scene-navigation.less
@@ -1,11 +1,9 @@
 #ui-left #ui-left-column-2 {
-    flex: 0 0 230px;
-
     .scene-wrapper {
         display: flex;
         gap: 2px;
         height: var(--control-size);
-        width: 100%;
+        // width: 100%;
 
         > ul {
             margin: 0;
@@ -33,7 +31,16 @@
             border 0.25s,
             color 0.25s;
         text-shadow: none;
-        width: 200px;
-        max-width: 200px;
+        max-width: 18vw;
+    }
+
+    #scene-navigation-viewed {
+        .scene {
+            flex: 1;
+        }
+    }
+
+    #scene-navigation-active:empty {
+        display: none;
     }
 }

--- a/styles/less/ui/scene-navigation/scene-navigation.less
+++ b/styles/less/ui/scene-navigation/scene-navigation.less
@@ -3,7 +3,6 @@
         display: flex;
         gap: 2px;
         height: var(--control-size);
-        // width: 100%;
 
         > ul {
             margin: 0;

--- a/templates/ui/sceneNavigation/scene-navigation.hbs
+++ b/templates/ui/sceneNavigation/scene-navigation.hbs
@@ -14,15 +14,15 @@
     {{#if scenes.levels}}
         <menu id="scene-navigation-levels" class="scene-levels scene-navigation-menu flexcol" 
             style="--max-levels: {{ scenes.levels.length }}">
-            {{#each scenes.levels}}
+            {{#each scenes.levels as |level|}}
             <li class="level-row">
-                <div class="ui-control scene scene-level {{ css }}" data-scene-id="{{ sceneId }}" data-level-id="{{ id }}" data-action="viewLevel">
-                    <span class="ellipsis">{{ name }}</span>
+                <div class="ui-control scene scene-level {{level.css}}" data-scene-id="{{level.sceneId}}" data-level-id="{{level.id}}" data-action="viewLevel">
+                    <span class="ellipsis">{{level.name}}</span>
                     {{#if users}}
                     <ul class="scene-players">
-                        {{#each users}}
-                        <li class="scene-player" style="--color-bg: {{ color }}; --color-border: {{ border }}" data-tooltip
-                            aria-label="{{ name }}">{{ letter }}</li>
+                        {{#each users as |user|}}
+                        <li class="scene-player" style="--color-bg: {{user.color}}; --color-border: {{user.border}}" data-tooltip
+                            aria-label="{{user.name}}">{{user.letter}}</li>
                         {{/each}}
                     </ul>
                     {{/if}}
@@ -32,9 +32,9 @@
         </menu>
     {{/if}}
     <menu id="scene-navigation-active" class="scene-navigation-menu flexcol">
-        {{#each scenes.active}}
+        {{~#each scenes.active}}
         {{> ".scene" }}
-        {{/each}}
+        {{/each~}}
     </menu>
     <menu id="scene-navigation-inactive" class="scene-navigation-menu flexcol">
         {{#each scenes.inactive as |scene|}}
@@ -45,16 +45,23 @@
 
 {{#*inline ".scene"}}
 <li class="scene-wrapper">
-    <div class="ui-control scene {{ cssClass }}" data-scene-id="{{ id }}" data-action="viewScene" 
-        {{#if tooltip}}data-tooltip-text="{{ tooltip }}"{{/if}}>
-        <span class="scene-name ellipsis">{{ name }}</span>
+    <div class="ui-control flexrow scene{{#if isView}} view{{/if}}" data-scene-id="{{id}}" data-action="viewScene" 
+        {{#if tooltip}}data-tooltip aria-label="{{tooltip}}"{{/if}}>
+        <span class="scene-name ellipsis">{{name}}</span>
         {{#if users}}
         <ul class="scene-players">
-            {{#each users}}
-            <li class="scene-player" style="--color-bg: {{ color }}; --color-border: {{ border }}" data-tooltip
-                aria-label="{{ name }}">{{ letter }}</li>
+            {{#each users as |user|}}
+            <li class="scene-player" style="--color-bg: {{user.color}}; --color-border: {{user.border}}" data-tooltip
+                aria-label="{{user.name}}">{{user.letter}}</li>
             {{/each}}
         </ul>
+        {{/if}}
+        {{#if icons}}
+        <span class="icons flexrow">
+            {{#each icons as |icon|}}
+            <i class="icon fa-solid fa-{{icon.class}}" data-tooltip aria-label="{{icon.tooltip}}"></i>
+            {{/each}}
+        </span>
         {{/if}}
     </div>
     {{#if hasEnvironments}}


### PR DESCRIPTION
Changed so that the SceneEnvironment icon is always displayed even if the scene is inactive. 
It's been a point of confusion for users when nothing seems to happen while they're doing session prep with a scene inactive and nothing seems to change.