### PR TITLE
[Fix] environment embed issues

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -313,7 +313,6 @@
                 "confirmDeleteAttack": "Are you sure you want to delete this adversary's attack?",
                 "Embed": {
                     "attack": "ATK",
-                    "potentialAdversaries": "Potential Adversaries",
                     "thresholds": "Thresholds"
                 },
                 "hordeDamage": "Horde Damage",
@@ -434,9 +433,6 @@
                 },
                 "noPartner": "No Partner selected"
             },
-            "Embed": {
-
-            },
             "Environment": {
                 "FIELDS": {
                     "description": {
@@ -455,7 +451,12 @@
                         "label": "Type"
                     }
                 },
-                "newAdversary": "New Adversary"
+                "newAdversary": "New Adversary",
+                "Embed": {
+                    "potentialAdversaries": "Potential Adversaries",
+                    "any": "Any",
+                    "special": "Special"
+                }
             },
             "NPC": {
                 "FIELDS": {

--- a/module/data/actor/environment.mjs
+++ b/module/data/actor/environment.mjs
@@ -98,7 +98,8 @@ export default class DhEnvironment extends BaseDataActor {
         return {
             ...(await super._prepareEmbedContext(options)),
             type: _loc(environmentTypes[this.type]?.label),
-            potentialAdversaries: adversaryGroups.join(', ')
+            difficulty: this.difficulty || _loc('DAGGERHEART.ACTORS.Environment.Embed.special'),
+            potentialAdversaries: adversaryGroups.join(', ') || _loc('DAGGERHEART.ACTORS.Environment.Embed.any')
         };
     }
 }

--- a/styles/less/global/embed.less
+++ b/styles/less/global/embed.less
@@ -45,10 +45,7 @@
         display: flex;
         align-items: baseline;
         padding-inline: 0.5rem;
-
-        > * {
-            white-space: nowrap;
-        }
+        flex-wrap: wrap;
     }
 
     .divider {

--- a/styles/less/utils/colors.less
+++ b/styles/less/utils/colors.less
@@ -99,10 +99,10 @@
     --dh-card-trim-highlight: #ff9933;
 
     --dh-color-text-shadow-contrast: light-dark(#ffffffa0, @dark-80);
-    --dh-embed-bg: #F4F0E7;
-    --dh-embed-stats-bg: white;
-    --dh-embed-color-text: black;
-    --dh-embed-color-border: #DDD0B9;
+    --dh-embed-bg: light-dark(#F4F0E7, #111);
+    --dh-embed-stats-bg: light-dark(white, black);
+    --dh-embed-color-text: light-dark(black, @color-text-primary);
+    --dh-embed-color-border: light-dark(#DDD0B9, @beige-80);
     --dh-input-color-border: light-dark(@dark, @beige);
     --dh-input-color-text: light-dark(@dark, @beige);
     --dh-button-color-bg: light-dark(transparent, @golden);

--- a/templates/components/actor-embed/environment.hbs
+++ b/templates/components/actor-embed/environment.hbs
@@ -6,7 +6,7 @@
         </div>
         <section class="description">{{{description}}}</section>
         <div class="impulses">
-            <strong>{{localize "DAGGERHEART.ACTORS.Adversary.FIELDS.motivesAndTactics.label"}}:</strong>
+            <strong>{{localize "DAGGERHEART.ACTORS.Environment.FIELDS.impulses.label"}}:</strong>
             {{actor.system.impulses}}
         </div>
     </header>
@@ -14,12 +14,12 @@
         <div class="row">
             <div class="difficulty">
                 <strong>{{localize "DAGGERHEART.GENERAL.difficulty"}}:</strong>
-                {{actor.system.difficulty}}
+                {{difficulty}}
             </div>
         </div>
         <div class="row attack">
             <div class="bonus">
-                <strong>{{localize "DAGGERHEART.ACTORS.Adversary.Embed.potentialAdversaries"}}:</strong>
+                <strong>{{localize "DAGGERHEART.ACTORS.Environment.Embed.potentialAdversaries"}}:</strong>
                 {{potentialAdversaries}}
             </div>
         </div>


### PR DESCRIPTION
The data doesn't have everything, so it can't all be represented, but reduces the divide a bit. Fixes some label issues, what happens on a long potential adversary list, and adds support for dark mode embeds in dark mode journals.