### PR TITLE
[Feature] Homebrew Domain Color Options

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2973,43 +2973,43 @@
                 "plural": "Domains",
                 "arcana": {
                     "label": "Arcana",
-                    "description": "This is the domain of the innate or instinctual use of magic. Those who walk this path tap into the raw, enigmatic forces of the realms to manipulate both the elements and their own energy. Arcana offers wielders a volatile power, but it is incredibly potent when correctly channeled."
+                    "description": "Arcana is the domain of innate and instinctual magic. Those who choose this path tap into the raw, enigmatic forces of the realms to manipulate both their own energy and the elements. Arcana offers wielders a volatile power, but it is incredibly potent when correctly channeled."
                 },
                 "blade": {
                     "label": "Blade",
-                    "description": "This is the domain of those who dedicate their lives to the mastery of weapons. Whether by blade, bow, or perhaps a more specialized arm, those who follow this path have the skill to cut short the lives of others. Blade requires study and dedication from its followers, in exchange for inexorable power over death."
+                    "description": "Blade is the domain of weapon mastery. Whether by steel, bow, or perhaps a more specialized arm, those who follow this path have the skill to cut short the lives of others. Wielders of Blade dedicate themselves to achieving inexorable power over death."
                 },
                 "bone": {
                     "label": "Bone",
-                    "description": "This is the domain of mastery of swiftness and tactical mastery. Practitioners of this domain have an uncanny control over their own physical abilities, and an eye for predicting the behaviors of others in combat. Bone grants its adherents unparalleled understanding of bodies and their movements in exchange for diligent training."
+                    "description": "Bone is the domain of tactics and the body. Practitioners of this domain have an uncanny control over their own physical abilities and an eye for predicting the behaviors of others in combat. Adherents to Bone gain an unparalleled understanding of bodies and their movements."
                 },
                 "codex": {
                     "label": "Codex",
-                    "description": "This is the domain of intensive magical study. Those who seek magical knowledge turn to the recipes of power recorded in books, on scrolls, etched into walls, or tattooed on bodies. Codex offers a commanding and versatile understanding of magic to those devotees who are willing to seek beyond the common knowledge."
+                    "description": "Codex is the domain of intensive magical study. Those who seek magical knowledge turn to the equations of power recorded in books, written on scrolls, etched into walls, or tattooed on bodies. Codex offers a commanding and versatile understanding of magic to devotees who pursue knowledge beyond the boundaries of common wisdom."
                 },
                 "dread": {
                     "label": "Dread",
-                    "description": "This is the domain of nightmares and fear. Those who choose this path can call forth monstrosities, enfeeble their foes, and channel terrifying magic to destroy their enemies. Dread grants its adherents power over forces most are too afraid to employ."
+                    "description": "Dread is the domain of nightmares and fear. Those who choose this path can call forth monstrosities, enfeeble their foes, and channel terrifying magic to destroy their enemies. Dread grants its adherents power over forces most are too afraid to employ."
                 },
                 "grace": {
                     "label": "Grace",
-                    "description": "This is the domain of charisma. Through rapturous storytelling, clever charm, or a shroud of lies, those who channel this power define the realities of their adversaries, bending perception to their will. Grace offers its wielders raw magnetism and mastery over language."
+                    "description": "Grace is the domain of charisma. Through rapturous storytelling, charming spells, or a shroud of lies, those who channel this power define the realities of their adversaries, bending perception to their will. Grace offers its wielders raw magnetism and mastery over language."
                 },
                 "midnight": {
                     "label": "Midnight",
-                    "description": "This is the domain of shadows and secrecy. Whether by clever tricks, or cloak of night those who channel these forces are practiced in that art of obscurity and there is nothing hidden they cannot reach. Midnight offers practitioners the incredible power to control and create enigmas."
+                    "description": "Midnight is the domain of shadows and secrecy. Whether by clever tricks, deft magic, or the cloak of night, those who channel these forces practice the art of obscurity and can uncover sequestered treasures. Midnight offers practitioners the power to control and create enigmas."
                 },
                 "sage": {
                     "label": "Sage",
-                    "description": "This is the domain of the natural world. Those who walk this path tap into the unfettered power of the earth and its creatures to unleash raw magic. Sage grants its adherents the vitality of a blooming flower and ferocity of a hungry predator."
+                    "description": "Sage is the domain of the natural world. Those who walk this path tap into the unfettered power of the earth and its creatures to unleash raw magic. Sage grants its adherents the vitality of a blooming flower and the ferocity of a ravenous predator."
                 },
                 "splendor": {
                     "label": "Splendor",
-                    "description": "This is the domain of life. Through this magic, followers gain the ability to heal, though such power also grants the wielder some control over death. Splendor offers its disciples the magnificent ability to both give and end life."
+                    "description": "Splendor is the domain of life. Through this magic, followers gain the ability to heal and, to an extent, control death. Splendor offers its disciples the magnificent ability to both give and end life."
                 },
                 "valor": {
                     "label": "Valor",
-                    "description": "This is the domain of protection. Whether through attack or defense, those who choose this discipline channel formidable strength to protect their allies in battle. Valor offers great power to those who raise their shield in defense of others."
+                    "description": "Valor is the domain of protection. Whether through attack or defense, those who choose this discipline channel formidable strength to protect their allies in battle. Valor offers great power to those who raise their shields in defense of others."
                 }
             },
             "Effect": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -3845,6 +3845,14 @@
                 "deleteResourceTitle": "Delete Homebrew Resource",
                 "deleteResourceText": "Are you sure you want to delete the resource?",
                 "FIELDS": {
+                    "domains": {
+                        "color": { 
+                            "label": "Banner Color" 
+                        },
+                        "invertText": {
+                            "label": "Invert Text Color"
+                        }
+                    },
                     "maxFear": {
                         "label": "Max Fear"
                     },

--- a/module/data/settings/Homebrew.mjs
+++ b/module/data/settings/Homebrew.mjs
@@ -144,7 +144,14 @@ export default class DhHomebrew extends foundry.abstract.DataModel {
                         base64: false,
                         label: 'Image'
                     }),
-                    description: new fields.HTMLField()
+                    description: new fields.HTMLField(),
+                    color: new fields.ColorField({ 
+                        label: 'DAGGERHEART.SETTINGS.Homebrew.FIELDS.domains.color.label',
+                        initial: '#000000'
+                    }),
+                    invertText: new fields.BooleanField({ 
+                        label: 'DAGGERHEART.SETTINGS.Homebrew.FIELDS.domains.invertText.label' 
+                    })
                 })
             ),
             adversaryTypes: new fields.TypedObjectField(

--- a/templates/components/card/domain.hbs
+++ b/templates/components/card/domain.hbs
@@ -3,7 +3,7 @@
         <img class="portrait" src="{{item.img}}"/>
         {{#> "systems/daggerheart/templates/components/card-banner.hbs" domain=domain}}
             <span class="level">{{item.system.level}}</span>
-            <span data-tooltip="{{domain.label}}">
+            <span data-tooltip="{{domain.description}}">
                 <!-- images ignore pointer events in journals for these, so we wrap it for tooltip -->
                 <img class="domain-icon" src="{{domain.src}}">
             </span>

--- a/templates/settings/homebrew-settings/domains.hbs
+++ b/templates/settings/homebrew-settings/domains.hbs
@@ -39,6 +39,8 @@
             <legend>{{localize "DAGGERHEART.SETTINGS.Homebrew.domains.editDomain"}} <button class="add-button" data-action="deleteDomain"><i class="fa-solid fa-x"></i></button></legend>
 
             <div class="domain-filepicker-row">{{formGroup settingFields.schema.fields.domains.element.fields.src value=selectedDomain.src name=(concat "domains." selectedDomain.id ".src") localize=true}}</div>
+            {{formGroup settingFields.schema.fields.domains.element.fields.color value=selectedDomain.color name=(concat "domains." selectedDomain.id ".color") localize=true}}
+            {{formGroup settingFields.schema.fields.domains.element.fields.invertText value=selectedDomain.invertText name=(concat "domains." selectedDomain.id ".invertText") localize=true}}
             <textarea name="{{concat "domains." selectedDomain.id ".description"}}">{{selectedDomain.description}}</textarea>
         </fieldset>
     </div>

--- a/templates/sheets/actors/character/header.hbs
+++ b/templates/sheets/actors/character/header.hbs
@@ -82,7 +82,7 @@
             <div class="domains-section">
                 {{#each document.system.domainData as |data|}}
                     <div class="domain">
-                        <img src="{{data.src}}" alt="" data-tooltip="{{data.label}}" />
+                        <img src="{{data.src}}" alt="" data-tooltip="{{data.description}}" />
                     </div>
                 {{/each}}
             </div>

--- a/templates/sheets/items/domainCard/header.hbs
+++ b/templates/sheets/items/domainCard/header.hbs
@@ -2,7 +2,7 @@
     <img class='profile' src='{{source.img}}' data-action='editImage' data-edit='img' />
     {{#> "systems/daggerheart/templates/components/card-banner.hbs" domain=@root.domain}}
         <span class="level">{{source.system.level}}</span>
-        <img class="domain-icon" src="{{domain.src}}" data-tooltip="{{domain.label}}">
+        <img class="domain-icon" src="{{domain.src}}" data-tooltip="{{domain.description}}">
     {{/ "systems/daggerheart/templates/components/card-banner.hbs"}}
 
     <div class="recall-cost" data-tooltip="DAGGERHEART.ITEMS.DomainCard.recallCost">


### PR DESCRIPTION
Fixes #2337
Added homebrew domain support for banner color and inverting the text color

----
I also changed so that the tooltip for hovering the domain icon in the DomainCard Sheet and the Character Sheet is the domain's description, instead of just showing the domain name.
<img width="710" height="901" alt="image" src="https://github.com/user-attachments/assets/f41324b6-80b8-4f2f-8309-eb734c058ff4" />
