### PR TITLE
[Fix] AutoRoll Criticals

### DIFF
--- a/module/data/chat-message/chatDamageData.mjs
+++ b/module/data/chat-message/chatDamageData.mjs
@@ -18,7 +18,7 @@ export class ChatDamageData extends foundry.abstract.DataModel {
             return Roll.fromJSON(this.parent.parent._source.rolls[0]).isCritical;
         }
 
-        return false;
+        return undefined;
     }
 
     static defineSchema() {

--- a/module/dice/damageRoll.mjs
+++ b/module/dice/damageRoll.mjs
@@ -217,7 +217,7 @@ export default class DamageRoll extends DHRoll {
                 }
             }
 
-            if (config.isCritical) {
+            if (config.isCritical && config.dialog.configure !== false) {
                 const total = formulaData.roll.dice.reduce((acc, term) => acc + term._faces * term._number, 0);
                 if (total > 0) {
                     formulaData.roll.terms.push(...this.formatModifier(total));


### PR DESCRIPTION
- Fixed so that critical damage ends up correctly in the chat message when using rollMode `Show Dialog` 
- Fixed so that rollMode `Always` doesn't add double critical damage