### PR TITLE
[Feature] Embed tooltips for adversaries/environments in the compendium browser

### DIFF
--- a/module/applications/ui/itemBrowser.mjs
+++ b/module/applications/ui/itemBrowser.mjs
@@ -298,6 +298,7 @@ export class ItemBrowser extends HandlebarsApplicationMixin(ApplicationV2) {
                 'systems/daggerheart/templates/ui/itemBrowser/itemContainer.hbs',
                 {
                     items: this.items,
+                    tooltipType: this.items[0] instanceof Item ? 'item' : ['environment', 'adversary'].includes(this.items[0]?.type) ? 'actor' : null,
                     menu: this.selectedMenu,
                     formatLabel: this.formatLabel,
                     viewSheet: this.items[0] instanceof Actor

--- a/module/data/actor/base.mjs
+++ b/module/data/actor/base.mjs
@@ -311,6 +311,7 @@ export default class BaseDataActor extends foundry.abstract.TypeDataModel {
         if (!template) return null;
 
         const context = await this._prepareEmbedContext(options);
+        context.config = config;
         const content = await foundry.applications.handlebars.renderTemplate(template, context);
         const container = document.createElement('div');
         container.innerHTML = content;

--- a/module/documents/tooltipManager.mjs
+++ b/module/documents/tooltipManager.mjs
@@ -21,6 +21,9 @@ export default class DhTooltipManager extends foundry.helpers.interaction.Toolti
         let html = options.html;
         const key = element.dataset.tooltip?.match(/^#([\w-]+)#/)?.[1];
         switch (key) {
+            case 'actor':
+                html = await this.#activateActor(element, options);
+                break;
             case 'battlepoints':
                 return this.#activateBattlepoints(element, options);
             case 'effect-display':
@@ -49,6 +52,27 @@ export default class DhTooltipManager extends foundry.helpers.interaction.Toolti
         this.noOffset = options.noOffset;
         super.activate(element, { ...options, html });
         if (typeof html === 'string') this.tooltip.innerHTML = html; // foundry likes to strip certain stuff like svgs, put it back
+    }
+    
+    async #activateActor(element, options) {
+        const actorUuid = element.dataset.tooltip.slice(7);
+        const actor = await foundry.utils.fromUuid(actorUuid);
+        if (!actor) return null;
+
+        // If there is support for embeds, use that instead.
+        const theme = game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.appearance).tooltipCardTheme;
+        const embed = actor instanceof Actor ? await actor.system.toEmbed({ includeAttribution: true, theme }) : null;
+        if (embed) {
+            if (embed instanceof HTMLCollection) {
+                this.tooltip.replaceChildren(...embed);
+            } else {
+                this.tooltip.replaceChildren(embed);
+            }
+            options.direction ??= this._determineItemTooltipDirection(element);
+            return this.tooltip.innerHTML;
+        }
+
+        return null;
     }
 
     async #activateBattlepoints(element, options) {

--- a/styles/less/global/embed.less
+++ b/styles/less/global/embed.less
@@ -4,7 +4,7 @@
     color: var(--dh-embed-color-text);
     border: 2px solid var(--dh-embed-color-border);
     border-radius: 12px;
-    padding: var(--spacer-8) 0;
+    padding: var(--spacer-12) 0;
     line-height: 1.2;
 
     header.main {    
@@ -15,18 +15,26 @@
         font-size: 1.5em;
         text-transform: uppercase;
         font-weight: 900;
-        line-height: 1.47;
+        line-height: 1;
+        margin-bottom: 0.15em;
     }
 
     .tier {
         font-size: 1.125em;
         font-style: italic;
         font-weight: 600;
-        line-height: 1.25;
+
+        .attribution {
+            display: inline;
+            font-weight: 500;
+            font-size: 0.888em;
+            color: @color-text-subtle;
+        }
     }
 
     .description {
         font-style: italic;
+        margin-bottom: 0.0625rem;
         p {
             margin: 0;
         }
@@ -97,8 +105,11 @@
         .typography();
         --paragraph-spacing: 0.25em;
 
-        padding-left: 1ch;     
-        margin-bottom: 0.25em;
+        padding-left: 1ch;
+
+        &:not(:last-child) {
+            margin-bottom: 0.25em;
+        }
 
         &.grouped {
             border-top: 1px dashed var(--dh-embed-color-border);

--- a/styles/less/utils/colors.less
+++ b/styles/less/utils/colors.less
@@ -99,7 +99,7 @@
     --dh-card-trim-highlight: #ff9933;
 
     --dh-color-text-shadow-contrast: light-dark(#ffffffa0, @dark-80);
-    --dh-embed-bg: light-dark(#F4F0E7, #111);
+    --dh-embed-bg: light-dark(#F4F0E7, #0f0f14);
     --dh-embed-stats-bg: light-dark(white, black);
     --dh-embed-color-text: light-dark(black, @color-text-primary);
     --dh-embed-color-border: light-dark(#DDD0B9, @beige-80);

--- a/styles/less/ux/tooltip/index.less
+++ b/styles/less/ux/tooltip/index.less
@@ -11,7 +11,7 @@
 /** Make tooltip container invisible for some types, leaving everything to the child */
 #tooltip,
 .locked-tooltip {
-    &:has(.dh-card) {
+    &:has(.dh-card, .embed) {
         padding: 0;
         background: none;
         backdrop-filter: unset;
@@ -23,9 +23,19 @@
             border-color: light-dark(@dark-80, @beige-80);
         }
     }
+
+    &:has(.embed) {
+        max-width: unset;
+        .embed {
+            width: 24rem;
+            max-height: 90vh;
+            overflow: auto;
+            font-size: var(--font-size-13);
+        }
+    }
 }
-aside[role='tooltip'].locked-tooltip:has(.dh-card) {
-    .dh-card {
+aside[role='tooltip'].locked-tooltip:has(.dh-card, .embed) {
+    .dh-card, .embed {
         box-shadow: 0 0 25px @golden-90;
         border-color: 1px solid light-dark(@dark-blue, @golden);
     }

--- a/templates/components/actor-embed/adversary.hbs
+++ b/templates/components/actor-embed/adversary.hbs
@@ -3,6 +3,9 @@
         <div class="name actor-name">{{actor.name}}</div>
         <div class="tier">
             {{localize "DAGGERHEART.GENERAL.Tiers.typed" tier=actor.system.tier type=type}}
+            {{#if (and config.includeAttribution actor.system.attributionLabel)}}
+                <div class="attribution">({{actor.system.attributionLabel}})</div>
+            {{/if}}
         </div>
         <section class="description">{{{description}}}</section>
         <div class="motives">

--- a/templates/ui/itemBrowser/itemContainer.hbs
+++ b/templates/ui/itemBrowser/itemContainer.hbs
@@ -2,7 +2,7 @@
     <div class="item-container" data-item-uuid="{{uuid}}" draggable="true">
         <div class="item-header">
             <div class="item-info" {{#if @root.viewSheet}}data-action="viewSheet"{{else}}data-action="expandContent"{{/if}}>
-                <img src="{{img}}" data-item-key="img" class="item-list-img" {{#if (and uuid (eq documentName "Item"))}}data-tooltip="#item#{{uuid}}"{{/if}}>
+                <img src="{{img}}" data-item-key="img" class="item-list-img" {{#if (and uuid @root.tooltipType)}}data-tooltip="#{{@root.tooltipType}}#{{uuid}}"{{/if}}>
                 <span data-item-key="name" class="item-list-name">{{name}}</span>
                 {{#each ../menu.data.columns}}
                     <span data-item-key="{{key}}">{{#with (@root.formatLabel ../this this) as | label |}}{{{label}}}{{/with}}</span>


### PR DESCRIPTION
Makes it easier to preview adversaries and environments in the compendium browser. Merge after conditionals are in.

While doing this I observed there's some consistency differences in the click behavior between adversaries and non-adversaries, but I don't think there's a good solution for it.