### PR TITLE
[Feature] Countdown Edit Menu Categories

### DIFF
--- a/module/applications/ui/countdownEdit.mjs
+++ b/module/applications/ui/countdownEdit.mjs
@@ -58,12 +58,13 @@ export default class CountdownEdit extends HandlebarsApplicationMixin(Applicatio
                         : 'DAGGERHEART.UI.Countdowns.loop'
                 : null;
             const randomizeValid = !new Roll(countdown.progress.startFormula ?? '').isDeterministic;
-            acc[key] = {
+
+            acc[countdown.type].countdowns[key] = {
                 ...countdown,
-                typeName: game.i18n.localize(CONFIG.DH.GENERAL.countdownTypes[countdown.type].label),
+                typeName: acc[countdown.type].name,
                 progress: {
                     ...countdown.progress,
-                    typeName: game.i18n.localize(
+                    typeName: _loc(
                         CONFIG.DH.GENERAL.countdownProgressionTypes[countdown.progress.type].label
                     )
                 },
@@ -73,7 +74,10 @@ export default class CountdownEdit extends HandlebarsApplicationMixin(Applicatio
             };
 
             return acc;
-        }, {});
+        }, Object.keys(CONFIG.DH.GENERAL.countdownTypes).reduce((acc, type) => {
+            acc[type] = { name: _loc(CONFIG.DH.GENERAL.countdownTypes[type].label), countdowns: {} };
+            return acc;
+        }, {}));
 
         return context;
     }
@@ -156,12 +160,12 @@ export default class CountdownEdit extends HandlebarsApplicationMixin(Applicatio
      * @this CountdownEdit
      * @type {import('@client/applications/_types.mjs').ApplicationClickAction}
      */
-    static #onAddCountdown() {
+    static #onAddCountdown(_event, button) {
         const id = foundry.utils.randomID();
         this.editingCountdowns.add(id);
         this.currentEditCountdown = id;
         this.updateSetting({
-            [`countdowns.${id}`]: DhCountdown.defaultCountdown(null, this.data.hideNewCountdowns)
+            [`countdowns.${id}`]: DhCountdown.defaultCountdown(button.dataset.type, this.data.hideNewCountdowns)
         });
     }
 

--- a/module/applications/ui/countdownEdit.mjs
+++ b/module/applications/ui/countdownEdit.mjs
@@ -59,6 +59,7 @@ export default class CountdownEdit extends HandlebarsApplicationMixin(Applicatio
                 : null;
             const randomizeValid = !new Roll(countdown.progress.startFormula ?? '').isDeterministic;
 
+            acc[countdown.type].nrCountdowns += 1;
             acc[countdown.type].countdowns[key] = {
                 ...countdown,
                 typeName: acc[countdown.type].name,
@@ -75,7 +76,7 @@ export default class CountdownEdit extends HandlebarsApplicationMixin(Applicatio
 
             return acc;
         }, Object.keys(CONFIG.DH.GENERAL.countdownTypes).reduce((acc, type) => {
-            acc[type] = { name: _loc(CONFIG.DH.GENERAL.countdownTypes[type].label), countdowns: {} };
+            acc[type] = { name: _loc(CONFIG.DH.GENERAL.countdownTypes[type].label), nrCountdowns: 0, countdowns: {} };
             return acc;
         }, {}));
 

--- a/styles/less/ui/countdown/countdown-edit.less
+++ b/styles/less/ui/countdown/countdown-edit.less
@@ -9,15 +9,6 @@
     color: light-dark(@dark, @beige);
     background-image: url('../assets/parchments/dh-parchment-dark.png');
 
-    .countdown-category {
-        padding-left: 0;
-        padding-right: 0;
-
-        legend {
-            margin-left: 0.75rem;
-        }
-    }
-
     .edit-container {
         display: flex;
         flex-direction: column;
@@ -44,20 +35,36 @@
             overflow-x: hidden;
             max-height: 500px;
 
+            .countdown-category {
+                padding-right: 0.5rem;
+                padding-left: 0.5rem;
+
+                legend {
+                    margin-left: 0.25rem;
+                    margin-right: 0.25rem;
+
+                    a {
+                        padding: 8px;
+                        margin: -8px;
+                    }
+                }
+            }
+
             .countdowns-container {
                 display: flex;
                 flex-direction: column;
-                gap: 6px;
+                gap: 3px;
 
                 .countdown-edit-outer-container {
                     display: flex;
                     flex-direction: column;
                     align-items: flex-start;
                     gap: 8px;
+                    padding: 4px;
+                    border-radius: 6px;
 
-                    &.many-countdowns:not(:last-child) {
-                        border-bottom: 2px solid @color-fieldset-border;
-                        padding-bottom: 6px;
+                    &.editing {
+                        background: @dark-blue-90;
                     }
 
                     .countdown-edit-container {
@@ -66,8 +73,6 @@
                         grid-template-columns: 48px 1fr 72px;
                         align-items: center;
                         gap: 8px;
-                        padding-right: 0.75rem;
-                        padding-left: 0.75rem;
 
                         img {
                             width: 52px;
@@ -127,8 +132,6 @@
                     display: flex;
                     flex-direction: column;
                     gap: 2px;
-                    padding-right: 0.75rem;
-                    padding-left: 0.75rem;
 
                     .countdown-edit-subrow {
                         display: flex;

--- a/styles/less/ui/countdown/countdown-edit.less
+++ b/styles/less/ui/countdown/countdown-edit.less
@@ -9,6 +9,15 @@
     color: light-dark(@dark, @beige);
     background-image: url('../assets/parchments/dh-parchment-dark.png');
 
+    .countdown-category {
+        padding-left: 0;
+        padding-right: 0;
+
+        legend {
+            margin-left: 0.75rem;
+        }
+    }
+
     .edit-container {
         display: flex;
         flex-direction: column;
@@ -38,7 +47,7 @@
             .countdowns-container {
                 display: flex;
                 flex-direction: column;
-                gap: 4px;
+                gap: 6px;
 
                 .countdown-edit-outer-container {
                     display: flex;
@@ -46,12 +55,19 @@
                     align-items: flex-start;
                     gap: 8px;
 
+                    &.many-countdowns:not(:last-child) {
+                        border-bottom: 2px solid @color-fieldset-border;
+                        padding-bottom: 6px;
+                    }
+
                     .countdown-edit-container {
                         width: 100%;
                         display: grid;
                         grid-template-columns: 48px 1fr 72px;
                         align-items: center;
                         gap: 8px;
+                        padding-right: 0.75rem;
+                        padding-left: 0.75rem;
 
                         img {
                             width: 52px;
@@ -111,6 +127,8 @@
                     display: flex;
                     flex-direction: column;
                     gap: 2px;
+                    padding-right: 0.75rem;
+                    padding-left: 0.75rem;
 
                     .countdown-edit-subrow {
                         display: flex;
@@ -169,22 +187,6 @@
                             font-size: 18px;
                         }
                     }
-
-                    // .countdown-random-container {
-                    //     width: 100%;
-                    //     display: flex;
-
-                    //     input {
-                    //         border-radius: 6px 0 0 6px;
-                    //         border-right: 0;
-                    //     }
-
-                    //     button {
-                    //         border-radius: 0 6px 6px 0;
-                    //         height: var(--input-height);
-                    //         border: 1px solid white;
-                    //     }
-                    // }
 
                     input,
                     select {

--- a/styles/less/ui/countdown/countdown-edit.less
+++ b/styles/less/ui/countdown/countdown-edit.less
@@ -15,7 +15,8 @@
 
         .dialog-header {
             display: flex;
-            align-items: center;
+            align-items: baseline;
+            justify-content: space-between;
             gap: 8px;
             padding-bottom: 0;
 
@@ -64,7 +65,7 @@
                     border-radius: 6px;
 
                     &.editing {
-                        background: @dark-blue-90;
+                        background: light-dark(@dark-blue-10, @beige-15);
                     }
 
                     .countdown-edit-container {

--- a/styles/less/ui/countdown/countdown-edit.less
+++ b/styles/less/ui/countdown/countdown-edit.less
@@ -12,17 +12,12 @@
     .edit-container {
         display: flex;
         flex-direction: column;
-        gap: 8px;
 
-        h2 {
-            text-align: center;
-            color: light-dark(@dark, @golden);
-        }
-
-        .header-tools {
+        .dialog-header {
             display: flex;
-            justify-content: space-between;
             align-items: center;
+            gap: 8px;
+            padding-bottom: 0;
 
             .hide-tools {
                 white-space: nowrap;
@@ -31,171 +26,171 @@
                 align-items: center;
                 gap: 4px;
             }
-
-            .header-main-button {
-                height: 32px;
-                width: 250px;
-            }
         }
 
         .edit-content {
             display: flex;
             flex-direction: column;
-            gap: 8px;
             overflow-y: auto;
             overflow-x: hidden;
             max-height: 500px;
 
-            .countdown-edit-outer-container {
+            .countdowns-container {
                 display: flex;
                 flex-direction: column;
-                align-items: flex-start;
-                gap: 8px;
+                gap: 4px;
 
-                .countdown-edit-container {
-                    width: 100%;
-                    display: grid;
-                    grid-template-columns: 48px 1fr 72px;
-                    align-items: center;
+                .countdown-edit-outer-container {
+                    display: flex;
+                    flex-direction: column;
+                    align-items: flex-start;
                     gap: 8px;
 
-                    img {
-                        width: 52px;
-                        height: 52px;
-                        border-radius: 6px;
-                    }
-
-                    .countdown-edit-text {
-                        display: flex;
-                        flex-direction: column;
-                        justify-content: center;
+                    .countdown-edit-container {
+                        width: 100%;
+                        display: grid;
+                        grid-template-columns: 48px 1fr 72px;
+                        align-items: center;
                         gap: 8px;
 
-                        .countdown-edit-subtext {
+                        img {
+                            width: 52px;
+                            height: 52px;
+                            border-radius: 6px;
+                        }
+
+                        .countdown-edit-text {
                             display: flex;
-                            align-items: center;
-                            gap: 10px;
+                            flex-direction: column;
+                            justify-content: center;
+                            gap: 8px;
 
-                            .countdown-edit-sub-tag {
-                                padding: 3px 5px;
-                                font-size: var(--font-size-12);
-                                font: @font-body;
+                            .countdown-edit-subtext {
+                                display: flex;
+                                align-items: center;
+                                gap: 10px;
 
-                                background: light-dark(@dark-15, @beige-15);
-                                border: 1px solid light-dark(@dark, @beige);
-                                border-radius: 3px;
-                            }
+                                .countdown-edit-sub-tag {
+                                    padding: 3px 5px;
+                                    font-size: var(--font-size-12);
+                                    font: @font-body;
 
-                            .countdown-edit-loop {
-                                position: relative;
+                                    background: light-dark(@dark-15, @beige-15);
+                                    border: 1px solid light-dark(@dark, @beige);
+                                    border-radius: 3px;
+                                }
 
-                                .loop-marker {
-                                    position: absolute;
-                                    top: -4px;
-                                    font-size: 10px;
+                                .countdown-edit-loop {
+                                    position: relative;
+
+                                    .loop-marker {
+                                        position: absolute;
+                                        top: -4px;
+                                        font-size: 10px;
+                                    }
                                 }
                             }
                         }
-                    }
 
-                    .countdown-edit-tools {
+                        .countdown-edit-tools {
+                            display: flex;
+                            gap: 8px;
+
+                            &.same-row {
+                                margin-top: 17.5px;
+                            }
+
+                            a {
+                                font-size: 16px;
+                            }
+                        }
+                    }
+                }
+
+                .countdown-edit-row-container {
+                    display: flex;
+                    flex-direction: column;
+                    gap: 2px;
+
+                    .countdown-edit-subrow {
                         display: flex;
                         gap: 8px;
+                    }
+                }
 
-                        &.same-row {
-                            margin-top: 17.5px;
+                .countdown-edit-input {
+                    position: relative;
+                    flex: 1;
+                    display: flex;
+                    flex-direction: column;
+                    align-items: flex-start;
+                    gap: 2px;
+
+                    &.type-input {
+                        min-width: 140px;
+                    }
+
+                    &.looping-input {
+                        min-width: 120px;
+                    }
+
+                    &.tiny {
+                        flex: 0;
+
+                        label {
+                            white-space: nowrap;
                         }
 
-                        a {
-                            font-size: 16px;
+                        input {
+                            min-width: 2.5rem;
                         }
                     }
-                }
-            }
 
-            .countdown-edit-row-container {
-                display: flex;
-                flex-direction: column;
-                gap: 2px;
-
-                .countdown-edit-subrow {
-                    display: flex;
-                    gap: 8px;
-                }
-            }
-
-            .countdown-edit-input {
-                position: relative;
-                flex: 1;
-                display: flex;
-                flex-direction: column;
-                align-items: flex-start;
-                gap: 2px;
-
-                &.type-input {
-                    min-width: 140px;
-                }
-
-                &.looping-input {
-                    min-width: 120px;
-                }
-
-                &.tiny {
-                    flex: 0;
-
-                    label {
-                        white-space: nowrap;
+                    .countdown-random-input {
+                        padding-right: var(--input-height);
                     }
 
-                    input {
-                        min-width: 2.5rem;
-                    }
-                }
+                    .countdown-random-button {
+                        position: absolute;
+                        right: 0px;
+                        bottom: 0px;
+                        border-radius: 0 6px 6px 0;
+                        height: var(--input-height);
+                        display: flex;
+                        align-items: center;
+                        justify-content: center;
+                        padding: 0 8px;
 
-                .countdown-random-input {
-                    padding-right: var(--input-height);
-                }
+                        &[disabled] {
+                            opacity: 0.5;
+                        }
 
-                .countdown-random-button {
-                    position: absolute;
-                    right: 0px;
-                    bottom: 0px;
-                    border-radius: 0 6px 6px 0;
-                    height: var(--input-height);
-                    display: flex;
-                    align-items: center;
-                    justify-content: center;
-                    padding: 0 8px;
-
-                    &[disabled] {
-                        opacity: 0.5;
+                        i {
+                            font-size: 18px;
+                        }
                     }
 
-                    i {
-                        font-size: 18px;
+                    // .countdown-random-container {
+                    //     width: 100%;
+                    //     display: flex;
+
+                    //     input {
+                    //         border-radius: 6px 0 0 6px;
+                    //         border-right: 0;
+                    //     }
+
+                    //     button {
+                    //         border-radius: 0 6px 6px 0;
+                    //         height: var(--input-height);
+                    //         border: 1px solid white;
+                    //     }
+                    // }
+
+                    input,
+                    select {
+                        background: light-dark(@beige, @dark-blue);
+                        color: light-dark(@dark, @beige);
                     }
-                }
-
-                // .countdown-random-container {
-                //     width: 100%;
-                //     display: flex;
-
-                //     input {
-                //         border-radius: 6px 0 0 6px;
-                //         border-right: 0;
-                //     }
-
-                //     button {
-                //         border-radius: 0 6px 6px 0;
-                //         height: var(--input-height);
-                //         border: 1px solid white;
-                //     }
-                // }
-
-                input,
-                select {
-                    background: light-dark(@beige, @dark-blue);
-                    color: light-dark(@dark, @beige);
                 }
             }
         }

--- a/templates/ui/countdowns/countdown-edit.hbs
+++ b/templates/ui/countdowns/countdown-edit.hbs
@@ -2,96 +2,101 @@
     <div class="edit-container">
         <header class="dialog-header">
             <h1>{{localize "DAGGERHEART.APPLICATIONS.CountdownEdit.editTitle"}}</h1>
+            <label class="hide-tools">
+                <span>{{localize "DAGGERHEART.APPLICATIONS.CountdownEdit.hideNewCountdowns"}}</span>
+                <input id="hide-new-countdowns" type="checkbox" name="hideNewCountdowns" {{checked hideNewCountdowns}} />
+            </label>
         </header>
 
-        <div class="header-tools">
-            <button class="header-main-button" data-action="addCountdown"><i class="fa-solid fa-plus"></i> {{localize "DAGGERHEART.APPLICATIONS.CountdownEdit.newCountdown"}}</button>
-            {{#if isGM}}
-                <label class="hide-tools">
-                    <span>{{localize "DAGGERHEART.APPLICATIONS.CountdownEdit.hideNewCountdowns"}}</span>
-                    <input id="hide-new-countdowns" type="checkbox" name="hideNewCountdowns" {{checked hideNewCountdowns}} />
-                </label>
-            {{/if}}
-        </div>
-
         <div class="edit-content">
-            {{#each countdowns as | countdown id | }}
-            <fieldset class="countdown-edit-outer-container">
-                <div class="countdown-edit-container {{#unless countdown.editing}}viewing{{/unless}}" data-id="{{id}}">
-                    <a data-action="editCountdownImage" id="{{id}}"><img src="{{countdown.img}}" /></a>
-                    {{#unless countdown.editing}} 
-                        <div class="countdown-edit-text">
-                            <h4>{{countdown.name}}</h4>
-                            <div class="countdown-edit-subtext">
-                                <div class="countdown-edit-sub-tag">{{localize "DAGGERHEART.APPLICATIONS.CountdownEdit.currentCountdownCurrent" value=countdown.progress.current}}</div>
-                                <div class="countdown-edit-sub-tag">{{localize "DAGGERHEART.APPLICATIONS.CountdownEdit.currentCountdownStart" value=countdown.progress.start}}</div>
-                                <div class="countdown-edit-sub-tag">{{countdown.typeName}}</div>
-                                <div class="countdown-edit-sub-tag">{{countdown.progress.typeName}}</div>
+            {{#each countdowns as | category id | }}
+                <fieldset>
+                    <legend>
+                        {{category.name}}
+                        <a data-action="addCountdown" data-type="{{id}}"><i class="fa-solid fa-plus"></i></a>
+                    </legend>
 
-                                {{#unless (eq countdown.progress.looping "noLooping")}}
-                                    <div class="countdown-edit-loop" data-tooltip="{{countdown.loopTooltip}}">
-                                        <i class="fa-solid fa-repeat"></i>
-                                        {{#if (eq countdown.progress.looping "increasing")}}
-                                            <i class="loop-marker fa-solid fa-angles-up"></i>
-                                        {{else if (eq countdown.progress.looping "decreasing")}}
-                                            <i class="loop-marker fa-solid fa-angles-down"></i>
-                                        {{/if}}
+                    <div class="countdowns-container">
+                        {{#each category.countdowns as | countdown id |}}
+                            <div class="countdown-edit-outer-container">
+                                <div class="countdown-edit-container {{#unless countdown.editing}}viewing{{/unless}}" data-id="{{id}}">
+                                    <a data-action="editCountdownImage" id="{{id}}"><img src="{{countdown.img}}" /></a>
+                                    {{#unless countdown.editing}} 
+                                        <div class="countdown-edit-text">
+                                            <h4>{{countdown.name}}</h4>
+                                            <div class="countdown-edit-subtext">
+                                                <div class="countdown-edit-sub-tag">{{localize "DAGGERHEART.APPLICATIONS.CountdownEdit.currentCountdownCurrent" value=countdown.progress.current}}</div>
+                                                <div class="countdown-edit-sub-tag">{{localize "DAGGERHEART.APPLICATIONS.CountdownEdit.currentCountdownStart" value=countdown.progress.start}}</div>
+                                                <div class="countdown-edit-sub-tag">{{countdown.typeName}}</div>
+                                                <div class="countdown-edit-sub-tag">{{countdown.progress.typeName}}</div>
+
+                                                {{#unless (eq countdown.progress.looping "noLooping")}}
+                                                    <div class="countdown-edit-loop" data-tooltip="{{countdown.loopTooltip}}">
+                                                        <i class="fa-solid fa-repeat"></i>
+                                                        {{#if (eq countdown.progress.looping "increasing")}}
+                                                            <i class="loop-marker fa-solid fa-angles-up"></i>
+                                                        {{else if (eq countdown.progress.looping "decreasing")}}
+                                                            <i class="loop-marker fa-solid fa-angles-down"></i>
+                                                        {{/if}}
+                                                    </div>
+                                                {{/unless}}
+                                            </div>
+                                        </div>
+                                    {{else}}
+                                        <div class="countdown-edit-input">
+                                            <label>{{localize "DAGGERHEART.APPLICATIONS.Countdown.FIELDS.countdowns.element.name.label"}}</label>
+                                            <input type="text" name="{{concat "countdowns." id ".name"}}" value="{{countdown.name}}" />
+                                        </div>
+                                    {{/unless}}
+                                    <div class="countdown-edit-tools {{#if countdown.editing}}same-row{{/if}}">
+                                        <a data-action="toggleCountdownEdit" data-countdown-id="{{id}}"><i class="fa-solid {{#unless countdown.editing}}fa-pen-to-square{{else}}fa-check{{/unless}}"></i></a>
+                                        <a data-action="editCountdownOwnership" data-countdown-id="{{id}}"><i class="fa-solid fa-users"></i></a>
+                                        <a data-action="removeCountdown" data-countdown-id="{{id}}"><i class="fa-solid fa-trash"></i></a>
                                     </div>
-                                {{/unless}}
+                                </div>
+                                {{#if countdown.editing}}
+                                    <div class="countdown-edit-row-container">
+                                        <div class="countdown-edit-subrow">
+                                            <div class="countdown-edit-input tiny">
+                                                <label>{{localize "DAGGERHEART.APPLICATIONS.CountdownEdit.current"}}</label>
+                                                <input type="number" name="{{concat "countdowns." id ".progress.current"}}" value="{{countdown.progress.current}}" />
+                                            </div>
+                                            <div class="countdown-edit-input tiny">
+                                                <label>{{localize "DAGGERHEART.APPLICATIONS.CountdownEdit.start"}}</label>
+                                                <input type="number" name="{{concat "countdowns." id ".progress.start"}}" value="{{countdown.progress.start}}" />
+                                            </div>
+                                            <div class="countdown-edit-input">
+                                                <label>{{localize "DAGGERHEART.APPLICATIONS.CountdownEdit.startFormula"}}</label>
+                                                <input class="countdown-random-input" type="text" name="{{concat "countdowns." id ".progress.startFormula"}}" value="{{countdown.progress.startFormula}}" />
+                                                <a class="countdown-random-button" data-action="randomiseCountdownStart" data-countdown-id="{{id}}" {{#unless countdown.randomizeValid}}disabled{{/unless}}><i class="fa-solid fa-dice fa-fw"></i></a>
+                                            </div>
+                                            
+                                        </div>
+                                        <div class="countdown-edit-subrow">
+                                            <div class="countdown-edit-input tiny type-input">
+                                                <label>{{localize "DAGGERHEART.GENERAL.type"}}</label>
+                                                <select name="{{concat "countdowns." id ".type"}}">
+                                                    {{selectOptions @root.countdownTypes selected=countdown.type localize=true}}
+                                                </select>
+                                            </div>
+                                            <div class="countdown-edit-input">
+                                                <label>{{localize "DAGGERHEART.APPLICATIONS.CountdownEdit.progressionType"}}</label>
+                                                <select name="{{concat "countdowns." id ".progress.type"}}">
+                                                    {{selectOptions @root.countdownProgressionTypes selected=countdown.progress.type localize=true}}
+                                                </select>
+                                            </div>
+                                            <div class="countdown-edit-input looping-input tiny">
+                                                <label>{{localize "DAGGERHEART.APPLICATIONS.CountdownEdit.looping"}}</label>
+                                                <select name="{{concat "countdowns." id ".progress.looping"}}">
+                                                    {{selectOptions @root.countdownLoopingTypes selected=countdown.progress.looping localize=true}}
+                                                </select>
+                                            </div>
+                                        </div>
+                                    </div>
+                                {{/if}}
                             </div>
-                        </div>
-                    {{else}}
-                        <div class="countdown-edit-input">
-                            <label>{{localize "DAGGERHEART.APPLICATIONS.Countdown.FIELDS.countdowns.element.name.label"}}</label>
-                            <input type="text" name="{{concat "countdowns." id ".name"}}" value="{{countdown.name}}" />
-                        </div>
-                    {{/unless}}
-                    <div class="countdown-edit-tools {{#if countdown.editing}}same-row{{/if}}">
-                        <a data-action="toggleCountdownEdit" data-countdown-id="{{id}}"><i class="fa-solid {{#unless countdown.editing}}fa-pen-to-square{{else}}fa-check{{/unless}}"></i></a>
-                        <a data-action="editCountdownOwnership" data-countdown-id="{{id}}"><i class="fa-solid fa-users"></i></a>
-                        <a data-action="removeCountdown" data-countdown-id="{{id}}"><i class="fa-solid fa-trash"></i></a>
+                        {{/each}}
                     </div>
-                </div>
-                {{#if countdown.editing}}
-                    <div class="countdown-edit-row-container">
-                        <div class="countdown-edit-subrow">
-                            <div class="countdown-edit-input tiny">
-                                <label>{{localize "DAGGERHEART.APPLICATIONS.CountdownEdit.current"}}</label>
-                                <input type="number" name="{{concat "countdowns." id ".progress.current"}}" value="{{countdown.progress.current}}" />
-                            </div>
-                            <div class="countdown-edit-input tiny">
-                                <label>{{localize "DAGGERHEART.APPLICATIONS.CountdownEdit.start"}}</label>
-                                <input type="number" name="{{concat "countdowns." id ".progress.start"}}" value="{{countdown.progress.start}}" />
-                            </div>
-                            <div class="countdown-edit-input">
-                                <label>{{localize "DAGGERHEART.APPLICATIONS.CountdownEdit.startFormula"}}</label>
-                                <input class="countdown-random-input" type="text" name="{{concat "countdowns." id ".progress.startFormula"}}" value="{{countdown.progress.startFormula}}" />
-                                <a class="countdown-random-button" data-action="randomiseCountdownStart" data-countdown-id="{{id}}" {{#unless countdown.randomizeValid}}disabled{{/unless}}><i class="fa-solid fa-dice fa-fw"></i></a>
-                            </div>
-                            
-                        </div>
-                        <div class="countdown-edit-subrow">
-                            <div class="countdown-edit-input tiny type-input">
-                                <label>{{localize "DAGGERHEART.GENERAL.type"}}</label>
-                                <select name="{{concat "countdowns." id ".type"}}">
-                                    {{selectOptions ../countdownTypes selected=countdown.type localize=true}}
-                                </select>
-                            </div>
-                            <div class="countdown-edit-input">
-                                <label>{{localize "DAGGERHEART.APPLICATIONS.CountdownEdit.progressionType"}}</label>
-                                <select name="{{concat "countdowns." id ".progress.type"}}">
-                                    {{selectOptions ../countdownProgressionTypes selected=countdown.progress.type localize=true}}
-                                </select>
-                            </div>
-                            <div class="countdown-edit-input looping-input tiny">
-                                <label>{{localize "DAGGERHEART.APPLICATIONS.CountdownEdit.looping"}}</label>
-                                <select name="{{concat "countdowns." id ".progress.looping"}}">
-                                    {{selectOptions ../countdownLoopingTypes selected=countdown.progress.looping localize=true}}
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                {{/if}}
                 </fieldset>
             {{/each}}
         </div>

--- a/templates/ui/countdowns/countdown-edit.hbs
+++ b/templates/ui/countdowns/countdown-edit.hbs
@@ -10,7 +10,7 @@
 
         <div class="edit-content">
             {{#each countdowns as | category id | }}
-                <fieldset>
+                <fieldset class="countdown-category">
                     <legend>
                         {{category.name}}
                         <a data-action="addCountdown" data-type="{{id}}"><i class="fa-solid fa-plus"></i></a>
@@ -18,7 +18,7 @@
 
                     <div class="countdowns-container">
                         {{#each category.countdowns as | countdown id |}}
-                            <div class="countdown-edit-outer-container">
+                            <div class="countdown-edit-outer-container {{#if (gt ../nrCountdowns 1)}}many-countdowns{{/if}}">
                                 <div class="countdown-edit-container {{#unless countdown.editing}}viewing{{/unless}}" data-id="{{id}}">
                                     <a data-action="editCountdownImage" id="{{id}}"><img src="{{countdown.img}}" /></a>
                                     {{#unless countdown.editing}} 

--- a/templates/ui/countdowns/countdown-edit.hbs
+++ b/templates/ui/countdowns/countdown-edit.hbs
@@ -18,7 +18,7 @@
 
                     <div class="countdowns-container">
                         {{#each category.countdowns as | countdown id |}}
-                            <div class="countdown-edit-outer-container {{#if (gt ../nrCountdowns 1)}}many-countdowns{{/if}}">
+                            <div class="countdown-edit-outer-container {{#if countdown.editing}}editing{{/if}}">
                                 <div class="countdown-edit-container {{#unless countdown.editing}}viewing{{/unless}}" data-id="{{id}}">
                                     <a data-action="editCountdownImage" id="{{id}}"><img src="{{countdown.img}}" /></a>
                                     {{#unless countdown.editing}} 


### PR DESCRIPTION
Fixes #2351 
Changed so that EditCountdowns has categories for each countdown type.
I didn't think this would be good at first, but I think it's actually neater than the current display.

<img width="765" height="610" alt="image" src="https://github.com/user-attachments/assets/14eb4616-e6ce-4872-b208-56f5651da79f" />

The benefits I see aside from the look is:
- The order will be the same as the UI element since the categories are in the right order, and the countdowns within also.
- When you add a new countdown, it'll be extremely clear where it ends up since you explicitly click on a + button for that section, instead of always getting a Shortterm countdown that ends up sorted somewhere.