### PR TITLE
Remove world setting to skip roll dialogs

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3312,7 +3312,7 @@
             "partner": "Partner",
             "player": {
                 "single": "Player",
-                "plurial": "Players"
+                "plural": "Players"
             },
             "portrait": "Portrait",
             "preview": "Preview",
@@ -3767,10 +3767,6 @@
                         "hint": "When a character is damaged, uses armor etc, a scrolling text will briefly appear by the token to signify this."
                     },
                     "roll": {
-                        "roll": {
-                            "label": "Roll",
-                            "hint": "Auto behavior for rolls like Attack, Spellcast, etc."
-                        },
                         "damage": {
                             "label": "Damage/Healing Roll",
                             "hint": "Auto behavior for Damage & Healing rolls after the Attack/Spellcast."

--- a/module/data/fields/action/rollField.mjs
+++ b/module/data/fields/action/rollField.mjs
@@ -142,8 +142,6 @@ export default class RollField extends fields.EmbeddedDataField {
     prepareConfig(config) {
         if (!config.hasRoll) return;
 
-        config.dialog.configure = RollField.getAutomation() ? !config.dialog.configure : config.dialog.configure;
-
         const roll = {
             baseModifiers: this.roll.getModifier(),
             label: 'Attack',
@@ -156,18 +154,5 @@ export default class RollField extends fields.EmbeddedDataField {
         if (this.roll.type === 'diceSet' || !this.hasRoll) roll.lite = true;
 
         config.roll = roll;
-    }
-
-    /**
-     * Return the automation setting for execute method for current user role
-     * @returns {boolean} If execute should be triggered automatically
-     */
-    static getAutomation() {
-        return (
-            (game.user.isGM &&
-                game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Automation).roll.roll.gm) ||
-            (!game.user.isGM &&
-                game.settings.get(CONFIG.DH.id, CONFIG.DH.SETTINGS.gameSettings.Automation).roll.roll.players)
-        );
     }
 }

--- a/module/data/settings/Automation.mjs
+++ b/module/data/settings/Automation.mjs
@@ -126,18 +126,6 @@ export default class DhAutomation extends foundry.abstract.DataModel {
                 })
             }),
             roll: new fields.SchemaField({
-                roll: new fields.SchemaField({
-                    gm: new fields.BooleanField({
-                        required: true,
-                        initial: false,
-                        label: 'DAGGERHEART.GENERAL.gm'
-                    }),
-                    players: new fields.BooleanField({
-                        required: true,
-                        initial: false,
-                        label: 'DAGGERHEART.GENERAL.player.plurial'
-                    })
-                }),
                 damage: new fields.SchemaField({
                     gm: new fields.StringField({
                         required: true,
@@ -149,7 +137,7 @@ export default class DhAutomation extends foundry.abstract.DataModel {
                         required: true,
                         initial: 'never',
                         choices: CONFIG.DH.SETTINGS.actionAutomationChoices,
-                        label: 'DAGGERHEART.GENERAL.player.plurial'
+                        label: 'DAGGERHEART.GENERAL.player.plural'
                     })
                 }),
                 save: new fields.SchemaField({
@@ -163,7 +151,7 @@ export default class DhAutomation extends foundry.abstract.DataModel {
                         required: true,
                         initial: 'never',
                         choices: CONFIG.DH.SETTINGS.actionAutomationChoices,
-                        label: 'DAGGERHEART.GENERAL.player.plurial'
+                        label: 'DAGGERHEART.GENERAL.player.plural'
                     })
                 }),
                 damageApply: new fields.SchemaField({
@@ -175,7 +163,7 @@ export default class DhAutomation extends foundry.abstract.DataModel {
                     players: new fields.BooleanField({
                         required: true,
                         initial: false,
-                        label: 'DAGGERHEART.GENERAL.player.plurial'
+                        label: 'DAGGERHEART.GENERAL.player.plural'
                     })
                 }),
                 effect: new fields.SchemaField({
@@ -187,7 +175,7 @@ export default class DhAutomation extends foundry.abstract.DataModel {
                     players: new fields.BooleanField({
                         required: true,
                         initial: false,
-                        label: 'DAGGERHEART.GENERAL.player.plurial'
+                        label: 'DAGGERHEART.GENERAL.player.plural'
                     })
                 })
             }),


### PR DESCRIPTION
Let me know if you think I should make this into a client setting (rather than a world setting) but I recall nobody really wanted to keep this.

Merge after conditional AEs are in.